### PR TITLE
cvt: add rfc4175 422be12 to le avx512 version

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -161,6 +161,13 @@ executable('PerfY210ToRfc4175422be10', perf_y210_to_rfc4175_422be10_sources,
   dependencies: [asan_dep, mtl, libpthread]
 )
 
+executable('PerfRfc4175422be12ToLe', perf_rfc4175_422be12_to_le_sources,
+  c_args : app_c_args,
+  link_args: app_ld_args,
+  # asan should be always the first dep
+  dependencies: [asan_dep, mtl, libpthread]
+)
+
 executable('TxVideoSample', video_tx_sample_sources,
   c_args : app_c_args,
   link_args: app_ld_args,

--- a/app/perf/meson.build
+++ b/app/perf/meson.build
@@ -10,4 +10,5 @@ perf_rfc4175_422be10_to_v210_sources = files('rfc4175_422be10_to_v210.c', '../sa
 perf_v210_to_rfc4175_422be10_sources = files('v210_to_rfc4175_422be10.c', '../sample/sample_util.c')
 perf_rfc4175_422be10_to_y210_sources = files('rfc4175_422be10_to_y210.c', '../sample/sample_util.c')
 perf_y210_to_rfc4175_422be10_sources = files('y210_to_rfc4175_422be10.c', '../sample/sample_util.c')
+perf_rfc4175_422be12_to_le_sources = files('rfc4175_422be12_to_le.c', '../sample/sample_util.c')
 perf_dma_sources = files('perf_dma.c', '../sample/sample_util.c')

--- a/app/perf/perf_test.sh
+++ b/app/perf/perf_test.sh
@@ -29,6 +29,7 @@ perf_func PerfRfc4175422be10ToV210
 perf_func PerfV210ToRfc4175422be10
 perf_func PerfRfc4175422be10ToY210
 perf_func PerfY210ToRfc4175422be10
+perf_func PerfRfc4175422be12ToLe
 perf_func PerfDma
 
 echo "****** All Perf test OK ******"

--- a/app/perf/rfc4175_422be12_to_le.c
+++ b/app/perf/rfc4175_422be12_to_le.c
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2022 Intel Corporation
+ */
+
+#include "../sample/sample_util.h"
+
+static int perf_cvt_422_12_pg2_be_to_le(mtl_handle st, int w, int h, int frames,
+                                        int fb_cnt) {
+  size_t fb_pg2_size = w * h * 3;
+  mtl_udma_handle dma = mtl_udma_create(st, 128, MTL_PORT_P);
+  struct st20_rfc4175_422_12_pg2_be* pg_be =
+      (struct st20_rfc4175_422_12_pg2_be*)mtl_hp_malloc(st, fb_pg2_size * fb_cnt,
+                                                        MTL_PORT_P);
+  struct st20_rfc4175_422_12_pg2_le* pg_le =
+      (struct st20_rfc4175_422_12_pg2_le*)malloc(fb_pg2_size * fb_cnt);
+  mtl_iova_t pg_be_iova = mtl_hp_virt2iova(st, pg_be);
+  mtl_iova_t pg_be_in_iova;
+  size_t planar_size = fb_pg2_size;
+  float planar_size_m = (float)planar_size / 1024 / 1024;
+  enum mtl_simd_level cpu_level = mtl_get_simd_level();
+
+  struct st20_rfc4175_422_12_pg2_be* pg_be_in;
+  struct st20_rfc4175_422_12_pg2_le* pg_le_out;
+
+  for (int i = 0; i < fb_cnt; i++) {
+    pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+    fill_rfc4175_422_12_pg2_data(pg_be_in, w, h);
+  }
+
+  clock_t start, end;
+  float duration;
+
+  start = clock();
+  for (int i = 0; i < frames * 1; i++) {
+    pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+    pg_le_out = pg_le + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_le));
+    st20_rfc4175_422be12_to_422le12_simd(pg_be_in, pg_le_out, w, h, MTL_SIMD_LEVEL_NONE);
+  }
+  end = clock();
+  duration = (float)(end - start) / CLOCKS_PER_SEC;
+  info("scalar, time: %f secs with %d frames(%dx%d,%fm@%d buffers)\n", duration, frames,
+       w, h, planar_size_m, fb_cnt);
+
+  if (cpu_level >= MTL_SIMD_LEVEL_AVX512) {
+    start = clock();
+    for (int i = 0; i < frames * 1; i++) {
+      pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+      pg_le_out = pg_le + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_le));
+      st20_rfc4175_422be12_to_422le12_simd(pg_be_in, pg_le_out, w, h,
+                                           MTL_SIMD_LEVEL_AVX512);
+    }
+    end = clock();
+    float duration_simd = (float)(end - start) / CLOCKS_PER_SEC;
+    info("avx512, time: %f secs with %d frames(%dx%d@%d buffers)\n", duration_simd,
+         frames, w, h, fb_cnt);
+    info("avx512, %fx performance to scalar\n", duration / duration_simd);
+
+    if (dma) {
+      start = clock();
+      for (int i = 0; i < frames; i++) {
+        pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+        pg_be_in_iova = pg_be_iova + (i % fb_cnt) * (fb_pg2_size);
+        pg_le_out = pg_le + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_le));
+        st20_rfc4175_422be12_to_422le12_simd_dma(dma, pg_be_in, pg_be_in_iova, pg_le_out,
+                                                 w, h, MTL_SIMD_LEVEL_AVX512);
+      }
+      end = clock();
+      float duration_simd = (float)(end - start) / CLOCKS_PER_SEC;
+      info("dma+avx512, time: %f secs with %d frames(%dx%d@%d buffers)\n", duration_simd,
+           frames, w, h, fb_cnt);
+      info("dma+avx512, %fx performance to scalar\n", duration / duration_simd);
+    }
+  }
+
+  mtl_hp_free(st, pg_be);
+  free(pg_le);
+  if (dma) mtl_udma_free(dma);
+
+  return 0;
+}
+
+static void* perf_thread(void* arg) {
+  mtl_handle dev_handle = arg;
+  int frames = 60;
+  int fb_cnt = 3;
+
+  unsigned int lcore = 0;
+  int ret = mtl_get_lcore(dev_handle, &lcore);
+  if (ret < 0) {
+    return NULL;
+  }
+  mtl_bind_to_lcore(dev_handle, pthread_self(), lcore);
+  info("%s, run in lcore %u\n", __func__, lcore);
+
+  perf_cvt_422_12_pg2_be_to_le(dev_handle, 640, 480, frames, fb_cnt);
+  perf_cvt_422_12_pg2_be_to_le(dev_handle, 1280, 720, frames, fb_cnt);
+  perf_cvt_422_12_pg2_be_to_le(dev_handle, 1920, 1080, frames, fb_cnt);
+  perf_cvt_422_12_pg2_be_to_le(dev_handle, 1920 * 2, 1080 * 2, frames, fb_cnt);
+  perf_cvt_422_12_pg2_be_to_le(dev_handle, 1920 * 4, 1080 * 4, frames, fb_cnt);
+
+  mtl_put_lcore(dev_handle, lcore);
+
+  return NULL;
+}
+
+int main(int argc, char** argv) {
+  struct st_sample_context ctx;
+  int ret;
+
+  memset(&ctx, 0, sizeof(ctx));
+  ret = tx_sample_parse_args(&ctx, argc, argv);
+  if (ret < 0) return ret;
+
+  ctx.st = mtl_init(&ctx.param);
+  if (!ctx.st) {
+    err("%s: mtl_init fail\n", __func__);
+    return -EIO;
+  }
+
+  pthread_t thread;
+  pthread_create(&thread, NULL, perf_thread, ctx.st);
+  pthread_join(thread, NULL);
+
+  /* release sample(st) dev */
+  if (ctx.st) {
+    mtl_uninit(ctx.st);
+    ctx.st = NULL;
+  }
+  return ret;
+}

