### PR TITLE
dev/queue: use queue info handle for get/put api

### DIFF
--- a/lib/src/mt_arp.c
+++ b/lib/src/mt_arp.c
@@ -59,7 +59,7 @@ static int arp_receive_request(struct mtl_main_impl* impl, struct rte_arp_hdr* r
   /* send arp reply packet */
   uint16_t send = mt_dev_tx_sys_queue_burst(impl, port, &rpl_pkt, 1);
   if (send < 1) {
-    err_once("%s(%d), rte_eth_tx_burst fail\n", __func__, port);
+    err_once("%s(%d), tx fail\n", __func__, port);
     rte_pktmbuf_free(rpl_pkt);
   }
 
@@ -146,7 +146,7 @@ int mt_arp_cni_get_mac(struct mtl_main_impl* impl, struct rte_ether_addr* ea,
     rte_mbuf_refcnt_update(req_pkt, 1);
     tx = mt_dev_tx_sys_queue_burst(impl, port, &req_pkt, 1);
     if (tx < 1) {
-      err("%s, rte_eth_tx_burst fail\n", __func__);
+      err("%s, tx fail\n", __func__);
       rte_mbuf_refcnt_update(req_pkt, -1);
     }
 

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -30,19 +30,42 @@ int mt_dev_stop(struct mtl_main_impl* impl);
 int mt_dev_dst_ip_mac(struct mtl_main_impl* impl, uint8_t dip[MTL_IP_ADDR_LEN],
                       struct rte_ether_addr* ea, enum mtl_port port);
 
-int mt_dev_request_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
-                            uint16_t* queue_id, uint64_t bytes_per_sec);
-int mt_dev_request_rx_queue(struct mtl_main_impl* impl, enum mtl_port port,
-                            uint16_t* queue_id, struct mt_rx_flow* flow);
-int mt_dev_free_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
-                         uint16_t queue_id);
-int mt_dev_free_rx_queue(struct mtl_main_impl* impl, enum mtl_port port,
-                         uint16_t queue_id);
-int mt_dev_flush_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
-                          uint16_t queue_id, struct rte_mbuf* pad);
+struct mt_tx_queue* mt_dev_get_tx_queue(struct mtl_main_impl* impl, enum mtl_port port,
+                                        uint64_t bytes_per_sec);
+int mt_dev_put_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue);
+static inline uint16_t mt_dev_tx_queue_id(struct mt_tx_queue* queue) {
+  return queue->queue_id;
+}
+int mt_dev_flush_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue,
+                          struct rte_mbuf* pad);
+static inline uint16_t mt_dev_tx_burst(struct mt_tx_queue* queue,
+                                       struct rte_mbuf** tx_pkts, uint16_t nb_pkts) {
+  return rte_eth_tx_burst(queue->port_id, queue->queue_id, tx_pkts, nb_pkts);
+}
+static inline void mt_dev_tx_burst_busy(struct mt_tx_queue* queue,
+                                        struct rte_mbuf** tx_pkts, uint16_t nb_pkts) {
+  uint32_t sent = 0;
+
+  /* Send this vector with busy looping */
+  while (sent < nb_pkts) {
+    sent += mt_dev_tx_burst(queue, &tx_pkts[sent], nb_pkts - sent);
+  }
+}
 
 uint16_t mt_dev_tx_sys_queue_burst(struct mtl_main_impl* impl, enum mtl_port port,
                                    struct rte_mbuf** tx_pkts, uint16_t nb_pkts);
+
+struct mt_rx_queue* mt_dev_get_rx_queue(struct mtl_main_impl* impl, enum mtl_port port,
+                                        struct mt_rx_flow* flow);
+int mt_dev_put_rx_queue(struct mtl_main_impl* impl, struct mt_rx_queue* queue);
+static inline uint16_t mt_dev_rx_queue_id(struct mt_rx_queue* queue) {
+  return queue->queue_id;
+}
+static inline uint16_t mt_dev_rx_burst(struct mt_rx_queue* queue,
+                                       struct rte_mbuf** rx_pkts,
+                                       const uint16_t nb_pkts) {
+  return rte_eth_rx_burst(queue->port_id, queue->queue_id, rx_pkts, nb_pkts);
+}
 
 int mt_dev_if_init(struct mtl_main_impl* impl);
 int mt_dev_if_uinit(struct mtl_main_impl* impl);

