### PR TITLE
Added support for 4:2:2 12 bits format

### DIFF
--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -971,6 +971,8 @@ static int parse_st22p_format(json_object* st22p_obj, st_json_st22p_session_t* s
   REQUIRED_ITEM(format);
   if (strcmp(format, "YUV422PLANAR10LE") == 0) {
     st22p->info.format = ST_FRAME_FMT_YUV422PLANAR10LE;
+  } else if (strcmp(format, "YUV422PLANAR12LE") == 0) {
+    st22p->info.format = ST_FRAME_FMT_YUV422PLANAR12LE;
   } else if (strcmp(format, "ARGB") == 0) {
     st22p->info.format = ST_FRAME_FMT_ARGB;
   } else if (strcmp(format, "BGRA") == 0) {
@@ -983,6 +985,8 @@ static int parse_st22p_format(json_object* st22p_obj, st_json_st22p_session_t* s
     st22p->info.format = ST_FRAME_FMT_YUV422PACKED8;
   } else if (strcmp(format, "YUV422RFC4175PG2BE10") == 0) {
     st22p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE10;
+  } else if (strcmp(format, "YUV422RFC4175PG2BE12") == 0) {
+    st22p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE12;
   } else if (strcmp(format, "RGB8") == 0) {
     st22p->info.format = ST_FRAME_FMT_RGB8;
   } else if (strcmp(format, "JPEGXS_CODESTREAM") == 0) {
@@ -1190,6 +1194,8 @@ static int parse_st20p_format(json_object* st20p_obj, st_json_st20p_session_t* s
   REQUIRED_ITEM(format);
   if (strcmp(format, "YUV422PLANAR10LE") == 0) {
     st20p->info.format = ST_FRAME_FMT_YUV422PLANAR10LE;
+  } else if (strcmp(format, "YUV422PLANAR12LE") == 0) {
+    st20p->info.format = ST_FRAME_FMT_YUV422PLANAR12LE;
   } else if (strcmp(format, "ARGB") == 0) {
     st20p->info.format = ST_FRAME_FMT_ARGB;
   } else if (strcmp(format, "BGRA") == 0) {
@@ -1202,6 +1208,8 @@ static int parse_st20p_format(json_object* st20p_obj, st_json_st20p_session_t* s
     st20p->info.format = ST_FRAME_FMT_YUV422PACKED8;
   } else if (strcmp(format, "YUV422RFC4175PG2BE10") == 0) {
     st20p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE10;
+  } else if (strcmp(format, "YUV422RFC4175PG2BE12") == 0) {
+    st20p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE12;
   } else if (strcmp(format, "RGB8") == 0) {
     st20p->info.format = ST_FRAME_FMT_RGB8;
   } else {

--- a/app/tools/convert_app_args.c
+++ b/app/tools/convert_app_args.c
@@ -54,8 +54,14 @@ static enum cvt_frame_fmt cvt_parse_fmt(const char* sfmt) {
   if (!strcmp(sfmt, "y210")) {
     return CVT_FRAME_FMT_Y210;
   }
+  if (!strcmp(sfmt, "yuv422p12le")) {
+    return CVT_FRAME_FMT_YUV422PLANAR12LE;
+  }
   if (!strcmp(sfmt, "yuv422rfc4175be10")) {
     return CVT_FRAME_FMT_YUV422RFC4175PG2BE10;
+  }
+  if (!strcmp(sfmt, "yuv422rfc4175be12")) {
+    return CVT_FRAME_FMT_YUV422RFC4175PG2BE12;
   }
 
   err("%s, unknown sfmt %s\n", __func__, sfmt);

--- a/app/tools/convert_app_base.h
+++ b/app/tools/convert_app_base.h
@@ -23,12 +23,17 @@
 enum cvt_frame_fmt {
   /** YUV 422 planar 10bit little endian */
   CVT_FRAME_FMT_YUV422PLANAR10LE = 0,
+  /** YUV 422 planar 12bit little endian */
+  CVT_FRAME_FMT_YUV422PLANAR12LE,
   /** YUV 422 packed, 3 samples on a 32-bit word, 10 bits per sample */
   CVT_FRAME_FMT_V210,
   /** YUV 422 packed, 16 bits per sample with least significant 6 paddings */
   CVT_FRAME_FMT_Y210,
   /** RFC4175 in ST2110, two YUV 422 10 bit pixel gruops on 5 bytes, big endian */
+  /** RFC4175 in ST2110, two YUV 422 10 bit pixel groups on 5 bytes, big endian */
   CVT_FRAME_FMT_YUV422RFC4175PG2BE10,
+  /** RFC4175 in ST2110, two YUV 422 12 bit pixel groups on 6 bytes, big endian */
+  CVT_FRAME_FMT_YUV422RFC4175PG2BE12,
   /** max value of this enum */
   CVT_FRAME_FMT_MAX,
 };

--- a/include/st20_dpdk_api.h
+++ b/include/st20_dpdk_api.h
@@ -505,6 +505,48 @@ struct st20_rfc4175_extra_rtp_hdr {
   uint16_t row_offset;
 } __attribute__((__packed__));
 
+/** Pixel Group describing two image pixels in YUV 4:2:2 12-bit format */
+struct st20_rfc4175_422_12_pg2_be {
+  uint8_t Cb00; /**< First 8 bit Blue */
+#ifdef ST_LITTLE_ENDIAN
+  uint8_t Y00 : 4;   /**< First 4 bits Luminance for Y0 */
+  uint8_t Cb00_ : 4; /**< Second 4 bit Blue */
+  uint8_t Y00_;      /**< Second 8 bits Luminance for Y0 */
+  uint8_t Cr00;      /**< First 8 bit Red */
+  uint8_t Y01 : 4;   /**< First 4 bits Luminance for Y1 */
+  uint8_t Cr00_ : 4; /**< Second 4 bit Red */
+#else
+  uint8_t Cb00_ : 4; /**< Second 4 bit Blue */
+  uint8_t Y00 : 4;   /**< First 4 bits Luminance for Y0 */
+  uint8_t Y00_;      /**< Second 8 bits Luminance for Y0 */
+  uint8_t Cr00;      /**< First 8 bit Red */
+  uint8_t Cr00_ : 4; /**< Second 4 bit Red */
+  uint8_t Y01 : 4;   /**< First 4 bits Luminance for Y1 */
+#endif
+  uint8_t Y01_; /**< Second 8 bits Luminance for Y1 */
+} __attribute__((__packed__));
+
+/** Pixel Group describing two image pixels in YUV 4:2:2 12-bit format */
+struct st20_rfc4175_422_12_pg2_le {
+  uint8_t Cb00; /**< First 8 bit Blue */
+#ifdef ST_LITTLE_ENDIAN
+  uint8_t Cb00_ : 4; /**< Second 4 bit Blue */
+  uint8_t Y00 : 4;   /**< First 4 bits Luminance for Y0 */
+  uint8_t Y00_;      /**< Second 8 bits Luminance for Y0 */
+  uint8_t Cr00;      /**< First 8 bit Red */
+  uint8_t Cr00_ : 4; /**< Second 4 bit Red */
+  uint8_t Y01 : 4;   /**< First 4 bits Luminance for Y1 */
+#else
+  uint8_t Y00 : 4;   /**< First 4 bits Luminance for Y0 */
+  uint8_t Cb00_ : 4; /**< Second 4 bit Blue */
+  uint8_t Y00_;      /**< Second 8 bits Luminance for Y0 */
+  uint8_t Cr00;      /**< First 8 bit Red */
+  uint8_t Y01 : 4;   /**< First 4 bits Luminance for Y1 */
+  uint8_t Cr00_ : 4; /**< Second 4 bit Red */
+#endif
+  uint8_t Y01_; /**< Second 8 bits Luminance for Y1 */
+} __attribute__((__packed__));
+
 /** Pixel Group describing two image pixels in YUV 4:2:2 10-bit format */
 struct st20_rfc4175_422_10_pg2_be {
   uint8_t Cb00; /**< First 8 bit Blue */
@@ -523,7 +565,7 @@ struct st20_rfc4175_422_10_pg2_be {
   uint8_t Cr00_ : 6; /**< Second 6 bit Red */
   uint8_t Y01 : 2;   /**< First 2 bits Luminance for Y1 */
 #endif
-  uint8_t Y01_; /**< Second 2 bits Luminance for Y1 */
+  uint8_t Y01_; /**< Second 8 bits Luminance for Y1 */
 } __attribute__((__packed__));
 
 /** Pixel Group describing two image pixels in YUV 4:2:2 10-bit format */
@@ -544,7 +586,7 @@ struct st20_rfc4175_422_10_pg2_le {
   uint8_t Y01 : 2;   /**< First 2 bits Luminance for Y1 */
   uint8_t Cr00_ : 6; /**< Second 6 bit Red */
 #endif
-  uint8_t Y01_; /**< Second 2 bits Luminance for Y1 */
+  uint8_t Y01_; /**< Second 8 bits Luminance for Y1 */
 } __attribute__((__packed__));
 
 /** Pixel Group describing two image pixels in YUV 4:2:2 8-bit format */

--- a/include/st_convert_api.h
+++ b/include/st_convert_api.h
@@ -224,6 +224,52 @@ static inline int st20_rfc4175_422be10_to_422le8_dma(
 }
 
 /**
+ * Convert rfc4175_422be12 to yuv422p12le with the max optimised SIMD level.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_422be12) data.
+ * @param y
+ *   Point to Y(yuv422p12le) vector.
+ * @param b
+ *   Point to b(yuv422p12le) vector.
+ * @param r
+ *   Point to r(yuv422p12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_422be12_to_yuv422p12le(
+    struct st20_rfc4175_422_12_pg2_be* pg, uint16_t* y, uint16_t* b, uint16_t* r,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_422be12_to_yuv422p12le_simd(pg, y, b, r, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert rfc4175_422be12 to rfc4175_422le12 with the max optimised SIMD level.
+ *
+ * @param pg_be
+ *   Point to pg(rfc4175_422be12) data.
+ * @param pg_le
+ *   Point to pg(rfc4175_422le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_422be12_to_422le12(
+    struct st20_rfc4175_422_12_pg2_be* pg_be, struct st20_rfc4175_422_12_pg2_le* pg_le,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_422be12_to_422le12_simd(pg_be, pg_le, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
  * Convert yuv422p10le to rfc4175_422be10.
  *
  * @param y
@@ -564,6 +610,98 @@ static inline int st20_y210_to_rfc4175_422be10_dma(
  */
 int st20_v210_to_rfc4175_422le10(uint8_t* pg_v210, uint8_t* pg_le, uint32_t w,
                                  uint32_t h);
+
+/**
+ * Convert yuv422p12le to rfc4175_422be12.
+ *
+ * @param y
+ *   Point to Y(yuv422p12le) vector.
+ * @param b
+ *   Point to b(yuv422p12le) vector.
+ * @param r
+ *   Point to r(yuv422p12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_422be10) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_yuv422p12le_to_rfc4175_422be12(
+    uint16_t* y, uint16_t* b, uint16_t* r, struct st20_rfc4175_422_12_pg2_be* pg,
+    uint32_t w, uint32_t h) {
+  return st20_yuv422p12le_to_rfc4175_422be12_simd(y, b, r, pg, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert rfc4175_422le12 to rfc4175_422be12.
+ *
+ * @param pg_le
+ *   Point to pg(rfc4175_422le12) data.
+ * @param pg_be
+ *   Point to pg(rfc4175_422be12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_422le12_to_422be12(
+    struct st20_rfc4175_422_12_pg2_le* pg_le, struct st20_rfc4175_422_12_pg2_be* pg_be,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_422le12_to_422be12_simd(pg_le, pg_be, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert yuv422p12le to rfc4175_422le12.
+ *
+ * @param y
+ *   Point to Y(yuv422p12le) vector.
+ * @param b
+ *   Point to b(yuv422p12le) vector.
+ * @param r
+ *   Point to r(yuv422p12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_422le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_yuv422p12le_to_rfc4175_422le12(uint16_t* y, uint16_t* b, uint16_t* r,
+                                        struct st20_rfc4175_422_12_pg2_le* pg, uint32_t w,
+                                        uint32_t h);
+
+/**
+ * Convert rfc4175_422le12 to yuv422p12le.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_422le12) data.
+ * @param y
+ *   Point to Y(yuv422p12le) vector.
+ * @param b
+ *   Point to b(yuv422p12le) vector.
+ * @param r
+ *   Point to r(yuv422p12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_422le12_to_yuv422p12le(struct st20_rfc4175_422_12_pg2_le* pg,
+                                        uint16_t* y, uint16_t* b, uint16_t* r, uint32_t w,
+                                        uint32_t h);
 
 /**
  * Convert AM824 subframe to AES3 subframe.

--- a/include/st_convert_internal.h
+++ b/include/st_convert_internal.h
@@ -240,6 +240,56 @@ int st20_rfc4175_422be10_to_422le8_simd_dma(st_udma_handle udma,
                                             enum st_simd_level level);
 
 /**
+ * Convert rfc4175_422be12 to yuv422p12le with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_422be12) data.
+ * @param y
+ *   Point to Y(yuv422p12le) vector.
+ * @param b
+ *   Point to b(yuv422p12le) vector.
+ * @param r
+ *   Point to r(yuv422p12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_422be12_to_yuv422p12le_simd(struct st20_rfc4175_422_12_pg2_be* pg,
+                                             uint16_t* y, uint16_t* b, uint16_t* r,
+                                             uint32_t w, uint32_t h,
+                                             enum st_simd_level level);
+
+/**
+ * Convert rfc4175_422be12 to rfc4175_422le12 with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param pg_be
+ *   Point to pg(rfc4175_422be12) data.
+ * @param pg_le
+ *   Point to pg(rfc4175_422le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_422be12_to_422le12_simd(struct st20_rfc4175_422_12_pg2_be* pg_be,
+                                         struct st20_rfc4175_422_12_pg2_le* pg_le,
+                                         uint32_t w, uint32_t h,
+                                         enum st_simd_level level);
+
+/**
  * Convert yuv422p10le to rfc4175_422be10 with required SIMD level.
  * Note the level may downgrade to the SIMD which system really support.
  *
@@ -350,6 +400,33 @@ int st20_v210_to_rfc4175_422be10_simd_dma(st_udma_handle udma, uint8_t* pg_v210,
                                           struct st20_rfc4175_422_10_pg2_be* pg_be,
                                           uint32_t w, uint32_t h,
                                           enum st_simd_level level);
+
+/**
+ * Convert yuv422p12le to rfc4175_422be12 with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param y
+ *   Point to Y(yuv422p12le) vector.
+ * @param b
+ *   Point to b(yuv422p12le) vector.
+ * @param r
+ *   Point to r(yuv422p12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_422be12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_yuv422p12le_to_rfc4175_422be12_simd(uint16_t* y, uint16_t* b, uint16_t* r,
+                                             struct st20_rfc4175_422_12_pg2_be* pg,
+                                             uint32_t w, uint32_t h,
+                                             enum st_simd_level level);
 
 /**
  * Convert rfc4175_422le10 to rfc4175_422be10 with required SIMD level.
@@ -527,6 +604,29 @@ int st20_y210_to_rfc4175_422be10_simd_dma(st_udma_handle udma, uint16_t* pg_y210
                                           struct st20_rfc4175_422_10_pg2_be* pg_be,
                                           uint32_t w, uint32_t h,
                                           enum st_simd_level level);
+
+/**
+ * Convert rfc4175_422le12 to rfc4175_422be12 with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param pg_le
+ *   Point to pg(rfc4175_422le12) data.
+ * @param pg_be
+ *   Point to pg(rfc4175_422be12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_422le12_to_422be12_simd(struct st20_rfc4175_422_12_pg2_le* pg_le,
+                                         struct st20_rfc4175_422_12_pg2_be* pg_be,
+                                         uint32_t w, uint32_t h,
+                                         enum st_simd_level level);
 
 #if defined(__cplusplus)
 }

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -117,6 +117,13 @@ enum st_frame_fmt {
   ST_FRAME_FMT_BGRA,
   /** one RGB pixel per 24 bit word, 8 bits per sample(aka ST20_FMT_RGB_8BIT) */
   ST_FRAME_FMT_RGB8,
+  /** YUV 422 planar 12bit little endian */
+  ST_FRAME_FMT_YUV422PLANAR12LE,
+  /**
+   * RFC4175 in ST2110(ST20_FMT_YUV_422_12BIT),
+   * two YUV 422 12 bit pixel groups on 6 bytes, big endian
+   */
+  ST_FRAME_FMT_YUV422RFC4175PG2BE12,
   /** ST22 jpegxs codestream */
   ST_FRAME_FMT_JPEGXS_CODESTREAM = 24,
   /** ST22 h264 cbr codestream */

--- a/lib/src/pipeline/st20_pipeline_rx.c
+++ b/lib/src/pipeline/st20_pipeline_rx.c
@@ -36,6 +36,15 @@ static inline int convert_rfc4175_422be10_to_yuv422p10le(void* src, void* dst,
       (p10_u16 + width * height * 3 / 2), width, height);
 }
 
+static inline int convert_rfc4175_422be12_to_yuv422p12le(void* src, void* dst,
+                                                         uint32_t width,
+                                                         uint32_t height) {
+  uint16_t* p12_u16 = (uint16_t*)dst;
+  return st20_rfc4175_422be12_to_yuv422p12le(
+      (struct st20_rfc4175_422_12_pg2_be*)src, p12_u16, (p12_u16 + width * height),
+      (p12_u16 + width * height * 3 / 2), width, height);
+}
+
 static uint16_t rx_st20p_next_idx(struct st20p_rx_ctx* ctx, uint16_t idx) {
   /* point to next */
   uint16_t next_idx = idx;
@@ -406,6 +415,17 @@ static int rx_st20p_get_converter_internal(struct st20p_rx_ctx* ctx,
           break;
         case ST_FRAME_FMT_YUV422PLANAR10LE:
           ctx->convert_func_internal = convert_rfc4175_422be10_to_yuv422p10le;
+          break;
+        default:
+          err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,
+              st_frame_fmt_name(input_fmt), st_frame_fmt_name(output_fmt));
+          return -EIO;
+      }
+      break;
+    case ST_FRAME_FMT_YUV422RFC4175PG2BE12:
+      switch (output_fmt) {
+        case ST_FRAME_FMT_YUV422PLANAR12LE:
+          ctx->convert_func_internal = convert_rfc4175_422be12_to_yuv422p12le;
           break;
         default:
           err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,

--- a/lib/src/pipeline/st20_pipeline_tx.c
+++ b/lib/src/pipeline/st20_pipeline_tx.c
@@ -29,6 +29,15 @@ static inline int convert_v210_to_rfc4175_422be10(void* src, void* dst, uint32_t
       (uint8_t*)src, (struct st20_rfc4175_422_10_pg2_be*)dst, width, height);
 }
 
+static inline int convert_yuv422p12le_to_rfc4175_422be12(void* src, void* dst,
+                                                         uint32_t width,
+                                                         uint32_t height) {
+  uint16_t* p12_u16 = (uint16_t*)src;
+  return st20_yuv422p12le_to_rfc4175_422be12(
+      p12_u16, (p12_u16 + width * height), (p12_u16 + width * height * 3 / 2),
+      (struct st20_rfc4175_422_12_pg2_be*)dst, width, height);
+}
+
 static uint16_t tx_st20p_next_idx(struct st20p_tx_ctx* ctx, uint16_t idx) {
   /* point to next */
   uint16_t next_idx = idx;
@@ -385,6 +394,17 @@ static int tx_st20p_get_converter_internal(struct st20p_tx_ctx* ctx,
       switch (output_fmt) {
         case ST_FRAME_FMT_YUV422RFC4175PG2BE10:
           ctx->convert_func_internal = convert_v210_to_rfc4175_422be10;
+          break;
+        default:
+          err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,
+              st_frame_fmt_name(input_fmt), st_frame_fmt_name(output_fmt));
+          return -EIO;
+      }
+      break;
+    case ST_FRAME_FMT_YUV422PLANAR12LE:
+      switch (output_fmt) {
+        case ST_FRAME_FMT_YUV422RFC4175PG2BE12:
+          ctx->convert_func_internal = convert_yuv422p12le_to_rfc4175_422be12;
           break;
         default:
           err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,

--- a/tests/src/cvt_test.cpp
+++ b/tests/src/cvt_test.cpp
@@ -2075,6 +2075,417 @@ TEST(Cvt, rotate_rfc4175_422be10_yuv422p10le_422le10_scalar) {
                                                   ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
 }
 
+static void test_cvt_rfc4175_422be12_to_yuv422p12le(int w, int h,
+                                                    enum st_simd_level cvt_level,
+                                                    enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_be* pg =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_be* pg_2 =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 2 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !pg_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (pg_2) st_test_free(pg_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_422be12_to_yuv422p12le_simd(
+      pg, p12_u16, (p12_u16 + w * h), (p12_u16 + w * h * 3 / 2), w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_yuv422p12le_to_rfc4175_422be12_simd(
+      p12_u16, (p12_u16 + w * h), (p12_u16 + w * h * 3 / 2), pg_2, w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg, pg_2, fb_pg2_size));
+
+  st_test_free(pg);
+  st_test_free(pg_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rfc4175_422be12_to_yuv422p12le) {
+  test_cvt_rfc4175_422be12_to_yuv422p12le(1920, 1080, ST_SIMD_LEVEL_MAX,
+                                          ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_422be12_to_yuv422p12le_scalar) {
+  test_cvt_rfc4175_422be12_to_yuv422p12le(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                          ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_yuv422p12le_to_rfc4175_422be12(int w, int h,
+                                                    enum st_simd_level cvt_level,
+                                                    enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_be* pg =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 2 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  uint16_t* p12_u16_2 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !p12_u16_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (p12_u16_2) st_test_free(p12_u16_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  for (size_t i = 0; i < (planar_size / 2); i++) {
+    p12_u16[i] = rand() & 0xfff; /* only 12 bit */
+  }
+
+  ret = st20_yuv422p12le_to_rfc4175_422be12_simd(
+      p12_u16, (p12_u16 + w * h), (p12_u16 + w * h * 3 / 2), pg, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_422be12_to_yuv422p12le_simd(
+      pg, p12_u16_2, (p12_u16_2 + w * h), (p12_u16_2 + w * h * 3 / 2), w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(p12_u16, p12_u16_2, planar_size));
+
+  st_test_free(pg);
+  st_test_free(p12_u16);
+  st_test_free(p12_u16_2);
+}
+
+TEST(Cvt, yuv422p12le_to_rfc4175_422be12) {
+  test_cvt_yuv422p12le_to_rfc4175_422be12(1920, 1080, ST_SIMD_LEVEL_MAX,
+                                          ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, yuv422p12le_to_rfc4175_422be12_scalar) {
+  test_cvt_yuv422p12le_to_rfc4175_422be12(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                          ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_422le12_to_yuv422p12le(int w, int h,
+                                                    enum st_simd_level cvt_level,
+                                                    enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_le* pg =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_le* pg_2 =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 2 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !pg_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (pg_2) st_test_free(pg_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_422le12_to_yuv422p12le(pg, p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 3 / 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_yuv422p12le_to_rfc4175_422le12(p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 3 / 2), pg_2, w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg, pg_2, fb_pg2_size));
+
+  st_test_free(pg);
+  st_test_free(pg_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rfc4175_422le12_to_yuv422p12le) {
+  test_cvt_rfc4175_422le12_to_yuv422p12le(1920, 1080, ST_SIMD_LEVEL_MAX,
+                                          ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_422le12_to_yuv422p12le_scalar) {
+  test_cvt_rfc4175_422le12_to_yuv422p12le(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                          ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_yuv422p12le_to_rfc4175_422le12(int w, int h,
+                                                    enum st_simd_level cvt_level,
+                                                    enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_le* pg =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 2 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  uint16_t* p12_u16_2 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !p12_u16_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (p12_u16_2) st_test_free(p12_u16_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  for (size_t i = 0; i < (planar_size / 2); i++) {
+    p12_u16[i] = rand() & 0xfff; /* only 12 bit */
+  }
+
+  ret = st20_yuv422p12le_to_rfc4175_422le12(p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 3 / 2), pg, w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_422le12_to_yuv422p12le(pg, p12_u16_2, (p12_u16_2 + w * h),
+                                            (p12_u16_2 + w * h * 3 / 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(p12_u16, p12_u16_2, planar_size));
+
+  st_test_free(pg);
+  st_test_free(p12_u16);
+  st_test_free(p12_u16_2);
+}
+
+TEST(Cvt, yuv422p12le_to_rfc4175_422le12) {
+  test_cvt_yuv422p12le_to_rfc4175_422le12(1920, 1080, ST_SIMD_LEVEL_MAX,
+                                          ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, yuv422p12le_to_rfc4175_422le12_scalar) {
+  test_cvt_yuv422p12le_to_rfc4175_422le12(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                          ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_422be12_to_422le12(int w, int h,
+                                                enum st_simd_level cvt_level,
+                                                enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_be* pg_be =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_le* pg_le =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_be || !pg_le || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_be) st_test_free(pg_be);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_be, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_422be12_to_422le12_simd(pg_be, pg_le, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_422le12_to_422be12_simd(pg_le, pg_be_2, w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+}
+
+TEST(Cvt, rfc4175_422be12_to_422le12) {
+  test_cvt_rfc4175_422be12_to_422le12(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_422be12_to_422le12_scalar) {
+  test_cvt_rfc4175_422be12_to_422le12(1920, 1080, ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_422le12_to_422be12(int w, int h,
+                                                enum st_simd_level cvt_level,
+                                                enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_le* pg_le =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_be* pg_be =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_le* pg_le_2 =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_be || !pg_le || !pg_le_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_be) st_test_free(pg_be);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_le_2) st_test_free(pg_le_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_le, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_422le12_to_422be12_simd(pg_le, pg_be, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_422be12_to_422le12_simd(pg_be, pg_le_2, w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  // st_test_cmp((uint8_t*)pg_le, (uint8_t*)pg_le_2, fb_pg2_size);
+  EXPECT_EQ(0, memcmp(pg_le, pg_le_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_le_2);
+}
+
+static void test_cvt_rfc4175_422le12_to_422be12_2(int w, int h,
+                                                  enum st_simd_level cvt_level,
+                                                  enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_le* pg_le =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_be* pg_be =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_be || !pg_le || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_be) st_test_free(pg_be);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_le, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_422le12_to_422be12_simd(pg_le, pg_be, w, h, ST_SIMD_LEVEL_NONE);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_422le12_to_422be12_simd(pg_le, pg_be_2, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  // st_test_cmp((uint8_t*)pg_be, (uint8_t*)pg_be_2, fb_pg2_size);
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+}
+
+TEST(Cvt, rfc4175_422le12_to_422be12) {
+  test_cvt_rfc4175_422le12_to_422be12_2(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_422le12_to_422be12_scalar) {
+  test_cvt_rfc4175_422le12_to_422be12(1920, 1080, ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
+static void test_rotate_rfc4175_422be12_422le12_yuv422p12le(
+    int w, int h, enum st_simd_level cvt1_level, enum st_simd_level cvt2_level,
+    enum st_simd_level cvt3_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_be* pg_be =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_le* pg_le =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 2 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  struct st20_rfc4175_422_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_le || !pg_be || !p12_u16 || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be) st_test_free(pg_be);
+    if (p12_u16) st_test_free(p12_u16);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_be, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_422be12_to_422le12_simd(pg_be, pg_le, w, h, cvt1_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_422le12_to_yuv422p12le(pg_le, p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 3 / 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_yuv422p12le_to_rfc4175_422be12_simd(
+      p12_u16, (p12_u16 + w * h), (p12_u16 + w * h * 3 / 2), pg_be_2, w, h, cvt3_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rotate_rfc4175_422be12_422le12_yuv422p12le_scalar) {
+  test_rotate_rfc4175_422be12_422le12_yuv422p12le(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                                  ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
+static void test_rotate_rfc4175_422be12_yuv422p12le_422le12(
+    int w, int h, enum st_simd_level cvt1_level, enum st_simd_level cvt2_level,
+    enum st_simd_level cvt3_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 6 / 2;
+  struct st20_rfc4175_422_12_pg2_be* pg_be =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_422_12_pg2_le* pg_le =
+      (struct st20_rfc4175_422_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 2 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  struct st20_rfc4175_422_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_422_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_le || !pg_be || !p12_u16 || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be) st_test_free(pg_be);
+    if (p12_u16) st_test_free(p12_u16);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_be, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_422be12_to_yuv422p12le_simd(
+      pg_be, p12_u16, (p12_u16 + w * h), (p12_u16 + w * h * 3 / 2), w, h, cvt1_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_yuv422p12le_to_rfc4175_422le12(p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 3 / 2), pg_le, w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_422le12_to_422be12(pg_le, pg_be_2, w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rotate_rfc4175_422be12_yuv422p12le_422le12_scalar) {
+  test_rotate_rfc4175_422be12_yuv422p12le_422le12(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                                  ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
 static void test_am824_to_aes3(int blocks) {
   int ret;
   int subframes = blocks * 2 * 192;


### PR DESCRIPTION
This PR adds support for 4:2:2 12 bits format in the convert app and st20 pipeline.

If you find this PR satisfactory, I will proceed to add YCbCr 4:4:4 and RGB 10/12 bits in the same way.