### PR TITLE
st20: add linesize(stride) support

### DIFF
--- a/include/st20_dpdk_api.h
+++ b/include/st20_dpdk_api.h
@@ -583,7 +583,11 @@ struct st20_tx_ops {
   uint32_t width;
   /** Session resolution height */
   uint32_t height;
-  /** Session linesize in bytes */
+  /**
+   * Session linesize(stride) in bytes
+   * only used for GPM_SL packing, 0 if not set
+   * Valid linesize should be wider than width size
+   */
   uint32_t linesize;
   /** Session resolution fps */
   enum st_fps fps;
@@ -816,7 +820,11 @@ struct st20_rx_ops {
   uint32_t width;
   /** Session resolution height */
   uint32_t height;
-  /** Session linesize in bytes */
+  /**
+   * Session linesize(stride) in bytes
+   * only used for GPM_SL packing, 0 if not set
+   * Valid linesize should be wider than width size
+   */
   uint32_t linesize;
   /** Session resolution fps */
   enum st_fps fps;

--- a/include/st20_dpdk_api.h
+++ b/include/st20_dpdk_api.h
@@ -583,6 +583,8 @@ struct st20_tx_ops {
   uint32_t width;
   /** Session resolution height */
   uint32_t height;
+  /** Session linesize in bytes */
+  uint32_t linesize;
   /** Session resolution fps */
   enum st_fps fps;
   /** Session resolution format */
@@ -814,6 +816,8 @@ struct st20_rx_ops {
   uint32_t width;
   /** Session resolution height */
   uint32_t height;
+  /** Session linesize in bytes */
+  uint32_t linesize;
   /** Session resolution fps */
   enum st_fps fps;
   /** Session resolution format */

--- a/lib/src/st_main.h
+++ b/lib/src/st_main.h
@@ -559,6 +559,7 @@ struct st_tx_video_session_impl {
 
   /* frame info */
   size_t st20_frame_size;   /* size per frame */
+  size_t st20_fb_size;      /* frame buffer size, with lines' padding */
   size_t st20_linesize;     /* line size including padding bytes */
   uint16_t st20_frames_cnt; /* numbers of frames requested */
   struct st_frame_trans* st20_frames;
@@ -836,7 +837,8 @@ struct st_rx_video_session_impl {
   struct st_rx_video_detector detector;
 
   /* frames info */
-  size_t st20_frame_size;        /* size per frame, not include padding */
+  size_t st20_frame_size;        /* size per frame, without padding */
+  size_t st20_fb_size;           /* frame buffer size, with lines' padding */
   size_t st20_linesize;          /* line size including padding bytes */
   size_t st20_frame_bitmap_size; /* bitmap size per frame */
   int st20_frames_cnt;           /* numbers of frames requested */

--- a/lib/src/st_main.h
+++ b/lib/src/st_main.h
@@ -559,6 +559,7 @@ struct st_tx_video_session_impl {
 
   /* frame info */
   size_t st20_frame_size;   /* size per frame */
+  size_t st20_linesize;     /* line size including padding bytes */
   uint16_t st20_frames_cnt; /* numbers of frames requested */
   struct st_frame_trans* st20_frames;
 
@@ -835,7 +836,8 @@ struct st_rx_video_session_impl {
   struct st_rx_video_detector detector;
 
   /* frames info */
-  size_t st20_frame_size;        /* size per frame */
+  size_t st20_frame_size;        /* size per frame, not include padding */
+  size_t st20_linesize;          /* line size including padding bytes */
   size_t st20_frame_bitmap_size; /* bitmap size per frame */
   int st20_frames_cnt;           /* numbers of frames requested */
   struct st_frame_trans* st20_frames;

--- a/lib/src/st_rx_video_session.c
+++ b/lib/src/st_rx_video_session.c
@@ -2402,6 +2402,8 @@ static int rv_handle_detect_pkt(struct st_rx_video_session_impl* s, struct rte_m
         s->st20_frame_size =
             ops->width * ops->height * s->st20_pg.size / s->st20_pg.coverage;
         if (ops->interlaced) s->st20_frame_size = s->st20_frame_size >> 1;
+        s->st20_linesize =
+            RTE_MAX(ops->linesize, ops->width * s->st20_pg.size / s->st20_pg.coverage);
         /* at least 1000 byte for each packet */
         s->st20_frame_bitmap_size = s->st20_frame_size / 1000 / 8;
         /* one line at line 2 packets for all the format */
@@ -2643,8 +2645,8 @@ static int rv_attach(struct st_main_impl* impl, struct st_rx_video_sessions_mgr*
     info("%s(%d), hdr_split enabled in ops\n", __func__, idx);
   }
 
-  s->st20_linesize = ops->width * s->st20_pg.size / s->st20_pg.coverage;
-  if (ops->linesize > s->st20_linesize) s->st20_linesize = ops->linesize;
+  s->st20_linesize =
+      RTE_MAX(ops->linesize, ops->width * s->st20_pg.size / s->st20_pg.coverage);
   s->slice_lines = ops->slice_lines;
   if (!s->slice_lines) s->slice_lines = ops->height / 32;
   s->slice_size = ops->width * s->slice_lines * s->st20_pg.size / s->st20_pg.coverage;

--- a/lib/src/st_rx_video_session.c
+++ b/lib/src/st_rx_video_session.c
@@ -2666,9 +2666,10 @@ static int rv_attach(struct st_main_impl* impl, struct st_rx_video_sessions_mgr*
   if (!s->slice_lines) s->slice_lines = ops->height / 32;
   s->slice_size = ops->width * s->slice_lines * s->st20_pg.size / s->st20_pg.coverage;
   s->st20_frames_cnt = ops->framebuff_cnt;
-  if (st22_ops)
+  if (st22_ops) {
     s->st20_frame_size = st22_ops->framebuff_max_size;
-  else
+    s->st20_fb_size = s->st20_frame_size;
+  } else
     s->st20_frame_size = ops->width * ops->height * s->st20_pg.size / s->st20_pg.coverage;
   s->st20_uframe_size = ops->uframe_size;
   if (ops->interlaced) s->st20_frame_size = s->st20_frame_size >> 1;

--- a/lib/src/st_rx_video_session.c
+++ b/lib/src/st_rx_video_session.c
@@ -628,7 +628,7 @@ static int rv_alloc_frames(struct st_main_impl* impl,
   enum st_port port = st_port_logic2phy(s->port_maps, ST_SESSION_PORT_P);
   int soc_id = st_socket_id(impl, port);
   int idx = s->idx;
-  size_t size = s->st20_uframe_size ? s->st20_uframe_size : s->st20_frame_size;
+  size_t size = s->st20_uframe_size ? s->st20_uframe_size : s->st20_fb_size;
   struct st_frame_trans* st20_frame;
   void* frame;
 
@@ -1628,8 +1628,8 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
     if (frame_recv_size >= s->st20_frame_size) end_frame = true;
   }
   if (end_frame) {
-    dbg("%s(%d,%d): full frame on %p(%lu)\n", __func__, s->idx, s_port, slot->frame,
-        frame_recv_size);
+    dbg("%s(%d,%d): full frame on %p(%" PRIu64 ")\n", __func__, s->idx, s_port,
+        slot->frame, frame_recv_size);
     dbg("%s(%d,%d): tmstamp %u slot %d\n", __func__, s->idx, s_port, slot->tmstamp,
         slot->idx);
     /* end of frame */
@@ -2402,8 +2402,15 @@ static int rv_handle_detect_pkt(struct st_rx_video_session_impl* s, struct rte_m
         s->st20_frame_size =
             ops->width * ops->height * s->st20_pg.size / s->st20_pg.coverage;
         if (ops->interlaced) s->st20_frame_size = s->st20_frame_size >> 1;
-        s->st20_linesize =
-            RTE_MAX(ops->linesize, ops->width * s->st20_pg.size / s->st20_pg.coverage);
+        s->st20_linesize = ops->width * s->st20_pg.size / s->st20_pg.coverage;
+        if (ops->linesize > s->st20_linesize)
+          s->st20_linesize = ops->linesize;
+        else if (ops->linesize) {
+          err("%s(%d), invalid linesize %u\n", __func__, s->idx, ops->linesize);
+          return -EINVAL;
+        }
+        s->st20_fb_size = s->st20_linesize * ops->height;
+        if (ops->interlaced) s->st20_fb_size = s->st20_fb_size >> 1;
         /* at least 1000 byte for each packet */
         s->st20_frame_bitmap_size = s->st20_frame_size / 1000 / 8;
         /* one line at line 2 packets for all the format */
@@ -2645,8 +2652,16 @@ static int rv_attach(struct st_main_impl* impl, struct st_rx_video_sessions_mgr*
     info("%s(%d), hdr_split enabled in ops\n", __func__, idx);
   }
 
-  s->st20_linesize =
-      RTE_MAX(ops->linesize, ops->width * s->st20_pg.size / s->st20_pg.coverage);
+  s->st20_linesize = ops->width * s->st20_pg.size / s->st20_pg.coverage;
+  if (ops->linesize > s->st20_linesize)
+    s->st20_linesize = ops->linesize;
+  else if (ops->linesize) {
+    err("%s(%d), invalid linesize %u\n", __func__, idx, ops->linesize);
+    return -EINVAL;
+  }
+
+  s->st20_fb_size = s->st20_linesize * ops->height;
+  if (ops->interlaced) s->st20_fb_size = s->st20_fb_size >> 1;
   s->slice_lines = ops->slice_lines;
   if (!s->slice_lines) s->slice_lines = ops->height / 32;
   s->slice_size = ops->width * s->slice_lines * s->st20_pg.size / s->st20_pg.coverage;
@@ -3535,7 +3550,7 @@ size_t st20_rx_get_framebuffer_size(st20_rx_handle handle) {
   }
 
   s = s_impl->impl;
-  return s->st20_frame_size;
+  return s->st20_fb_size;
 }
 
 int st20_rx_get_framebuffer_count(st20_rx_handle handle) {

--- a/lib/src/st_tx_video_session.c
+++ b/lib/src/st_tx_video_session.c
@@ -1771,7 +1771,7 @@ static int tv_mempool_init(struct st_main_impl* impl,
       hdr_room_size += sizeof(struct st20_rfc4175_extra_rtp_hdr);
     /* attach extbuf used, only placeholder mbuf */
     chain_room_size = 0;
-  }
+    }
 
   for (int i = 0; i < num_port; i++) {
     port = st_port_logic2phy(s->port_maps, i);
@@ -2107,6 +2107,7 @@ static int tv_attach(struct st_main_impl* impl, struct st_tx_video_sessions_mgr*
       s->st22_box_hdr_length = sizeof(struct st22_boxes);
     s->st22_codestream_size = st22_frame_ops->framebuff_max_size;
     s->st20_frame_size = s->st22_codestream_size + s->st22_box_hdr_length;
+    s->st20_fb_size = s->st20_frame_size;
   } else {
     s->st20_frame_size = ops->width * height * s->st20_pg.size / s->st20_pg.coverage;
     s->st20_fb_size = s->st20_linesize * height;

--- a/lib/src/st_tx_video_session.c
+++ b/lib/src/st_tx_video_session.c
@@ -2091,8 +2091,8 @@ static int tv_attach(struct st_main_impl* impl, struct st_tx_video_sessions_mgr*
     return ret;
   }
 
-  s->st20_linesize = ops->width * s->st20_pg.size / s->st20_pg.coverage;
-  if (ops->linesize > s->st20_linesize) s->st20_linesize = ops->linesize;
+  s->st20_linesize =
+      RTE_MAX(ops->linesize, ops->width * s->st20_pg.size / s->st20_pg.coverage);
 
   uint32_t height = ops->interlaced ? (ops->height >> 1) : ops->height;
   if (st22_frame_ops) {

--- a/lib/src/st_tx_video_session.c
+++ b/lib/src/st_tx_video_session.c
@@ -1771,7 +1771,7 @@ static int tv_mempool_init(struct st_main_impl* impl,
       hdr_room_size += sizeof(struct st20_rfc4175_extra_rtp_hdr);
     /* attach extbuf used, only placeholder mbuf */
     chain_room_size = 0;
-    }
+  }
 
   for (int i = 0; i < num_port; i++) {
     port = st_port_logic2phy(s->port_maps, i);

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -115,7 +115,7 @@ static int tx_notify_ext_frame_done(void* priv, uint16_t frame_idx,
 
   void* frame_addr = st20_tx_get_framebuffer((st20_tx_handle)ctx->handle, frame_idx);
   for (int i = 0; i < ctx->fb_cnt; ++i) {
-    if (frame_addr == ctx->ext_fb + i * ctx->frame_size) {
+    if (frame_addr == ctx->ext_frames[i].buf_addr) {
       ctx->ext_fb_in_use[i] = false;
       return 0;
     }
@@ -1633,7 +1633,7 @@ static void st20_digest_rx_frame_check(void* args) {
       ctx->buf_q.pop();
       dbg("%s, frame %p\n", __func__, frame);
       int i;
-      SHA256((unsigned char*)frame, ctx->uframe_size ? ctx->uframe_size : ctx->frame_size,
+      SHA256((unsigned char*)frame, ctx->uframe_size ? ctx->uframe_size : ctx->fb_size,
              result);
       for (i = 0; i < TEST_SHA_HIST_NUM; i++) {
         unsigned char* target_sha = ctx->shas[i];
@@ -1666,7 +1666,7 @@ static void st20_digest_rx_field_check(void* args) {
       ctx->second_field_q.pop();
       dbg("%s, frame %p\n", __func__, frame);
       int i;
-      SHA256((unsigned char*)frame, ctx->uframe_size ? ctx->uframe_size : ctx->frame_size,
+      SHA256((unsigned char*)frame, ctx->uframe_size ? ctx->uframe_size : ctx->fb_size,
              result);
       for (i = 0; i < TEST_SHA_HIST_NUM; i++) {
         unsigned char* target_sha = ctx->shas[i];
@@ -1870,6 +1870,7 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
     rx_handle[i] = st20_rx_create(m_handle, &ops_rx);
 
     test_ctx_rx[i]->frame_size = test_ctx_tx[i]->frame_size;
+    test_ctx_rx[i]->fb_size = test_ctx_tx[i]->frame_size;
     test_ctx_rx[i]->width = ops_rx.width;
     st20_get_pgroup(ops_rx.fmt, &test_ctx_rx[i]->st20_pg);
     memcpy(test_ctx_rx[i]->shas, test_ctx_tx[i]->shas,
@@ -3091,6 +3092,7 @@ static void st20_rx_uframe_test(enum st20_type rx_type[], enum st20_packing pack
     rx_handle[i] = st20_rx_create(m_handle, &ops_rx);
 
     test_ctx_rx[i]->frame_size = test_ctx_tx[i]->frame_size;
+    test_ctx_rx[i]->fb_size = test_ctx_tx[i]->frame_size;
     test_ctx_rx[i]->width = ops_rx.width;
     test_ctx_rx[i]->uframe_size = ops_rx.uframe_size;
     st20_get_pgroup(ops_rx.fmt, &test_ctx_rx[i]->st20_pg);
@@ -3378,6 +3380,7 @@ static void st20_rx_detect_test(enum st20_type tx_type[], enum st20_type rx_type
     rx_handle[i] = st20_rx_create(m_handle, &ops_rx);
 
     test_ctx_rx[i]->frame_size = test_ctx_tx[i]->frame_size;
+    test_ctx_rx[i]->fb_size = test_ctx_tx[i]->frame_size;
     test_ctx_rx[i]->uframe_size = ops_rx.uframe_size;
     test_ctx_rx[i]->width = ops_tx.width;
     st20_get_pgroup(ops_rx.fmt, &test_ctx_rx[i]->st20_pg);
@@ -3876,6 +3879,7 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
     rx_handle[i] = st20_rx_create(m_handle, &ops_rx);
 
     test_ctx_rx[i]->frame_size = test_ctx_tx[i]->frame_size;
+    test_ctx_rx[i]->fb_size = test_ctx_tx[i]->frame_size;
     test_ctx_rx[i]->width = ops_rx.width;
     st20_get_pgroup(ops_rx.fmt, &test_ctx_rx[i]->st20_pg);
     memcpy(test_ctx_rx[i]->shas, test_ctx_tx[i]->shas,
@@ -4139,6 +4143,7 @@ static void st20_tx_timestamp_test(int width[], int height[], enum st20_fmt fmt[
     rx_handle[i] = st20_rx_create(m_handle, &ops_rx);
 
     test_ctx_rx[i]->frame_size = test_ctx_tx[i]->frame_size;
+    test_ctx_rx[i]->fb_size = test_ctx_tx[i]->frame_size;
     test_ctx_rx[i]->width = ops_rx.width;
     st20_get_pgroup(ops_rx.fmt, &test_ctx_rx[i]->st20_pg);
     memcpy(test_ctx_rx[i]->shas, test_ctx_tx[i]->shas,
@@ -4199,4 +4204,299 @@ TEST(St20_tx, tx_timestamp) {
   int height[1] = {1080};
   enum st20_fmt fmt[1] = {ST20_FMT_YUV_422_10BIT};
   st20_tx_timestamp_test(width, height, fmt, ST_TEST_LEVEL_MANDATORY, 1);
+}
+
+static void st20_linesize_digest_test(enum st20_packing packing[], enum st_fps fps[],
+                                      int width[], int height[], int linesize[],
+                                      bool interlaced[], enum st20_fmt fmt[],
+                                      bool check_fps, enum st_test_level level,
+                                      int sessions = 1, bool ext = false) {
+  auto ctx = (struct st_tests_context*)st_test_ctx();
+  auto m_handle = ctx->handle;
+  int ret;
+  struct st20_tx_ops ops_tx;
+  struct st20_rx_ops ops_rx;
+
+  /* return if level small than global */
+  if (level < ctx->level) return;
+
+  if (ctx->para.num_ports != 2) {
+    info("%s, dual port should be enabled for tx test, one for tx and one for rx\n",
+         __func__);
+    return;
+  }
+
+  bool has_dma = st_test_dma_available(ctx);
+
+  std::vector<tests_context*> test_ctx_tx;
+  std::vector<tests_context*> test_ctx_rx;
+  std::vector<st20_tx_handle> tx_handle;
+  std::vector<st20_rx_handle> rx_handle;
+  std::vector<double> expect_framerate;
+  std::vector<double> framerate;
+  std::vector<std::thread> sha_check;
+
+  test_ctx_tx.resize(sessions);
+  test_ctx_rx.resize(sessions);
+  tx_handle.resize(sessions);
+  rx_handle.resize(sessions);
+  expect_framerate.resize(sessions);
+  framerate.resize(sessions);
+  sha_check.resize(sessions);
+
+  for (int i = 0; i < sessions; i++) {
+    expect_framerate[i] = st_frame_rate(fps[i]);
+    test_ctx_tx[i] = new tests_context();
+    ASSERT_TRUE(test_ctx_tx[i] != NULL);
+
+    test_ctx_tx[i]->idx = i;
+    test_ctx_tx[i]->ctx = ctx;
+    test_ctx_tx[i]->fb_cnt = TEST_SHA_HIST_NUM;
+    test_ctx_tx[i]->fb_idx = 0;
+    test_ctx_tx[i]->check_sha = true;
+    memset(&ops_tx, 0, sizeof(ops_tx));
+    ops_tx.name = "st20_linesize_digest_test";
+    ops_tx.priv = test_ctx_tx[i];
+    ops_tx.num_port = 1;
+    memcpy(ops_tx.dip_addr[ST_PORT_P], ctx->para.sip_addr[ST_PORT_R], ST_IP_ADDR_LEN);
+    strncpy(ops_tx.port[ST_PORT_P], ctx->para.port[ST_PORT_P], ST_PORT_MAX_LEN);
+    ops_tx.udp_port[ST_PORT_P] = 10000 + i;
+    ops_tx.pacing = ST21_PACING_NARROW;
+    ops_tx.packing = packing[i];
+    ops_tx.type = ST20_TYPE_FRAME_LEVEL;
+    ops_tx.width = width[i];
+    ops_tx.height = height[i];
+    ops_tx.linesize = linesize[i];
+    ops_tx.interlaced = interlaced[i];
+    ops_tx.fps = fps[i];
+    ops_tx.fmt = fmt[i];
+    ops_tx.payload_type = ST20_TEST_PAYLOAD_TYPE;
+
+    ops_tx.framebuff_cnt = test_ctx_tx[i]->fb_cnt;
+    if (ext) {
+      ops_tx.flags |= ST20_TX_FLAG_EXT_FRAME;
+      ops_tx.get_next_frame =
+          interlaced[i] ? tx_next_ext_video_field : tx_next_ext_video_frame;
+      ops_tx.notify_frame_done = tx_notify_ext_frame_done;
+    } else {
+      ops_tx.get_next_frame = interlaced[i] ? tx_next_video_field : tx_next_video_frame;
+    }
+
+    tx_handle[i] = st20_tx_create(m_handle, &ops_tx);
+    ASSERT_TRUE(tx_handle[i] != NULL);
+
+    /* sha caculate */
+    struct st20_pgroup st20_pg;
+    st20_get_pgroup(ops_tx.fmt, &st20_pg);
+    size_t frame_size = ops_tx.width * ops_tx.height * st20_pg.size / st20_pg.coverage;
+    if (interlaced[i]) frame_size = frame_size >> 1;
+    test_ctx_tx[i]->frame_size = frame_size;
+    test_ctx_tx[i]->height = ops_tx.height;
+    test_ctx_tx[i]->stride = ops_tx.width / st20_pg.coverage * st20_pg.size;
+
+    size_t fb_size = frame_size;
+    if (linesize[i] > test_ctx_tx[i]->stride) {
+      test_ctx_tx[i]->stride = linesize[i];
+      fb_size = linesize[i] * height[i];
+      if (interlaced[i]) fb_size = fb_size >> 1;
+    }
+    test_ctx_tx[i]->fb_size = fb_size;
+    EXPECT_EQ(st20_tx_get_framebuffer_size(tx_handle[i]), fb_size);
+    EXPECT_EQ(st20_tx_get_framebuffer_count(tx_handle[i]), test_ctx_tx[i]->fb_cnt);
+
+    if (ext) {
+      test_ctx_tx[i]->ext_frames = (struct st20_ext_frame*)malloc(
+          sizeof(*test_ctx_tx[i]->ext_frames) * test_ctx_tx[i]->fb_cnt);
+      size_t fbs_size = fb_size * test_ctx_tx[i]->fb_cnt;
+      st_dma_mem_handle dma_mem = st_dma_mem_alloc(m_handle, fbs_size);
+      ASSERT_TRUE(dma_mem != NULL);
+      test_ctx_tx[i]->dma_mem = dma_mem;
+
+      for (int j = 0; j < test_ctx_tx[i]->fb_cnt; j++) {
+        test_ctx_tx[i]->ext_frames[j].buf_addr =
+            (uint8_t*)st_dma_mem_addr(dma_mem) + j * fb_size;
+        test_ctx_tx[i]->ext_frames[j].buf_iova = st_dma_mem_iova(dma_mem) + j * fb_size;
+        test_ctx_tx[i]->ext_frames[j].buf_len = fb_size;
+      }
+    }
+
+    uint8_t* fb;
+    int total_lines = height[i];
+    size_t bytes_per_line = ops_tx.width / st20_pg.coverage * st20_pg.size;
+    if (interlaced[i]) total_lines /= 2;
+    for (int frame = 0; frame < TEST_SHA_HIST_NUM; frame++) {
+      if (ext) {
+        fb = (uint8_t*)test_ctx_tx[i]->ext_frames[frame].buf_addr;
+      } else {
+        fb = (uint8_t*)st20_tx_get_framebuffer(tx_handle[i], frame);
+      }
+
+      ASSERT_TRUE(fb != NULL);
+
+      for (int line = 0; line < total_lines; line++) {
+        st_test_rand_data(fb + test_ctx_tx[i]->stride, bytes_per_line, frame);
+      }
+      unsigned char* result = test_ctx_tx[i]->shas[frame];
+      SHA256((unsigned char*)fb, fb_size, result);
+      test_sha_dump("st20_rx", result);
+    }
+
+    test_ctx_tx[i]->handle = tx_handle[i]; /* all ready now */
+  }
+
+  for (int i = 0; i < sessions; i++) {
+    test_ctx_rx[i] = new tests_context();
+    ASSERT_TRUE(test_ctx_rx[i] != NULL);
+
+    test_ctx_rx[i]->idx = i;
+    test_ctx_rx[i]->ctx = ctx;
+    test_ctx_rx[i]->fb_cnt = 3;
+    test_ctx_rx[i]->fb_idx = 0;
+    test_ctx_rx[i]->check_sha = true;
+
+    test_ctx_rx[i]->fb_size = test_ctx_tx[i]->fb_size;
+    test_ctx_rx[i]->frame_size = test_ctx_tx[i]->frame_size;
+
+    if (ext) {
+      test_ctx_rx[i]->ext_frames = (struct st20_ext_frame*)malloc(
+          sizeof(*test_ctx_rx[i]->ext_frames) * test_ctx_rx[i]->fb_cnt);
+      size_t fbs_size = test_ctx_rx[i]->fb_size * test_ctx_rx[i]->fb_cnt;
+      st_dma_mem_handle dma_mem = st_dma_mem_alloc(m_handle, fbs_size);
+      ASSERT_TRUE(dma_mem != NULL);
+      test_ctx_rx[i]->dma_mem = dma_mem;
+
+      for (int j = 0; j < test_ctx_rx[i]->fb_cnt; j++) {
+        test_ctx_rx[i]->ext_frames[j].buf_addr =
+            (uint8_t*)st_dma_mem_addr(dma_mem) + j * test_ctx_rx[i]->fb_size;
+        test_ctx_rx[i]->ext_frames[j].buf_iova =
+            st_dma_mem_iova(dma_mem) + j * test_ctx_rx[i]->fb_size;
+        test_ctx_rx[i]->ext_frames[j].buf_len = test_ctx_rx[i]->fb_size;
+      }
+    }
+
+    memset(&ops_rx, 0, sizeof(ops_rx));
+    ops_rx.name = "st20_linesize_digest_test";
+    ops_rx.priv = test_ctx_rx[i];
+    ops_rx.num_port = 1;
+    memcpy(ops_rx.sip_addr[ST_PORT_P], ctx->para.sip_addr[ST_PORT_P], ST_IP_ADDR_LEN);
+    strncpy(ops_rx.port[ST_PORT_P], ctx->para.port[ST_PORT_R], ST_PORT_MAX_LEN);
+    ops_rx.udp_port[ST_PORT_P] = 10000 + i;
+    ops_rx.pacing = ST21_PACING_NARROW;
+    ops_rx.type = ST20_TYPE_FRAME_LEVEL;
+    ops_rx.width = width[i];
+    ops_rx.height = height[i];
+    ops_rx.linesize = linesize[i];
+    ops_rx.fps = fps[i];
+    ops_rx.fmt = fmt[i];
+    ops_rx.payload_type = ST20_TEST_PAYLOAD_TYPE;
+    ops_rx.interlaced = interlaced[i];
+    ops_rx.framebuff_cnt = test_ctx_rx[i]->fb_cnt;
+    ops_rx.notify_frame_ready =
+        interlaced[i] ? st20_digest_rx_field_ready : st20_digest_rx_frame_ready;
+    ops_rx.flags = ST20_RX_FLAG_DMA_OFFLOAD;
+    if (ext) ops_rx.ext_frames = test_ctx_rx[i]->ext_frames;
+
+    rx_handle[i] = st20_rx_create(m_handle, &ops_rx);
+
+    test_ctx_rx[i]->width = ops_rx.width;
+    test_ctx_rx[i]->height = ops_rx.height;
+    st20_get_pgroup(ops_rx.fmt, &test_ctx_rx[i]->st20_pg);
+    memcpy(test_ctx_rx[i]->shas, test_ctx_tx[i]->shas,
+           TEST_SHA_HIST_NUM * SHA256_DIGEST_LENGTH);
+    test_ctx_rx[i]->total_pkts_in_frame = test_ctx_tx[i]->total_pkts_in_frame;
+    ASSERT_TRUE(rx_handle[i] != NULL);
+    test_ctx_rx[i]->handle = rx_handle[i];
+
+    test_ctx_rx[i]->stop = false;
+    if (interlaced[i]) {
+      sha_check[i] = std::thread(st20_digest_rx_field_check, test_ctx_rx[i]);
+    } else {
+      sha_check[i] = std::thread(st20_digest_rx_frame_check, test_ctx_rx[i]);
+    }
+
+    bool dma_enabled = st20_rx_dma_enabled(rx_handle[i]);
+    if (has_dma) {
+      EXPECT_TRUE(dma_enabled);
+    } else {
+      EXPECT_FALSE(dma_enabled);
+    }
+    struct st_queue_meta meta;
+    ret = st20_rx_get_queue_meta(rx_handle[i], &meta);
+    EXPECT_GE(ret, 0);
+  }
+
+  ret = st_start(m_handle);
+  EXPECT_GE(ret, 0);
+  sleep(ST20_TRAIN_TIME_S * sessions); /* time for train_pacing */
+  sleep(10 * 1);
+
+  for (int i = 0; i < sessions; i++) {
+    uint64_t cur_time_ns = st_test_get_monotonic_time();
+    double time_sec = (double)(cur_time_ns - test_ctx_rx[i]->start_time) / NS_PER_S;
+    framerate[i] = test_ctx_rx[i]->fb_rec / time_sec;
+    test_ctx_rx[i]->stop = true;
+    {
+      std::unique_lock<std::mutex> lck(test_ctx_rx[i]->mtx);
+      test_ctx_rx[i]->cv.notify_all();
+    }
+    sha_check[i].join();
+  }
+
+  ret = st_stop(m_handle);
+  EXPECT_GE(ret, 0);
+  for (int i = 0; i < sessions; i++) {
+    EXPECT_GE(test_ctx_rx[i]->fb_rec, 0);
+    EXPECT_GT(test_ctx_rx[i]->check_sha_frame_cnt, 0);
+
+    EXPECT_LT(test_ctx_rx[i]->incomplete_frame_cnt, 2);
+    EXPECT_EQ(test_ctx_rx[i]->incomplete_slice_cnt, 0);
+    EXPECT_EQ(test_ctx_rx[i]->fail_cnt, 0);
+    info("%s, session %d fb_rec %d framerate %f fb_send %d\n", __func__, i,
+         test_ctx_rx[i]->fb_rec, framerate[i], test_ctx_tx[i]->fb_send);
+    if (check_fps) {
+      EXPECT_NEAR(framerate[i], expect_framerate[i], expect_framerate[i] * 0.1);
+    }
+
+    ret = st20_tx_free(tx_handle[i]);
+    EXPECT_GE(ret, 0);
+    ret = st20_rx_free(rx_handle[i]);
+    EXPECT_GE(ret, 0);
+    if (ext) {
+      st_dma_mem_free(m_handle, test_ctx_tx[i]->dma_mem);
+      st_test_free(test_ctx_tx[i]->ext_frames);
+      st_dma_mem_free(m_handle, test_ctx_rx[i]->dma_mem);
+      st_test_free(test_ctx_rx[i]->ext_frames);
+    }
+    if (test_ctx_rx[i]->priv) st_test_free(test_ctx_rx[i]->priv);
+    delete test_ctx_tx[i];
+    delete test_ctx_rx[i];
+  }
+}
+
+TEST(St20_rx, linesize_digest_s3) {
+  enum st20_packing packing[3] = {ST20_PACKING_GPM_SL, ST20_PACKING_GPM_SL,
+                                  ST20_PACKING_GPM_SL};
+  enum st_fps fps[3] = {ST_FPS_P59_94, ST_FPS_P50, ST_FPS_P50};
+  int width[3] = {1280, 1920, 1920};
+  int height[3] = {720, 1080, 1080};
+  int linesize[3] = {4096, 5120, 8192};
+  bool interlaced[3] = {false, true, false};
+  enum st20_fmt fmt[3] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT,
+                          ST20_FMT_YUV_422_10BIT};
+  st20_linesize_digest_test(packing, fps, width, height, linesize, interlaced, fmt, true,
+                            ST_TEST_LEVEL_MANDATORY, 3);
+}
+
+TEST(St20_rx, linesize_digest_ext_s3) {
+  enum st20_packing packing[3] = {ST20_PACKING_GPM_SL, ST20_PACKING_GPM_SL,
+                                  ST20_PACKING_GPM_SL};
+  enum st_fps fps[3] = {ST_FPS_P59_94, ST_FPS_P50, ST_FPS_P50};
+  int width[3] = {1280, 1920, 1920};
+  int height[3] = {720, 1080, 1080};
+  int linesize[3] = {4096, 5120, 8192};
+  bool interlaced[3] = {true, false, false};
+  enum st20_fmt fmt[3] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT,
+                          ST20_FMT_YUV_422_10BIT};
+  st20_linesize_digest_test(packing, fps, width, height, linesize, interlaced, fmt, true,
+                            ST_TEST_LEVEL_MANDATORY, 3, true);
 }

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -1633,8 +1633,13 @@ static void st20_digest_rx_frame_check(void* args) {
       ctx->buf_q.pop();
       dbg("%s, frame %p\n", __func__, frame);
       int i;
-      SHA256((unsigned char*)frame, ctx->uframe_size ? ctx->uframe_size : ctx->frame_size,
-             result);
+      size_t sha_size;
+      if (ctx->stride) {
+        sha_size = ctx->stride * ctx->height;
+      } else {
+        sha_size = ctx->uframe_size ? ctx->uframe_size : ctx->frame_size;
+      }
+      SHA256((unsigned char*)frame, sha_size, result);
       for (i = 0; i < TEST_SHA_HIST_NUM; i++) {
         unsigned char* target_sha = ctx->shas[i];
         if (!memcmp(result, target_sha, SHA256_DIGEST_LENGTH)) break;
@@ -1666,8 +1671,13 @@ static void st20_digest_rx_field_check(void* args) {
       ctx->second_field_q.pop();
       dbg("%s, frame %p\n", __func__, frame);
       int i;
-      SHA256((unsigned char*)frame, ctx->uframe_size ? ctx->uframe_size : ctx->frame_size,
-             result);
+      size_t sha_size;
+      if (ctx->stride) {
+        sha_size = ctx->stride * ctx->height / 2;
+      } else {
+        sha_size = ctx->uframe_size ? ctx->uframe_size : ctx->frame_size;
+      }
+      SHA256((unsigned char*)frame, sha_size, result);
       for (i = 0; i < TEST_SHA_HIST_NUM; i++) {
         unsigned char* target_sha = ctx->shas[i];
         if (!memcmp(result, target_sha, SHA256_DIGEST_LENGTH)) break;
@@ -3691,9 +3701,10 @@ static int rx_query_ext_frame(void* priv, st20_ext_frame* ext_frame) {
 
 static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
                                              enum st_fps fps[], int width[], int height[],
-                                             bool interlaced[], enum st20_fmt fmt[],
-                                             bool check_fps, enum st_test_level level,
-                                             int sessions = 1, bool dynamic = false) {
+                                             int linesize[], bool interlaced[],
+                                             enum st20_fmt fmt[], bool check_fps,
+                                             enum st_test_level level, int sessions = 1,
+                                             bool dynamic = false) {
   auto ctx = (struct st_tests_context*)st_test_ctx();
   auto m_handle = ctx->handle;
   int ret;
@@ -3753,6 +3764,7 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;
     ops_tx.width = width[i];
     ops_tx.height = height[i];
+    ops_tx.linesize = linesize[i];
     ops_tx.interlaced = interlaced[i];
     ops_tx.fps = fps[i];
     ops_tx.fmt = fmt[i];
@@ -3769,14 +3781,16 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
     /* sha caculate */
     struct st20_pgroup st20_pg;
     st20_get_pgroup(ops_tx.fmt, &st20_pg);
-    size_t frame_size = ops_tx.width * ops_tx.height * st20_pg.size / st20_pg.coverage;
+    test_ctx_tx[i]->stride = ops_tx.width * st20_pg.size / st20_pg.coverage;
+    if (linesize[i] > test_ctx_tx[i]->stride) test_ctx_tx[i]->stride = linesize[i];
+    size_t frame_size = test_ctx_tx[i]->stride * ops_tx.height;
     if (interlaced[i]) frame_size = frame_size >> 1;
     EXPECT_EQ(st20_tx_get_framebuffer_size(tx_handle[i]), frame_size);
     EXPECT_EQ(st20_tx_get_framebuffer_count(tx_handle[i]), test_ctx_tx[i]->fb_cnt);
 
     test_ctx_tx[i]->frame_size = frame_size;
+    test_ctx_tx[i]->width = ops_tx.width;
     test_ctx_tx[i]->height = ops_tx.height;
-    test_ctx_tx[i]->stride = ops_tx.width / st20_pg.coverage * st20_pg.size;
 
     test_ctx_tx[i]->ext_frames = (struct st20_ext_frame*)malloc(
         sizeof(*test_ctx_tx[i]->ext_frames) * test_ctx_tx[i]->fb_cnt);
@@ -3805,7 +3819,16 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
       fb = (uint8_t*)test_ctx_tx[i]->ext_fb + frame * frame_size;
 
       ASSERT_TRUE(fb != NULL);
-      st_test_rand_data(fb, frame_size, frame);
+      if (linesize[i]) { /* leave padding data as 0 */
+        size_t valid_linesize = ops_tx.width * st20_pg.size / st20_pg.coverage;
+        int total_lines = height[i];
+        if (interlaced[i]) total_lines = total_lines / 2;
+        for (int line = 0; line < total_lines; line++) {
+          st_test_rand_data(fb + line * linesize[i], valid_linesize, frame);
+        }
+      } else {
+        st_test_rand_data(fb, frame_size, frame);
+      }
       unsigned char* result = test_ctx_tx[i]->shas[frame];
       SHA256((unsigned char*)fb, frame_size, result);
       test_sha_dump("st20_rx", result);
@@ -3826,7 +3849,7 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
 
     test_ctx_rx[i]->ext_frames = (struct st20_ext_frame*)malloc(
         sizeof(*test_ctx_rx[i]->ext_frames) * test_ctx_rx[i]->fb_cnt);
-    size_t frame_size = st20_frame_size(fmt[i], width[i], height[i]);
+    size_t frame_size = test_ctx_tx[i]->frame_size;
     size_t pg_sz = st_page_size(m_handle);
     size_t fb_size = frame_size * test_ctx_rx[i]->fb_cnt;
     test_ctx_rx[i]->ext_fb_iova_map_sz = st_size_page_align(fb_size, pg_sz); /* align */
@@ -3858,6 +3881,7 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
     ops_rx.type = ST20_TYPE_FRAME_LEVEL;
     ops_rx.width = width[i];
     ops_rx.height = height[i];
+    ops_rx.linesize = linesize[i];
     ops_rx.fps = fps[i];
     ops_rx.fmt = fmt[i];
     ops_rx.payload_type = ST20_TEST_PAYLOAD_TYPE;
@@ -3875,8 +3899,11 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
 
     rx_handle[i] = st20_rx_create(m_handle, &ops_rx);
 
-    test_ctx_rx[i]->frame_size = test_ctx_tx[i]->frame_size;
+    test_ctx_rx[i]->frame_size = st20_frame_size(fmt[i], width[i], height[i]);
+    if (interlaced[i]) test_ctx_rx[i]->frame_size = test_ctx_rx[i]->frame_size >> 1;
     test_ctx_rx[i]->width = ops_rx.width;
+    test_ctx_rx[i]->height = ops_rx.height;
+    test_ctx_rx[i]->stride = ops_rx.linesize;
     st20_get_pgroup(ops_rx.fmt, &test_ctx_rx[i]->st20_pg);
     memcpy(test_ctx_rx[i]->shas, test_ctx_tx[i]->shas,
            TEST_SHA_HIST_NUM * SHA256_DIGEST_LENGTH);
@@ -3957,10 +3984,11 @@ TEST(St20_rx, ext_frame_digest_frame_1080p_fps59_94_s1) {
   enum st_fps fps[1] = {ST_FPS_P59_94};
   int width[1] = {1920};
   int height[1] = {1080};
+  int linesize[1] = {0};
   bool interlaced[1] = {false};
   enum st20_fmt fmt[1] = {ST20_FMT_YUV_422_10BIT};
-  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, interlaced, fmt, true,
-                                   ST_TEST_LEVEL_ALL);
+  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, linesize, interlaced, fmt,
+                                   true, ST_TEST_LEVEL_ALL);
 }
 
 TEST(St20_rx, ext_frame_digest20_field_1080p_fps59_94_s1) {
@@ -3968,10 +3996,11 @@ TEST(St20_rx, ext_frame_digest20_field_1080p_fps59_94_s1) {
   enum st_fps fps[1] = {ST_FPS_P59_94};
   int width[1] = {1920};
   int height[1] = {1080};
+  int linesize[1] = {0};
   bool interlaced[1] = {true};
   enum st20_fmt fmt[1] = {ST20_FMT_YUV_422_10BIT};
-  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, interlaced, fmt, true,
-                                   ST_TEST_LEVEL_ALL);
+  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, linesize, interlaced, fmt,
+                                   true, ST_TEST_LEVEL_ALL);
 }
 
 TEST(St20_rx, ext_frame_digest_frame_720p_fps59_94_s1_gpm) {
@@ -3979,10 +4008,11 @@ TEST(St20_rx, ext_frame_digest_frame_720p_fps59_94_s1_gpm) {
   enum st_fps fps[1] = {ST_FPS_P59_94};
   int width[1] = {1280};
   int height[1] = {720};
+  int linesize[1] = {0};
   bool interlaced[1] = {false};
   enum st20_fmt fmt[1] = {ST20_FMT_YUV_422_10BIT};
-  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, interlaced, fmt, true,
-                                   ST_TEST_LEVEL_ALL);
+  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, linesize, interlaced, fmt,
+                                   true, ST_TEST_LEVEL_ALL);
 }
 
 TEST(St20_rx, ext_frame_s3) {
@@ -3990,11 +4020,26 @@ TEST(St20_rx, ext_frame_s3) {
   enum st_fps fps[3] = {ST_FPS_P59_94, ST_FPS_P50, ST_FPS_P50};
   int width[3] = {1280, 1920, 1920};
   int height[3] = {720, 1080, 1080};
+  int linesize[3] = {0, 0, 0};
   bool interlaced[3] = {true, true, true};
   enum st20_fmt fmt[3] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT,
                           ST20_FMT_YUV_422_10BIT};
-  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, interlaced, fmt, true,
-                                   ST_TEST_LEVEL_MANDATORY, 3);
+  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, linesize, interlaced, fmt,
+                                   true, ST_TEST_LEVEL_MANDATORY, 3);
+}
+
+TEST(St20_rx, ext_frame_s3_linesize) {
+  enum st20_packing packing[3] = {ST20_PACKING_GPM_SL, ST20_PACKING_GPM_SL,
+                                  ST20_PACKING_GPM_SL};
+  enum st_fps fps[3] = {ST_FPS_P59_94, ST_FPS_P50, ST_FPS_P50};
+  int width[3] = {1280, 1920, 1920};
+  int height[3] = {720, 1080, 1080};
+  int linesize[3] = {4096, 5120, 8192};
+  bool interlaced[3] = {false, true, false};
+  enum st20_fmt fmt[3] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT,
+                          ST20_FMT_YUV_422_10BIT};
+  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, linesize, interlaced, fmt,
+                                   true, ST_TEST_LEVEL_MANDATORY, 3);
 }
 
 TEST(St20_rx, ext_frame_s3_2) {
@@ -4002,11 +4047,12 @@ TEST(St20_rx, ext_frame_s3_2) {
   enum st_fps fps[3] = {ST_FPS_P59_94, ST_FPS_P50, ST_FPS_P50};
   int width[3] = {1280, 1920, 1920};
   int height[3] = {720, 1080, 1080};
+  int linesize[3] = {0, 0, 0};
   bool interlaced[3] = {true, false, true};
   enum st20_fmt fmt[3] = {ST20_FMT_YUV_422_12BIT, ST20_FMT_YUV_422_10BIT,
                           ST20_FMT_YUV_422_8BIT};
-  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, interlaced, fmt, true,
-                                   ST_TEST_LEVEL_MANDATORY, 3);
+  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, linesize, interlaced, fmt,
+                                   true, ST_TEST_LEVEL_MANDATORY, 3);
 }
 
 TEST(St20_rx, dynamic_ext_frame_s3) {
@@ -4014,11 +4060,12 @@ TEST(St20_rx, dynamic_ext_frame_s3) {
   enum st_fps fps[3] = {ST_FPS_P59_94, ST_FPS_P50, ST_FPS_P29_97};
   int width[3] = {1280, 1280, 1920};
   int height[3] = {720, 720, 1080};
+  int linesize[3] = {0, 0, 0};
   bool interlaced[3] = {false, false, false};
   enum st20_fmt fmt[3] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT,
                           ST20_FMT_YUV_422_10BIT};
-  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, interlaced, fmt, true,
-                                   ST_TEST_LEVEL_MANDATORY, 3, true);
+  st20_tx_ext_frame_rx_digest_test(packing, fps, width, height, linesize, interlaced, fmt,
+                                   true, ST_TEST_LEVEL_MANDATORY, 3, true);
 }
 
 static void st20_tx_timestamp_test(int width[], int height[], enum st20_fmt fmt[],

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -1633,12 +1633,7 @@ static void st20_digest_rx_frame_check(void* args) {
       ctx->buf_q.pop();
       dbg("%s, frame %p\n", __func__, frame);
       int i;
-      size_t sha_size;
-      if (ctx->stride) {
-        sha_size = ctx->stride * ctx->height;
-      } else {
-        sha_size = ctx->uframe_size ? ctx->uframe_size : ctx->frame_size;
-      }
+      size_t sha_size = ctx->uframe_size ? ctx->uframe_size : (ctx->stride * ctx->height);
       SHA256((unsigned char*)frame, sha_size, result);
       for (i = 0; i < TEST_SHA_HIST_NUM; i++) {
         unsigned char* target_sha = ctx->shas[i];
@@ -1671,12 +1666,8 @@ static void st20_digest_rx_field_check(void* args) {
       ctx->second_field_q.pop();
       dbg("%s, frame %p\n", __func__, frame);
       int i;
-      size_t sha_size;
-      if (ctx->stride) {
-        sha_size = ctx->stride * ctx->height / 2;
-      } else {
-        sha_size = ctx->uframe_size ? ctx->uframe_size : ctx->frame_size;
-      }
+      size_t sha_size =
+          ctx->uframe_size ? ctx->uframe_size : (ctx->stride * ctx->height / 2);
       SHA256((unsigned char*)frame, sha_size, result);
       for (i = 0; i < TEST_SHA_HIST_NUM; i++) {
         unsigned char* target_sha = ctx->shas[i];

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -231,6 +231,7 @@ class tests_context {
   int lines_per_slice = 0;
 
   size_t frame_size = 0;
+  size_t fb_size;
   size_t uframe_size = 0;
   uint8_t shas[TEST_MAX_SHA_HIST_NUM][SHA256_DIGEST_LENGTH] = {};
   uint8_t* frame_buf[TEST_MAX_SHA_HIST_NUM] = {};
@@ -252,6 +253,7 @@ class tests_context {
   struct st20_ext_frame* ext_frames;
   int ext_idx = 0;
   bool ext_fb_in_use[3] = {false}; /* assume 3 framebuffer */
+  st_dma_mem_handle dma_mem = NULL;
 };
 
 int tx_next_frame(void* priv, uint16_t* next_frame_idx);


### PR DESCRIPTION
st20 frame only support positive stride, the linesize should be wider than the original width size.
Linesize can only be used with single line packing mode now, for other packing has packet payload from 2 lines which is not continuous memory.

Signed-off-by: Ric Li <ming3.li@intel.com>