### PR TITLE
udp: support mac address by user

### DIFF
--- a/app/sample/sample_util.h
+++ b/app/sample/sample_util.h
@@ -73,6 +73,8 @@ struct st_sample_context {
   uint8_t fwd_dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN]; /* fwd destination IP */
   char tx_url[ST_SAMPLE_URL_MAX_LEN];
   char rx_url[ST_SAMPLE_URL_MAX_LEN];
+  bool has_tx_dst_mac[MTL_PORT_MAX];
+  uint8_t tx_dst_mac[MTL_PORT_MAX][MTL_MAC_ADDR_LEN];
 
   uint32_t width;
   uint32_t height;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -182,35 +182,20 @@ static int app_args_parse_lcores(struct mtl_init_params* p, char* list) {
   return 0;
 }
 
-static int app_args_parse_p_tx_mac(struct st_app_context* ctx, char* mac_str) {
+static int app_args_parse_tx_mac(struct st_app_context* ctx, char* mac_str,
+                                 enum mtl_port port) {
   int ret;
   uint8_t* mac;
 
   if (!mac_str) return -EIO;
   dbg("%s, tx dst mac %s\n", __func__, mac_str);
 
-  mac = &ctx->tx_dst_mac[MTL_PORT_P][0];
+  mac = &ctx->tx_dst_mac[port][0];
   ret = sscanf(mac_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &mac[0], &mac[1],
                &mac[2], &mac[3], &mac[4], &mac[5]);
   if (ret < 0) return ret;
 
-  ctx->has_tx_dst_mac[MTL_PORT_P] = true;
-  return 0;
-}
-
-static int app_args_parse_r_tx_mac(struct st_app_context* ctx, char* mac_str) {
-  int ret;
-  uint8_t* mac;
-
-  if (!mac_str) return -EIO;
-  dbg("%s, tx dst mac %s\n", __func__, mac_str);
-
-  mac = &ctx->tx_dst_mac[MTL_PORT_R][0];
-  ret = sscanf(mac_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &mac[0], &mac[1],
-               &mac[2], &mac[3], &mac[4], &mac[5]);
-  if (ret < 0) return ret;
-
-  ctx->has_tx_dst_mac[MTL_PORT_R] = true;
+  ctx->has_tx_dst_mac[port] = true;
   return 0;
 }
 
@@ -429,10 +414,10 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         }
         break;
       case ST_ARG_P_TX_DST_MAC:
-        app_args_parse_p_tx_mac(ctx, optarg);
+        app_args_parse_tx_mac(ctx, optarg, MTL_PORT_P);
         break;
       case ST_ARG_R_TX_DST_MAC:
-        app_args_parse_r_tx_mac(ctx, optarg);
+        app_args_parse_tx_mac(ctx, optarg, MTL_PORT_R);
         break;
       case ST_ARG_NIC_RX_PROMISCUOUS:
         p->flags |= MTL_FLAG_NIC_RX_PROMISCUOUS;

--- a/app/udp/udp_client_sample.c
+++ b/app/udp/udp_client_sample.c
@@ -178,6 +178,8 @@ int main(int argc, char** argv) {
       goto error;
     }
     if (ctx.udp_tx_bps) mudp_set_tx_rate(app[i]->socket, ctx.udp_tx_bps);
+    if (ctx.has_tx_dst_mac[MTL_PORT_P])
+      mudp_set_tx_mac(app[i]->socket, ctx.tx_dst_mac[MTL_PORT_P]);
 
     struct timeval tv;
     tv.tv_sec = 0;

--- a/app/udp/udp_server_sample.c
+++ b/app/udp/udp_server_sample.c
@@ -235,6 +235,8 @@ int main(int argc, char** argv) {
       goto error;
     }
     if (ctx.udp_tx_bps) mudp_set_tx_rate(app[i]->socket, ctx.udp_tx_bps);