--- a/lib/src/st2110/st_ancillary_transmitter.c
+++ b/lib/src/st2110/st_ancillary_transmitter.c
@@ -29,7 +29,7 @@ static int st_ancillary_trs_tasklet_stop(void* priv) {
 
   for (port = 0; port < mt_num_ports(impl); port++) {
     /* flush all the pkts in the tx ring desc */
-    mt_dev_flush_tx_queue(impl, port, mgr->queue_id[port], mt_get_pad(impl, port));
+    mt_dev_flush_tx_queue(impl, mgr->queue[port], mt_get_pad(impl, port));
     mt_ring_dequeue_clean(mgr->ring[port]);
     info("%s(%d), port %d, remaining entries %d\n", __func__, idx, port,
          rte_ring_count(mgr->ring[port]));
@@ -57,7 +57,7 @@ static int st_ancillary_trs_session_tasklet(struct mtl_main_impl* impl,
   /* check if any inflight pkts in transmitter */
   pkt = trs->inflight[port];
   if (pkt) {
-    n = rte_eth_tx_burst(mgr->port_id[port], mgr->queue_id[port], &pkt, 1);
+    n = mt_dev_tx_burst(mgr->queue[port], &pkt, 1);
     if (n >= 1) {
       trs->inflight[port] = NULL;
     } else {
@@ -76,7 +76,7 @@ static int st_ancillary_trs_session_tasklet(struct mtl_main_impl* impl,
       return MT_TASKLET_ALL_DONE; /* all done */
     }
 
-    n = rte_eth_tx_burst(mgr->port_id[port], mgr->queue_id[port], &pkt, 1);
+    n = mt_dev_tx_burst(mgr->queue[port], &pkt, 1);
     mgr->st40_stat_pkts_burst += n;
     if (n < 1) {
       trs->inflight[port] = pkt;

--- a/lib/src/st2110/st_audio_transmitter.c
+++ b/lib/src/st2110/st_audio_transmitter.c
@@ -29,7 +29,7 @@ static int st_audio_trs_tasklet_stop(void* priv) {
 
   for (port = 0; port < mt_num_ports(impl); port++) {
     /* flush all the pkts in the tx ring desc */
-    mt_dev_flush_tx_queue(impl, port, mgr->queue_id[port], mt_get_pad(impl, port));
+    mt_dev_flush_tx_queue(impl, mgr->queue[port], mt_get_pad(impl, port));
     mt_ring_dequeue_clean(mgr->ring[port]);
     info("%s(%d), port %d, remaining entries %d\n", __func__, idx, port,
          rte_ring_count(mgr->ring[port]));
@@ -57,7 +57,7 @@ static int st_audio_trs_session_tasklet(struct mtl_main_impl* impl,
   /* check if any inflight pkts in transmitter */
   pkt = trs->inflight[port];
   if (pkt) {
-    n = rte_eth_tx_burst(mgr->port_id[port], mgr->queue_id[port], &pkt, 1);
+    n = mt_dev_tx_burst(mgr->queue[port], &pkt, 1);
     if (n >= 1) {
       trs->inflight[port] = NULL;
     } else {
@@ -75,7 +75,7 @@ static int st_audio_trs_session_tasklet(struct mtl_main_impl* impl,
       return MT_TASKLET_ALL_DONE; /* all done */
     }
 
-    n = rte_eth_tx_burst(mgr->port_id[port], mgr->queue_id[port], &pkt, 1);
+    n = mt_dev_tx_burst(mgr->queue[port], &pkt, 1);
     mgr->st30_stat_pkts_burst += n;
     if (n < 1) {
       trs->inflight[port] = pkt;

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -273,8 +273,7 @@ struct st_tx_video_session_impl {
   struct rte_ring* ring[ST_SESSION_PORT_MAX];
   struct rte_ring* packet_ring; /* rtp ring */
   uint16_t port_id[ST_SESSION_PORT_MAX];
-  uint16_t queue_id[ST_SESSION_PORT_MAX];
-  uint16_t queue_active[ST_SESSION_PORT_MAX];
+  struct mt_tx_queue* queue[ST_SESSION_PORT_MAX];
   int idx; /* index for current tx_session */
   uint64_t advice_sleep_us;
 
@@ -579,8 +578,7 @@ struct st_rx_video_session_impl {
   uint64_t advice_sleep_us;
 
   enum mtl_port port_maps[ST_SESSION_PORT_MAX];
-  uint16_t queue_id[ST_SESSION_PORT_MAX]; /* queue id for the session */
-  bool queue_active[ST_SESSION_PORT_MAX];
+  struct mt_rx_queue* queue[ST_SESSION_PORT_MAX];
   uint16_t port_id[ST_SESSION_PORT_MAX];
   uint16_t st20_src_port[ST_SESSION_PORT_MAX]; /* udp port */
   uint16_t st20_dst_port[ST_SESSION_PORT_MAX]; /* udp port */
@@ -769,8 +767,7 @@ struct st_tx_audio_sessions_mgr {
   /* all audio sessions share same ring/queue */
   struct rte_ring* ring[MTL_PORT_MAX];
   uint16_t port_id[MTL_PORT_MAX];
-  uint16_t queue_id[MTL_PORT_MAX];
-  uint16_t queue_active[MTL_PORT_MAX];
+  struct mt_tx_queue* queue[MTL_PORT_MAX];
 
   struct st_tx_audio_session_impl* sessions[ST_MAX_TX_AUDIO_SESSIONS];
   /* protect session, spin(fast) lock as it call from tasklet aslo */
@@ -838,8 +835,7 @@ struct st_rx_audio_session_impl {
   char ops_name[ST_MAX_NAME_LEN];
 
   enum mtl_port port_maps[ST_SESSION_PORT_MAX];
-  uint16_t queue_id[ST_SESSION_PORT_MAX]; /* queue id for the session */
-  bool queue_active[ST_SESSION_PORT_MAX];
+  struct mt_rx_queue* queue[ST_SESSION_PORT_MAX];
   uint16_t port_id[ST_SESSION_PORT_MAX];
 
   uint16_t st30_src_port[ST_SESSION_PORT_MAX]; /* udp port */
@@ -956,8 +952,7 @@ struct st_tx_ancillary_sessions_mgr {
   /* all anc sessions share same ring/queue */
   struct rte_ring* ring[MTL_PORT_MAX];
   uint16_t port_id[MTL_PORT_MAX];
-  uint16_t queue_id[MTL_PORT_MAX];
-  uint16_t queue_active[MTL_PORT_MAX];
+  struct mt_tx_queue* queue[MTL_PORT_MAX];
 
   struct st_tx_ancillary_session_impl* sessions[ST_MAX_TX_ANC_SESSIONS];
   /* protect session, spin(fast) lock as it call from tasklet aslo */
@@ -977,8 +972,7 @@ struct st_rx_ancillary_session_impl {
   char ops_name[ST_MAX_NAME_LEN];
 
   enum mtl_port port_maps[ST_SESSION_PORT_MAX];
-  uint16_t queue_id[ST_SESSION_PORT_MAX]; /* queue id for the session */
-  bool queue_active[ST_SESSION_PORT_MAX];
+  struct mt_rx_queue* queue[ST_SESSION_PORT_MAX];
   uint16_t port_id[ST_SESSION_PORT_MAX];
   struct rte_ring* packet_ring;
 

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -503,9 +503,8 @@ static int rx_audio_session_tasklet(struct mtl_main_impl* impl,
   bool done = true;
 
   for (int s_port = 0; s_port < num_port; s_port++) {
-    if (!s->queue_active[s_port]) continue;
-    rv = rte_eth_rx_burst(s->port_id[s_port], s->queue_id[s_port], &mbuf[0],
-                          ST_RX_AUDIO_BURTS_SIZE);
+    if (!s->queue[s_port]) continue;
+    rv = mt_dev_rx_burst(s->queue[s_port], &mbuf[0], ST_RX_AUDIO_BURTS_SIZE);
     if (rv > 0) {
       if (ST30_TYPE_FRAME_LEVEL == st30_type) {
         for (uint16_t i = 0; i < rv; i++)
@@ -551,14 +550,11 @@ static int rx_audio_sessions_tasklet_handler(void* priv) {
 static int rx_audio_session_uinit_hw(struct mtl_main_impl* impl,
                                      struct st_rx_audio_session_impl* s) {
   int num_port = s->ops.num_port;
-  enum mtl_port port;
 
   for (int i = 0; i < num_port; i++) {
-    port = mt_port_logic2phy(s->port_maps, i);
-
-    if (s->queue_active[i]) {
-      mt_dev_free_rx_queue(impl, port, s->queue_id[i]);
-      s->queue_active[i] = false;
+    if (s->queue[i]) {
+      mt_dev_put_rx_queue(impl, s->queue[i]);
+      s->queue[i] = NULL;
     }
   }
 
@@ -568,13 +564,12 @@ static int rx_audio_session_uinit_hw(struct mtl_main_impl* impl,
 static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
                                     struct st_rx_audio_session_impl* s) {
   int idx = s->idx, num_port = s->ops.num_port;
-  int ret;
-  uint16_t queue;
   struct mt_rx_flow flow;
   enum mtl_port port;
 
   for (int i = 0; i < num_port; i++) {
     port = mt_port_logic2phy(s->port_maps, i);
+    s->port_id[i] = mt_port_id(impl, port);
 
     memset(&flow, 0, sizeof(flow));
     rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
@@ -584,19 +579,16 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST30_RX_FLAG_DATA_PATH_ONLY))
-      ret = mt_dev_request_rx_queue(impl, port, &queue, NULL);
+      s->queue[i] = mt_dev_get_rx_queue(impl, port, NULL);
     else
-      ret = mt_dev_request_rx_queue(impl, port, &queue, &flow);
-    if (ret < 0) {
+      s->queue[i] = mt_dev_get_rx_queue(impl, port, &flow);
+    if (!s->queue[i]) {
       rx_audio_session_uinit_hw(impl, s);
-      return ret;
+      return -EIO;
     }
 
-    s->port_id[i] = mt_port_id(impl, port);
-    s->queue_id[i] = queue;
-    s->queue_active[i] = true;
-    info("%s(%d), port(l:%d,p:%d), queue %d udp %d\n", __func__, idx, i, port, queue,
-         flow.dst_port);
+    info("%s(%d), port(l:%d,p:%d), queue %d udp %d\n", __func__, idx, i, port,
+         mt_dev_rx_queue_id(s->queue[i]), flow.dst_port);
   }
 
   return 0;
@@ -1243,7 +1235,7 @@ int st30_rx_get_queue_meta(st30_rx_handle handle, struct st_queue_meta* meta) {
       /* af_xdp pmd */
       meta->start_queue[i] = mt_start_queue(impl, port);
     }
-    meta->queue_id[i] = s->queue_id[i];
+    meta->queue_id[i] = mt_dev_rx_queue_id(s->queue[i]);
   }
 
   return 0;

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -746,9 +746,9 @@ static int tx_audio_sessions_mgr_uinit_hw(struct mtl_main_impl* impl,
       rte_ring_free(mgr->ring[i]);
       mgr->ring[i] = NULL;
     }
-    if (mgr->queue_active[i]) {
-      mt_dev_free_tx_queue(impl, i, mgr->queue_id[i]);
-      mgr->queue_active[i] = false;
+    if (mgr->queue[i]) {
+      mt_dev_put_tx_queue(impl, mgr->queue[i]);
+      mgr->queue[i] = NULL;
     }
   }
 
@@ -762,19 +762,15 @@ static int tx_audio_sessions_mgr_init_hw(struct mtl_main_impl* impl,
   struct rte_ring* ring;
   char ring_name[32];
   int mgr_idx = mgr->idx;
-  int ret;
-  uint16_t queue = 0;
 
   for (int i = 0; i < mt_num_ports(impl); i++) {
-    /* do we need quota for audio? */
-    ret = mt_dev_request_tx_queue(impl, i, &queue, 0);
-    if (ret < 0) {
-      tx_audio_sessions_mgr_uinit_hw(impl, mgr);
-      return ret;
-    }
-    mgr->queue_id[i] = queue;
-    mgr->queue_active[i] = true;
     mgr->port_id[i] = mt_port_id(impl, i);
+    /* do we need quota for audio? */
+    mgr->queue[i] = mt_dev_get_tx_queue(impl, i, 0);
+    if (!mgr->queue[i]) {
+      tx_audio_sessions_mgr_uinit_hw(impl, mgr);
+      return -EIO;
+    }
 
     snprintf(ring_name, 32, "TX-AUDIO-RING-M%d-P%d", mgr_idx, i);
     flags = RING_F_MP_HTS_ENQ | RING_F_SC_DEQ; /* multi-producer and single-consumer */
@@ -786,7 +782,8 @@ static int tx_audio_sessions_mgr_init_hw(struct mtl_main_impl* impl,
       return -ENOMEM;
     }
     mgr->ring[i] = ring;
-    info("%s(%d,%d), succ, queue %d\n", __func__, mgr_idx, i, queue);
+    info("%s(%d,%d), succ, queue %d\n", __func__, mgr_idx, i,
+         mt_dev_tx_queue_id(mgr->queue[i]));
   }
 
   return 0;


### PR DESCRIPTION
queue user should not direct use the queue id and tx/rx burst function.

Signed-off-by: Du, Frank <frank.du@intel.com>