### PR TITLE
build: fix windows build with nfds_t

### DIFF
--- a/app/src/app_platform.h
+++ b/app/src/app_platform.h
@@ -46,6 +46,10 @@
 #define POLLIN 0x001
 #endif
 
+#ifdef WINDOWSENV
+typedef unsigned long int nfds_t;
+#endif
+
 enum st_tx_frame_status {
   ST_TX_FRAME_FREE = 0,
   ST_TX_FRAME_READY,


### PR DESCRIPTION
declare nfds_t for windows.
typedef unsigned long int nfds_t;

Signed-off-by: Frank Du <frank.du@intel.com>