### PR TITLE
tx/queue: arp/mcast/ptp use one shared tx queue.

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -48,7 +48,7 @@ jobs:
         rm build -rf
         ./build.sh debug
 
-     - name: Build with kni
+    - name: Build with kni
       run: |
         rm build -rf
         MTL_BUILD_ENABLE_KNI=true ./build.sh

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -47,3 +47,8 @@ jobs:
       run: |
         rm build -rf
         ./build.sh debug
+
+     - name: Build with kni
+      run: |
+        rm build -rf
+        MTL_BUILD_ENABLE_KNI=true ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,8 @@ function usage()
 buildtype=release
 disable_pcapng=false
 enable_asan=false
+enable_kni=false
+enable_tap=false
 
 if [ -n "$MTL_BUILD_DISABLE_PCAPNG" ];  then
     if [ $MTL_BUILD_DISABLE_PCAPNG == "true" ]; then
@@ -27,6 +29,20 @@ if [ -n "$MTL_BUILD_ENABLE_ASAN" ];  then
         enable_asan=true
         buildtype=debug # use debug build as default for asan
         echo "Enable asan check."
+    fi
+fi
+
+if [ -n "$MTL_BUILD_ENABLE_KNI" ];  then
+    if [ $MTL_BUILD_ENABLE_KNI == "true" ]; then
+        enable_kni=true
+        echo "Enable kni"
+    fi
+fi
+
+if [ -n "$MTL_BUILD_ENABLE_TAP" ];  then
+    if [ $MTL_BUILD_ENABLE_TAP == "true" ]; then
+        enable_tap=true
+        echo "Enable tap"
     fi
 fi
 
@@ -58,7 +74,7 @@ TEST_BUILD_DIR=${WORKSPACE}/build/tests
 PLUGINS_BUILD_DIR=${WORKSPACE}/build/plugins
 
 # build lib
-meson ${LIB_BUILD_DIR} -Dbuildtype=$buildtype -Ddisable_pcapng=$disable_pcapng -Denable_asan=$enable_asan
+meson ${LIB_BUILD_DIR} -Dbuildtype=$buildtype -Ddisable_pcapng=$disable_pcapng -Denable_asan=$enable_asan -Denable_kni=$enable_kni -Denable_tap=$enable_tap
 pushd ${LIB_BUILD_DIR}
 ninja
 sudo ninja install

--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -199,7 +199,7 @@ static int cni_queues_init(struct mtl_main_impl* impl, struct mt_cni_impl* cni) 
     /* no cni for kernel based pmd */
     if (mt_pmd_is_kernel(impl, i)) continue;
 
-    ret = mt_dev_requemt_rx_queue(impl, i, &cni->rx_q_id[i], NULL);
+    ret = mt_dev_request_rx_queue(impl, i, &cni->rx_q_id[i], NULL);
     if (ret < 0) {
       err("%s(%d), kni_rx_q create fail\n", __func__, i);
       cni_queues_uinit(impl);

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -30,9 +30,9 @@ int mt_dev_stop(struct mtl_main_impl* impl);
 int mt_dev_dst_ip_mac(struct mtl_main_impl* impl, uint8_t dip[MTL_IP_ADDR_LEN],
                       struct rte_ether_addr* ea, enum mtl_port port);
 
-int mt_dev_requemt_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
+int mt_dev_request_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
                             uint16_t* queue_id, uint64_t bytes_per_sec);
-int mt_dev_requemt_rx_queue(struct mtl_main_impl* impl, enum mtl_port port,
+int mt_dev_request_rx_queue(struct mtl_main_impl* impl, enum mtl_port port,
                             uint16_t* queue_id, struct mt_rx_flow* flow);
 int mt_dev_free_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
                          uint16_t queue_id);
@@ -40,6 +40,9 @@ int mt_dev_free_rx_queue(struct mtl_main_impl* impl, enum mtl_port port,
                          uint16_t queue_id);
 int mt_dev_flush_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
                           uint16_t queue_id, struct rte_mbuf* pad);