--- a/app/perf/rfc4175_422be12_to_le.c
+++ b/app/perf/rfc4175_422be12_to_le.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(c) 2022 Intel Corporation
+ * Copyright(c) 2023 Intel Corporation
  */
 
 #include "../sample/sample_util.h"

--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -390,3 +390,31 @@ void fill_rfc4175_422_10_pg2_data(struct st20_rfc4175_422_10_pg2_be* data, int w
     y1 += 2;
   }
 }
+
+void fill_rfc4175_422_12_pg2_data(struct st20_rfc4175_422_12_pg2_be* data, int w, int h) {
+  int pg_size = w * h / 2;
+  uint16_t cb, y0, cr, y1; /* 12 bit */
+
+  y0 = 0x111;
+
+  cb = 0x222;
+  cr = 0x333;
+  y1 = y0 + 1;
+
+  for (int pg = 0; pg < pg_size; pg++) {
+    data->Cb00 = cb >> 4;
+    data->Cb00_ = cb;
+    data->Y00 = y0 >> 8;
+    data->Y00_ = y0;
+    data->Cr00 = cr >> 4;
+    data->Cr00_ = cr;
+    data->Y01 = y1 >> 8;
+    data->Y01_ = y1;
+    data++;
+
+    cb++;
+    y0 += 2;
+    cr++;
+    y1 += 2;
+  }
+}

--- a/app/sample/sample_util.h
+++ b/app/sample/sample_util.h
@@ -118,6 +118,8 @@ int dma_sample_parse_args(struct st_sample_context* ctx, int argc, char** argv);
 
 void fill_rfc4175_422_10_pg2_data(struct st20_rfc4175_422_10_pg2_be* data, int w, int h);
 
