### PR TITLE
asan: print backtrace info of rte_malloc leaks

### DIFF
--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -369,6 +369,10 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
   int num_ports = p->num_ports;
   struct mt_kport_info kport_info;
 
+#ifdef MTL_HAS_ASAN
+  mt_asan_init();
+#endif
+
   RTE_BUILD_BUG_ON(MT_SESSION_PORT_MAX > (int)MTL_PORT_MAX);
   RTE_BUILD_BUG_ON(sizeof(struct mt_udp_hdr) != 42);
 

--- a/lib/src/mt_mem.h
+++ b/lib/src/mt_mem.h
@@ -21,6 +21,7 @@ static inline void* mt_zmalloc(size_t sz) {
 static inline void mt_free(void* p) { free(p); }
 
 #ifdef MTL_HAS_ASAN
+int mt_asan_init(void);
 int mt_asan_check(void);
 void* mt_rte_malloc_socket(size_t sz, int socket);
 void* mt_rte_zmalloc_socket(size_t sz, int socket);

--- a/lib/src/mt_stat.c
+++ b/lib/src/mt_stat.c
@@ -4,7 +4,7 @@
 
 #include "mt_stat.h"
 
-//#define DEBUG
+// #define DEBUG
 #include "mt_log.h"
 
 static inline struct mt_stat_mgr* get_stat_mgr(struct mtl_main_impl* impl) {
@@ -42,10 +42,11 @@ int mt_stat_register(struct mtl_main_impl* impl, mt_stat_cb_t cb, void* priv) {
 
 int mt_stat_unregister(struct mtl_main_impl* impl, mt_stat_cb_t cb, void* priv) {
   struct mt_stat_mgr* mgr = get_stat_mgr(impl);
-  struct mt_stat_item* item;
+  struct mt_stat_item *item, *tmp_item;
 
   mt_pthread_mutex_lock(&mgr->mutex);
-  MT_TAILQ_FOREACH(item, &mgr->head, next) {
+  for (item = MT_TAILQ_FIRST(&mgr->head); item != NULL; item = tmp_item) {
+    tmp_item = MT_TAILQ_NEXT(item, next);
     if ((item->cb_func == cb && item->cb_priv == priv)) {
       /* found the matched item, remove it */
       MT_TAILQ_REMOVE(&mgr->head, item, next);
@@ -75,7 +76,7 @@ int mt_stat_uinit(struct mtl_main_impl* impl) {
   struct mt_stat_item* item;
 
   /* check if any not unregister */
-  MT_TAILQ_FOREACH(item, &mgr->head, next) {
+  while ((item = MT_TAILQ_FIRST(&mgr->head))) {
     warn("%s, %p not unregister\n", __func__, item->cb_priv);
     MT_TAILQ_REMOVE(&mgr->head, item, next);
     mt_free(item);

--- a/tests/src/st30_test.cpp
+++ b/tests/src/st30_test.cpp
@@ -380,7 +380,7 @@ static void st30_tx_fps_test(enum st30_type type[], enum st30_sampling sample[],
     EXPECT_NEAR(framerate[i], expect_framerate, expect_framerate * 0.1);
     ret = st30_tx_free(handle[i]);
     EXPECT_GE(ret, 0);
-    st_test_free(test_ctx[i]);
+    delete test_ctx[i];
   }
 }
 


### PR DESCRIPTION
for example:

MT: mt_asan_check, leak of 128 byte(s) at 0x7f1f2d62c500
MT: mt_asan_check, backtrace info:
MT: mt_asan_check, /lib/x86_64-linux-gnu/libasan.so.6(+0x45c0e) [0x7f43d78dcc0e]
MT: mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(mt_rte_zmalloc_socket+0x18d) [0x7f43d755cc91]
MT: mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(mt_sch_register_tasklet+0x112) [0x7f43d74e912a]
MT: mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(st_video_transmitter_init+0x2e2) [0x7f43d7616bb4]
MT: mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(st_tx_video_sessions_sch_init+0x12d) [0x7f43d76041f6]
MT: mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(+0x140641) [0x7f43d757b641]
MT: mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(+0x1412a2) [0x7f43d757c2a2]
MT: mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(+0x1414b7) [0x7f43d757c4b7]
MT: mt_asan_check, /lib/x86_64-linux-gnu/libc.so.6(+0x94b43) [0x7f43d6fabb43]
MT: mt_asan_check, /lib/x86_64-linux-gnu/libc.so.6(+0x126a00) [0x7f43d703da00]
MT: mt_asan_check, found 8 mem leak(s) in total
MT: mtl_uninit, succ

also refine tailq usage, REMOVE is not safe in FOREACH