+
+uint16_t mt_dev_tx_sys_queue_burst(struct mtl_main_impl* impl, enum mtl_port port,
+                                   struct rte_mbuf** tx_pkts, uint16_t nb_pkts);
 
 int mt_dev_if_init(struct mtl_main_impl* impl);
 int mt_dev_if_uinit(struct mtl_main_impl* impl);

--- a/lib/src/mt_kni.c
+++ b/lib/src/mt_kni.c
@@ -220,7 +220,7 @@ int mt_kni_init(struct mtl_main_impl* impl) {
 
   ret = rte_kni_init(num_ports);
   if (ret < 0) {
-    info("%s, rte_kni_init fail %d\n", __func__, ret);
+    err("%s, rte_kni_init fail %d\n", __func__, ret);
     cni->has_kni_kmod = false;
     return 0;
   }

--- a/lib/src/mt_kni.c
+++ b/lib/src/mt_kni.c
@@ -202,7 +202,7 @@ static int kni_queues_init(struct mtl_main_impl* impl, struct mt_cni_impl* cni) 
   int ret;
 
   for (int i = 0; i < num_ports; i++) {
-    ret = mt_dev_requemt_tx_queue(impl, i, &cni->tx_q_id[i], 0);
+    ret = mt_dev_request_tx_queue(impl, i, &cni->tx_q_id[i], 0);
     if (ret < 0) {
       err("%s(%d), kni_tx_q create fail\n", __func__, i);
       kni_queues_uinit(impl);

--- a/lib/src/mt_kni.c
+++ b/lib/src/mt_kni.c
@@ -183,43 +183,10 @@ static int kni_start_port(struct mtl_main_impl* impl, enum mtl_port port) {
   return 0;
 }
 
-static int kni_queues_uinit(struct mtl_main_impl* impl) {
-  int num_ports = mt_num_ports(impl);
-  struct mt_cni_impl* cni = mt_get_cni(impl);
-
-  for (int i = 0; i < num_ports; i++) {
-    if (cni->tx_q_active[i]) {
-      mt_dev_free_tx_queue(impl, i, cni->tx_q_id[i]);
-      cni->tx_q_active[i] = false;
-    }
-  }
-
-  return 0;
-}
-
-static int kni_queues_init(struct mtl_main_impl* impl, struct mt_cni_impl* cni) {
-  int num_ports = mt_num_ports(impl);
-  int ret;
-
-  for (int i = 0; i < num_ports; i++) {
-    ret = mt_dev_request_tx_queue(impl, i, &cni->tx_q_id[i], 0);
-    if (ret < 0) {
-      err("%s(%d), kni_tx_q create fail\n", __func__, i);
-      kni_queues_uinit(impl);
-      return ret;
-    }
-    cni->tx_q_active[i] = true;
-    info("%s(%d), tx q %d\n", __func__, i, cni->tx_q_id[i]);
-  }
-
-  return 0;
-}
-
 int mt_kni_handle(struct mtl_main_impl* impl, enum mtl_port port,
                   struct rte_mbuf** rx_pkts, uint16_t nb_pkts) {
   struct mt_cni_impl* cni = mt_get_cni(impl);
   struct rte_kni* rkni = cni->rkni[port];
-  uint16_t port_id = mt_port_id(impl, port);
 
   if (!cni->has_kni_kmod) return 0;
 
@@ -238,7 +205,7 @@ int mt_kni_handle(struct mtl_main_impl* impl, enum mtl_port port,
   if (rx > 0) {
     cni->kni_rx_cnt[port] += rx;
     // dbg("%s(%d), rte_kni_rx_burst %d\n", __func__, port, rx);
-    rte_eth_tx_burst(port_id, cni->tx_q_id[port], pkts_rx, rx);
+    mt_dev_tx_sys_queue_burst(impl, port, pkts_rx, rx);
     /* How to handle the pkts not bursted? */
   }
 
@@ -261,9 +228,6 @@ int mt_kni_init(struct mtl_main_impl* impl) {
   cni->has_kni_kmod = true;
   rte_atomic32_set(&cni->stop_kni, 0);
   kni_set_global_impl(impl);
-
-  ret = kni_queues_init(impl, cni);
-  if (ret < 0) return ret;
 
   for (i = 0; i < num_ports; i++) {
     rte_atomic32_set(&cni->if_up[i], 0);
@@ -315,8 +279,6 @@ int mt_kni_uinit(struct mtl_main_impl* impl) {
       if (ret < 0) err("%s(%d), rte_kni_release fail %d\n", __func__, i, ret);
     }
   }
-
-  kni_queues_uinit(impl);
 
   rte_kni_close();
   kni_set_global_impl(NULL);

--- a/lib/src/mt_log.h
+++ b/lib/src/mt_log.h
@@ -8,13 +8,13 @@
 #define _MT_LIB_LOG_HEAD_H_
 
 /* log define */
-#define RTE_LOGTYPE_ST (RTE_LOGTYPE_USER1)
+#define RTE_LOGTYPE_MT (RTE_LOGTYPE_USER1)
 
 /* Debug-level messages */
 #ifdef DEBUG
 #define dbg(...)                     \
   do {                               \
-    RTE_LOG(DEBUG, ST, __VA_ARGS__); \
+    RTE_LOG(DEBUG, MT, __VA_ARGS__); \
   } while (0)
 #else
 #define dbg(...) \
@@ -25,13 +25,13 @@
 /* Informational */
 #define info(...)                   \
   do {                              \
-    RTE_LOG(INFO, ST, __VA_ARGS__); \
+    RTE_LOG(INFO, MT, __VA_ARGS__); \
   } while (0)
 #define info_once(...)                \
   do {                                \
     static bool once = true;          \
     if (once) {                       \
-      RTE_LOG(INFO, ST, __VA_ARGS__); \
+      RTE_LOG(INFO, MT, __VA_ARGS__); \
       once = false;                   \
     }                                 \
   } while (0)
@@ -39,55 +39,55 @@
 /* Normal but significant condition. */
 #define notice(...)                   \
   do {                                \
-    RTE_LOG(NOTICE, ST, __VA_ARGS__); \
+    RTE_LOG(NOTICE, MT, __VA_ARGS__); \
   } while (0)
 #define notice_once(...)                \
   do {                                  \
     static bool once = true;            \
     if (once) {                         \
-      RTE_LOG(NOTICE, ST, __VA_ARGS__); \
+      RTE_LOG(NOTICE, MT, __VA_ARGS__); \
       once = false;                     \
     }                                   \
   } while (0)
 
 /* Warning conditions. */
-#define warn(...)                      \
-  do {                                 \
-    RTE_LOG(WARNING, ST, __VA_ARGS__); \
+#define warn(...)                               \
+  do {                                          \
+    RTE_LOG(WARNING, MT, "Warn: " __VA_ARGS__); \
   } while (0)
-#define warn_once(...)                   \
-  do {                                   \
-    static bool once = true;             \
-    if (once) {                          \
-      RTE_LOG(WARNING, ST, __VA_ARGS__); \
-      once = false;                      \
-    }                                    \
+#define warn_once(...)                            \
+  do {                                            \
+    static bool once = true;                      \
+    if (once) {                                   \
+      RTE_LOG(WARNING, MT, "Warn: " __VA_ARGS__); \
+      once = false;                               \
+    }                                             \
   } while (0)
 
 /* Error conditions. */
-#define err(...)                   \
-  do {                             \
-    RTE_LOG(ERR, ST, __VA_ARGS__); \
+#define err(...)                             \
+  do {                                       \
+    RTE_LOG(ERR, MT, "Error: " __VA_ARGS__); \
   } while (0)
-#define err_once(...)                \
-  do {                               \
-    static bool once = true;         \
-    if (once) {                      \
-      RTE_LOG(ERR, ST, __VA_ARGS__); \
-      once = false;                  \
-    }                                \
+#define err_once(...)                          \
+  do {                                         \
+    static bool once = true;                   \
+    if (once) {                                \
+      RTE_LOG(ERR, MT, "Error: " __VA_ARGS__); \
+      once = false;                            \
+    }                                          \
   } while (0)
 
 /* Critical conditions		*/
 #define critical(...)               \
   do {                              \
-    RTE_LOG(CRIT, ST, __VA_ARGS__); \
+    RTE_LOG(CRIT, MT, __VA_ARGS__); \
   } while (0)
 #define critical_once(...)            \
   do {                                \
     static bool once = true;          \
     if (once) {                       \
-      RTE_LOG(CRIT, ST, __VA_ARGS__); \
+      RTE_LOG(CRIT, MT, __VA_ARGS__); \
       once = false;                   \
     }                                 \
   } while (0)

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -123,8 +123,7 @@ struct mt_ptp_impl {
   struct mtl_main_impl* impl;
   enum mtl_port port;
   uint16_t port_id;
-  uint16_t tx_queue_id;
-  bool tx_queue_active;
+
   uint16_t rx_queue_id;
   bool rx_queue_active;
   struct rte_mempool* mbuf_pool;
@@ -212,8 +211,6 @@ struct mt_arp_impl {
   uint32_t ip[MTL_PORT_MAX];
   struct rte_ether_addr ea[MTL_PORT_MAX];
   rte_atomic32_t mac_ready[MTL_PORT_MAX];
-  uint16_t tx_q_id[MTL_PORT_MAX]; /* arp tx queue id */
-  bool tx_q_active[MTL_PORT_MAX];
 };
 
 struct mt_mcast_impl {
@@ -221,8 +218,6 @@ struct mt_mcast_impl {
   uint32_t group_ip[MTL_PORT_MAX][ST_MCAST_GROUP_MAX];
   uint32_t group_ref_cnt[MTL_PORT_MAX][ST_MCAST_GROUP_MAX];
   uint16_t group_num[MTL_PORT_MAX];
-  uint16_t tx_q_id[MTL_PORT_MAX]; /* mcast tx queue id */
-  bool tx_q_active[MTL_PORT_MAX];
 };
 
 #define MT_TASKLET_HAS_PENDING (1)
@@ -291,7 +286,7 @@ struct mt_sch_impl {
   struct mtl_main_impl* parnet;
   int idx; /* index for current sch */
   rte_atomic32_t started;
-  rte_atomic32_t requemtl_stop;
+  rte_atomic32_t requestl_stop;
   rte_atomic32_t stopped;
   rte_atomic32_t active; /* if this sch is active */
   rte_atomic32_t ref_cnt;
@@ -399,6 +394,11 @@ struct mt_interface {
   int max_tx_queues;
   struct mt_tx_queue* tx_queues;
   pthread_mutex_t tx_queues_mutex; /* protect tx_queues */
+
+  /* the shared tx sys queue */
+  uint16_t tx_sys_queue;
+  bool tx_sys_queue_active;
+  pthread_mutex_t tx_sys_queue_mutex; /* protect tx_sys_queue */
 
   /* rx queue resources */
   int max_rx_queues;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -286,7 +286,7 @@ struct mt_sch_impl {
   struct mtl_main_impl* parnet;
   int idx; /* index for current sch */
   rte_atomic32_t started;
-  rte_atomic32_t requestl_stop;
+  rte_atomic32_t request_stop;
   rte_atomic32_t stopped;
   rte_atomic32_t active; /* if this sch is active */
   rte_atomic32_t ref_cnt;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -182,6 +182,7 @@ struct mt_cni_impl {
   struct mt_sch_tasklet_impl* tasklet;
   /* stat */
   int eth_rx_cnt[MTL_PORT_MAX];
+
 #ifdef MTL_HAS_KNI
   bool has_kni_kmod;
   rte_atomic32_t if_up[MTL_PORT_MAX];
@@ -189,8 +190,6 @@ struct mt_cni_impl {
   struct rte_kni* rkni[MTL_PORT_MAX];
   pthread_t kni_bkg_tid; /* bkg thread id for kni */
   rte_atomic32_t stop_kni;
-  uint16_t tx_q_id[MTL_PORT_MAX]; /* cni tx queue id */
-  bool tx_q_active[MTL_PORT_MAX];
   int kni_rx_cnt[MTL_PORT_MAX];
 #endif
 

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -123,7 +123,7 @@ static int sch_tasklet_func(void* args) {
 
   sch->sleep_ratio_start_ns = mt_get_tsc(impl);
 
-  while (rte_atomic32_read(&sch->requemtl_stop) == 0) {
+  while (rte_atomic32_read(&sch->requestl_stop) == 0) {
     int pending = MT_TASKLET_ALL_DONE;
 
     num_tasklet = sch->max_tasklet_idx;
@@ -177,7 +177,7 @@ static int sch_start(struct mt_sch_impl* sch) {
   }
 
   mt_sch_set_cpu_busy(sch, false);
-  rte_atomic32_set(&sch->requemtl_stop, 0);
+  rte_atomic32_set(&sch->requestl_stop, 0);
   rte_atomic32_set(&sch->stopped, 0);
 
   if (!sch->run_in_thread) {
@@ -217,7 +217,7 @@ static int sch_stop(struct mt_sch_impl* sch) {
     return 0;
   }
 
-  rte_atomic32_set(&sch->requemtl_stop, 1);
+  rte_atomic32_set(&sch->requestl_stop, 1);
   while (rte_atomic32_read(&sch->stopped) == 0) {
     mt_sleep_ms(10);
   }

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -123,7 +123,7 @@ static int sch_tasklet_func(void* args) {
 
   sch->sleep_ratio_start_ns = mt_get_tsc(impl);
 
-  while (rte_atomic32_read(&sch->requestl_stop) == 0) {
+  while (rte_atomic32_read(&sch->request_stop) == 0) {
     int pending = MT_TASKLET_ALL_DONE;
 
     num_tasklet = sch->max_tasklet_idx;
@@ -177,7 +177,7 @@ static int sch_start(struct mt_sch_impl* sch) {
   }
 
   mt_sch_set_cpu_busy(sch, false);
-  rte_atomic32_set(&sch->requestl_stop, 0);
+  rte_atomic32_set(&sch->request_stop, 0);
   rte_atomic32_set(&sch->stopped, 0);
 
   if (!sch->run_in_thread) {
@@ -217,7 +217,7 @@ static int sch_stop(struct mt_sch_impl* sch) {
     return 0;
   }
 
-  rte_atomic32_set(&sch->requestl_stop, 1);
+  rte_atomic32_set(&sch->request_stop, 1);
   while (rte_atomic32_read(&sch->stopped) == 0) {
     mt_sleep_ms(10);
   }

--- a/lib/src/mt_tap.c
+++ b/lib/src/mt_tap.c
@@ -811,7 +811,7 @@ static int tap_queues_init(struct mtl_main_impl* impl, struct mt_cni_impl* cni) 
     return ret;
   }
   for (i = 0; i < num_ports; i++) {
-    ret = mt_dev_requemt_tx_queue(impl, mt_port_id(impl, i), &cni->tap_tx_q_id[i],
+    ret = mt_dev_request_tx_queue(impl, mt_port_id(impl, i), &cni->tap_tx_q_id[i],
                                   1024 * 1024 * 1024);
     if (ret < 0) {
       err("%s(%d), tap_tx_q create fail\n", __func__, i);
@@ -843,7 +843,7 @@ static int tap_queues_init(struct mtl_main_impl* impl, struct mt_cni_impl* cni) 
     info("%s(%d), tx q %d\n", __func__, i, cni->tap_tx_q_id[i]);
   }
   for (i = 0; i < num_ports; i++) {
-    ret = mt_dev_requemt_rx_queue(impl, i, &cni->tap_rx_q_id[i], NULL);
+    ret = mt_dev_request_rx_queue(impl, i, &cni->tap_rx_q_id[i], NULL);
     if (ret < 0) {
       err("%s(%d), tap_rx_q create fail\n", __func__, i);
       tap_queues_uinit(impl);

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -13,7 +13,7 @@ static int g_mt_rte_malloc_cnt;
 
 int mt_asan_check(void) {
   if (g_mt_rte_malloc_cnt != 0) {
-    rte_panic("%s, detect not free memory by rte_malloc, error cnt %d\n", __func__,
+    rte_panic("%s, detect not free memory by rte_malloc, leak cnt %d\n", __func__,
               g_mt_rte_malloc_cnt);
   }
 

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -189,9 +189,9 @@ static int rx_ancillary_session_init_hw(struct mtl_main_impl* impl,
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST40_RX_FLAG_DATA_PATH_ONLY))
-      ret = mt_dev_requemt_rx_queue(impl, port, &queue, NULL);
+      ret = mt_dev_request_rx_queue(impl, port, &queue, NULL);
     else
-      ret = mt_dev_requemt_rx_queue(impl, port, &queue, &flow);
+      ret = mt_dev_request_rx_queue(impl, port, &queue, &flow);
     if (ret < 0) {
       rx_ancillary_session_uinit_hw(impl, s);
       return ret;

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -584,9 +584,9 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST30_RX_FLAG_DATA_PATH_ONLY))
-      ret = mt_dev_requemt_rx_queue(impl, port, &queue, NULL);
+      ret = mt_dev_request_rx_queue(impl, port, &queue, NULL);
     else
-      ret = mt_dev_requemt_rx_queue(impl, port, &queue, &flow);
+      ret = mt_dev_request_rx_queue(impl, port, &queue, &flow);
     if (ret < 0) {
       rx_audio_session_uinit_hw(impl, s);
       return ret;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2600,9 +2600,9 @@ static int rv_init_hw(struct mtl_main_impl* impl, struct st_rx_video_session_imp
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY))
-      ret = mt_dev_requemt_rx_queue(impl, port, &queue, NULL);
+      ret = mt_dev_request_rx_queue(impl, port, &queue, NULL);
     else
-      ret = mt_dev_requemt_rx_queue(impl, port, &queue, &flow);
+      ret = mt_dev_request_rx_queue(impl, port, &queue, &flow);
     if (ret < 0) {
       rv_uinit_hw(impl, s);
       return ret;

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -817,7 +817,7 @@ static int tx_ancillary_sessions_mgr_init_hw(struct mtl_main_impl* impl,
 
   for (int i = 0; i < mt_num_ports(impl); i++) {
     /* do we need quota for anc? */
-    ret = mt_dev_requemt_tx_queue(impl, i, &queue, 0);
+    ret = mt_dev_request_tx_queue(impl, i, &queue, 0);
     if (ret < 0) {
       tx_ancillary_sessions_mgr_uinit_hw(impl, mgr);
       return ret;

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -767,7 +767,7 @@ static int tx_audio_sessions_mgr_init_hw(struct mtl_main_impl* impl,
 
   for (int i = 0; i < mt_num_ports(impl); i++) {
     /* do we need quota for audio? */
-    ret = mt_dev_requemt_tx_queue(impl, i, &queue, 0);
+    ret = mt_dev_request_tx_queue(impl, i, &queue, 0);
     if (ret < 0) {
       tx_audio_sessions_mgr_uinit_hw(impl, mgr);
       return ret;

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -1710,7 +1710,7 @@ static int tv_init_hw(struct mtl_main_impl* impl, struct st_tx_video_sessions_mg
     port = mt_port_logic2phy(s->port_maps, i);
     port_id = mt_port_id(impl, port);
 
-    ret = mt_dev_requemt_tx_queue(impl, port, &queue, tv_rl_bps(s));
+    ret = mt_dev_request_tx_queue(impl, port, &queue, tv_rl_bps(s));
     if (ret < 0) {
       tv_uinit_hw(impl, s);
       return ret;


### PR DESCRIPTION
Reduce tx queue usage since some device only has 2 or 4 queues.

Signed-off-by: Du, Frank <frank.du@intel.com>