### PR TITLE
tasklet: add timer option for sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * build: add clang support. See "Build with clang" section in build.md.
 * tx: add user pacing control, see ST20_TX_FLAG_USER_PACING, ST30_TX_FLAG_USER_PACING, ST40_TX_FLAG_USER_PACING.
 * video: add notify_vsync callback which happened when epoch time change to a new frame, vsync period is same to fps. See notify_vsync parameter in the session create ops for detail.
+* csc: add y210 format support, y210 is the format for GPU yuv422 layout.
+* sch/tasklet: enhance sleep feature with timer based sleep and user control.
 
 ## Change log for 22.09:
 * License: update to BSD-3

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -451,9 +451,15 @@ struct st_app_rx_st20p_session {
   uint64_t stat_latency_us_sum;
 };
 
+struct st_app_var_params {
+  /* force sleep time(us) for sch tasklet sleep */
+  uint64_t sch_force_sleep_us;
+};
+
 struct st_app_context {
   st_json_context_t* json_ctx;
   struct st_init_params para;
+  struct st_app_var_params var_para;
   st_handle st;
   int test_time_s;
   bool stop;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -79,6 +79,7 @@ enum st_args_cmd {
   ST_ARG_TX_COPY_ONCE,
   ST_ARG_TASKLET_THREAD,
   ST_ARG_TASKLET_SLEEP,
+  ST_ARG_TASKLET_SLEEP_US,
   ST_ARG_APP_THREAD,
   ST_ARG_RXTX_SIMD_512,
   ST_ARG_MAX,
@@ -161,6 +162,7 @@ static struct option st_app_args_options[] = {
     {"tx_copy_once", no_argument, 0, ST_ARG_TX_COPY_ONCE},
     {"tasklet_thread", no_argument, 0, ST_ARG_TASKLET_THREAD},
     {"tasklet_sleep", no_argument, 0, ST_ARG_TASKLET_SLEEP},
+    {"tasklet_sleep_us", required_argument, 0, ST_ARG_TASKLET_SLEEP_US},
     {"app_thread", no_argument, 0, ST_ARG_APP_THREAD},
     {"rxtx_simd_512", no_argument, 0, ST_ARG_RXTX_SIMD_512},
 
@@ -493,6 +495,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct st_init_params* p, int 
         break;
       case ST_ARG_TASKLET_SLEEP:
         p->flags |= ST_FLAG_TASKLET_SLEEP;
+        break;
+      case ST_ARG_TASKLET_SLEEP_US:
+        ctx->var_para.sch_force_sleep_us = atoi(optarg);
         break;
       case ST_ARG_TASKLET_THREAD:
         p->flags |= ST_FLAG_TASKLET_THREAD;

--- a/app/src/rxtx_app.c
+++ b/app/src/rxtx_app.c
@@ -68,6 +68,11 @@ static void user_param_init(struct st_app_context* ctx, struct st_init_params* p
   app_set_log_level(p->log_level);
 }
 
+static void var_param_init(struct st_app_context* ctx) {
+  if (ctx->var_para.sch_force_sleep_us)
+    st_sch_set_sleep_us(ctx->st, ctx->var_para.sch_force_sleep_us);
+}
+
 static void st_app_ctx_init(struct st_app_context* ctx) {
   user_param_init(ctx, &ctx->para);
 
@@ -284,6 +289,8 @@ int main(int argc, char** argv) {
   }
 
   g_app_ctx = ctx;
+
+  var_param_init(ctx);
 
   if (signal(SIGINT, st_app_sig_handler) == SIG_ERR) {
     err("%s, cat SIGINT fail\n", __func__);

--- a/doc/run.md
+++ b/doc/run.md
@@ -167,9 +167,11 @@ For the supported parameters in the json, please refer to [JSON configuration gu
 --nb_rx_desc <count>                 : debug option, number of receive descriptors for each NIC RX queue, affect the memory usage and the performance.
 --tasklet_time                       : debug option, enable stat info for tasklet running time.
 --tsc                                : debug option, force to use tsc pacing.
+--pacing_way                         : debug option, set pacing way, ex, auto, rl, tsc, ptp, tsn.
 --mono_pool                          : debug option, use mono pool for all tx and rx queues(sessions).
 --tasklet_thread                     : debug option, run the tasklet under thread instead of a pinned lcore.
 --tasklet_sleep                      : debug option, enable sleep if all tasklet report done status.
+--tasklet_sleep_us                   : debug option, set the sleep us value if tasklet decide to enter sleep state.
 --app_thread                         : debug option, run the app thread under a common os thread instead of a pinned lcore.
 --rxtx_simd_512                      : debug option, enable dpdk simd 512 path for rx/tx burst function, see --force-max-simd-bitwidth=512 in dpdk for detail.
 ```

--- a/include/st_dpdk_api.h
+++ b/include/st_dpdk_api.h
@@ -671,6 +671,35 @@ int st_get_cap(st_handle st, struct st_cap* cap);
 int st_get_stats(st_handle st, struct st_stats* stats);
 
 /**
+ * Enable or disable sleep mode for sch.
+ *
+ * @param st
+ *   The handle to the media transport device context.
+ * @param sch_idx
+ *   The sch index, get from st20_tx_get_sch_idx or st20_rx_get_sch_idx.
+ * @param enable
+ *   enable or not.
+ * @return
+ *   - 0: Success.
+ *   - <0: Error code.
+ */
+int st_sch_enable_sleep(st_handle st, int sch_idx, bool enable);
+
+/**
+ * Set the sleep us for the sch if ST_FLAG_TASKLET_SLEEP is enabled.
+ * Debug usage only.
+ *
+ * @param st
+ *   The handle to the media transport device context.
+ * @param us
+ *   The max sleep us.
+ * @return
+ *   - 0: Success.
+ *   - <0: Error code.
+ */
+int st_sch_set_sleep_us(st_handle st, uint64_t us);
+
+/**
  * Request one DPDK lcore from the media transport device context.
  *
  * @param st

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -1181,6 +1181,17 @@ void* st20p_tx_get_fb_addr(st20p_tx_handle handle, uint16_t idx);
 size_t st20p_tx_frame_size(st20p_tx_handle handle);
 
 /**
+ * Get the scheduler index for the tx st2110-20(pipeline) session.
+ *
+ * @param handle
+ *   The handle to the tx st2110-20(pipeline) session.
+ * @return
+ *   - >=0 the scheduler index.
+ *   - <0: Error code.
+ */
+int st20p_tx_get_sch_idx(st20p_tx_handle handle);
+
+/**
  * Create one rx st2110-20 pipeline session.
  *
  * @param st
@@ -1285,6 +1296,17 @@ int st20p_rx_pcapng_dump(st20p_rx_handle handle, uint32_t max_dump_packets, bool
  *   - <0: Error code.
  */
 int st20p_rx_get_queue_meta(st20p_rx_handle handle, struct st_queue_meta* meta);
+
+/**
+ * Get the scheduler index for the rx st2110-20(pipeline) session.
+ *
+ * @param handle
+ *   The handle to the rx st2110-20(pipeline) session.
+ * @return
+ *   - >=0 the scheduler index.
+ *   - <0: Error code.
+ */
+int st20p_rx_get_sch_idx(st20p_rx_handle handle);
 
 /**
  * Calculate the frame size per the format, w and h

--- a/lib/src/pipeline/st20_pipeline_rx.c
+++ b/lib/src/pipeline/st20_pipeline_rx.c
@@ -685,3 +685,15 @@ int st20p_rx_get_queue_meta(st20p_rx_handle handle, struct st_queue_meta* meta) 
 
   return st20_rx_get_queue_meta(ctx->transport, meta);
 }
+
+int st20p_rx_get_sch_idx(st20p_rx_handle handle) {
+  struct st20p_rx_ctx* ctx = handle;
+  int cidx = ctx->idx;
+
+  if (ctx->type != ST20_SESSION_TYPE_PIPELINE_RX) {
+    err("%s(%d), invalid type %d\n", __func__, cidx, ctx->type);
+    return 0;
+  }
+
+  return st20_rx_get_sch_idx(ctx->transport);
+}

--- a/lib/src/pipeline/st20_pipeline_tx.c
+++ b/lib/src/pipeline/st20_pipeline_tx.c
@@ -685,3 +685,15 @@ size_t st20p_tx_frame_size(st20p_tx_handle handle) {
 
   return ctx->src_size;
 }
+
+int st20p_tx_get_sch_idx(st20p_tx_handle handle) {
+  struct st20p_tx_ctx* ctx = handle;
+  int cidx = ctx->idx;
+
+  if (ctx->type != ST20_SESSION_TYPE_PIPELINE_TX) {
+    err("%s(%d), invalid type %d\n", __func__, cidx, ctx->type);
+    return 0;
+  }
+
+  return st20_tx_get_sch_idx(ctx->transport);
+}

--- a/lib/src/st_dev.c
+++ b/lib/src/st_dev.c
@@ -1818,6 +1818,7 @@ int st_dev_free(struct st_main_impl* impl) {
 
   st_sch_put(impl->main_sch, 0);
 
+  st_sch_mrg_uinit(impl);
   dev_uinit_lcores(impl);
 
   for (i = 0; i < num_ports; i++) {

--- a/lib/src/st_platform.h
+++ b/lib/src/st_platform.h
@@ -36,6 +36,9 @@
 #define ST_CLOCK_MONOTONIC_ID CLOCK_MONOTONIC
 #endif
 
+/* use CLOCK_MONOTONIC for st_pthread_cond_timedwait */
+#define ST_THREAD_TIMEDWAIT_CLOCK_ID CLOCK_MONOTONIC
+
 #ifdef WINDOWSENV
 #define ST_FLOCK_PATH "c:/temp/kahawai_lcore.lock"
 #else
@@ -66,6 +69,11 @@ static inline int st_pthread_cond_init(pthread_cond_t* cond,
 
 static inline int st_pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex) {
   return pthread_cond_wait(cond, mutex);
+}
+
+static inline int st_pthread_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex,
+                                            const struct timespec* time) {
+  return pthread_cond_timedwait(cond, mutex, time);
 }
 
 static inline int st_pthread_cond_destroy(pthread_cond_t* cond) {

--- a/lib/src/st_sch.h
+++ b/lib/src/st_sch.h
@@ -29,6 +29,10 @@ static inline bool st_sch_started(struct st_sch_impl* sch) {
     return false;
 }
 
+static inline void st_sch_enable_allow_sleep(struct st_sch_impl* sch, bool enable) {
+  sch->allow_sleep = enable;
+}
+
 static inline bool st_sch_has_busy(struct st_sch_impl* sch) {
   if (!sch->allow_sleep || sch->sleep_ratio_score > 70.0)
     return true;
@@ -37,10 +41,16 @@ static inline bool st_sch_has_busy(struct st_sch_impl* sch) {
 }
 
 int st_sch_mrg_init(struct st_main_impl* impl, int data_quota_mbs_limit);
+int st_sch_mrg_uinit(struct st_main_impl* impl);
 
 struct st_sch_tasklet_impl* st_sch_register_tasklet(
     struct st_sch_impl* sch, struct st_sch_tasklet_ops* tasklet_ops);
 int st_sch_unregister_tasklet(struct st_sch_tasklet_impl* tasklet);
+
+static inline void st_tasklet_set_sleep(struct st_sch_tasklet_impl* tasklet,
+                                        uint64_t advice_sleep_us) {
+  tasklet->ops.advice_sleep_us = advice_sleep_us;
+}
 
 int st_sch_add_quota(struct st_sch_impl* sch, int quota_mbs);
 

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -679,6 +679,11 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     tx_handle[i] = st20p_tx_create(st, &ops_tx);
     ASSERT_TRUE(tx_handle[i] != NULL);
 
+    int sch = st20p_tx_get_sch_idx(tx_handle[i]);
+    EXPECT_GE(sch, 0);
+    ret = st_sch_enable_sleep(st, sch, false);
+    EXPECT_GE(ret, 0);
+
     /* sha caculate */
     size_t frame_size = test_ctx_tx[i]->frame_size;
     uint8_t* fb;
@@ -821,6 +826,11 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
 
     rx_handle[i] = st20p_rx_create(st, &ops_rx);
     ASSERT_TRUE(rx_handle[i] != NULL);
+
+    int sch = st20p_rx_get_sch_idx(rx_handle[i]);
+    EXPECT_GE(sch, 0);
+    ret = st_sch_enable_sleep(st, sch, false);
+    EXPECT_GE(ret, 0);
 
     test_ctx_rx[i]->handle = rx_handle[i];
 


### PR DESCRIPTION
1. each tasklet can set the expected sleep interval(us).
2. use timer if the tasklet sleep time > threshold(200us), use timer.
3. app can control if sch can enable sleep or not, by st_sch_enable_sleep

Signed-off-by: Du, Frank <frank.du@intel.com>