### PR TITLE
ufd: add internal api.

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -2,5 +2,5 @@
 # Copyright 2022 Intel Corporation
 
 install_headers('mtl_api.h', 'st_api.h', 'st_convert_api.h', 'st_convert_internal.h', 'st_pipeline_api.h', 'st20_api.h', 'st30_api.h', 'st40_api.h',
-  'st20_redundant_api.h', 'mudp_api.h', 'mudp_sockfd_api.h',
+  'st20_redundant_api.h', 'mudp_api.h', 'mudp_sockfd_api.h', 'mudp_sockfd_internal.h',
   subdir : meson.project_name())

--- a/include/mudp_sockfd_internal.h
+++ b/include/mudp_sockfd_internal.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+/**
+ * @file mudp_sockfd_internal.h
+ *
+ * Internal interfaces to udp transport context.
+ * For debug/test usage only
+ *
+ */
+
+#ifndef _MUDP_SOCKFD_INTERNAL_HEAD_H_
+/** Marco for re-inculde protect */
+#define _MUDP_SOCKFD_INTERNAL_HEAD_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * All init params should be parsed from MUFD_CFG_ENV_NAME json config file.
+ * But we still need a runtime entry for debug/test usage.
+ */
+struct mufd_init_params {
+  /** mtl init params */
+  struct mtl_init_params mt_params;
+  /** max nb of udp sockets supported */
+  int slots_nb_max;
+  /** fd base of udp sockets */
+  int fd_base;
+  /** bit per sec for q */
+  uint64_t txq_bps;
+};
+
+/**
+ * Commit the runtime parameters of mufd instance.
+ *
+ * @param p
+ *   The pointer to the mufd init parameters.
+ * @return
+ *   - >=0: Success.
+ *   - <0: Error code.
+ */
+int mufd_commit_init_params(struct mufd_init_params* p);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/lib/src/udp/ufd_main.h
+++ b/lib/src/udp/ufd_main.h
@@ -10,6 +10,7 @@
 /* include "struct sockaddr_in" define before include mudp_sockfd_api */
 // clang-format off
 #include <mudp_sockfd_api.h>
+#include <mudp_sockfd_internal.h>
 // clang-format on
 
 #define UFD_FD_BASE_DEFAULT (10000)
@@ -20,14 +21,11 @@ struct ufd_slot {
 };
 
 struct ufd_mt_ctx {
-  struct mtl_init_params mt_params;
+  struct mufd_init_params init_params;
   struct mtl_main_impl* mt;
-  int fd_base;
-  uint64_t txq_bps; /* bit per sec for q */
 
-  int slots_nb_max;
   int slot_last_idx;
-  struct ufd_slot** slots;
+  struct ufd_slot** slots;    /* slots with init_params.slots_nb_max */
   pthread_mutex_t slots_lock; /* lock slots */
 };
 


### PR DESCRIPTION
To support the incoming gtest routine which not use json cfg. That test can be easily deployed.

Signed-off-by: Frank Du <frank.du@intel.com>