+    if (ctx.has_tx_dst_mac[MTL_PORT_P])
+      mudp_set_tx_mac(app[i]->socket, ctx.tx_dst_mac[MTL_PORT_P]);
     mudp_init_sockaddr(&app[i]->client_addr, ctx.rx_sip_addr[MTL_PORT_P],
                        ctx.udp_port + i);
     bool mcast = mudp_is_multicast(&app[i]->client_addr);

--- a/app/udp/ufd_client_sample.c
+++ b/app/udp/ufd_client_sample.c
@@ -181,6 +181,8 @@ int main(int argc, char** argv) {
       goto error;
     }
     if (ctx.udp_tx_bps) mufd_set_tx_rate(app[i]->socket, ctx.udp_tx_bps);
+    if (ctx.has_tx_dst_mac[MTL_PORT_P])
+      mufd_set_tx_mac(app[i]->socket, ctx.tx_dst_mac[MTL_PORT_P]);
 
     struct timeval tv;
     tv.tv_sec = 0;

--- a/app/udp/ufd_server_sample.c
+++ b/app/udp/ufd_server_sample.c
@@ -237,6 +237,8 @@ int main(int argc, char** argv) {
       goto error;
     }
     if (ctx.udp_tx_bps) mufd_set_tx_rate(app[i]->socket, ctx.udp_tx_bps);
+    if (ctx.has_tx_dst_mac[MTL_PORT_P])
+      mufd_set_tx_mac(app[i]->socket, ctx.tx_dst_mac[MTL_PORT_P]);
     mufd_init_sockaddr(&app[i]->client_addr, ctx.rx_sip_addr[MTL_PORT_P],
                        ctx.udp_port + i);
     bool mcast = mudp_is_multicast(&app[i]->client_addr);