+void fill_rfc4175_422_12_pg2_data(struct st20_rfc4175_422_12_pg2_be* data, int w, int h);
+
 /* Monotonic time (in nanoseconds) since some unspecified starting point. */
 static inline uint64_t sample_get_monotonic_time() {
   struct timespec ts;

--- a/doc/convert.md
+++ b/doc/convert.md
@@ -32,7 +32,7 @@ For full API usage please refer to [st_convert_api.h](../include/st_convert_api.
 | src_format| dest_format | scalar | avx2 | avx512 | avx512_vbmi |
 | :---      |     :---    | :----: |:----:| :----: |    :----:   |
 | rfc4175_422be12   | yuv422p12le       | &#x2705; |          |          |          |
-| rfc4175_422be12   | rfc4175_422le12   | &#x2705; |          |          |          |
+| rfc4175_422be12   | rfc4175_422le12   | &#x2705; |          | &#x2705; |          |
 | rfc4175_422le12   | yuv422p12le       | &#x2705; |          |          |          |
 | rfc4175_422le12   | rfc4175_422be12   | &#x2705; |          |          |          |
 | yuv422p12le       | rfc4175_422be12   | &#x2705; |          |          |          |

--- a/include/st_convert_api.h
+++ b/include/st_convert_api.h
@@ -270,6 +270,34 @@ static inline int st20_rfc4175_422be12_to_422le12(
 }
 
 /**
+ * Convert rfc4175_422be12 to rfc4175_422le12 with max SIMD level and DMA helper.
+ * Profiling shows gain with 4k/8k solution due to LLC cache miss migration, thus pls
+ * only applied with 4k/8k.
+ *
+ * @param udma
+ *   Point to dma engine.
+ * @param pg_be
+ *   Point to pg(rfc4175_422be12) data.
+ * @param pg_be_iova
+ *   The mtl_iova_t address of the pg_be buffer.
+ * @param pg_le
+ *   Point to pg(rfc4175_422le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+static inline int st20_rfc4175_422be12_to_422le12_dma(
+    mtl_udma_handle udma, struct st20_rfc4175_422_12_pg2_be* pg_be, mtl_iova_t pg_be_iova,
+    struct st20_rfc4175_422_12_pg2_le* pg_le, uint32_t w, uint32_t h) {
+  return st20_rfc4175_422be12_to_422le12_simd_dma(udma, pg_be, pg_be_iova, pg_le, w, h,
+                                                  MTL_SIMD_LEVEL_MAX);
+}
+
+/**
  * Convert rfc4175_444be10 to yuv444p10le with the max optimised SIMD level.
  *
  * @param pg

--- a/include/st_convert_internal.h
+++ b/include/st_convert_internal.h
@@ -291,6 +291,37 @@ int st20_rfc4175_422be12_to_422le12_simd(struct st20_rfc4175_422_12_pg2_be* pg_b
                                          enum mtl_simd_level level);
 
 /**
+ * Convert rfc4175_422be12 to rfc4175_422le12 with required SIMD level and DMA helper.
+ * Note the level may downgrade to the SIMD which system really support.
+ * Profiling shows gain with 4k/8k solution due to LLC cache miss migration, thus pls
+ * only applied with 4k/8k.
+ *
+ * @param udma
+ *   Point to dma engine.
+ * @param pg_be
+ *   Point to pg(rfc4175_422be12) data.
+ * @param pg_be_iova
+ *   The mtl_iova_t address of the pg_be buffer.
+ * @param pg_le
+ *   Point to pg(rfc4175_422le12) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @param level
+ *   simd level.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
+int st20_rfc4175_422be12_to_422le12_simd_dma(mtl_udma_handle udma,
+                                             struct st20_rfc4175_422_12_pg2_be* pg_be,
+                                             mtl_iova_t pg_be_iova,
+                                             struct st20_rfc4175_422_12_pg2_le* pg_le,
+                                             uint32_t w, uint32_t h,
+                                             enum mtl_simd_level level);
+
+/**
  * Convert rfc4175_444be10 to yuv444p10le/gbrp10le with required SIMD level.
  * Note the level may downgrade to the SIMD which system really support.
  *

--- a/lib/src/st2110/st_avx512.h
+++ b/lib/src/st2110/st_avx512.h
@@ -92,4 +92,15 @@ int st20_y210_to_rfc4175_422be10_avx512_dma(struct mtl_dma_lender_dev* dma,
                                             uint16_t* pg_y210, mtl_iova_t pg_y210_iova,
                                             struct st20_rfc4175_422_10_pg2_be* pg_be,
                                             uint32_t w, uint32_t h);
+
+int st20_rfc4175_422be12_to_422le12_avx512(struct st20_rfc4175_422_12_pg2_be* pg_be,
+                                           struct st20_rfc4175_422_12_pg2_le* pg_le,
+                                           uint32_t w, uint32_t h);
+
+int st20_rfc4175_422be12_to_422le12_avx512_dma(struct mtl_dma_lender_dev* dma,
+                                               struct st20_rfc4175_422_12_pg2_be* pg_be,
+                                               mtl_iova_t pg_be_iova,
+                                               struct st20_rfc4175_422_12_pg2_le* pg_le,
+                                               uint32_t w, uint32_t h);
+
 #endif

--- a/lib/src/st2110/st_convert.c
+++ b/lib/src/st2110/st_convert.c
@@ -1726,7 +1726,49 @@ int st20_rfc4175_422be12_to_422le12_simd(struct st20_rfc4175_422_12_pg2_be* pg_b
                                          struct st20_rfc4175_422_12_pg2_le* pg_le,
                                          uint32_t w, uint32_t h,
                                          enum mtl_simd_level level) {
-  /* the only option */
+  enum mtl_simd_level cpu_level = mtl_get_simd_level();
+  int ret;
+
+  MT_MAY_UNUSED(cpu_level);
+  MT_MAY_UNUSED(ret);
+
+#ifdef MTL_HAS_AVX512
+  if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
+    dbg("%s, avx512 ways\n", __func__);
+    ret = st20_rfc4175_422be12_to_422le12_avx512(pg_be, pg_le, w, h);
+    if (ret == 0) return 0;
+    dbg("%s, avx512 ways failed\n", __func__);
+  }
+#endif
+
+  /* the last option */
+  return st20_rfc4175_422be12_to_422le12_scalar(pg_be, pg_le, w, h);
+}
+
+int st20_rfc4175_422be12_to_422le12_simd_dma(mtl_udma_handle udma,
+                                             struct st20_rfc4175_422_12_pg2_be* pg_be,
+                                             mtl_iova_t pg_be_iova,
+                                             struct st20_rfc4175_422_12_pg2_le* pg_le,
+                                             uint32_t w, uint32_t h,
+                                             enum mtl_simd_level level) {
+  struct mtl_dma_lender_dev* dma = udma;
+  enum mtl_simd_level cpu_level = mtl_get_simd_level();
+  int ret;
+
+  MT_MAY_UNUSED(cpu_level);
+  MT_MAY_UNUSED(ret);
+  MT_MAY_UNUSED(dma);
+
+#ifdef MTL_HAS_AVX512
+  if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
+    dbg("%s, avx512 ways\n", __func__);
+    ret = st20_rfc4175_422be12_to_422le12_avx512_dma(dma, pg_be, pg_be_iova, pg_le, w, h);
+    if (ret == 0) return 0;
+    dbg("%s, avx512 ways failed\n", __func__);
+  }
+#endif
+
+  /* the last option */
   return st20_rfc4175_422be12_to_422le12_scalar(pg_be, pg_le, w, h);
 }
 


