### PR TITLE
api: add netmask support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Change log for 23.03:
+* mtl_init_params: add gateway and netmask support for wan.
 
 ## Change log for 22.12:
 * tasklet: add thread and sleep option for core usage, see ST_FLAG_TASKLET_THREAD and ST_FLAG_TASKLET_SLEEP.

--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -26,6 +26,8 @@ enum sample_args_cmd {
   SAMPLE_ARG_QUEUES_CNT,
   SAMPLE_ARG_P_TX_DST_MAC,
   SAMPLE_ARG_R_TX_DST_MAC,
+  SAMPLE_ARG_P_NETMASK,
+  SAMPLE_ARG_R_NETMASK,
 
   SAMPLE_ARG_TX_VIDEO_URL = 0x200,
   SAMPLE_ARG_RX_VIDEO_URL,
@@ -62,6 +64,8 @@ static struct option sample_args_options[] = {
     {"queues_cnt", required_argument, 0, SAMPLE_ARG_QUEUES_CNT},
     {"p_tx_dst_mac", required_argument, 0, SAMPLE_ARG_P_TX_DST_MAC},
     {"r_tx_dst_mac", required_argument, 0, SAMPLE_ARG_R_TX_DST_MAC},
+    {"p_netmask", required_argument, 0, SAMPLE_ARG_P_NETMASK},
+    {"r_netmask", required_argument, 0, SAMPLE_ARG_R_NETMASK},
 
     {"tx_url", required_argument, 0, SAMPLE_ARG_TX_VIDEO_URL},
     {"rx_url", required_argument, 0, SAMPLE_ARG_RX_VIDEO_URL},
@@ -137,6 +141,12 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         break;
       case SAMPLE_ARG_P_FWD_IP:
         inet_pton(AF_INET, optarg, ctx->fwd_dip_addr[MTL_PORT_P]);
+        break;
+      case SAMPLE_ARG_P_NETMASK:
+        inet_pton(AF_INET, optarg, p->netmask[MTL_PORT_P]);
+        break;
+      case SAMPLE_ARG_R_NETMASK:
+        inet_pton(AF_INET, optarg, p->netmask[MTL_PORT_R]);
         break;
       case SAMPLE_ARG_LOG_LEVEL:
         if (!strcmp(optarg, "debug"))

--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -28,6 +28,8 @@ enum sample_args_cmd {
   SAMPLE_ARG_R_TX_DST_MAC,
   SAMPLE_ARG_P_NETMASK,
   SAMPLE_ARG_R_NETMASK,
+  SAMPLE_ARG_P_GATEWAY,
+  SAMPLE_ARG_R_GATEWAY,
 
   SAMPLE_ARG_TX_VIDEO_URL = 0x200,
   SAMPLE_ARG_RX_VIDEO_URL,
@@ -66,6 +68,8 @@ static struct option sample_args_options[] = {
     {"r_tx_dst_mac", required_argument, 0, SAMPLE_ARG_R_TX_DST_MAC},
     {"p_netmask", required_argument, 0, SAMPLE_ARG_P_NETMASK},
     {"r_netmask", required_argument, 0, SAMPLE_ARG_R_NETMASK},
+    {"p_gateway", required_argument, 0, SAMPLE_ARG_P_GATEWAY},
+    {"r_gateway", required_argument, 0, SAMPLE_ARG_R_GATEWAY},
 
     {"tx_url", required_argument, 0, SAMPLE_ARG_TX_VIDEO_URL},
     {"rx_url", required_argument, 0, SAMPLE_ARG_RX_VIDEO_URL},
@@ -147,6 +151,12 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         break;
       case SAMPLE_ARG_R_NETMASK:
         inet_pton(AF_INET, optarg, p->netmask[MTL_PORT_R]);
+        break;
+      case SAMPLE_ARG_P_GATEWAY:
+        inet_pton(AF_INET, optarg, p->gateway[MTL_PORT_P]);
+        break;
+      case SAMPLE_ARG_R_GATEWAY:
+        inet_pton(AF_INET, optarg, p->gateway[MTL_PORT_R]);
         break;
       case SAMPLE_ARG_LOG_LEVEL:
         if (!strcmp(optarg, "debug"))

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -338,6 +338,13 @@ struct mtl_init_params {
    */
   uint8_t netmask[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
   /**
+   * gateway of ports, mandatory if need wan support.
+   * User can use "route -n" to get gateway before bind the port to DPDK PMD.
+   * For MTL_PMD_DPDK_AF_XDP, lib will try to fetch gateway by route command
+   * if this value is not assigned.
+   */
+  uint8_t gateway[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  /**
    * mandatory for MTL_TRANSPORT_ST2110.
    * max tx sessions(st20, st22, st30, st40) requested the lib to support,
    * use mtl_get_cap to query the actual count.

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -322,16 +322,21 @@ struct mtl_af_xdp_params {
  */
 struct mtl_init_params {
   /* below are mandatory parameters */
-  /** Pcie BDF(ex: 0000:af:00.0) or enp175s0f0(AF_XDP) */
+  /** Pcie BDF(ex: 0000:af:00.0) or enp175s0f0(MTL_PMD_DPDK_AF_XDP) */
   char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
   /** number of pcie ports, 1 or 2, mandatory */
   uint8_t num_ports;
-  /** source IP of ports, olny for MTL_PMD_DPDK_AF_XDP */
+  /** source IP of ports, for MTL_PMD_DPDK_USER */
   uint8_t sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
 
   /* below are optional parameters */
   /** transport type, st2110 or udp */
   enum mtl_transport_type transport;
+  /**
+   * net mask of ports, for MTL_PMD_DPDK_USER.
+   * Lib will use 255.255.255.0 if this value is blank
+   */
+  uint8_t netmask[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
   /**
    * mandatory for MTL_TRANSPORT_ST2110.
    * max tx sessions(st20, st22, st30, st40) requested the lib to support,
@@ -1023,7 +1028,8 @@ enum mtl_pmd_type mtl_pmd_by_port_name(const char* port);
  *   - 0: Success.
  *   - <0: Error code.
  */
-int mtl_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN]);
+int mtl_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
+                  uint8_t netmask[MTL_IP_ADDR_LEN]);
 
 /**
  * Helper function which align a size with pages

--- a/lib/src/mt_arp.c
+++ b/lib/src/mt_arp.c
@@ -91,7 +91,10 @@ static int arp_receive_reply(struct mtl_main_impl* impl, struct rte_arp_hdr* rep
   }
 
   uint8_t* ip = (uint8_t*)&reply->arp_data.arp_sip;
-  info_once("%s(%d), from %d.%d.%d.%d\n", __func__, port, ip[0], ip[1], ip[2], ip[3]);
+  uint8_t* addr_bytes = reply->arp_data.arp_sha.addr_bytes;
+  info_once("%s(%d), from %d.%d.%d.%d, mac: %02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx\n",
+            __func__, port, ip[0], ip[1], ip[2], ip[3], addr_bytes[0], addr_bytes[1],
+            addr_bytes[2], addr_bytes[3], addr_bytes[4], addr_bytes[5]);
 
   struct mt_arp_impl* arp_impl = get_arp(impl, port);
 

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -459,6 +459,7 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
     if (p->pmd[i] != MTL_PMD_DPDK_USER) {
       uint8_t if_ip[MTL_IP_ADDR_LEN];
       uint8_t if_netmask[MTL_IP_ADDR_LEN];
+      uint8_t if_gateway[MTL_IP_ADDR_LEN];
       ret = mt_socket_get_if_ip(impl->user_para.port[i], if_ip, if_netmask);
       if (ret < 0) {
         err("%s(%d), get IP fail\n", __func__, i);
@@ -467,6 +468,14 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
       /* update the sip and net mask */
       rte_memcpy(impl->user_para.sip_addr[i], if_ip, MTL_IP_ADDR_LEN);
       rte_memcpy(impl->user_para.netmask[i], if_netmask, MTL_IP_ADDR_LEN);
+      if (!mt_ip_to_u32(impl->user_para.gateway[i])) {
+        /* try to fetch gateway */
+        ret = mt_socket_get_if_gateway(impl->user_para.port[i], if_gateway);
+        if (ret >= 0) {
+          info("%s(%d), get gateway succ from if\n", __func__, i);
+          rte_memcpy(impl->user_para.gateway[i], if_gateway, MTL_IP_ADDR_LEN);
+        }
+      }
     } else { /* MTL_PMD_DPDK_USER */
       uint32_t netmask = mt_ip_to_u32(impl->user_para.netmask[i]);
       if (!netmask) { /* set to default if user not set a netmask */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -545,7 +545,7 @@ struct mt_admin {
 };
 
 struct mt_kport_info {
-  /* dpdk port name for kernel port */
+  /* dpdk port name for kernel port(MTL_PMD_DPDK_AF_XDP) */
   char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
 };
 
@@ -843,6 +843,10 @@ enum mtl_port mt_port_by_id(struct mtl_main_impl* impl, uint16_t port_id);
 
 static inline uint8_t* mt_sip_addr(struct mtl_main_impl* impl, enum mtl_port port) {
   return mt_get_user_params(impl)->sip_addr[port];
+}
+
+static inline uint8_t* mt_sip_netmask(struct mtl_main_impl* impl, enum mtl_port port) {
+  return mt_get_user_params(impl)->netmask[port];
 }
 
 static inline enum mtl_pmd_type mt_pmd_type(struct mtl_main_impl* impl,

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -849,6 +849,10 @@ static inline uint8_t* mt_sip_netmask(struct mtl_main_impl* impl, enum mtl_port 
   return mt_get_user_params(impl)->netmask[port];
 }
 
+static inline uint8_t* mt_sip_gatway(struct mtl_main_impl* impl, enum mtl_port port) {
+  return mt_get_user_params(impl)->gateway[port];
+}
+
 static inline enum mtl_pmd_type mt_pmd_type(struct mtl_main_impl* impl,
                                             enum mtl_port port) {
   return mt_get_user_params(impl)->pmd[port];

--- a/lib/src/mt_socket.c
+++ b/lib/src/mt_socket.c
@@ -59,7 +59,7 @@ int mt_socket_get_if_gateway(char* if_name, uint8_t gateway[MTL_IP_ADDR_LEN]) {
     return ret;
   }
 
-  info("%s, cmd %s out %s\n", __func__, cmd, out);
+  dbg("%s, cmd %s out %s\n", __func__, cmd, out);
   gateway[0] = a;
   gateway[1] = b;
   gateway[2] = c;

--- a/lib/src/mt_socket.c
+++ b/lib/src/mt_socket.c
@@ -43,6 +43,30 @@ int mt_socket_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
   return 0;
 }
 
+int mt_socket_get_if_gateway(char* if_name, uint8_t gateway[MTL_IP_ADDR_LEN]) {
+  char cmd[256];
+  char out[256];
+
+  snprintf(cmd, sizeof(cmd), "route -n | grep 'UG' | grep '%s' | awk '{print $2}'",
+           if_name);
+  int ret = mt_run_cmd(cmd, out, sizeof(out));
+  if (ret < 0) return ret;
+
+  uint8_t a, b, c, d;
+  ret = sscanf(out, "%" SCNu8 ".%" SCNu8 ".%" SCNu8 ".%" SCNu8 "", &a, &b, &c, &d);
+  if (ret < 0) {
+    info("%s, cmd: %s fail\n", __func__, cmd);
+    return ret;
+  }
+
+  info("%s, cmd %s out %s\n", __func__, cmd, out);
+  gateway[0] = a;
+  gateway[1] = b;
+  gateway[2] = c;
+  gateway[3] = d;
+  return 0;
+}
+
 int mt_socket_get_if_mac(char* if_name, struct rte_ether_addr* ea) {
   int sock, ret;
   struct ifreq ifr;
@@ -309,6 +333,10 @@ int mt_socket_remove_flow(struct mtl_main_impl* impl, enum mtl_port port, int fl
 #else
 int mt_socket_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
                         uint8_t netmask[MTL_IP_ADDR_LEN]) {
+  return -ENOTSUP;
+}
+
+int mt_socket_get_if_gateway(char* if_name, uint8_t gateway[MTL_IP_ADDR_LEN]) {
   return -ENOTSUP;
 }
 

--- a/lib/src/mt_socket.h
+++ b/lib/src/mt_socket.h
@@ -10,6 +10,8 @@
 int mt_socket_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
                         uint8_t netmask[MTL_IP_ADDR_LEN]);
 
+int mt_socket_get_if_gateway(char* if_name, uint8_t gateway[MTL_IP_ADDR_LEN]);
+
 int mt_socket_get_if_mac(char* if_name, struct rte_ether_addr* ea);
 
 int mt_socket_join_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group);

--- a/lib/src/mt_socket.h
+++ b/lib/src/mt_socket.h
@@ -7,7 +7,8 @@
 
 #include "mt_main.h"
 
-int mt_socket_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN]);
+int mt_socket_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
+                        uint8_t netmask[MTL_IP_ADDR_LEN]);
 
 int mt_socket_get_if_mac(char* if_name, struct rte_ether_addr* ea);
 

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -15,11 +15,21 @@ static inline bool mt_rtp_len_valid(uint16_t len) {
 }
 
 /* ip from 224.x.x.x to 239.x.x.x */
-static inline uint64_t mt_is_multicast_ip(uint8_t ip[MTL_IP_ADDR_LEN]) {
+static inline bool mt_is_multicast_ip(uint8_t ip[MTL_IP_ADDR_LEN]) {
   if (ip[0] >= 224 && ip[0] <= 239)
     return true;
   else
     return false;
+}
+
+/* if it is a local address area */
+static inline bool mt_is_lan_ip(uint8_t ip[MTL_IP_ADDR_LEN], uint8_t sip[MTL_IP_ADDR_LEN],
+                                uint8_t netmask[MTL_IP_ADDR_LEN]) {
+  for (int i = 0; i < MTL_IP_ADDR_LEN; i++) {
+    if ((ip[i] & netmask[i]) != (sip[i] & netmask[i])) return false;
+  }
+
+  return true;
 }
 
 static inline uint32_t mt_ip_to_u32(uint8_t ip[MTL_IP_ADDR_LEN]) {

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -497,7 +497,7 @@ GTEST_API_ int main(int argc, char** argv) {
   for (int i = 0; i < ctx->para.num_ports; i++) {
     ctx->para.pmd[i] = mtl_pmd_by_port_name(ctx->para.port[i]);
     if (ctx->para.pmd[i] != MTL_PMD_DPDK_USER) {
-      mtl_get_if_ip(ctx->para.port[i], ctx->para.sip_addr[i]);
+      mtl_get_if_ip(ctx->para.port[i], ctx->para.sip_addr[i], ctx->para.netmask[i]);
       ctx->para.flags |= MTL_FLAG_RX_SEPARATE_VIDEO_LCORE;
       ctx->para.tx_sessions_cnt_max = 8;
       ctx->para.rx_sessions_cnt_max = 8;


### PR DESCRIPTION
An address has both ip and netmask, netmask can be used to decide if a IP is lan or wan. Later we will add a hook way to get mac for wan.

Signed-off-by: Frank Du <frank.du@intel.com>