### PR TITLE
Added support for 4:4:4 12 bits formats

### DIFF
--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -413,6 +413,8 @@ static int parse_video_pg_format(json_object* video_obj, st_json_video_session_t
     video->info.pg_format = ST20_FMT_YUV_422_16BIT;
   } else if (strcmp(pg_format, "YUV_444_10bit") == 0) {
     video->info.pg_format = ST20_FMT_YUV_444_10BIT;
+  } else if (strcmp(pg_format, "YUV_444_12bit") == 0) {
+    video->info.pg_format = ST20_FMT_YUV_444_12BIT;
   } else if (strcmp(pg_format, "YUV_420_8bit") == 0) {
     video->info.pg_format = ST20_FMT_YUV_420_8BIT;
   } else if (strcmp(pg_format, "YUV_420_10bit") == 0) {
@@ -987,16 +989,24 @@ static int parse_st22p_format(json_object* st22p_obj, st_json_st22p_session_t* s
     st22p->info.format = ST_FRAME_FMT_YUV422PACKED8;
   } else if (strcmp(format, "YUV444PLANAR10LE") == 0) {
     st22p->info.format = ST_FRAME_FMT_YUV444PLANAR10LE;
+  } else if (strcmp(format, "YUV444PLANAR12LE") == 0) {
+    st22p->info.format = ST_FRAME_FMT_YUV444PLANAR12LE;
   } else if (strcmp(format, "GBRPLANAR10LE") == 0) {
     st22p->info.format = ST_FRAME_FMT_GBRPLANAR10LE;
+  } else if (strcmp(format, "GBRPLANAR12LE") == 0) {
+    st22p->info.format = ST_FRAME_FMT_GBRPLANAR12LE;
   } else if (strcmp(format, "YUV422RFC4175PG2BE10") == 0) {
     st22p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE10;
   } else if (strcmp(format, "YUV422RFC4175PG2BE12") == 0) {
     st22p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE12;
   } else if (strcmp(format, "YUV444RFC4175PG4BE10") == 0) {
     st22p->info.format = ST_FRAME_FMT_YUV444RFC4175PG4BE10;
+  } else if (strcmp(format, "YUV444RFC4175PG2BE12") == 0) {
+    st22p->info.format = ST_FRAME_FMT_YUV444RFC4175PG2BE12;
   } else if (strcmp(format, "RGBRFC4175PG4BE10") == 0) {
     st22p->info.format = ST_FRAME_FMT_RGBRFC4175PG4BE10;
+  } else if (strcmp(format, "RGBRFC4175PG2BE12") == 0) {
+    st22p->info.format = ST_FRAME_FMT_RGBRFC4175PG2BE12;
   } else if (strcmp(format, "RGB8") == 0) {
     st22p->info.format = ST_FRAME_FMT_RGB8;
   } else if (strcmp(format, "JPEGXS_CODESTREAM") == 0) {
@@ -1220,16 +1230,24 @@ static int parse_st20p_format(json_object* st20p_obj, st_json_st20p_session_t* s
     st20p->info.format = ST_FRAME_FMT_YUV422PACKED8;
   } else if (strcmp(format, "YUV444PLANAR10LE") == 0) {
     st20p->info.format = ST_FRAME_FMT_YUV444PLANAR10LE;
+  } else if (strcmp(format, "YUV444PLANAR12LE") == 0) {
+    st20p->info.format = ST_FRAME_FMT_YUV444PLANAR12LE;
   } else if (strcmp(format, "GBRPLANAR10LE") == 0) {
     st20p->info.format = ST_FRAME_FMT_GBRPLANAR10LE;
+  } else if (strcmp(format, "GBRPLANAR12LE") == 0) {
+    st20p->info.format = ST_FRAME_FMT_GBRPLANAR12LE;
   } else if (strcmp(format, "YUV422RFC4175PG2BE10") == 0) {
     st20p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE10;
   } else if (strcmp(format, "YUV422RFC4175PG2BE12") == 0) {
     st20p->info.format = ST_FRAME_FMT_YUV422RFC4175PG2BE12;
   } else if (strcmp(format, "YUV444RFC4175PG4BE10") == 0) {
     st20p->info.format = ST_FRAME_FMT_YUV444RFC4175PG4BE10;
+  } else if (strcmp(format, "YUV444RFC4175PG2BE12") == 0) {
+    st20p->info.format = ST_FRAME_FMT_YUV444RFC4175PG2BE12;
   } else if (strcmp(format, "RGBRFC4175PG4BE10") == 0) {
     st20p->info.format = ST_FRAME_FMT_RGBRFC4175PG4BE10;
+  } else if (strcmp(format, "RGBRFC4175PG2BE12") == 0) {
+    st20p->info.format = ST_FRAME_FMT_RGBRFC4175PG2BE12;
   } else if (strcmp(format, "RGB8") == 0) {
     st20p->info.format = ST_FRAME_FMT_RGB8;
   } else {
@@ -1254,6 +1272,8 @@ static int parse_st20p_transport_format(json_object* st20p_obj,
     st20p->info.transport_format = ST20_FMT_YUV_422_16BIT;
   } else if (strcmp(t_format, "YUV_444_10bit") == 0) {
     st20p->info.transport_format = ST20_FMT_YUV_444_10BIT;
+  } else if (strcmp(t_format, "YUV_444_12bit") == 0) {
+    st20p->info.transport_format = ST20_FMT_YUV_444_12BIT;
   } else if (strcmp(t_format, "YUV_420_8bit") == 0) {
     st20p->info.transport_format = ST20_FMT_YUV_420_8BIT;
   } else if (strcmp(t_format, "YUV_420_10bit") == 0) {

--- a/app/tools/convert_app.c
+++ b/app/tools/convert_app.c
@@ -23,16 +23,24 @@ static enum st_frame_fmt fmt_cvt2frame(enum cvt_frame_fmt fmt) {
       return ST_FRAME_FMT_Y210;
     case CVT_FRAME_FMT_YUV444PLANAR10LE:
       return ST_FRAME_FMT_YUV444PLANAR10LE;
+    case CVT_FRAME_FMT_YUV444PLANAR12LE:
+      return ST_FRAME_FMT_YUV444PLANAR12LE;
     case CVT_FRAME_FMT_GBRPLANAR10LE:
       return ST_FRAME_FMT_GBRPLANAR10LE;
+    case CVT_FRAME_FMT_GBRPLANAR12LE:
+      return ST_FRAME_FMT_GBRPLANAR12LE;
     case CVT_FRAME_FMT_YUV422RFC4175PG2BE10:
       return ST_FRAME_FMT_YUV422RFC4175PG2BE10;
     case CVT_FRAME_FMT_YUV422RFC4175PG2BE12:
       return ST_FRAME_FMT_YUV422RFC4175PG2BE12;
     case CVT_FRAME_FMT_YUV444RFC4175PG4BE10:
       return ST_FRAME_FMT_YUV444RFC4175PG4BE10;
+    case CVT_FRAME_FMT_YUV444RFC4175PG2BE12:
+      return ST_FRAME_FMT_YUV444RFC4175PG2BE12;
     case CVT_FRAME_FMT_RGBRFC4175PG4BE10:
       return ST_FRAME_FMT_RGBRFC4175PG4BE10;
+    case CVT_FRAME_FMT_RGBRFC4175PG2BE12:
+      return ST_FRAME_FMT_RGBRFC4175PG2BE12;
     default:
       break;
   }
@@ -156,6 +164,19 @@ static int convert(struct conv_app_context* ctx) {
         ret = -EIO;
         goto out;
       }
+    } else if (fmt_in == CVT_FRAME_FMT_YUV444PLANAR12LE) {
+      if (fmt_out == CVT_FRAME_FMT_YUV444RFC4175PG2BE12) {
+        uint16_t *y, *b, *r;
+        y = (uint16_t*)buf_in;
+        b = y + w * h;
+        r = b + w * h;
+        st20_yuv444p12le_to_rfc4175_444be12(
+            y, b, r, (struct st20_rfc4175_444_12_pg2_be*)buf_out, w, h);
+      } else {
+        err("%s, err fmt in %d out %d\n", __func__, fmt_in, fmt_out);
+        ret = -EIO;
+        goto out;
+      }
     } else if (fmt_in == CVT_FRAME_FMT_GBRPLANAR10LE) {
       if (fmt_out == CVT_FRAME_FMT_RGBRFC4175PG4BE10) {
         uint16_t *g, *b, *r;
@@ -164,6 +185,19 @@ static int convert(struct conv_app_context* ctx) {
         r = b + w * h;
         st20_gbrp10le_to_rfc4175_444be10(
             g, b, r, (struct st20_rfc4175_444_10_pg4_be*)buf_out, w, h);
+      } else {
+        err("%s, err fmt in %d out %d\n", __func__, fmt_in, fmt_out);
+        ret = -EIO;
+        goto out;
+      }
+    } else if (fmt_in == CVT_FRAME_FMT_GBRPLANAR12LE) {
+      if (fmt_out == CVT_FRAME_FMT_RGBRFC4175PG2BE12) {
+        uint16_t *g, *b, *r;
+        g = (uint16_t*)buf_in;
+        b = g + w * h;
+        r = b + w * h;
+        st20_gbrp12le_to_rfc4175_444be12(
+            g, b, r, (struct st20_rfc4175_444_12_pg2_be*)buf_out, w, h);
       } else {
         err("%s, err fmt in %d out %d\n", __func__, fmt_in, fmt_out);
         ret = -EIO;
@@ -214,6 +248,19 @@ static int convert(struct conv_app_context* ctx) {
         ret = -EIO;
         goto out;
       }
+    } else if (fmt_in == CVT_FRAME_FMT_YUV444RFC4175PG2BE12) {
+      if (fmt_out == CVT_FRAME_FMT_YUV444PLANAR12LE) {
+        uint16_t *y, *b, *r;
+        y = (uint16_t*)buf_out;
+        b = y + w * h;
+        r = b + w * h;
+        st20_rfc4175_444be12_to_yuv444p12le((struct st20_rfc4175_444_12_pg2_be*)buf_in, y,
+                                            b, r, w, h);
+      } else {
+        err("%s, err fmt in %d out %d\n", __func__, fmt_in, fmt_out);
+        ret = -EIO;
+        goto out;
+      }
     } else if (fmt_in == CVT_FRAME_FMT_RGBRFC4175PG4BE10) {
       if (fmt_out == CVT_FRAME_FMT_GBRPLANAR10LE) {
         uint16_t *g, *b, *r;
@@ -221,6 +268,19 @@ static int convert(struct conv_app_context* ctx) {
         b = g + w * h;
         r = b + w * h;
         st20_rfc4175_444be10_to_gbrp10le((struct st20_rfc4175_444_10_pg4_be*)buf_in, g, b,
+                                         r, w, h);
+      } else {
+        err("%s, err fmt in %d out %d\n", __func__, fmt_in, fmt_out);
+        ret = -EIO;
+        goto out;
+      }
+    } else if (fmt_in == CVT_FRAME_FMT_RGBRFC4175PG2BE12) {
+      if (fmt_out == CVT_FRAME_FMT_GBRPLANAR12LE) {
+        uint16_t *g, *b, *r;
+        g = (uint16_t*)buf_out;
+        b = g + w * h;
+        r = b + w * h;
+        st20_rfc4175_444be12_to_gbrp12le((struct st20_rfc4175_444_12_pg2_be*)buf_in, g, b,
                                          r, w, h);
       } else {
         err("%s, err fmt in %d out %d\n", __func__, fmt_in, fmt_out);

--- a/app/tools/convert_app_args.c
+++ b/app/tools/convert_app_args.c
@@ -60,8 +60,14 @@ static enum cvt_frame_fmt cvt_parse_fmt(const char* sfmt) {
   if (!strcmp(sfmt, "yuv444p10le")) {
     return CVT_FRAME_FMT_YUV444PLANAR10LE;
   }
+  if (!strcmp(sfmt, "yuv444p12le")) {
+    return CVT_FRAME_FMT_YUV444PLANAR12LE;
+  }
   if (!strcmp(sfmt, "gbrp10le")) {
     return CVT_FRAME_FMT_GBRPLANAR10LE;
+  }
+  if (!strcmp(sfmt, "gbrp12le")) {
+    return CVT_FRAME_FMT_GBRPLANAR12LE;
   }
   if (!strcmp(sfmt, "yuv422rfc4175be10")) {
     return CVT_FRAME_FMT_YUV422RFC4175PG2BE10;
@@ -72,8 +78,14 @@ static enum cvt_frame_fmt cvt_parse_fmt(const char* sfmt) {
   if (!strcmp(sfmt, "yuv444rfc4175be10")) {
     return CVT_FRAME_FMT_YUV444RFC4175PG4BE10;
   }
+  if (!strcmp(sfmt, "yuv444rfc4175be12")) {
+    return CVT_FRAME_FMT_YUV444RFC4175PG2BE12;
+  }
   if (!strcmp(sfmt, "rgbrfc4175be10")) {
     return CVT_FRAME_FMT_RGBRFC4175PG4BE10;
+  }
+  if (!strcmp(sfmt, "rgbrfc4175be12")) {
+    return CVT_FRAME_FMT_RGBRFC4175PG2BE12;
   }
 
   err("%s, unknown sfmt %s\n", __func__, sfmt);

--- a/app/tools/convert_app_base.h
+++ b/app/tools/convert_app_base.h
@@ -31,16 +31,24 @@ enum cvt_frame_fmt {
   CVT_FRAME_FMT_Y210,
   /** YUV 444 planar 10bit little endian */
   CVT_FRAME_FMT_YUV444PLANAR10LE,
+  /** YUV 444 planar 12bit little endian */
+  CVT_FRAME_FMT_YUV444PLANAR12LE,
   /** GBR planar 10bit little endian */
   CVT_FRAME_FMT_GBRPLANAR10LE,
+  /** GBR planar 12bit little endian */
+  CVT_FRAME_FMT_GBRPLANAR12LE,
   /** RFC4175 in ST2110, two YUV 422 10 bit pixel groups on 5 bytes, big endian */
   CVT_FRAME_FMT_YUV422RFC4175PG2BE10,
   /** RFC4175 in ST2110, two YUV 422 12 bit pixel groups on 6 bytes, big endian */
   CVT_FRAME_FMT_YUV422RFC4175PG2BE12,
   /** RFC4175 in ST2110, four YUV 444 10 bit pixel groups on 15 bytes, big endian */
   CVT_FRAME_FMT_YUV444RFC4175PG4BE10,
+  /** RFC4175 in ST2110, two YUV 444 12 bit pixel groups on 9 bytes, big endian */
+  CVT_FRAME_FMT_YUV444RFC4175PG2BE12,
   /** RFC4175 in ST2110, four RGB 10 bit pixel groups on 15 bytes, big endian */
   CVT_FRAME_FMT_RGBRFC4175PG4BE10,
+  /** RFC4175 in ST2110, two RGB 12 bit pixel groups on 9 bytes, big endian */
+  CVT_FRAME_FMT_RGBRFC4175PG2BE12,
   /** max value of this enum */
   CVT_FRAME_FMT_MAX,
 };

--- a/include/st20_dpdk_api.h
+++ b/include/st20_dpdk_api.h
@@ -525,6 +525,64 @@ struct st20_rfc4175_extra_rtp_hdr {
   uint16_t row_offset;
 } __attribute__((__packed__));
 
+/** Pixel Group describing two image pixels in YUV 4:4:4 or RGB 12-bit format */
+struct st20_rfc4175_444_12_pg2_be {
+  uint8_t Cb_R00; /**< First 8 bits for Cb/Red 0 */
+#ifdef ST_LITTLE_ENDIAN
+  uint8_t Y_G00 : 4;   /**< First 4 bits for Y/Green 0 */
+  uint8_t Cb_R00_ : 4; /**< Second 4 bits for Cb/Red 0 */
+  uint8_t Y_G00_;      /**< Second 8 bits for Y/Green 0 */
+  uint8_t Cr_B00;      /**< First 8 bits for Cr/Blue 0 */
+  uint8_t Cb_R01 : 4;  /**< First 4 bits for Cb/Red 1 */
+  uint8_t Cr_B00_ : 4; /**< Second 4 bits for Cr/Blue 0 */
+  uint8_t Cb_R01_;     /**< Second 8 bits for Cb/Red 1 */
+  uint8_t Y_G01;       /**< First 8 bits for Y/Green 1 */
+  uint8_t Cr_B01 : 4;  /**< First 4 bits for Cr/Blue 1 */
+  uint8_t Y_G01_ : 4;  /**< Second 4 bits for Y/Green 1 */
+#else
+  uint8_t Cb_R00_ : 4; /**< Second 4 bits for Cb/Red 0 */
+  uint8_t Y_G00 : 4;   /**< First 4 bits for Y/Green 0 */
+  uint8_t Y_G00_;      /**< Second 8 bits for Y/Green 0 */
+  uint8_t Cr_B00;      /**< First 8 bits for Cr/Blue 0 */
+  uint8_t Cr_B00_ : 4; /**< Second 4 bits for Cr/Blue 0 */
+  uint8_t Cb_R01 : 4;  /**< First 4 bits for Cb/Red 1 */
+  uint8_t Cb_R01_;     /**< Second 8 bits for Cb/Red 1 */
+  uint8_t Y_G01;       /**< First 8 bits for Y/Green 1 */
+  uint8_t Y_G01_ : 4;  /**< Second 4 bits for Y/Green 1 */
+  uint8_t Cr_B01 : 4;  /**< First 4 bits for Cr/Blue 1 */
+#endif
+  uint8_t Cr_B01_; /**< Second 8 bits for Cr/Blue 1 */
+} __attribute__((__packed__));
+
+/** Pixel Group describing two image pixels in YUV 4:4:4 or RGB 12-bit format */
+struct st20_rfc4175_444_12_pg2_le {
+  uint8_t Cb_R00; /**< First 8 bits for Cb/Red 0 */
+#ifdef ST_LITTLE_ENDIAN
+  uint8_t Cb_R00_ : 4; /**< Second 4 bits for Cb/Red 0 */
+  uint8_t Y_G00 : 4;   /**< First 4 bits for Y/Green 0 */
+  uint8_t Y_G00_;      /**< Second 8 bits for Y/Green 0 */
+  uint8_t Cr_B00;      /**< First 8 bits for Cr/Blue 0 */
+  uint8_t Cr_B00_ : 4; /**< Second 4 bits for Cr/Blue 0 */
+  uint8_t Cb_R01 : 4;  /**< First 4 bits for Cb/Red 1 */
+  uint8_t Cb_R01_;     /**< Second 8 bits for Cb/Red 1 */
+  uint8_t Y_G01;       /**< First 8 bits for Y/Green 1 */
+  uint8_t Y_G01_ : 4;  /**< Second 4 bits for Y/Green 1 */
+  uint8_t Cr_B01 : 4;  /**< First 4 bits for Cr/Blue 1 */
+#else
+  uint8_t Y_G00 : 4;   /**< First 4 bits for Y/Green 0 */
+  uint8_t Cb_R00_ : 4; /**< Second 4 bits for Cb/Red 0 */
+  uint8_t Y_G00_;      /**< Second 8 bits for Y/Green 0 */
+  uint8_t Cr_B00;      /**< First 8 bits for Cr/Blue 0 */
+  uint8_t Cb_R01 : 4;  /**< First 4 bits for Cb/Red 1 */
+  uint8_t Cr_B00_ : 4; /**< Second 4 bits for Cr/Blue 0 */
+  uint8_t Cb_R01_;     /**< Second 8 bits for Cb/Red 1 */
+  uint8_t Y_G01;       /**< First 8 bits for Y/Green 1 */
+  uint8_t Cr_B01 : 4;  /**< First 4 bits for Cr/Blue 1 */
+  uint8_t Y_G01_ : 4;  /**< Second 4 bits for Y/Green 1 */
+#endif
+  uint8_t Cr_B01_; /**< Second 8 bits for Cr/Blue 1 */
+} __attribute__((__packed__));
+
 /** Pixel Group describing four image pixels in YUV 4:4:4 or RGB 10-bit format */
 struct st20_rfc4175_444_10_pg4_be {
   uint8_t Cb_R00; /**< First 8 bits for Cb/Red 0 */

--- a/include/st_convert_api.h
+++ b/include/st_convert_api.h
@@ -341,6 +341,77 @@ static inline int st20_rfc4175_444be10_to_444le10(
 }
 
 /**
+ * Convert rfc4175_444be12 to yuv444p12le with the max optimised SIMD level.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_444be12) data.
+ * @param y
+ *   Point to Y(yuv444p12le) vector.
+ * @param b
+ *   Point to b(yuv444p12le) vector.
+ * @param r
+ *   Point to r(yuv444p12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_444be12_to_yuv444p12le(
+    struct st20_rfc4175_444_12_pg2_be* pg, uint16_t* y, uint16_t* b, uint16_t* r,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_444be12_to_444p12le_simd(pg, y, b, r, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert rfc4175_444be12 to gbrp12le with the max optimised SIMD level.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_444be12) data.
+ * @param g
+ *   Point to g(gbrp12le) vector.
+ * @param b
+ *   Point to b(gbrp12le) vector.
+ * @param r
+ *   Point to r(gbrp12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_444be12_to_gbrp12le(struct st20_rfc4175_444_12_pg2_be* pg,
+                                                   uint16_t* g, uint16_t* b, uint16_t* r,
+                                                   uint32_t w, uint32_t h) {
+  return st20_rfc4175_444be12_to_444p12le_simd(pg, g, r, b, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert rfc4175_444be12 to rfc4175_444le12 with the max optimised SIMD level.
+ *
+ * @param pg_be
+ *   Point to pg(rfc4175_444be12) data.
+ * @param pg_le
+ *   Point to pg(rfc4175_444le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_444be12_to_444le12(
+    struct st20_rfc4175_444_12_pg2_be* pg_be, struct st20_rfc4175_444_12_pg2_le* pg_le,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_444be12_to_444le12_simd(pg_be, pg_le, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
  * Convert yuv422p10le to rfc4175_422be10.
  *
  * @param y
@@ -944,6 +1015,178 @@ static inline int st20_rfc4175_444le10_to_gbrp10le(struct st20_rfc4175_444_10_pg
                                                    uint32_t w, uint32_t h) {
   return st20_rfc4175_444le10_to_444p10le(pg, g, r, b, w, h);
 }
+
+/**
+ * Convert yuv444p12le to rfc4175_444be12.
+ *
+ * @param y
+ *   Point to Y(yuv444p12le) vector.
+ * @param b
+ *   Point to b(yuv444p12le) vector.
+ * @param r
+ *   Point to r(yuv444p12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_444be12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_yuv444p12le_to_rfc4175_444be12(
+    uint16_t* y, uint16_t* b, uint16_t* r, struct st20_rfc4175_444_12_pg2_be* pg,
+    uint32_t w, uint32_t h) {
+  return st20_444p12le_to_rfc4175_444be12_simd(y, b, r, pg, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert rfc4175_444le12 to rfc4175_444be12.
+ *
+ * @param pg_le
+ *   Point to pg(rfc4175_444le12) data.
+ * @param pg_be
+ *   Point to pg(rfc4175_444be12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_444le12_to_444be12(
+    struct st20_rfc4175_444_12_pg2_le* pg_le, struct st20_rfc4175_444_12_pg2_be* pg_be,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_444le12_to_444be12_simd(pg_le, pg_be, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert yuv444p12le to rfc4175_444le12.
+ *
+ * @param y
+ *   Point to Y(yuv444p12le) vector.
+ * @param b
+ *   Point to b(yuv444p12le) vector.
+ * @param r
+ *   Point to r(yuv444p12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_444le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_yuv444p12le_to_rfc4175_444le12(
+    uint16_t* y, uint16_t* b, uint16_t* r, struct st20_rfc4175_444_12_pg2_le* pg,
+    uint32_t w, uint32_t h) {
+  return st20_444p12le_to_rfc4175_444le12(y, b, r, pg, w, h);
+}
+
+/**
+ * Convert rfc4175_444le12 to yuv444p12le.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_444le12) data.
+ * @param y
+ *   Point to Y(yuv444p12le) vector.
+ * @param b
+ *   Point to b(yuv444p12le) vector.
+ * @param r
+ *   Point to r(yuv444p12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_444le12_to_yuv444p12le(
+    struct st20_rfc4175_444_12_pg2_le* pg, uint16_t* y, uint16_t* b, uint16_t* r,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_444le12_to_444p12le(pg, y, b, r, w, h);
+}
+
+/**
+ * Convert gbrp12le to rfc4175_444be12.
+ *
+ * @param g
+ *   Point to g(gbrp12le) vector.
+ * @param b
+ *   Point to b(gbrp12le) vector.
+ * @param r
+ *   Point to r(gbrp12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_444be12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_gbrp12le_to_rfc4175_444be12(uint16_t* g, uint16_t* b, uint16_t* r,
+                                                   struct st20_rfc4175_444_12_pg2_be* pg,
+                                                   uint32_t w, uint32_t h) {
+  return st20_444p12le_to_rfc4175_444be12_simd(g, r, b, pg, w, h, ST_SIMD_LEVEL_MAX);
+}
+
+/**
+ * Convert gbrp12le to rfc4175_444le12.
+ *
+ * @param g
+ *   Point to g(gbrp12le) vector.
+ * @param b
+ *   Point to b(gbrp12le) vector.
+ * @param r
+ *   Point to r(gbrp12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_444le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_gbrp12le_to_rfc4175_444le12(uint16_t* g, uint16_t* b, uint16_t* r,
+                                                   struct st20_rfc4175_444_12_pg2_le* pg,
+                                                   uint32_t w, uint32_t h) {
+  return st20_444p12le_to_rfc4175_444le12(g, r, b, pg, w, h);
+}
+
+/**
+ * Convert rfc4175_444le12 to gbrp12le.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_444le12) data.
+ * @param g
+ *   Point to g(gbrp12le) vector.
+ * @param b
+ *   Point to b(gbrp12le) vector.
+ * @param r
+ *   Point to r(gbrp12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_444le12_to_gbrp12le(struct st20_rfc4175_444_12_pg2_le* pg,
+                                                   uint16_t* g, uint16_t* b, uint16_t* r,
+                                                   uint32_t w, uint32_t h) {
+  return st20_rfc4175_444le12_to_444p12le(pg, g, r, b, w, h);
+}
+
 /**
  * Convert AM824 subframe to AES3 subframe.
  *

--- a/include/st_convert_internal.h
+++ b/include/st_convert_internal.h
@@ -340,6 +340,56 @@ int st20_rfc4175_444be10_to_444le10_simd(struct st20_rfc4175_444_10_pg4_be* pg_b
                                          enum st_simd_level level);
 
 /**
+ * Convert rfc4175_444be12 to yuv444p12le/gbrp12le with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param pg
+ *   Point to pg(rfc4175_444be12) data.
+ * @param y_g
+ *   Point to Y(yuv444p12le) or g(gbrp12le) vector.
+ * @param b_r
+ *   Point to b(yuv444p12le) or r(gbrp12le) vector.
+ * @param r_b
+ *   Point to r(yuv444p12le) or b(gbrp12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_444be12_to_444p12le_simd(struct st20_rfc4175_444_12_pg2_be* pg,
+                                          uint16_t* y_g, uint16_t* b_r, uint16_t* r_b,
+                                          uint32_t w, uint32_t h,
+                                          enum st_simd_level level);
+
+/**
+ * Convert rfc4175_444be12 to rfc4175_444le12 with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param pg_be
+ *   Point to pg(rfc4175_444be12) data.
+ * @param pg_le
+ *   Point to pg(rfc4175_444le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_444be12_to_444le12_simd(struct st20_rfc4175_444_12_pg2_be* pg_be,
+                                         struct st20_rfc4175_444_12_pg2_le* pg_le,
+                                         uint32_t w, uint32_t h,
+                                         enum st_simd_level level);
+
+/**
  * Convert yuv422p10le to rfc4175_422be10 with required SIMD level.
  * Note the level may downgrade to the SIMD which system really support.
  *
@@ -502,6 +552,33 @@ int st20_yuv422p12le_to_rfc4175_422be12_simd(uint16_t* y, uint16_t* b, uint16_t*
  */
 int st20_444p10le_to_rfc4175_444be10_simd(uint16_t* y_g, uint16_t* b_r, uint16_t* r_b,
                                           struct st20_rfc4175_444_10_pg4_be* pg,
+                                          uint32_t w, uint32_t h,
+                                          enum st_simd_level level);
+
+/**
+ * Convert yuv444p12le or gbrp12le to rfc4175_444be12 with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param y_g
+ *   Point to Y(yuv444p12le) or g(gbrp12le) vector.
+ * @param b_r
+ *   Point to b(yuv444p12le) or r(gbrp12le) vector.
+ * @param r_b
+ *   Point to r(yuv444p12le) or b(gbrp12le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_444be10) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_444p12le_to_rfc4175_444be12_simd(uint16_t* y_g, uint16_t* b_r, uint16_t* r_b,
+                                          struct st20_rfc4175_444_12_pg2_be* pg,
                                           uint32_t w, uint32_t h,
                                           enum st_simd_level level);
 
@@ -770,6 +847,74 @@ int st20_444p10le_to_rfc4175_444le10(uint16_t* y_g, uint16_t* b_r, uint16_t* r_b
  *   - <0: Error code if convert fail.
  */
 int st20_rfc4175_444le10_to_444p10le(struct st20_rfc4175_444_10_pg4_le* pg, uint16_t* y_g,
+                                     uint16_t* b_r, uint16_t* r_b, uint32_t w,
+                                     uint32_t h);
+
+/**
+ * Convert rfc4175_444le12 to rfc4175_444be12 with required SIMD level.
+ * Note the level may downgrade to the SIMD which system really support.
+ *
+ * @param pg_le
+ *   Point to pg(rfc4175_444le12) data.
+ * @param pg_be
+ *   Point to pg(rfc4175_444be12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_444le12_to_444be12_simd(struct st20_rfc4175_444_12_pg2_le* pg_le,
+                                         struct st20_rfc4175_444_12_pg2_be* pg_be,
+                                         uint32_t w, uint32_t h,
+                                         enum st_simd_level level);
+/**
+ * Convert yuv444p12le or gbrp12le to rfc4175_444le12.
+ *
+ * @param y_g
+ *   Point to Y(yuv444p12le) or g(gbrp12le) vector.
+ * @param b_r
+ *   Point to b(yuv444p12le) or r(gbrp12le) vector.
+ * @param r_b
+ *   Point to r(yuv444p12le) or b(gbrp12le) vector.
+ * @param pg_le
+ *   Point to pg(rfc4175_444le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_444p12le_to_rfc4175_444le12(uint16_t* y_g, uint16_t* b_r, uint16_t* r_b,
+                                     struct st20_rfc4175_444_12_pg2_le* pg, uint32_t w,
+                                     uint32_t h);
+
+/**
+ * Convert rfc4175_444le12 to yuv444p12le or gbrp12le.
+ *
+ * @param pg_le
+ *   Point to pg(rfc4175_444le12) data.
+ * @param y_g
+ *   Point to Y(yuv444p12le) or g(gbrp12le) vector.
+ * @param b_r
+ *   Point to b(yuv444p12le) or r(gbrp12le) vector.
+ * @param r_b
+ *   Point to r(yuv444p12le) or b(gbrp12le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_444le12_to_444p12le(struct st20_rfc4175_444_12_pg2_le* pg, uint16_t* y_g,
                                      uint16_t* b_r, uint16_t* r_b, uint32_t w,
                                      uint32_t h);
 

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -131,6 +131,13 @@ enum st_frame_fmt {
    * four YUV 444 10 bit pixel groups on 15 bytes, big endian
    */
   ST_FRAME_FMT_YUV444RFC4175PG4BE10,
+  /** YUV 444 planar 12bit little endian */
+  ST_FRAME_FMT_YUV444PLANAR12LE,
+  /**
+   * RFC4175 in ST2110(ST20_FMT_YUV_444_12BIT),
+   * two YUV 444 12 bit pixel groups on 9 bytes, big endian
+   */
+  ST_FRAME_FMT_YUV444RFC4175PG2BE12,
   /** GBR planar 10bit little endian */
   ST_FRAME_FMT_GBRPLANAR10LE,
   /**
@@ -138,6 +145,13 @@ enum st_frame_fmt {
    * four RGB 10 bit pixel groups on 15 bytes, big endian
    */
   ST_FRAME_FMT_RGBRFC4175PG4BE10,
+  /** GBR planar 12bit little endian */
+  ST_FRAME_FMT_GBRPLANAR12LE,
+  /**
+   * RFC4175 in ST2110(ST20_FMT_RGB_12BIT),
+   * two RGB 12 bit pixel groups on 9 bytes, big endian
+   */
+  ST_FRAME_FMT_RGBRFC4175PG2BE12,
   /** ST22 jpegxs codestream */
   ST_FRAME_FMT_JPEGXS_CODESTREAM = 24,
   /** ST22 h264 cbr codestream */

--- a/lib/src/pipeline/st20_pipeline_rx.c
+++ b/lib/src/pipeline/st20_pipeline_rx.c
@@ -68,6 +68,23 @@ static inline int convert_rfc4175_444be10_to_gbrp10le(void* src, void* dst,
                                           (p10_u16 + width * height * 2), width, height);
 }
 
+static inline int convert_rfc4175_444be12_to_yuv444p12le(void* src, void* dst,
+                                                         uint32_t width,
+                                                         uint32_t height) {
+  uint16_t* p12_u16 = (uint16_t*)dst;
+  return st20_rfc4175_444be12_to_yuv444p12le(
+      (struct st20_rfc4175_444_12_pg2_be*)src, p12_u16, (p12_u16 + width * height),
+      (p12_u16 + width * height * 2), width, height);
+}
+
+static inline int convert_rfc4175_444be12_to_gbrp12le(void* src, void* dst,
+                                                      uint32_t width, uint32_t height) {
+  uint16_t* p12_u16 = (uint16_t*)dst;
+  return st20_rfc4175_444be12_to_gbrp12le((struct st20_rfc4175_444_12_pg2_be*)src,
+                                          p12_u16, (p12_u16 + width * height),
+                                          (p12_u16 + width * height * 2), width, height);
+}
+
 static uint16_t rx_st20p_next_idx(struct st20p_rx_ctx* ctx, uint16_t idx) {
   /* point to next */
   uint16_t next_idx = idx;
@@ -471,10 +488,32 @@ static int rx_st20p_get_converter_internal(struct st20p_rx_ctx* ctx,
           return -EIO;
       }
       break;
+    case ST_FRAME_FMT_YUV444RFC4175PG2BE12:
+      switch (output_fmt) {
+        case ST_FRAME_FMT_YUV444PLANAR12LE:
+          ctx->convert_func_internal = convert_rfc4175_444be12_to_yuv444p12le;
+          break;
+        default:
+          err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,
+              st_frame_fmt_name(input_fmt), st_frame_fmt_name(output_fmt));
+          return -EIO;
+      }
+      break;
     case ST_FRAME_FMT_RGBRFC4175PG4BE10:
       switch (output_fmt) {
         case ST_FRAME_FMT_GBRPLANAR10LE:
           ctx->convert_func_internal = convert_rfc4175_444be10_to_gbrp10le;
+          break;
+        default:
+          err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,
+              st_frame_fmt_name(input_fmt), st_frame_fmt_name(output_fmt));
+          return -EIO;
+      }
+      break;
+    case ST_FRAME_FMT_RGBRFC4175PG2BE12:
+      switch (output_fmt) {
+        case ST_FRAME_FMT_GBRPLANAR12LE:
+          ctx->convert_func_internal = convert_rfc4175_444be12_to_gbrp12le;
           break;
         default:
           err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,

--- a/lib/src/pipeline/st20_pipeline_tx.c
+++ b/lib/src/pipeline/st20_pipeline_tx.c
@@ -61,6 +61,23 @@ static inline int convert_gbrp10le_to_rfc4175_444be10(void* src, void* dst,
       (struct st20_rfc4175_444_10_pg4_be*)dst, width, height);
 }
 
+static inline int convert_yuv444p12le_to_rfc4175_444be12(void* src, void* dst,
+                                                         uint32_t width,
+                                                         uint32_t height) {
+  uint16_t* p12_u16 = (uint16_t*)src;
+  return st20_yuv444p12le_to_rfc4175_444be12(
+      p12_u16, (p12_u16 + width * height), (p12_u16 + width * height * 2),
+      (struct st20_rfc4175_444_12_pg2_be*)dst, width, height);
+}
+
+static inline int convert_gbrp12le_to_rfc4175_444be12(void* src, void* dst,
+                                                      uint32_t width, uint32_t height) {
+  uint16_t* p12_u16 = (uint16_t*)src;
+  return st20_gbrp12le_to_rfc4175_444be12(
+      p12_u16, (p12_u16 + width * height), (p12_u16 + width * height * 2),
+      (struct st20_rfc4175_444_12_pg2_be*)dst, width, height);
+}
+
 static uint16_t tx_st20p_next_idx(struct st20p_tx_ctx* ctx, uint16_t idx) {
   /* point to next */
   uint16_t next_idx = idx;
@@ -442,10 +459,32 @@ static int tx_st20p_get_converter_internal(struct st20p_tx_ctx* ctx,
           return -EIO;
       }
       break;
+    case ST_FRAME_FMT_YUV444RFC4175PG2BE12:
+      switch (input_fmt) {
+        case ST_FRAME_FMT_YUV444PLANAR12LE:
+          ctx->convert_func_internal = convert_yuv444p12le_to_rfc4175_444be12;
+          break;
+        default:
+          err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,
+              st_frame_fmt_name(input_fmt), st_frame_fmt_name(output_fmt));
+          return -EIO;
+      }
+      break;
     case ST_FRAME_FMT_RGBRFC4175PG4BE10:
       switch (input_fmt) {
         case ST_FRAME_FMT_GBRPLANAR10LE:
           ctx->convert_func_internal = convert_gbrp10le_to_rfc4175_444be10;
+          break;
+        default:
+          err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,
+              st_frame_fmt_name(input_fmt), st_frame_fmt_name(output_fmt));
+          return -EIO;
+      }
+      break;
+    case ST_FRAME_FMT_RGBRFC4175PG2BE12:
+      switch (input_fmt) {
+        case ST_FRAME_FMT_GBRPLANAR12LE:
+          ctx->convert_func_internal = convert_gbrp12le_to_rfc4175_444be12;
           break;
         default:
           err("%s(%d), format not supported, input: %s, output: %s\n", __func__, ctx->idx,

--- a/tests/src/cvt_test.cpp
+++ b/tests/src/cvt_test.cpp
@@ -2983,8 +2983,510 @@ static void test_rotate_rfc4175_444be10_444p10le_444le10(int w, int h,
   st_test_free(p10_u16);
 }
 
-TEST(Cvt, rotate_rfc4175_444be10_44p10le_444le10_scalar) {
+TEST(Cvt, rotate_rfc4175_444be10_444p10le_444le10_scalar) {
   test_rotate_rfc4175_444be10_444p10le_444le10(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                               ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_444be12_to_444p12le(int w, int h,
+                                                 enum st_simd_level cvt_level,
+                                                 enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_be* pg =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_be* pg_2 =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !pg_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (pg_2) st_test_free(pg_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444be12_to_444p12le_simd(pg, p12_u16, (p12_u16 + w * h),
+                                              (p12_u16 + w * h * 2), w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_444p12le_to_rfc4175_444be12_simd(
+      p12_u16, (p12_u16 + w * h), (p12_u16 + w * h * 2), pg_2, w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg, pg_2, fb_pg2_size));
+
+  st_test_free(pg);
+  st_test_free(pg_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rfc4175_444be12_to_444p12le) {
+  test_cvt_rfc4175_444be12_to_444p12le(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_444be12_to_444p12le_scalar) {
+  test_cvt_rfc4175_444be12_to_444p12le(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                       ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_444p12le_to_rfc4175_444be12(int w, int h,
+                                                 enum st_simd_level cvt_level,
+                                                 enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_be* pg =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  uint16_t* p12_u16_2 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !p12_u16_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (p12_u16_2) st_test_free(p12_u16_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  for (size_t i = 0; i < (planar_size / 2); i++) {
+    p12_u16[i] = rand() & 0xfff; /* only 12 bit */
+  }
+
+  ret = st20_444p12le_to_rfc4175_444be12_simd(p12_u16, (p12_u16 + w * h),
+                                              (p12_u16 + w * h * 2), pg, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444be12_to_444p12le_simd(pg, p12_u16_2, (p12_u16_2 + w * h),
+                                              (p12_u16_2 + w * h * 2), w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(p12_u16, p12_u16_2, planar_size));
+
+  st_test_free(pg);
+  st_test_free(p12_u16);
+  st_test_free(p12_u16_2);
+}
+
+TEST(Cvt, 444p12le_to_rfc4175_444be12) {
+  test_cvt_444p12le_to_rfc4175_444be12(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, 444p12le_to_rfc4175_444be12_scalar) {
+  test_cvt_444p12le_to_rfc4175_444be12(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                       ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_444le12_to_yuv444p12le(int w, int h,
+                                                    enum st_simd_level cvt_level,
+                                                    enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_le* pg =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_le* pg_2 =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !pg_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (pg_2) st_test_free(pg_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444le12_to_yuv444p12le(pg, p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_yuv444p12le_to_rfc4175_444le12(p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 2), pg_2, w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg, pg_2, fb_pg2_size));
+
+  st_test_free(pg);
+  st_test_free(pg_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rfc4175_444le12_to_yuv444p12le) {
+  test_cvt_rfc4175_444le12_to_yuv444p12le(1920, 1080, ST_SIMD_LEVEL_MAX,
+                                          ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_444le12_to_yuv444p12le_scalar) {
+  test_cvt_rfc4175_444le12_to_yuv444p12le(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                          ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_444le12_to_gbrp12le(int w, int h,
+                                                 enum st_simd_level cvt_level,
+                                                 enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_le* pg =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_le* pg_2 =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !pg_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (pg_2) st_test_free(pg_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444le12_to_gbrp12le(pg, p12_u16, (p12_u16 + w * h),
+                                         (p12_u16 + w * h * 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_gbrp12le_to_rfc4175_444le12(p12_u16, (p12_u16 + w * h),
+                                         (p12_u16 + w * h * 2), pg_2, w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg, pg_2, fb_pg2_size));
+
+  st_test_free(pg);
+  st_test_free(pg_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rfc4175_444le12_to_gbrp12le) {
+  test_cvt_rfc4175_444le12_to_gbrp12le(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_444le12_to_gbrp12le_scalar) {
+  test_cvt_rfc4175_444le12_to_gbrp12le(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                       ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_yuv444p12le_to_rfc4175_444le12(int w, int h,
+                                                    enum st_simd_level cvt_level,
+                                                    enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_le* pg =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  uint16_t* p12_u16_2 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !p12_u16_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (p12_u16_2) st_test_free(p12_u16_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  for (size_t i = 0; i < (planar_size / 2); i++) {
+    p12_u16[i] = rand() & 0xfff; /* only 12 bit */
+  }
+
+  ret = st20_yuv444p12le_to_rfc4175_444le12(p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 2), pg, w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444le12_to_yuv444p12le(pg, p12_u16_2, (p12_u16_2 + w * h),
+                                            (p12_u16_2 + w * h * 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(p12_u16, p12_u16_2, planar_size));
+
+  st_test_free(pg);
+  st_test_free(p12_u16);
+  st_test_free(p12_u16_2);
+}
+
+TEST(Cvt, yuv444p12le_to_rfc4175_444le12) {
+  test_cvt_yuv444p12le_to_rfc4175_444le12(1920, 1080, ST_SIMD_LEVEL_MAX,
+                                          ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, yuv444p12le_to_rfc4175_444le12_scalar) {
+  test_cvt_yuv444p12le_to_rfc4175_444le12(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                          ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_gbrp12le_to_rfc4175_444le12(int w, int h,
+                                                 enum st_simd_level cvt_level,
+                                                 enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_le* pg =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  uint16_t* p12_u16_2 = (uint16_t*)st_test_zmalloc(planar_size);
+
+  if (!pg || !p12_u16_2 || !p12_u16) {
+    EXPECT_EQ(0, 1);
+    if (pg) st_test_free(pg);
+    if (p12_u16_2) st_test_free(p12_u16_2);
+    if (p12_u16) st_test_free(p12_u16);
+    return;
+  }
+
+  for (size_t i = 0; i < (planar_size / 2); i++) {
+    p12_u16[i] = rand() & 0xfff; /* only 12 bit */
+  }
+
+  ret = st20_gbrp12le_to_rfc4175_444le12(p12_u16, (p12_u16 + w * h),
+                                         (p12_u16 + w * h * 2), pg, w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444le12_to_gbrp12le(pg, p12_u16_2, (p12_u16_2 + w * h),
+                                         (p12_u16_2 + w * h * 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(p12_u16, p12_u16_2, planar_size));
+
+  st_test_free(pg);
+  st_test_free(p12_u16);
+  st_test_free(p12_u16_2);
+}
+
+TEST(Cvt, gbrp12le_to_rfc4175_444le12) {
+  test_cvt_gbrp12le_to_rfc4175_444le12(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, gbrp12le_to_rfc4175_444le12_scalar) {
+  test_cvt_gbrp12le_to_rfc4175_444le12(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                       ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_444be12_to_444le12(int w, int h,
+                                                enum st_simd_level cvt_level,
+                                                enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_be* pg_be =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_le* pg_le =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_be || !pg_le || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_be) st_test_free(pg_be);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_be, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444be12_to_444le12_simd(pg_be, pg_le, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444le12_to_444be12_simd(pg_le, pg_be_2, w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+}
+
+TEST(Cvt, rfc4175_444be12_to_444le12) {
+  test_cvt_rfc4175_444be12_to_444le12(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_444be12_to_444le12_scalar) {
+  test_cvt_rfc4175_444be12_to_444le12(1920, 1080, ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
+static void test_cvt_rfc4175_444le12_to_444be12(int w, int h,
+                                                enum st_simd_level cvt_level,
+                                                enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_le* pg_le =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_be* pg_be =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_le* pg_le_2 =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_be || !pg_le || !pg_le_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_be) st_test_free(pg_be);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_le_2) st_test_free(pg_le_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_le, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444le12_to_444be12_simd(pg_le, pg_be, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444be12_to_444le12_simd(pg_be, pg_le_2, w, h, back_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_le, pg_le_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_le_2);
+}
+
+static void test_cvt_rfc4175_444le12_to_444be12_2(int w, int h,
+                                                  enum st_simd_level cvt_level,
+                                                  enum st_simd_level back_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_le* pg_le =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_be* pg_be =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_be || !pg_le || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_be) st_test_free(pg_be);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_le, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444le12_to_444be12_simd(pg_le, pg_be, w, h, ST_SIMD_LEVEL_NONE);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444le12_to_444be12_simd(pg_le, pg_be_2, w, h, cvt_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+}
+
+TEST(Cvt, rfc4175_444le12_to_444be12) {
+  test_cvt_rfc4175_444le12_to_444be12_2(1920, 1080, ST_SIMD_LEVEL_MAX, ST_SIMD_LEVEL_MAX);
+}
+
+TEST(Cvt, rfc4175_444le12_to_444be12_scalar) {
+  test_cvt_rfc4175_444le12_to_444be12(1920, 1080, ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
+static void test_rotate_rfc4175_444be12_444le12_444p12le(int w, int h,
+                                                         enum st_simd_level cvt1_level,
+                                                         enum st_simd_level cvt2_level,
+                                                         enum st_simd_level cvt3_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_be* pg_be =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_le* pg_le =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  struct st20_rfc4175_444_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_le || !pg_be || !p12_u16 || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be) st_test_free(pg_be);
+    if (p12_u16) st_test_free(p12_u16);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_be, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444be12_to_444le12_simd(pg_be, pg_le, w, h, cvt1_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444le12_to_yuv444p12le(pg_le, p12_u16, (p12_u16 + w * h),
+                                            (p12_u16 + w * h * 2), w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_444p12le_to_rfc4175_444be12_simd(
+      p12_u16, (p12_u16 + w * h), (p12_u16 + w * h * 2), pg_be_2, w, h, cvt3_level);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rotate_rfc4175_444be12_444le12_444p12le_scalar) {
+  test_rotate_rfc4175_444be12_444le12_444p12le(1920, 1080, ST_SIMD_LEVEL_NONE,
+                                               ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
+}
+
+static void test_rotate_rfc4175_444be12_444p12le_444le12(int w, int h,
+                                                         enum st_simd_level cvt1_level,
+                                                         enum st_simd_level cvt2_level,
+                                                         enum st_simd_level cvt3_level) {
+  int ret;
+  size_t fb_pg2_size = w * h * 9 / 2;
+  struct st20_rfc4175_444_12_pg2_be* pg_be =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+  struct st20_rfc4175_444_12_pg2_le* pg_le =
+      (struct st20_rfc4175_444_12_pg2_le*)st_test_zmalloc(fb_pg2_size);
+  size_t planar_size = w * h * 3 * sizeof(uint16_t);
+  uint16_t* p12_u16 = (uint16_t*)st_test_zmalloc(planar_size);
+  struct st20_rfc4175_444_12_pg2_be* pg_be_2 =
+      (struct st20_rfc4175_444_12_pg2_be*)st_test_zmalloc(fb_pg2_size);
+
+  if (!pg_le || !pg_be || !p12_u16 || !pg_be_2) {
+    EXPECT_EQ(0, 1);
+    if (pg_le) st_test_free(pg_le);
+    if (pg_be) st_test_free(pg_be);
+    if (p12_u16) st_test_free(p12_u16);
+    if (pg_be_2) st_test_free(pg_be_2);
+    return;
+  }
+
+  st_test_rand_data((uint8_t*)pg_be, fb_pg2_size, 0);
+
+  ret = st20_rfc4175_444be12_to_444p12le_simd(pg_be, p12_u16, (p12_u16 + w * h),
+                                              (p12_u16 + w * h * 2), w, h, cvt1_level);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_444p12le_to_rfc4175_444le12(p12_u16, (p12_u16 + w * h),
+                                         (p12_u16 + w * h * 2), pg_le, w, h);
+  EXPECT_EQ(0, ret);
+
+  ret = st20_rfc4175_444le12_to_444be12(pg_le, pg_be_2, w, h);
+  EXPECT_EQ(0, ret);
+
+  EXPECT_EQ(0, memcmp(pg_be, pg_be_2, fb_pg2_size));
+
+  st_test_free(pg_be);
+  st_test_free(pg_le);
+  st_test_free(pg_be_2);
+  st_test_free(p12_u16);
+}
+
+TEST(Cvt, rotate_rfc4175_444be12_444p12le_444le12_scalar) {
+  test_rotate_rfc4175_444be12_444p12le_444le12(1920, 1080, ST_SIMD_LEVEL_NONE,
                                                ST_SIMD_LEVEL_NONE, ST_SIMD_LEVEL_NONE);
 }
 


### PR DESCRIPTION
This adds support for YCbCr 4:4:4 12 bits and RGB 4:4:4 12 bits.

I will look at updating the documentation for the new formats next.