### PR TITLE
ci: fix gtest workflow for push

### DIFF
--- a/.github/workflows/ubuntu_build_with_gtest.yml
+++ b/.github/workflows/ubuntu_build_with_gtest.yml
@@ -29,7 +29,7 @@ on:
       - .github/workflows/ubuntu_build_with_gtest.yml
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
add a fallback value for concurrency
refer to https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

Signed-off-by: Ric Li <ming3.li@intel.com>