### PR TITLE
video: add notify_vsync callback support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * lib/log: add noice level log, see ST_LOG_LEVEL_NOTICE.
 * build: add clang support. See "Build with clang" section in build.md.
 * tx: add user pacing control, see ST20_TX_FLAG_USER_PACING, ST30_TX_FLAG_USER_PACING, ST40_TX_FLAG_USER_PACING.
+* video: add notify_vsync callback which happened when epoch time change to a new frame, vsync period is same to fps. See notify_vsync parameter in the session create ops for detail.
 
 ## Change log for 22.09:
 * License: update to BSD-3

--- a/app/src/tx_video_app.c
+++ b/app/src/tx_video_app.c
@@ -4,6 +4,14 @@
 
 #include "tx_video_app.h"
 
+static int app_tx_video_vsync(void* priv, struct st10_vsync_meta* meta) {
+#ifdef DEBUG
+  struct st_app_tx_video_session* s = priv;
+  dbg("%s(%d), epoch %" PRIu64 "\n", __func__, s->idx, meta->epoch);
+#endif
+  return 0;
+}
+
 static int app_tx_video_next_frame(void* priv, uint16_t* next_frame_idx,
                                    struct st20_tx_frame_meta* meta) {
   struct st_app_tx_video_session* s = priv;
@@ -673,6 +681,7 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.notify_frame_done = app_tx_video_frame_done;
   ops.query_frame_lines_ready = app_tx_video_frame_lines_ready;
   ops.notify_rtp_done = app_tx_video_rtp_done;
+  ops.notify_vsync = app_tx_video_vsync;
   ops.framebuff_cnt = 2;
   ops.payload_type = video ? video->base.payload_type : ST_APP_PAYLOAD_TYPE_VIDEO;
 

--- a/include/st20_dpdk_api.h
+++ b/include/st20_dpdk_api.h
@@ -672,6 +672,12 @@ struct st20_tx_ops {
    * tasklet routine.
    */
   int (*notify_rtp_done)(void* priv);
+
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /**
@@ -769,6 +775,12 @@ struct st22_tx_ops {
    * for ST22_TYPE_RTP_LEVEL
    */
   int (*notify_rtp_done)(void* priv);
+
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /**
@@ -933,6 +945,12 @@ struct st20_rx_ops {
    */
   int (*query_ext_frame)(void* priv, struct st20_ext_frame* ext_frame,
                          struct st20_rx_frame_meta* meta);
+
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /**
@@ -1008,6 +1026,12 @@ struct st22_rx_ops {
    * For ST22_TYPE_RTP_LEVEL.
    */
   int (*notify_rtp_ready)(void* priv);
+
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /**

--- a/include/st20_redundant_api.h
+++ b/include/st20_redundant_api.h
@@ -99,6 +99,11 @@ struct st20r_rx_ops {
    * routine.
    */
   int (*notify_frame_ready)(void* priv, void* frame, struct st20_rx_frame_meta* meta);
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /**

--- a/include/st_dpdk_api.h
+++ b/include/st_dpdk_api.h
@@ -528,6 +528,18 @@ struct st_queue_meta {
 };
 
 /**
+ * Vsync callback meta data
+ */
+struct st10_vsync_meta {
+  /** current vsync epoch */
+  uint64_t epoch;
+  /** current ptp time */
+  uint64_t ptp;
+  /** frame time in ns */
+  double frame_time;
+};
+
+/**
  * Inline function returning primary port pointer from st_init_params
  * @param p
  *   The pointer to the init parameters.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -547,6 +547,11 @@ struct st20p_tx_ops {
    * tasklet routine.
    */
   int (*notify_frame_done)(void* priv, struct st_frame* frame);
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /** The structure describing how to create a rx st2110-20 pipeline session. */
@@ -593,6 +598,11 @@ struct st20p_rx_ops {
    */
   int (*query_ext_frame)(void* priv, struct st20_ext_frame* ext_frame,
                          struct st20_rx_frame_meta* meta);
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /** The structure describing how to create a tx st2110-22 pipeline session. */
@@ -647,6 +657,11 @@ struct st22p_tx_ops {
    * tasklet routine.
    */
   int (*notify_frame_done)(void* priv, struct st_frame* frame);
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /** The structure describing how to create a rx st2110-22 pipeline session. */
@@ -688,6 +703,11 @@ struct st22p_rx_ops {
    * tasklet routine.
    */
   int (*notify_frame_available)(void* priv);
+  /**
+   * vsync callback, lib will call this when ptp come to a new epoch(frame time).
+   * Only non-block method can be used in this callback as it run from lcore routine.
+   */
+  int (*notify_vsync)(void* priv, struct st10_vsync_meta* meta);
 };
 
 /**

--- a/lib/src/pipeline/st20_pipeline_rx.c
+++ b/lib/src/pipeline/st20_pipeline_rx.c
@@ -157,6 +157,16 @@ static int rx_st20p_query_ext_frame(void* priv, struct st20_ext_frame* ext_frame
   return 0;
 }
 
+static int rx_st20p_frame_vsync(void* priv, struct st10_vsync_meta* meta) {
+  struct st20p_rx_ctx* ctx = priv;
+
+  if (ctx->ops.notify_vsync) {
+    ctx->ops.notify_vsync(ctx->ops.priv, meta);
+  }
+
+  return 0;
+}
+
 static struct st20_convert_frame_meta* rx_st20p_convert_get_frame(void* priv) {
   struct st20p_rx_ctx* ctx = priv;
   int idx = ctx->idx;
@@ -281,6 +291,7 @@ static int rx_st20p_create_transport(st_handle st, struct st20p_rx_ctx* ctx,
   ops_rx.type = ST20_TYPE_FRAME_LEVEL;
   ops_rx.framebuff_cnt = ops->framebuff_cnt;
   ops_rx.notify_frame_ready = rx_st20p_frame_ready;
+  ops_rx.notify_vsync = rx_st20p_frame_vsync;
   if (ctx->derive) {
     /* ext frame info directly passed down to st20 lib */
     if (ops->ext_frames) ops_rx.ext_frames = ops->ext_frames;

--- a/lib/src/pipeline/st20_pipeline_tx.c
+++ b/lib/src/pipeline/st20_pipeline_tx.c
@@ -129,6 +129,16 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   return ret;
 }
 
+static int tx_st20p_frame_vsync(void* priv, struct st10_vsync_meta* meta) {
+  struct st20p_tx_ctx* ctx = priv;
+
+  if (ctx->ops.notify_vsync) {
+    ctx->ops.notify_vsync(ctx->ops.priv, meta);
+  }
+
+  return 0;
+}
+
 static struct st20_convert_frame_meta* tx_st20p_convert_get_frame(void* priv) {
   struct st20p_tx_ctx* ctx = priv;
   int idx = ctx->idx;
@@ -257,6 +267,7 @@ static int tx_st20p_create_transport(st_handle st, struct st20p_tx_ctx* ctx,
   ops_tx.framebuff_cnt = ops->framebuff_cnt;
   ops_tx.get_next_frame = tx_st20p_next_frame;
   ops_tx.notify_frame_done = tx_st20p_frame_done;
+  ops_tx.notify_vsync = tx_st20p_frame_vsync;
   if (ctx->derive && ops->flags & ST20P_TX_FLAG_EXT_FRAME)
     ops_tx.flags |= ST20_TX_FLAG_EXT_FRAME;
   if (ops->flags & ST20P_TX_FLAG_USER_PACING) ops_tx.flags |= ST20_TX_FLAG_USER_PACING;

--- a/lib/src/pipeline/st22_pipeline_rx.c
+++ b/lib/src/pipeline/st22_pipeline_rx.c
@@ -80,6 +80,16 @@ static int rx_st22p_frame_ready(void* priv, void* frame,
   return 0;
 }
 
+static int rx_st22p_frame_vsync(void* priv, struct st10_vsync_meta* meta) {
+  struct st22p_rx_ctx* ctx = priv;
+
+  if (ctx->ops.notify_vsync) {
+    ctx->ops.notify_vsync(ctx->ops.priv, meta);
+  }
+
+  return 0;
+}
+
 static struct st22_decode_frame_meta* rx_st22p_decode_get_frame(void* priv) {
   struct st22p_rx_ctx* ctx = priv;
   int idx = ctx->idx;
@@ -202,6 +212,7 @@ static int rx_st22p_create_transport(st_handle st, struct st22p_rx_ctx* ctx,
   ops_rx.framebuff_cnt = ops->framebuff_cnt;
   ops_rx.framebuff_max_size = ctx->max_codestream_size;
   ops_rx.notify_frame_ready = rx_st22p_frame_ready;
+  ops_rx.notify_vsync = rx_st22p_frame_vsync;
 
   transport = st22_rx_create(st, &ops_rx);
   if (!transport) {

--- a/lib/src/pipeline/st22_pipeline_tx.c
+++ b/lib/src/pipeline/st22_pipeline_tx.c
@@ -111,6 +111,16 @@ static int tx_st22p_frame_done(void* priv, uint16_t frame_idx,
   return ret;
 }
 
+static int tx_st22p_frame_vsync(void* priv, struct st10_vsync_meta* meta) {
+  struct st22p_tx_ctx* ctx = priv;
+
+  if (ctx->ops.notify_vsync) {
+    ctx->ops.notify_vsync(ctx->ops.priv, meta);
+  }
+
+  return 0;
+}
+
 static struct st22_encode_frame_meta* tx_st22p_encode_get_frame(void* priv) {
   struct st22p_tx_ctx* ctx = priv;
   int idx = ctx->idx;
@@ -241,6 +251,7 @@ static int tx_st22p_create_transport(st_handle st, struct st22p_tx_ctx* ctx,
   ops_tx.framebuff_max_size = ctx->encode_impl->codestream_max_size;
   ops_tx.get_next_frame = tx_st22p_next_frame;
   ops_tx.notify_frame_done = tx_st22p_frame_done;
+  ops_tx.notify_vsync = tx_st22p_frame_vsync;
   if (ops->codec != ST22_CODEC_JPEGXS) {
     ops_tx.flags |= ST22_TX_FLAG_DISABLE_BOXES;
   }

--- a/lib/src/redundant/st20_redundant_rx.c
+++ b/lib/src/redundant/st20_redundant_rx.c
@@ -99,6 +99,16 @@ static int rx_st20r_frame_ready(void* priv, void* frame,
   return 0;
 }
 
+static int rx_st20r_frame_vsync(void* priv, struct st10_vsync_meta* meta) {
+  struct st20r_rx_ctx* ctx = priv;
+
+  if (ctx->ops.notify_vsync) {
+    ctx->ops.notify_vsync(ctx->ops.priv, meta);
+  }
+
+  return 0;
+}
+
 static int rx_st20r_free_transport(struct st20r_rx_transport* transport) {
   if (transport->handle) {
     st20_rx_free(transport->handle);
@@ -156,6 +166,8 @@ static int rx_st20r_create_transport(struct st20r_rx_ctx* ctx, struct st20r_rx_o
   ops_rx.type = ST20_TYPE_FRAME_LEVEL;
   ops_rx.framebuff_cnt = ops->framebuff_cnt;
   ops_rx.notify_frame_ready = rx_st20r_frame_ready;
+  if (port == ST_PORT_P) /* only register vsync to p port now */
+    ops_rx.notify_vsync = rx_st20r_frame_vsync;
 
   st_sch_mask_t sch_mask = ST_SCH_MASK_ALL;
   if (port == ST_PORT_R) {

--- a/lib/src/st_tx_video_session.c
+++ b/lib/src/st_tx_video_session.c
@@ -158,6 +158,22 @@ static int tv_free_frames(struct st_tx_video_session_impl* s) {
   return 0;
 }
 
+static int tv_poll_vsync(struct st_main_impl* impl, struct st_tx_video_session_impl* s) {
+  struct st_vsync_info* vsync = &s->vsync;
+  uint64_t cur_tsc = st_get_tsc(impl);
+
+  if (cur_tsc > vsync->next_epoch_tsc) {
+    uint64_t tsc_delta = cur_tsc - vsync->next_epoch_tsc;
+    dbg("%s(%d), vsync with epochs %" PRIu64 "\n", __func__, s->idx, vsync->meta.epoch);
+    s->ops.notify_vsync(s->ops.priv, &vsync->meta);
+    st_vsync_calculate(impl, vsync); /* set next vsync */
+    /* check tsc delta for status */
+    if (tsc_delta > NS_PER_MS) s->stat_vsync_mismatch++;
+  }
+
+  return 0;
+}
+
 static int double_cmp(const void* a, const void* b) {
   const double* ai = a;
   const double* bi = b;
@@ -994,7 +1010,21 @@ static uint64_t tv_pacing_required_tai(struct st_tx_video_session_impl* s,
 
 static int tv_tasklet_pre_start(void* priv) { return 0; }
 
-static int tv_tasklet_start(void* priv) { return 0; }
+static int tv_tasklet_start(void* priv) {
+  struct st_tx_video_sessions_mgr* mgr = priv;
+  struct st_main_impl* impl = mgr->parnet;
+  struct st_tx_video_session_impl* s;
+
+  for (int sidx = 0; sidx < mgr->max_idx; sidx++) {
+    s = tx_video_session_try_get(mgr, sidx);
+    if (!s) continue;
+    /* re-calculate the vsync */
+    st_vsync_calculate(impl, &s->vsync);
+    tx_video_session_put(mgr, sidx);
+  }
+
+  return 0;
+}
 
 static int tv_tasklet_stop(void* priv) { return 0; }
 
@@ -1614,6 +1644,9 @@ static int tvs_tasklet_handler(void* priv) {
     s = tx_video_session_try_get(mgr, sidx);
     if (!s) continue;
 
+    /* check vsync if it has callback */
+    if (s->ops.notify_vsync) tv_poll_vsync(impl, s);
+
     s->stat_build_ret_code = 0;
     if (s->st22_info)
       pending = tv_tasklet_st22(impl, s);
@@ -2220,6 +2253,10 @@ static int tv_attach(struct st_main_impl* impl, struct st_tx_video_sessions_mgr*
     return ret;
   }
 
+  s->vsync.meta.frame_time = s->pacing.frame_time;
+  st_vsync_calculate(impl, &s->vsync);
+  s->vsync.init = true;
+
   s->stat_lines_not_ready = 0;
   s->stat_user_busy = 0;
   s->stat_user_busy_first = true;
@@ -2328,6 +2365,11 @@ static void tv_stat(struct st_tx_video_sessions_mgr* mgr,
     notice("TX_VIDEO_SESSION(%d,%d): query new lines but app not ready %u\n", m_idx, idx,
            s->stat_lines_not_ready);
     s->stat_lines_not_ready = 0;
+  }
+  if (s->stat_vsync_mismatch) {
+    notice("TX_VIDEO_SESSION(%d,%d): vsync mismatch cnt %u\n", m_idx, idx,
+           s->stat_vsync_mismatch);
+    s->stat_vsync_mismatch = 0;
   }
   if (frame_cnt <= 0) {
     /* error level */
@@ -3112,6 +3154,7 @@ st22_tx_handle st22_tx_create(st_handle st, struct st22_tx_ops* ops) {
   st20_ops.rtp_frame_total_pkts = ops->rtp_frame_total_pkts;
   st20_ops.rtp_pkt_size = ops->rtp_pkt_size;
   st20_ops.notify_rtp_done = ops->notify_rtp_done;
+  st20_ops.notify_vsync = ops->notify_vsync;
   st_pthread_mutex_lock(&sch->tx_video_mgr_mutex);
   if (ST22_TYPE_RTP_LEVEL == ops->type) {
     s = tv_mgr_attach(&sch->tx_video_mgr, &st20_ops, ST22_SESSION_TYPE_TX_VIDEO, NULL);

--- a/lib/src/st_util.c
+++ b/lib/src/st_util.c
@@ -467,3 +467,15 @@ int st_frame_trans_uinit(struct st_frame_trans* frame) {
 
   return 0;
 }
+
+int st_vsync_calculate(struct st_main_impl* impl, struct st_vsync_info* vsync) {
+  uint64_t ptp_time = st_get_ptp_time(impl, ST_PORT_P);
+  uint64_t to_next_epochs;
+
+  vsync->meta.epoch = ptp_time / vsync->meta.frame_time + 1;
+  to_next_epochs = vsync->meta.epoch * vsync->meta.frame_time - ptp_time;
+  vsync->next_epoch_tsc = st_get_tsc(impl) + to_next_epochs;
+
+  dbg("%s, to_next_epochs %fms\n", __func__, (float)to_next_epochs / NS_PER_MS);
+  return 0;
+}

--- a/lib/src/st_util.h
+++ b/lib/src/st_util.h
@@ -158,4 +158,6 @@ int st_rx_source_info_check(struct st_rx_source_info* src, int num_ports);
 
 int st_frame_trans_uinit(struct st_frame_trans* frame);
 
+int st_vsync_calculate(struct st_main_impl* impl, struct st_vsync_info* vsync);
+
 #endif

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -203,6 +203,8 @@ class tests_context {
   uint16_t fb_idx = 0;
   int fb_send = 0;
   int fb_rec = 0;
+  int vsync_cnt = 0;
+  uint64_t first_vsync_time = 0;
   int packet_rec = 0;
   uint64_t start_time = 0;
   void* handle = NULL;


### PR DESCRIPTION
notify_vsync callback which happened when epoch time change to a new frame, vsync period is same to fps.

Signed-off-by: Du, Frank <frank.du@intel.com>