--- a/include/mudp_api.h
+++ b/include/mudp_api.h
@@ -192,6 +192,20 @@ int mudp_setsockopt(mudp_handle ut, int level, int optname, const void* optval,
                     socklen_t optlen);
 
 /**
+ * Set the tx dst mac for the udp transport socket. MTL focus on data plane and only has
+ * ARP support. For the WAN transport, user can use this API to mannual set the dst mac.
+ *
+ * @param ut
+ *   The handle to udp transport socket.
+ * @param mac
+ *   The mac address.
+ * @return
+ *   - 0: Success.
+ *   - <0: Error code.
+ */
+int mudp_set_tx_mac(mudp_handle ut, uint8_t mac[MTL_MAC_ADDR_LEN]);
+
+/**
  * Set the rate(speed) for one udp transport socket. Call before mudp_bind.
  *
  * @param ut

--- a/include/mudp_sockfd_api.h
+++ b/include/mudp_sockfd_api.h
@@ -206,6 +206,20 @@ int mufd_cleanup(void);
 int mufd_abort(void);
 
 /**
+ * Set the tx dst mac for the udp transport socket. MTL focus on data plane and only has
+ * ARP support. For the WAN transport, user can use this API to mannual set the dst mac.
+ *
+ * @param sockfd
+ *   The handle to udp transport socket.
+ * @param mac
+ *   The mac address.
+ * @return
+ *   - 0: Success.
+ *   - <0: Error code.
+ */
+int mufd_set_tx_mac(int sockfd, uint8_t mac[MTL_MAC_ADDR_LEN]);
+
+/**
  * Set the rate(speed) for one udp transport socket. Call before mudp_bind.
  *
  * @param sockfd

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -127,10 +127,10 @@ static int tx_ancillary_session_init_hdr(struct mtl_main_impl* impl,
 
   /* ether hdr */
   if ((s_port == MT_SESSION_PORT_P) && (ops->flags & ST40_TX_FLAG_USER_P_MAC)) {
-    rte_memcpy(d_addr, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
+    rte_memcpy(d_addr->addr_bytes, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
     info("%s, USER_P_TX_MAC\n", __func__);
   } else if ((s_port == MT_SESSION_PORT_R) && (ops->flags & ST40_TX_FLAG_USER_R_MAC)) {
-    rte_memcpy(d_addr, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
+    rte_memcpy(d_addr->addr_bytes, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
     info("%s, USER_R_TX_MAC\n", __func__);
   } else {
     ret = mt_dev_dst_ip_mac(impl, dip, d_addr, port, 0);

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -126,10 +126,10 @@ static int tx_audio_session_init_hdr(struct mtl_main_impl* impl,
 
   /* ether hdr */
   if ((s_port == MT_SESSION_PORT_P) && (ops->flags & ST30_TX_FLAG_USER_P_MAC)) {
-    rte_memcpy(d_addr, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
+    rte_memcpy(d_addr->addr_bytes, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
     info("%s, USER_P_TX_MAC\n", __func__);
   } else if ((s_port == MT_SESSION_PORT_R) && (ops->flags & ST30_TX_FLAG_USER_R_MAC)) {
-    rte_memcpy(d_addr, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
+    rte_memcpy(d_addr->addr_bytes, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
     info("%s, USER_R_TX_MAC\n", __func__);
   } else {
     ret = mt_dev_dst_ip_mac(impl, dip, d_addr, port, 0);

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -516,10 +516,10 @@ static int tv_init_hdr(struct mtl_main_impl* impl, struct st_tx_video_session_im
 
   /* ether hdr */
   if ((s_port == MT_SESSION_PORT_P) && (ops->flags & ST20_TX_FLAG_USER_P_MAC)) {
-    rte_memcpy(d_addr, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
+    rte_memcpy(d_addr->addr_bytes, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
     info("%s, USER_P_TX_MAC\n", __func__);
   } else if ((s_port == MT_SESSION_PORT_R) && (ops->flags & ST20_TX_FLAG_USER_R_MAC)) {
-    rte_memcpy(d_addr, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
+    rte_memcpy(d_addr->addr_bytes, &ops->tx_dst_mac[s_port][0], RTE_ETHER_ADDR_LEN);
     info("%s, USER_R_TX_MAC\n", __func__);
   } else {
     ret = mt_dev_dst_ip_mac(impl, dip, d_addr, port, 0);

--- a/lib/src/udp/udp_main.h
+++ b/lib/src/udp/udp_main.h
@@ -19,6 +19,8 @@
 #define MUDP_RXQ_ALLOC (MTL_BIT32(2))
 /* if mcast init or not */
 #define MUDP_MCAST_INIT (MTL_BIT32(3))
+/* if tx mac is defined by user */
+#define MUDP_TX_USER_MAC (MTL_BIT32(4))
 
 /* 1g */
 #define MUDP_DEFAULT_RL_BPS (1ul * 1024 * 1024 * 1024)
@@ -49,6 +51,7 @@ struct mudp_impl {
   int arp_timeout_ms;
   int tx_timeout_ms;
   int rx_timeout_ms;
+  uint8_t user_mac[MTL_MAC_ADDR_LEN];
 
   uint32_t* mcast_addrs;
   int mcast_addrs_nb;

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -473,6 +473,11 @@ int mufd_abort(void) {
   return 0;
 }
 
+int mufd_set_tx_mac(int sockfd, uint8_t mac[MTL_MAC_ADDR_LEN]) {
+  struct ufd_slot* slot = ufd_fd2slot(sockfd);
+  return mudp_set_tx_mac(slot->handle, mac);
+}
+
 int mufd_set_tx_rate(int sockfd, uint64_t bps) {
   struct ufd_slot* slot = ufd_fd2slot(sockfd);
   return mudp_set_tx_rate(slot->handle, bps);


### PR DESCRIPTION
use mudp_set_tx_mac/mufd_set_tx_mac

udp test:
./build/app/UdpClientSample --p_tx_dst_mac 42:c7:17:08:92:29 ./build/app/UdpServerSample --p_tx_dst_mac 0e:48:fa:3d:55:83

ufd test:
MUFD_CFG=app/udp/ufd_client.json ./build/app/UfdClientSample --p_tx_dst_mac 42:c7:17:08:92:29
MUFD_CFG=app/udp/ufd_server.json ./build/app/UfdServerSample --p_tx_dst_mac 0e:48:fa:3d:55:83

Signed-off-by: Frank Du <frank.du@intel.com>