### PR TITLE
st20p/rx: add get_ext_frame api

### DIFF
--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -360,13 +360,6 @@ enum st22_quality_mode {
  */
 #define ST22P_RX_FLAG_ENABLE_VSYNC (ST_BIT32(1))
 /**
- * Flag bit in flags of struct st20p_rx_ops.
- * Only used for internal convert mode.
- * The external frames are provided by calling
- * st20_rx_get_ext_frame.
- */
-#define ST20P_RX_FLAG_EXT_FRAME (ST_BIT32(2))
-/**
  * Flag bit in flags of struct st22p_rx_ops.
  * If set, lib will pass the incomplete frame to app also.
  * User can check st_frame_status data for the frame integrity
@@ -384,6 +377,13 @@ enum st22_quality_mode {
  * If enabled, lib will pass ST_EVENT_VSYNC by the notify_event on every epoch start.
  */
 #define ST20P_RX_FLAG_ENABLE_VSYNC (ST_BIT32(1))
+/**
+ * Flag bit in flags of struct st20p_rx_ops.
+ * Only used for internal convert mode.
+ * The external frames are provided by calling
+ * st20_rx_get_ext_frame.
+ */
+#define ST20P_RX_FLAG_EXT_FRAME (ST_BIT32(2))
 /**
  * Flag bit in flags of struct st20p_rx_ops.
  * If set, lib will pass the incomplete frame to app also.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -325,7 +325,9 @@ enum st22_quality_mode {
 #define ST20P_TX_FLAG_USER_R_MAC (ST_BIT32(1))
 /**
  * Flag bit in flags of struct st20p_tx_ops.
- * Lib uses user allocated memory for frames
+ * Lib uses user allocated memory for frames.
+ * The external frames are provided by calling
+ * st20_tx_put_ext_frame.
  */
 #define ST20P_TX_FLAG_EXT_FRAME (ST_BIT32(2))
 /**
@@ -357,6 +359,13 @@ enum st22_quality_mode {
  * If enabled, lib will pass ST_EVENT_VSYNC by the notify_event on every epoch start.
  */
 #define ST22P_RX_FLAG_ENABLE_VSYNC (ST_BIT32(1))
+/**
+ * Flag bit in flags of struct st20p_rx_ops.
+ * Only used for internal convert mode.
+ * The external frames are provided by calling
+ * st20_rx_get_ext_frame.
+ */
+#define ST20P_RX_FLAG_EXT_FRAME (ST_BIT32(2))
 /**
  * Flag bit in flags of struct st22p_rx_ops.
  * If set, lib will pass the incomplete frame to app also.
@@ -1303,6 +1312,22 @@ st20p_rx_handle st20p_rx_create(st_handle st, struct st20p_rx_ops* ops);
  *   - <0: Error code of the rx st2110-20 pipeline session free.
  */
 int st20p_rx_free(st20p_rx_handle handle);
+
+/**
+ * Get one rx frame from the rx st2110-20 pipeline session with external framebuffer.
+ * This is only used for internal convert mode, the convert is done in this call.
+ * Call st20p_rx_put_frame to return the frame to session.
+ *
+ * @param handle
+ *   The handle to the rx st2110-20 pipeline session.
+ * @param ext_frame
+ *   The pointer to the structure describing external framebuffer.
+ * @return
+ *   - NULL if no avaiable frame in the session.
+ *   - Otherwise, the frame pointer.
+ */
+struct st_frame* st20p_rx_get_ext_frame(st20p_rx_handle handle,
+                                        struct st_ext_frame* ext_frame);
 
 /**
  * Get one rx frame from the rx st2110-20 pipeline session.

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -388,12 +388,26 @@ static void test_st20p_rx_frame_thread(void* args) {
 
   dbg("%s(%d), start\n", __func__, s->idx);
   while (!s->stop) {
-    frame = st20p_rx_get_frame((st20p_rx_handle)handle);
-    if (!frame) { /* no frame */
-      lck.lock();
-      if (!s->stop) s->cv.wait(lck);
-      lck.unlock();
-      continue;
+    if (s->rx_get_ext) {
+      frame =
+          st20p_rx_get_ext_frame((st20p_rx_handle)handle, &s->p_ext_frames[s->ext_idx]);
+      if (!frame) { /* no frame */
+        lck.lock();
+        if (!s->stop) s->cv.wait(lck);
+        lck.unlock();
+        continue;
+      }
+      // s->ext_fb_in_use[s->ext_idx] = true;
+      s->ext_idx++;
+      if (s->ext_idx >= s->fb_cnt) s->ext_idx = 0;
+    } else {
+      frame = st20p_rx_get_frame((st20p_rx_handle)handle);
+      if (!frame) { /* no frame */
+        lck.lock();
+        if (!s->stop) s->cv.wait(lck);
+        lck.unlock();
+        continue;
+      }
     }
 
     if (!st_is_frame_complete(frame->status)) {
@@ -552,6 +566,7 @@ struct st20p_rx_digest_test_para {
   int timeout_ms;
   bool tx_ext;
   bool rx_ext;
+  bool rx_get_ext;
   bool check_fps;
   bool dynamic;
   enum st_test_level level;
@@ -568,6 +583,7 @@ static void test_st20p_init_rx_digest_para(struct st20p_rx_digest_test_para* par
   para->timeout_ms = 0;
   para->tx_ext = false;
   para->rx_ext = false;
+  para->rx_get_ext = false;
   para->check_fps = true;
   para->dynamic = false;
   para->level = ST_TEST_LEVEL_MANDATORY;
@@ -781,6 +797,7 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     test_ctx_rx[i]->height = height[i];
     test_ctx_rx[i]->fmt = rx_fmt[i];
     test_ctx_rx[i]->user_timestamp = para->user_timestamp;
+    test_ctx_rx[i]->rx_get_ext = para->rx_get_ext;
     /* copy sha */
     memcpy(test_ctx_rx[i]->shas, test_ctx_tx[i]->shas,
            TEST_SHA_HIST_NUM * SHA256_DIGEST_LENGTH);
@@ -847,7 +864,7 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     if (para->dynamic) {
       ops_rx.query_ext_frame = test_st20p_rx_query_ext_frame;
       ops_rx.flags |= ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
-    } else if (para->rx_ext) {
+    } else if (para->rx_ext && !para->rx_get_ext) {
       ops_rx.ext_frames = test_ctx_rx[i]->p_ext_frames;
     }
     if (para->vsync) ops_rx.flags |= ST20P_RX_FLAG_ENABLE_VSYNC;
@@ -1211,6 +1228,24 @@ TEST(St20p, rx_dynamic_ext_digest_1080p_no_convert_s2) {
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
   para.rx_ext = true;
   para.dynamic = true;
+
+  st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
+}
+
+TEST(St20p, rx_get_ext_digest_1080p_convert_s2) {
+  enum st_fps fps[2] = {ST_FPS_P29_97, ST_FPS_P59_94};
+  int width[2] = {1920, 1280};
+  int height[2] = {1080, 720};
+  enum st_frame_fmt tx_fmt[2] = {ST_FRAME_FMT_YUV422PLANAR10LE, ST_FRAME_FMT_Y210};
+  enum st20_fmt t_fmt[2] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT};
+  enum st_frame_fmt rx_fmt[2] = {ST_FRAME_FMT_YUV422PLANAR10LE, ST_FRAME_FMT_Y210};
+
+  struct st20p_rx_digest_test_para para;
+  test_st20p_init_rx_digest_para(&para);
+  para.sessions = 2;
+  para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
+  para.rx_ext = true;
+  para.rx_get_ext = true;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -260,6 +260,7 @@ class tests_context {
   int ext_idx = 0;
   bool ext_fb_in_use[3] = {false}; /* assume 3 framebuffer */
   st_dma_mem_handle dma_mem = NULL;
+  bool rx_get_ext = false;
 
   bool user_pacing = false;
   /* user timestamp which advanced by 1 for erery frame */


### PR DESCRIPTION
This function is only used for internal convert mode and the ST20P_RX_FLAG_EXT_FRAME flag should be set, the convert is done in this call.

Signed-off-by: Ric Li <ming3.li@intel.com>