### PR TITLE
build: fix uninitialized error in ubuntu 22.04 build

### DIFF
--- a/app/sample/rx_st20_tx_st20_split_fwd.c
+++ b/app/sample/rx_st20_tx_st20_split_fwd.c
@@ -180,7 +180,7 @@ static int split_fwd_sample_free_app(struct split_fwd_sample_ctx* app) {
     app->rx_handle = NULL;
   }
   if (app->frame_ring) {
-    struct frame_info* fi;
+    struct frame_info* fi = NULL;
     int ret;
     /* dequeue and free all frames in the ring */
     do {


### PR DESCRIPTION
../../app/sample/rx_st20_tx_st20_split_fwd.c:190:7: error: ‘fi’ may be used uninitialized in this function [-Werror=maybe-uninitialized]

Signed-off-by: Du, Frank <frank.du@intel.com>