### PR TITLE
ptp: add tsc as ptp source for debug usage.

### DIFF
--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -30,6 +30,7 @@ enum sample_args_cmd {
   SAMPLE_ARG_R_NETMASK,
   SAMPLE_ARG_P_GATEWAY,
   SAMPLE_ARG_R_GATEWAY,
+  SAMPLE_ARG_PTP_TSC,
 
   SAMPLE_ARG_TX_VIDEO_URL = 0x200,
   SAMPLE_ARG_RX_VIDEO_URL,
@@ -70,6 +71,7 @@ static struct option sample_args_options[] = {
     {"r_netmask", required_argument, 0, SAMPLE_ARG_R_NETMASK},
     {"p_gateway", required_argument, 0, SAMPLE_ARG_P_GATEWAY},
     {"r_gateway", required_argument, 0, SAMPLE_ARG_R_GATEWAY},
+    {"ptp_tsc", no_argument, 0, SAMPLE_ARG_PTP_TSC},
 
     {"tx_url", required_argument, 0, SAMPLE_ARG_TX_VIDEO_URL},
     {"rx_url", required_argument, 0, SAMPLE_ARG_RX_VIDEO_URL},
@@ -177,6 +179,9 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         break;
       case SAMPLE_ARG_SHARED_QUEUES:
         p->flags |= MTL_FLAG_SHARED_QUEUE;
+        break;
+      case SAMPLE_ARG_PTP_TSC:
+        p->flags |= MTL_FLAG_PTP_SOURCE_TSC;
         break;
       case SAMPLE_ARG_QUEUES_CNT:
         p->rx_queues_cnt_max = atoi(optarg);

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -89,6 +89,7 @@ enum st_args_cmd {
   ST_ARG_PTP_PI,
   ST_ARG_PTP_KP,
   ST_ARG_PTP_KI,
+  ST_ARG_PTP_TSC,
   ST_ARG_MAX,
 };
 
@@ -179,6 +180,7 @@ static struct option st_app_args_options[] = {
     {"pi", no_argument, 0, ST_ARG_PTP_PI},
     {"kp", required_argument, 0, ST_ARG_PTP_KP},
     {"ki", required_argument, 0, ST_ARG_PTP_KI},
+    {"ptp_tsc", no_argument, 0, ST_ARG_PTP_TSC},
 
     {0, 0, 0, 0}};
 
@@ -529,6 +531,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_PTP_KI:
         p->ki = strtod(optarg, NULL);
+        break;
+      case ST_ARG_PTP_TSC:
+        p->flags |= MTL_FLAG_PTP_SOURCE_TSC;
         break;
       case '?':
         break;

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -304,6 +304,11 @@ enum st21_tx_pacing_way {
  * Disable system rx queues, pls use mcast or manual TX mac.
  */
 #define MTL_FLAG_DISABLE_SYSTEM_RX_QUEUES (MTL_BIT64(28))
+/**
+ * Flag bit in flags of struct mtl_init_params, debug usage only.
+ * Force to get ptp time from tsc source.
+ */
+#define MTL_FLAG_PTP_SOURCE_TSC (MTL_BIT64(29))
 
 /**
  * The structure describing how to init af_xdp interface.

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -72,6 +72,8 @@ int mt_dev_put_lcore(struct mtl_main_impl* impl, unsigned int lcore);
 int mt_dev_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore);
 bool mt_dev_lcore_valid(struct mtl_main_impl* impl, unsigned int lcore);
 
+int mt_dev_tsc_done_action(struct mtl_main_impl* impl);
+
 uint32_t mt_dev_softrss(uint32_t* input_tuple, uint32_t input_len);
 
 struct mt_rx_flow_rsp* mt_dev_create_rx_flow(struct mtl_main_impl* impl,

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -88,6 +88,7 @@ static void* mt_calibrate_tsc(void* arg) {
     tsc_hz_sum += array[i];
   }
   impl->tsc_hz = tsc_hz_sum / (loop - trim * 2);
+  mt_dev_tsc_done_action(impl);
 
   info("%s, tscHz %" PRIu64 "\n", __func__, impl->tsc_hz);
   return NULL;

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -546,8 +546,10 @@ static int ptp_parse_annouce(struct mt_ptp_impl* ptp, struct mt_ptp_announce_msg
           htons(sizeof(struct rte_udp_hdr) + sizeof(struct mt_ptp_sync_msg));
     }
 
-    /* point ptp fn to eth if no user assigned ptp source */
-    if (mt_has_user_ptp(ptp->impl))
+    /* point ptp fn to eth phc */
+    if (mt_ptp_tsc_source(ptp->impl))
+      warn("%s(%d), skip as ptp force to tsc\n", __func__, port);
+    else if (mt_has_user_ptp(ptp->impl))
       warn("%s(%d), skip as user provide ptp source already\n", __func__, port);
     else
       mt_if(ptp->impl, port)->ptp_get_time_fn = ptp_from_eth;


### PR DESCRIPTION
To debug issue which user ptp source is not stable, use --ptp_tsc to enable.

Signed-off-by: Frank Du <frank.du@intel.com>