### PR DESCRIPTION
scalar, time: 0.051987 secs with 60 frames(640x480,0.878906m@3 buffers)
avx512, time: 0.006813 secs with 60 frames(640x480@3 buffers)
avx512, 7.630559x performance to scalar
dma+avx512, time: 0.009418 secs with 60 frames(640x480@3 buffers)
dma+avx512, 5.519962x performance to scalar
scalar, time: 0.102720 secs with 60 frames(1280x720,2.636719m@3 buffers)
avx512, time: 0.019190 secs with 60 frames(1280x720@3 buffers)
avx512, 5.352788x performance to scalar
dma+avx512, time: 0.032228 secs with 60 frames(1280x720@3 buffers)
dma+avx512, 3.187290x performance to scalar
scalar, time: 0.212847 secs with 60 frames(1920x1080,5.932617m@3 buffers)
avx512, time: 0.035059 secs with 60 frames(1920x1080@3 buffers)
avx512, 6.071108x performance to scalar
dma+avx512, time: 0.051582 secs with 60 frames(1920x1080@3 buffers)
dma+avx512, 4.126381x performance to scalar
scalar, time: 0.914501 secs with 60 frames(3840x2160,23.730469m@3 buffers)
avx512, time: 0.226793 secs with 60 frames(3840x2160@3 buffers)
avx512, 4.032316x performance to scalar
dma+avx512, time: 0.194247 secs with 60 frames(3840x2160@3 buffers)
dma+avx512, 4.707929x performance to scalar
scalar, time: 3.183831 secs with 60 frames(7680x4320,94.921875m@3 buffers)
avx512, time: 0.845883 secs with 60 frames(7680x4320@3 buffers)
avx512, 3.763914x performance to scalar
dma+avx512, time: 0.659178 secs with 60 frames(7680x4320@3 buffers)
dma+avx512, 4.830002x performance to scalar

Signed-off-by: Ric Li <ming3.li@intel.com>