### PR TITLE
plugin/st22: fix st22_ffmpeg on new frame API.

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -27,6 +27,7 @@ jobs:
         apt-get update -y
         apt-get install -y sudo git gcc meson python3 python3-pip pkg-config libnuma-dev libjson-c-dev libpcap-dev libgtest-dev libsdl2-dev libsdl2-ttf-dev libssl-dev
         apt-get install -y dpdk-dev
+        apt-get install -y libavcodec-dev
 
     - name: Install the python package
       run: pip install pyelftools ninja
@@ -42,6 +43,10 @@ jobs:
     - name: Build
       run: |
         ./build.sh
+
+    - name: Build st22 ffmpeg plugin
+      run: |
+        ./script/build_st22_ffmpeg_plugin.sh
 
     - name: Build with debug
       run: |

--- a/app/sample/sample_util.h
+++ b/app/sample/sample_util.h
@@ -64,8 +64,6 @@ struct st_sample_context {
   enum st20_fmt fmt;
   enum st_frame_fmt input_fmt;
   enum st_frame_fmt output_fmt;
-  enum st_frame_fmt st22p_input_fmt;
-  enum st_frame_fmt st22p_output_fmt;
   uint16_t framebuff_cnt;
   uint16_t udp_port;
   uint8_t payload_type;
@@ -76,6 +74,10 @@ struct st_sample_context {
   char logo_url[ST_SAMPLE_URL_MAX_LEN];
   uint32_t logo_width;
   uint32_t logo_height;
+
+  enum st_frame_fmt st22p_input_fmt;
+  enum st_frame_fmt st22p_output_fmt;
+  enum st22_codec st22p_codec; /* st22 codec */
 
   bool exit;
 };

--- a/app/sample/tx_st22_pipeline_sample.c
+++ b/app/sample/tx_st22_pipeline_sample.c
@@ -132,7 +132,16 @@ static void tx_st22p_build_frame(struct tx_st22p_sample_ctx* s, struct st_frame*
   }
   uint8_t* src = s->frame_cursor;
 
-  mtl_memcpy(frame->addr[0], src, s->frame_size);
+  uint8_t planes = st_frame_fmt_planes(frame->fmt);
+  for (uint8_t plane = 0; plane < planes; plane++) {
+    size_t plane_sz = st_frame_plane_size(frame, plane);
+    dbg("%s(%d), src frame, plane %u size %lu addr %p\n", __func__, s->idx, plane,
+        plane_sz, frame->addr[plane]);
+    dbg("%s(%d), plane %u src addr %p\n", __func__, s->idx, plane, src);
+    mtl_memcpy(frame->addr[plane], src, plane_sz);
+    src += plane_sz;
+  }
+
   if (s->logo_buf) {
     st_draw_logo(frame, &s->logo_meta, 16, 16);
   }
@@ -200,7 +209,7 @@ int main(int argc, char** argv) {
 
     struct st22p_tx_ops ops_tx;
     memset(&ops_tx, 0, sizeof(ops_tx));
-    ops_tx.name = "st22p_test";
+    ops_tx.name = "st22p_sample";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.port.num_port = 1;
     memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
@@ -213,7 +222,7 @@ int main(int argc, char** argv) {
     ops_tx.fps = ctx.fps;
     ops_tx.input_fmt = ctx.st22p_input_fmt;
     ops_tx.pack_type = ST22_PACK_CODESTREAM;
-    ops_tx.codec = ST22_CODEC_JPEGXS;
+    ops_tx.codec = ctx.st22p_codec;
     ops_tx.device = ST_PLUGIN_DEVICE_AUTO;
     ops_tx.quality = ST22_QUALITY_MODE_QUALITY;
     ops_tx.codec_thread_cnt = 2;

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -233,7 +233,7 @@ struct st_frame {
   size_t linesize[ST_MAX_PLANES];
   /** frame format */
   enum st_frame_fmt fmt;
-  /** frame buffer size */
+  /** frame buffer size, include all planes */
   size_t buffer_size;
   /**
    * frame valid data size, may <= buffer_size for one encoded frame.
@@ -1507,6 +1507,17 @@ int st_frame_sanity_check(struct st_frame* frame);
 const char* st_frame_fmt_name(enum st_frame_fmt fmt);
 
 /**
+ * Get st_frame_fmt from name
+ *
+ * @param name
+ *   name.
+ * @return
+ *   The frmae fmt.
+ *   ST_FRAME_FMT_MAX: Fail.
+ */
+enum st_frame_fmt st_frame_name_to_fmt(const char* name);
+
+/**
  * Get number of planes of st_frame_fmt
  *
  * @param fmt
@@ -1568,6 +1579,18 @@ bool st_frame_fmt_equal_transport(enum st_frame_fmt fmt, enum st20_fmt tfmt);
  *   - <0: Error code if put fail.
  */
 int st_draw_logo(struct st_frame* frame, struct st_frame* logo, uint32_t x, uint32_t y);
+
+/**
+ * Helper to get st frame plane size
+ *
+ * @param frame
+ *   The st_frame pointer.
+ * @return
+ *   size
+ */
+static inline size_t st_frame_plane_size(struct st_frame* frame, uint8_t plane) {
+  return frame->linesize[plane] * frame->height;
+}
 
 #if defined(__cplusplus)
 }

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -392,23 +392,11 @@ static int rx_st20p_init_dst_fbs(struct mtl_main_impl* impl, struct st20p_rx_ctx
           rx_st20p_uinit_dst_fbs(ctx);
           return -ENOMEM;
         }
-        for (uint8_t plane = 0; plane < planes; plane++) {
-          frames[i].dst.linesize[plane] =
-              st_frame_least_linesize(frames[i].dst.fmt, frames[i].dst.width, plane);
-          if (plane == 0) {
-            frames[i].dst.addr[plane] = dst;
-            frames[i].dst.iova[plane] = mtl_hp_virt2iova(ctx->impl, dst);
-          } else {
-            frames[i].dst.addr[plane] =
-                frames[i].dst.addr[plane - 1] +
-                frames[i].dst.linesize[plane - 1] * frames[i].dst.height;
-            frames[i].dst.iova[plane] =
-                frames[i].dst.iova[plane - 1] +
-                frames[i].dst.linesize[plane - 1] * frames[i].dst.height;
-          }
-        }
         frames[i].dst.buffer_size = dst_size;
         frames[i].dst.data_size = dst_size;
+        /* init plane */
+        st_frame_init_plane_single_src(&frames[i].dst, dst,
+                                       mtl_hp_virt2iova(ctx->impl, dst));
       }
       if (!(ops->flags & ST20P_RX_FLAG_EXT_FRAME) &&
           st_frame_sanity_check(&frames[i].dst) < 0) {

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -347,23 +347,12 @@ static int tx_st20p_init_src_fbs(struct mtl_main_impl* impl, struct st20p_tx_ctx
           tx_st20p_uinit_src_fbs(ctx);
           return -ENOMEM;
         }
-        for (uint8_t plane = 0; plane < planes; plane++) {
-          frames[i].src.linesize[plane] =
-              st_frame_least_linesize(frames[i].src.fmt, frames[i].src.width, plane);
-          if (plane == 0) {
-            frames[i].src.addr[plane] = src;
-            frames[i].src.iova[plane] = mtl_hp_virt2iova(ctx->impl, src);
-          } else {
-            frames[i].src.addr[plane] =
-                frames[i].src.addr[plane - 1] +
-                frames[i].src.linesize[plane - 1] * frames[i].src.height;
-            frames[i].src.iova[plane] =
-                frames[i].src.iova[plane - 1] +
-                frames[i].src.linesize[plane - 1] * frames[i].src.height;
-          }
-        }
         frames[i].src.buffer_size = src_size;
         frames[i].src.data_size = src_size;
+        /* init plane */
+        st_frame_init_plane_single_src(&frames[i].src, src,
+                                       mtl_hp_virt2iova(ctx->impl, src));
+        /* check plane */
         if (st_frame_sanity_check(&frames[i].src) < 0) {
           err("%s(%d), src frame %d sanity check fail\n", __func__, idx, i);
           tx_st20p_uinit_src_fbs(ctx);

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -279,13 +279,20 @@ static int rx_st22p_init_dst_fbs(struct mtl_main_impl* impl, struct st22p_rx_ctx
       rx_st22p_uinit_dst_fbs(ctx);
       return -ENOMEM;
     }
-    frames[i].dst.addr[0] = dst;
     frames[i].dst.fmt = ops->output_fmt;
     frames[i].dst.buffer_size = dst_size;
     frames[i].dst.data_size = dst_size;
     frames[i].dst.width = ops->width;
     frames[i].dst.height = ops->height;
     frames[i].dst.priv = &frames[i];
+    /* init plane */
+    st_frame_init_plane_single_src(&frames[i].dst, dst, mtl_hp_virt2iova(ctx->impl, dst));
+    /* check plane */
+    if (st_frame_sanity_check(&frames[i].dst) < 0) {
+      err("%s(%d), dst frame %d sanity check fail\n", __func__, idx, i);
+      rx_st22p_uinit_dst_fbs(ctx);
+      return -EINVAL;
+    }
   }
 
   info("%s(%d), size %ld fmt %d with %u frames\n", __func__, idx, dst_size,

--- a/lib/src/st2110/st_fmt.h
+++ b/lib/src/st2110/st_fmt.h
@@ -58,4 +58,6 @@ static inline void st20_unpack_pg2be_422le10(struct st20_rfc4175_422_10_pg2_be* 
   *y01 = y1;
 }
 
+void st_frame_init_plane_single_src(struct st_frame* frame, void* addr, mtl_iova_t iova);
+
 #endif

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -250,6 +250,7 @@ struct st22_tx_video_info {
 
   struct st22_boxes st22_boxes;
   int st22_total_pkts;
+  int st22_min_pkts;
 };
 
 struct st_vsync_info {
@@ -338,6 +339,7 @@ struct st_tx_video_session_impl {
   uint32_t st20_rtp_time;    /* keep track of rtp time */
   int st21_vrx_narrow;       /* pass criteria for narrow */
   int st21_vrx_wide;         /* pass criteria for wide */
+  int st20_min_pkts;
 
   struct st20_packet_group_info st20_pkt_info[ST20_PKT_TYPE_MAX];
   struct rte_mbuf* pad[ST_SESSION_PORT_MAX][ST20_PKT_TYPE_MAX];

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -339,7 +339,6 @@ struct st_tx_video_session_impl {
   uint32_t st20_rtp_time;    /* keep track of rtp time */
   int st21_vrx_narrow;       /* pass criteria for narrow */
   int st21_vrx_wide;         /* pass criteria for wide */
-  int st20_min_pkts;
 
   struct st20_packet_group_info st20_pkt_info[ST20_PKT_TYPE_MAX];
   struct rte_mbuf* pad[ST_SESSION_PORT_MAX][ST20_PKT_TYPE_MAX];

--- a/plugins/st22_ffmpeg/README.md
+++ b/plugins/st22_ffmpeg/README.md
@@ -40,18 +40,12 @@ ffmpeg -s 1920x1080 -pix_fmt yuv420p -i yuv420p8le.yuv -pix_fmt yuv422p test_pla
         },
 ```
 
-#### 3.3 Prepare a yuv422p8le file.
-Modify tx_st22_pipeline_sample.c and rx_st22_pipeline_sample.c to use h264 codec.
+#### 3.3 Run the sample with tx and rx based on h264 CBR.
+Tx run:
 ```bash
-ops_tx.codec = ST22_CODEC_H264_CBR;
+./build/app/TxSt22PipelineSample --st22_codec h264_cbr --st22_fmt YUV422PLANAR8 --tx_url test_planar8.yuv
 ```
+Rx run:
 ```bash
-ops_rx.codec = ST22_CODEC_H264_CBR;
-```
-Build and run TxSt22PipelineSample, RxSt22PipelineSample.
-```bash
-ST_PORT_P=0000:af:00.1 ./build/app/TxSt22PipelineSample
-```
-```bash
-ST_PORT_P=0000:af:00.0 ./build/app/RxSt22PipelineSample
+./build/app/RxSt22PipelineSample --st22_codec h264_cbr --st22_fmt YUV422PLANAR8 --rx_url out_planar8.yuv
 ```

--- a/plugins/st22_ffmpeg/meson.build
+++ b/plugins/st22_ffmpeg/meson.build
@@ -2,7 +2,7 @@
 # Copyright 2022 Intel Corporation
 
 project('st22 encoder plugins based on ffmpeg', 'c', default_options: ['buildtype=release'],
-        version: run_command(find_program('cat', 'more'), files('../../../VERSION'), check: true).stdout().strip(),)
+        version: run_command(find_program('cat', 'more'), files('../../VERSION'), check: true).stdout().strip(),)
 
 # allow experimental api
 add_global_arguments('-DALLOW_EXPERIMENTAL_API', language : 'c')

--- a/plugins/st22_ffmpeg/st22_ffmpeg_plugin.c
+++ b/plugins/st22_ffmpeg/st22_ffmpeg_plugin.c
@@ -22,9 +22,7 @@ static int encode_frame(struct st22_encoder_session* s,
   AVFrame* f = s->codec_frame;
   AVPacket* p = s->codec_pkt;
   AVCodecContext* ctx = s->codec_ctx;
-  size_t res_size = s->req.width * s->req.height;
   size_t data_size = 0;
-  void* src_addr = frame->src->addr[0];
   int ret;
   bool measure_time = false;
   uint64_t start_time = 0, end_time = 0;
@@ -39,13 +37,9 @@ static int encode_frame(struct st22_encoder_session* s,
   f->pict_type = AV_PICTURE_TYPE_I; /* all are i frame */
   f->pts = f_idx;
   /* only YUV422P now */
-  mtl_memcpy(f->data[0], src_addr, res_size);
-  src_addr += res_size;
-  res_size /= 2;
-  mtl_memcpy(f->data[1], src_addr, res_size);
-  src_addr += res_size;
-  mtl_memcpy(f->data[2], src_addr, res_size);
-  src_addr += res_size;
+  mtl_memcpy(f->data[0], frame->src->addr[0], st_frame_plane_size(frame->src, 0));
+  mtl_memcpy(f->data[1], frame->src->addr[1], st_frame_plane_size(frame->src, 1));
+  mtl_memcpy(f->data[2], frame->src->addr[2], st_frame_plane_size(frame->src, 2));
 
   ret = avcodec_send_frame(ctx, f);
   s->frame_idx++;
@@ -81,6 +75,8 @@ exit:
   }
   s->frame_cnt++;
   frame->dst->data_size = data_size;
+  dbg("%s(%d), bitstream data size %" PRIu64 " on frame %d\n", __func__, idx, data_size,
+      f_idx);
   return data_size > 0 ? 0 : -EIO;
 }
 
@@ -169,7 +165,7 @@ static int encoder_init_session(struct st22_encoder_session* session,
   /* bit per second */
   int64_t bit_rate = (req->codestream_size * 8) * fps;
   bit_rate = bit_rate * 7 / 10;
-  bit_rate /= 10; /* temp for fps */
+  // bit_rate /= 10; /* temp for fps */
   c->bit_rate = bit_rate;
   c->rc_max_rate = bit_rate;
   c->rc_buffer_size = bit_rate * 3;
@@ -289,7 +285,6 @@ static int decode_frame(struct st22_decoder_session* s,
   AVPacket* p = s->codec_pkt;
   int ret;
   size_t src_size = frame->src->data_size;
-  void* dst_addr = frame->dst->addr[0];
   size_t frame_size = 0;
 
   s->frame_idx++;
@@ -317,13 +312,10 @@ static int decode_frame(struct st22_decoder_session* s,
         f_idx);
     frame_size = f->width * f->height;
     /* only YUV422P now */
-    mtl_memcpy(dst_addr, f->data[0], frame_size);
-    dst_addr += frame_size;
+    mtl_memcpy(frame->dst->addr[0], f->data[0], frame_size);
     frame_size /= 2;
-    mtl_memcpy(dst_addr, f->data[1], frame_size);
-    dst_addr += frame_size;
-    mtl_memcpy(dst_addr, f->data[2], frame_size);
-    dst_addr += frame_size;
+    mtl_memcpy(frame->dst->addr[1], f->data[1], frame_size);
+    mtl_memcpy(frame->dst->addr[2], f->data[2], frame_size);
 
     av_frame_unref(f);
   }

--- a/plugins/st22_ffmpeg/st22_ffmpeg_plugin.h
+++ b/plugins/st22_ffmpeg/st22_ffmpeg_plugin.h
@@ -7,7 +7,7 @@
 
 #include <libavcodec/avcodec.h>
 #include <libavutil/opt.h>
-#include <st_pipeline_api.h>
+#include <mtl/st_pipeline_api.h>
 
 #define MAX_ST22_ENCODER_SESSIONS (8)
 #define MAX_ST22_DECODER_SESSIONS (8)

--- a/tests/src/st22p_test.cpp
+++ b/tests/src/st22p_test.cpp
@@ -420,6 +420,10 @@ static void frame_name_test() {
 
   result = strcmp(fail, st_frame_fmt_name(ST_FRAME_FMT_MAX));
   EXPECT_EQ(result, 0);
+
+  EXPECT_EQ(st_frame_name_to_fmt("YUV422PLANAR10LE"), ST_FRAME_FMT_YUV422PLANAR10LE);
+  EXPECT_EQ(st_frame_name_to_fmt("UYVY"), ST_FRAME_FMT_UYVY);
+  EXPECT_EQ(st_frame_name_to_fmt("UNKNOWN"), ST_FRAME_FMT_MAX);
 }
 
 TEST(St22p, frame_size) { frame_size_test(); }


### PR DESCRIPTION
./build/app/TxSt22PipelineSample --st22_codec h264_cbr --st22_fmt YUV422PLANAR8 --tx_url test_planar8.yuv

./build/app/RxSt22PipelineSample --st22_codec h264_cbr --st22_fmt YUV422PLANAR8 --rx_url out_planar8.yuv

Signed-off-by: Du, Frank <frank.du@intel.com>