### PR TITLE
lib/init: add multi port support for the init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change log
 
 ## Change log for 23.03:
+* dpdk: upgrade dpdk version to latest 22.11 for both windows and linux.
+* ptp: add pi controller and software frequency adjust to improve the accuracy to ~100ns.
 * mtl_init_params: add gateway and netmask support for wan.
 * udp: introduce a highly efficient udp stack support, see mudp_api.h
 * udp: add POSIX socket compatible(file descriptor) API support, see mudp_sockfd_api.h
+* udp: add sample code, see app/udp
+* arp: add zero timeout support for UDP stack.
+* mtl_init_params: add multi port support, user can initial MTL instance with up to 8 ports. See tests/script/multi_port_json/ for how to use from RxTxApp.
 
 ## Change log for 22.12:
 * tasklet: add thread and sleep option for core usage, see ST_FLAG_TASKLET_THREAD and ST_FLAG_TASKLET_SLEEP.

--- a/app/sample/rx_rtp_video_sample.c
+++ b/app/sample/rx_rtp_video_sample.c
@@ -89,9 +89,11 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_rx.type = ST20_TYPE_RTP_LEVEL;
     ops_rx.width = ctx.width;
     ops_rx.height = ctx.height;

--- a/app/sample/rx_slice_video_sample.c
+++ b/app/sample/rx_slice_video_sample.c
@@ -173,9 +173,11 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = ctx.udp_port + i;  // user config the udp port.
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;  // user config the udp port.
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = ST20_TYPE_SLICE_LEVEL;
     ops_rx.width = ctx.width;

--- a/app/sample/rx_st20_pipeline_sample.c
+++ b/app/sample/rx_st20_pipeline_sample.c
@@ -176,10 +176,11 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_rx.port.payload_type = ctx.payload_type;
     ops_rx.width = ctx.width;
     ops_rx.height = ctx.height;

--- a/app/sample/rx_st20_redundant_sample.c
+++ b/app/sample/rx_st20_redundant_sample.c
@@ -162,12 +162,16 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20r_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 2;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    memcpy(ops_rx.sip_addr[MTL_PORT_R], ctx.rx_sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    strncpy(ops_rx.port[MTL_PORT_R], ctx.param.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = ctx.udp_port + i;
-    ops_rx.udp_port[MTL_PORT_R] = ctx.udp_port + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_R], ctx.rx_sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_R], ctx.param.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
+    ops_rx.udp_port[MTL_SESSION_PORT_R] = ctx.udp_port + i;
     ops_rx.width = ctx.width;
     ops_rx.height = ctx.height;
     ops_rx.fps = ctx.fps;

--- a/app/sample/rx_st20_tx_st20_fwd.c
+++ b/app/sample/rx_st20_tx_st20_fwd.c
@@ -332,9 +332,10 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20_fwd";
   ops_rx.priv = &app;
   ops_rx.num_port = 1;
-  memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_rx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_rx.udp_port[MTL_PORT_P] = ctx.udp_port;  // user config the udp port.
+  memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;  // user config the udp port.
   ops_rx.pacing = ST21_PACING_NARROW;
   ops_rx.type = ST20_TYPE_FRAME_LEVEL;
   ops_rx.width = ctx.width;
@@ -358,9 +359,10 @@ int main(int argc, char** argv) {
   ops_tx.name = "st20_fwd";
   ops_tx.priv = &app;
   ops_tx.num_port = 1;
-  memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_tx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_tx.pacing = ST21_PACING_NARROW;
   ops_tx.type = ST20_TYPE_FRAME_LEVEL;
   ops_tx.width = ctx.width;

--- a/app/sample/rx_st20_tx_st20_split_fwd.c
+++ b/app/sample/rx_st20_tx_st20_split_fwd.c
@@ -219,9 +219,10 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20_fwd";
   ops_rx.priv = &app;
   ops_rx.num_port = 1;
-  memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_rx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_rx.udp_port[MTL_PORT_P] = ctx.udp_port;  // user config the udp port.
+  memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;  // user config the udp port.
   ops_rx.pacing = ST21_PACING_NARROW;
   ops_rx.type = ST20_TYPE_FRAME_LEVEL;
   ops_rx.width = ctx.width;
@@ -248,9 +249,11 @@ int main(int argc, char** argv) {
     ops_tx.name = "st20_fwd";
     ops_tx.priv = tx;
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = ST20_PACKING_BPM;
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;

--- a/app/sample/rx_st20p_tx_st20p_downsample_fwd.c
+++ b/app/sample/rx_st20p_tx_st20p_downsample_fwd.c
@@ -135,9 +135,11 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_test";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_rx.port.payload_type = ctx.payload_type;
   ops_rx.width = ctx.width;
   ops_rx.height = ctx.height;
@@ -161,9 +163,11 @@ int main(int argc, char** argv) {
   ops_tx.name = "st20p_fwd";
   ops_tx.priv = &app;  // app handle register to lib
   ops_tx.port.num_port = 1;
-  memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_tx.port.payload_type = ctx.payload_type;
   ops_tx.width = ctx.width / 2;
   ops_tx.height = ctx.height / 2;

--- a/app/sample/rx_st20p_tx_st20p_downsample_merge_fwd.c
+++ b/app/sample/rx_st20p_tx_st20p_downsample_merge_fwd.c
@@ -192,9 +192,11 @@ int main(int argc, char** argv) {
   ops_tx.name = "st20p_fwd";
   ops_tx.priv = &app;
   ops_tx.port.num_port = 1;
-  memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_tx.port.payload_type = ctx.payload_type;
   ops_tx.width = ctx.width;
   ops_tx.height = ctx.height;
@@ -223,10 +225,11 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_rx";
     ops_rx.priv = rx;
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_rx.port.payload_type = ctx.payload_type;
     ops_rx.width = ctx.width;
     ops_rx.height = ctx.height;

--- a/app/sample/rx_st20p_tx_st20p_fwd.c
+++ b/app/sample/rx_st20p_tx_st20p_fwd.c
@@ -258,9 +258,11 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_test";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_rx.port.payload_type = ctx.payload_type;
   ops_rx.width = ctx.width;
   ops_rx.height = ctx.height;
@@ -284,9 +286,11 @@ int main(int argc, char** argv) {
   ops_tx.name = "st20p_fwd";
   ops_tx.priv = &app;  // app handle register to lib
   ops_tx.port.num_port = 1;
-  memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_tx.port.payload_type = ctx.payload_type;
   ops_tx.width = ctx.width;
   ops_tx.height = ctx.height;

--- a/app/sample/rx_st20p_tx_st20p_merge_fwd.c
+++ b/app/sample/rx_st20p_tx_st20p_merge_fwd.c
@@ -194,9 +194,11 @@ int main(int argc, char** argv) {
   ops_tx.name = "st20p_fwd";
   ops_tx.priv = &app;
   ops_tx.port.num_port = 1;
-  memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_tx.port.payload_type = ctx.payload_type;
   ops_tx.width = ctx.width;
   ops_tx.height = ctx.height;
@@ -225,10 +227,11 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_rx";
     ops_rx.priv = rx;
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_rx.port.payload_type = ctx.payload_type;
     ops_rx.width = ctx.width / 2;
     ops_rx.height = ctx.height / 2;

--- a/app/sample/rx_st20p_tx_st20p_split_fwd.c
+++ b/app/sample/rx_st20p_tx_st20p_split_fwd.c
@@ -152,9 +152,11 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_rx";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_rx.port.payload_type = ctx.payload_type;
   ops_rx.width = ctx.width;
   ops_rx.height = ctx.height;
@@ -183,10 +185,11 @@ int main(int argc, char** argv) {
     ops_tx.name = "st20p_fwd";
     ops_tx.priv = tx;
     ops_tx.port.num_port = 1;
-    memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+    memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_tx.port.payload_type = ctx.payload_type;
     ops_tx.width = ctx.width / 2;
     ops_tx.height = ctx.height / 2;

--- a/app/sample/rx_st20p_tx_st22p_fwd.c
+++ b/app/sample/rx_st20p_tx_st22p_fwd.c
@@ -183,9 +183,11 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_test";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_rx.port.payload_type = ctx.payload_type;
   ops_rx.width = ctx.width;
   ops_rx.height = ctx.height;
@@ -209,9 +211,11 @@ int main(int argc, char** argv) {
   ops_tx.name = "st22_fwd";
   ops_tx.priv = &app;  // app handle register to lib
   ops_tx.port.num_port = 1;
-  memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.fwd_dip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;
   ops_tx.port.payload_type = ctx.payload_type;
   ops_tx.width = ctx.width;
   ops_tx.height = ctx.height;

--- a/app/sample/rx_st22_pipeline_sample.c
+++ b/app/sample/rx_st22_pipeline_sample.c
@@ -153,10 +153,11 @@ int main(int argc, char** argv) {
     ops_rx.name = "st22p_sample";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_rx.port.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_rx.port.payload_type = ctx.payload_type;
     ops_rx.width = ctx.width;
     ops_rx.height = ctx.height;

--- a/app/sample/rx_st22_video_sample.c
+++ b/app/sample/rx_st22_video_sample.c
@@ -152,10 +152,12 @@ int main(int argc, char** argv) {
     ops_rx.name = "st22_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
     // user could config the udp port in this interface.
-    ops_rx.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_rx.width = ctx.width;
     ops_rx.height = ctx.height;
     ops_rx.fps = ctx.fps;

--- a/app/sample/rx_video_sample.c
+++ b/app/sample/rx_video_sample.c
@@ -160,9 +160,11 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20_rx";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx.rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = ctx.udp_port + i;  // user config the udp port.
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;  // user config the udp port.
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = ST20_TYPE_FRAME_LEVEL;
     ops_rx.width = ctx.width;

--- a/app/sample/tx_rtp_video_sample.c
+++ b/app/sample/tx_rtp_video_sample.c
@@ -134,9 +134,11 @@ int main(int argc, char** argv) {
     ops_tx.name = "st20_test";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.type = ST20_TYPE_RTP_LEVEL;
     ops_tx.width = ctx.width;

--- a/app/sample/tx_slice_video_sample.c
+++ b/app/sample/tx_slice_video_sample.c
@@ -205,9 +205,11 @@ int main(int argc, char** argv) {
     ops_tx.name = "st20_tx";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = ctx.udp_port + i;  // udp port
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;  // udp port
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.type = ST20_TYPE_SLICE_LEVEL;
     ops_tx.width = ctx.width;

--- a/app/sample/tx_st20_pipeline_sample.c
+++ b/app/sample/tx_st20_pipeline_sample.c
@@ -233,15 +233,17 @@ int main(int argc, char** argv) {
     ops_tx.name = "st20p_test";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.port.num_port = ctx.param.num_ports;
-    memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
+    memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     if (ops_tx.port.num_port > 1) {
-      memcpy(ops_tx.port.dip_addr[MTL_PORT_R], ctx.tx_dip_addr[MTL_PORT_R],
+      memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_R], ctx.tx_dip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_tx.port.port[MTL_PORT_R], ctx.param.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-      ops_tx.port.udp_port[MTL_PORT_R] = ctx.udp_port + i;
+      strncpy(ops_tx.port.port[MTL_SESSION_PORT_R], ctx.param.port[MTL_PORT_R],
+              MTL_PORT_MAX_LEN);
+      ops_tx.port.udp_port[MTL_SESSION_PORT_R] = ctx.udp_port + i;
     }
     ops_tx.port.payload_type = ctx.payload_type;
     ops_tx.width = ctx.width;

--- a/app/sample/tx_st22_pipeline_sample.c
+++ b/app/sample/tx_st22_pipeline_sample.c
@@ -213,10 +213,11 @@ int main(int argc, char** argv) {
     ops_tx.name = "st22p_sample";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.port.num_port = 1;
-    memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
+    memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.port.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_tx.port.payload_type = ctx.payload_type;
     ops_tx.width = ctx.width;
     ops_tx.height = ctx.height;

--- a/app/sample/tx_st22_video_sample.c
+++ b/app/sample/tx_st22_video_sample.c
@@ -167,9 +167,11 @@ int main(int argc, char** argv) {
     ops_tx.name = "st22_test";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.width = ctx.width;
     ops_tx.height = ctx.height;

--- a/app/sample/tx_video_sample.c
+++ b/app/sample/tx_video_sample.c
@@ -177,10 +177,12 @@ int main(int argc, char** argv) {
     ops_tx.name = "st20_tx";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
     if (ctx.ext_frame) ops_tx.flags |= ST20_TX_FLAG_EXT_FRAME;
-    ops_tx.udp_port[MTL_PORT_P] = ctx.udp_port + i;  // udp port
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;  // udp port
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;
     ops_tx.width = ctx.width;

--- a/app/sample/tx_video_split_sample.c
+++ b/app/sample/tx_video_split_sample.c
@@ -101,14 +101,16 @@ int main(int argc, char** argv) {
     ops_tx.name = "st20_tx";
     ops_tx.priv = app[i];  // app handle register to lib
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx.tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx.param.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx.tx_dip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx.param.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
 
     struct st20_pgroup st20_pg;
     st20_get_pgroup(ST20_FMT_YUV_422_10BIT, &st20_pg);
 
     ops_tx.flags |= ST20_TX_FLAG_EXT_FRAME;
-    ops_tx.udp_port[MTL_PORT_P] = ctx.udp_port + i;
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = ST20_PACKING_GPM_SL;
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;

--- a/app/src/parse_json.h
+++ b/app/src/parse_json.h
@@ -124,8 +124,8 @@ typedef struct st_json_interface {
 } st_json_interface_t;
 
 typedef struct st_json_session_base {
-  uint8_t ip[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
-  st_json_interface_t* inf[MTL_PORT_MAX];
+  uint8_t ip[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  st_json_interface_t* inf[MTL_SESSION_PORT_MAX];
   int num_inf;
   uint16_t udp_port;
   uint8_t payload_type;

--- a/app/src/rx_ancillary_app.c
+++ b/app/src/rx_ancillary_app.c
@@ -126,20 +126,21 @@ static int app_rx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   ops.name = name;
   ops.priv = s;
   ops.num_port = anc ? anc->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_PORT_P],
-         anc ? anc->base.ip[MTL_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P],
-          anc ? anc->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
+         anc ? anc->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops.port[MTL_SESSION_PORT_P],
+          anc ? anc->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = anc ? anc->base.udp_port : (10200 + s->idx);
+  ops.udp_port[MTL_SESSION_PORT_P] = anc ? anc->base.udp_port : (10200 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_PORT_R],
-           anc ? anc->base.ip[MTL_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+           anc ? anc->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R],
-            anc ? anc->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+    strncpy(ops.port[MTL_SESSION_PORT_R],
+            anc ? anc->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
             MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = anc ? anc->base.udp_port : (10200 + s->idx);
+    ops.udp_port[MTL_SESSION_PORT_R] = anc ? anc->base.udp_port : (10200 + s->idx);
   }
   ops.rtp_ring_size = 1024;
   ops.payload_type = anc ? anc->base.payload_type : ST_APP_PAYLOAD_TYPE_ANCILLARY;

--- a/app/src/rx_audio_app.c
+++ b/app/src/rx_audio_app.c
@@ -217,21 +217,21 @@ static int app_rx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = audio ? audio->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_PORT_P],
-         audio ? audio->base.ip[MTL_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
+         audio ? audio->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P],
-          audio ? audio->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port[MTL_SESSION_PORT_P],
+          audio ? audio->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = audio ? audio->base.udp_port : (10100 + s->idx);
+  ops.udp_port[MTL_SESSION_PORT_P] = audio ? audio->base.udp_port : (10100 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_PORT_R],
-           audio ? audio->base.ip[MTL_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+           audio ? audio->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R],
+    strncpy(ops.port[MTL_SESSION_PORT_R],
             audio ? audio->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
             MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = audio ? audio->base.udp_port : (10100 + s->idx);
+    ops.udp_port[MTL_SESSION_PORT_R] = audio ? audio->base.udp_port : (10100 + s->idx);
   }
   ops.notify_frame_ready = app_rx_audio_frame_done;
   ops.notify_rtp_ready = app_rx_audio_rtp_ready;

--- a/app/src/rx_st20p_app.c
+++ b/app/src/rx_st20p_app.c
@@ -136,21 +136,23 @@ static int app_rx_st20p_init(struct st_app_context* ctx,
   ops.name = name;
   ops.priv = s;
   ops.port.num_port = st20p ? st20p->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.port.sip_addr[MTL_PORT_P],
-         st20p ? st20p->base.ip[MTL_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+  memcpy(ops.port.sip_addr[MTL_SESSION_PORT_P],
+         st20p ? st20p->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port.port[MTL_PORT_P],
-          st20p ? st20p->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port.port[MTL_SESSION_PORT_P],
+          st20p ? st20p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.port.udp_port[MTL_PORT_P] = st20p ? st20p->base.udp_port : (10000 + s->idx);
+  ops.port.udp_port[MTL_SESSION_PORT_P] = st20p ? st20p->base.udp_port : (10000 + s->idx);
   if (ops.port.num_port > 1) {
-    memcpy(ops.port.sip_addr[MTL_PORT_R],
-           st20p ? st20p->base.ip[MTL_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+    memcpy(ops.port.sip_addr[MTL_SESSION_PORT_R],
+           st20p ? st20p->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port.port[MTL_PORT_R],
-            st20p ? st20p->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.port.udp_port[MTL_PORT_R] = st20p ? st20p->base.udp_port : (10000 + s->idx);
+    strncpy(
+        ops.port.port[MTL_SESSION_PORT_R],
+        st20p ? st20p->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.port.udp_port[MTL_SESSION_PORT_R] =
+        st20p ? st20p->base.udp_port : (10000 + s->idx);
   }
 
   ops.width = st20p ? st20p->info.width : 1920;

--- a/app/src/rx_st20r_app.c
+++ b/app/src/rx_st20r_app.c
@@ -251,21 +251,22 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_PORT_P],
-         video ? video->base.ip[MTL_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
+         video ? video->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P],
+  strncpy(ops.port[MTL_SESSION_PORT_P],
           video ? video->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
+  ops.udp_port[MTL_SESSION_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_PORT_R],
-           video ? video->base.ip[MTL_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+           video ? video->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R],
-            video ? video->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = video ? video->base.udp_port : (10000 + s->idx);
+    strncpy(
+        ops.port[MTL_SESSION_PORT_R],
+        video ? video->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.udp_port[MTL_SESSION_PORT_R] = video ? video->base.udp_port : (10000 + s->idx);
   }
   ops.pacing = ST21_PACING_NARROW;
   ops.flags = ST20R_RX_FLAG_DMA_OFFLOAD;
@@ -281,12 +282,12 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
   st_pthread_mutex_init(&s->st20_wake_mutex, NULL);
   st_pthread_cond_init(&s->st20_wake_cond, NULL);
 
-  if (mtl_pmd_by_port_name(ops.port[MTL_PORT_P]) == MTL_PMD_DPDK_AF_XDP) {
+  if (mtl_pmd_by_port_name(ops.port[MTL_SESSION_PORT_P]) == MTL_PMD_DPDK_AF_XDP) {
     snprintf(s->st20_dst_url, ST_APP_URL_MAX_LEN, "st_app%d_%d_%d_%s.yuv", idx, ops.width,
-             ops.height, ops.port[MTL_PORT_P]);
+             ops.height, ops.port[MTL_SESSION_PORT_P]);
   } else {
     uint32_t soc = 0, b = 0, d = 0, f = 0;
-    sscanf(ops.port[MTL_PORT_P], "%x:%x:%x.%x", &soc, &b, &d, &f);
+    sscanf(ops.port[MTL_SESSION_PORT_P], "%x:%x:%x.%x", &soc, &b, &d, &f);
     snprintf(s->st20_dst_url, ST_APP_URL_MAX_LEN,
              "st_app%d_%d_%d_%02x_%02x_%02x-%02x.yuv", idx, ops.width, ops.height, soc, b,
              d, f);

--- a/app/src/rx_st22_app.c
+++ b/app/src/rx_st22_app.c
@@ -191,13 +191,14 @@ static int app_rx_st22_init(struct st_app_context* ctx, struct st22_app_rx_sessi
   ops.name = name;
   ops.priv = s;
   ops.num_port = ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_PORT_P], ctx->rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = 15000 + s->idx;
+  memcpy(ops.sip_addr[MTL_SESSION_PORT_P], ctx->rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  strncpy(ops.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops.udp_port[MTL_SESSION_PORT_P] = 15000 + s->idx;
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_PORT_R], ctx->rx_sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = 15000 + s->idx;
+    memcpy(ops.sip_addr[MTL_SESSION_PORT_R], ctx->rx_sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops.port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops.udp_port[MTL_SESSION_PORT_R] = 15000 + s->idx;
   }
   ops.pacing = ST21_PACING_NARROW;
   ops.width = s->width;

--- a/app/src/rx_st22p_app.c
+++ b/app/src/rx_st22p_app.c
@@ -136,21 +136,23 @@ static int app_rx_st22p_init(struct st_app_context* ctx,
   ops.name = name;
   ops.priv = s;
   ops.port.num_port = st22p ? st22p->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.port.sip_addr[MTL_PORT_P],
-         st22p ? st22p->base.ip[MTL_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+  memcpy(ops.port.sip_addr[MTL_SESSION_PORT_P],
+         st22p ? st22p->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port.port[MTL_PORT_P],
-          st22p ? st22p->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port.port[MTL_SESSION_PORT_P],
+          st22p ? st22p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.port.udp_port[MTL_PORT_P] = st22p ? st22p->base.udp_port : (10000 + s->idx);
+  ops.port.udp_port[MTL_SESSION_PORT_P] = st22p ? st22p->base.udp_port : (10000 + s->idx);
   if (ops.port.num_port > 1) {
-    memcpy(ops.port.sip_addr[MTL_PORT_R],
-           st22p ? st22p->base.ip[MTL_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+    memcpy(ops.port.sip_addr[MTL_SESSION_PORT_R],
+           st22p ? st22p->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port.port[MTL_PORT_R],
-            st22p ? st22p->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.port.udp_port[MTL_PORT_R] = st22p ? st22p->base.udp_port : (10000 + s->idx);
+    strncpy(
+        ops.port.port[MTL_SESSION_PORT_R],
+        st22p ? st22p->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.port.udp_port[MTL_SESSION_PORT_R] =
+        st22p ? st22p->base.udp_port : (10000 + s->idx);
   }
 
   ops.width = st22p ? st22p->info.width : 1920;

--- a/app/src/rx_video_app.c
+++ b/app/src/rx_video_app.c
@@ -436,21 +436,22 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_PORT_P],
-         video ? video->base.ip[MTL_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
+         video ? video->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P],
-          video ? video->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port[MTL_SESSION_PORT_P],
+          video ? video->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
+  ops.udp_port[MTL_SESSION_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_PORT_R],
-           video ? video->base.ip[MTL_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+           video ? video->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R],
-            video ? video->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = video ? video->base.udp_port : (10000 + s->idx);
+    strncpy(
+        ops.port[MTL_SESSION_PORT_R],
+        video ? video->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.udp_port[MTL_SESSION_PORT_R] = video ? video->base.udp_port : (10000 + s->idx);
   }
   ops.pacing = ST21_PACING_NARROW;
   if (ctx->rx_video_rtp_ring_size > 0)
@@ -490,12 +491,12 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
   st_pthread_mutex_init(&s->st20_wake_mutex, NULL);
   st_pthread_cond_init(&s->st20_wake_cond, NULL);
 
-  if (mtl_pmd_by_port_name(ops.port[MTL_PORT_P]) == MTL_PMD_DPDK_AF_XDP) {
+  if (mtl_pmd_by_port_name(ops.port[MTL_SESSION_PORT_P]) == MTL_PMD_DPDK_AF_XDP) {
     snprintf(s->st20_dst_url, ST_APP_URL_MAX_LEN, "st_app%d_%d_%d_%s.yuv", idx, ops.width,
-             ops.height, ops.port[MTL_PORT_P]);
+             ops.height, ops.port[MTL_SESSION_PORT_P]);
   } else {
     uint32_t soc = 0, b = 0, d = 0, f = 0;
-    sscanf(ops.port[MTL_PORT_P], "%x:%x:%x.%x", &soc, &b, &d, &f);
+    sscanf(ops.port[MTL_SESSION_PORT_P], "%x:%x:%x.%x", &soc, &b, &d, &f);
     snprintf(s->st20_dst_url, ST_APP_URL_MAX_LEN,
              "st_app%d_%d_%d_%02x_%02x_%02x-%02x.yuv", idx, ops.width, ops.height, soc, b,
              d, f);

--- a/app/src/tx_ancillary_app.c
+++ b/app/src/tx_ancillary_app.c
@@ -408,26 +408,28 @@ static int app_tx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   ops.name = name;
   ops.priv = s;
   ops.num_port = anc ? anc->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.dip_addr[MTL_PORT_P],
-         anc ? anc->base.ip[MTL_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P],
-          anc ? anc->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  memcpy(ops.dip_addr[MTL_SESSION_PORT_P],
+         anc ? anc->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops.port[MTL_SESSION_PORT_P],
+          anc ? anc->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = anc ? anc->base.udp_port : (10200 + s->idx);
+  ops.udp_port[MTL_SESSION_PORT_P] = anc ? anc->base.udp_port : (10200 + s->idx);
   if (ctx->has_tx_dst_mac[MTL_PORT_P]) {
-    memcpy(&ops.tx_dst_mac[MTL_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P], MTL_MAC_ADDR_LEN);
+    memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P],
+           MTL_MAC_ADDR_LEN);
     ops.flags |= ST40_TX_FLAG_USER_P_MAC;
   }
   if (ops.num_port > 1) {
-    memcpy(ops.dip_addr[MTL_PORT_R],
-           anc ? anc->base.ip[MTL_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+    memcpy(ops.dip_addr[MTL_SESSION_PORT_R],
+           anc ? anc->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R],
-            anc ? anc->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+    strncpy(ops.port[MTL_SESSION_PORT_R],
+            anc ? anc->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
             MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = anc ? anc->base.udp_port : (10200 + s->idx);
+    ops.udp_port[MTL_SESSION_PORT_R] = anc ? anc->base.udp_port : (10200 + s->idx);
     if (ctx->has_tx_dst_mac[MTL_PORT_R]) {
-      memcpy(&ops.tx_dst_mac[MTL_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
+      memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
              MTL_MAC_ADDR_LEN);
       ops.flags |= ST40_TX_FLAG_USER_R_MAC;
     }

--- a/app/src/tx_audio_app.c
+++ b/app/src/tx_audio_app.c
@@ -377,27 +377,29 @@ static int app_tx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = audio ? audio->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.dip_addr[MTL_PORT_P],
-         audio ? audio->base.ip[MTL_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+  memcpy(ops.dip_addr[MTL_SESSION_PORT_P],
+         audio ? audio->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P],
-          audio ? audio->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port[MTL_SESSION_PORT_P],
+          audio ? audio->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = audio ? audio->base.udp_port : (10100 + s->idx);
+  ops.udp_port[MTL_SESSION_PORT_P] = audio ? audio->base.udp_port : (10100 + s->idx);
   if (ctx->has_tx_dst_mac[MTL_PORT_P]) {
-    memcpy(&ops.tx_dst_mac[MTL_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P], MTL_MAC_ADDR_LEN);
+    memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P],
+           MTL_MAC_ADDR_LEN);
     ops.flags |= ST30_TX_FLAG_USER_P_MAC;
   }
   if (ops.num_port > 1) {
-    memcpy(ops.dip_addr[MTL_PORT_R],
+    memcpy(ops.dip_addr[MTL_SESSION_PORT_R],
            audio ? audio->base.ip[MTL_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R],
-            audio ? audio->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = audio ? audio->base.udp_port : (10100 + s->idx);
+    strncpy(
+        ops.port[MTL_SESSION_PORT_R],
+        audio ? audio->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.udp_port[MTL_SESSION_PORT_R] = audio ? audio->base.udp_port : (10100 + s->idx);
     if (ctx->has_tx_dst_mac[MTL_PORT_R]) {
-      memcpy(&ops.tx_dst_mac[MTL_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
+      memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
              MTL_MAC_ADDR_LEN);
       ops.flags |= ST30_TX_FLAG_USER_R_MAC;
     }

--- a/app/src/tx_st20p_app.c
+++ b/app/src/tx_st20p_app.c
@@ -198,27 +198,30 @@ static int app_tx_st20p_init(struct st_app_context* ctx, st_json_st20p_session_t
   ops.name = name;
   ops.priv = s;
   ops.port.num_port = st20p ? st20p->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.port.dip_addr[MTL_PORT_P],
-         st20p ? st20p->base.ip[MTL_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+  memcpy(ops.port.dip_addr[MTL_SESSION_PORT_P],
+         st20p ? st20p->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port.port[MTL_PORT_P],
-          st20p ? st20p->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port.port[MTL_SESSION_PORT_P],
+          st20p ? st20p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.port.udp_port[MTL_PORT_P] = st20p ? st20p->base.udp_port : (10000 + s->idx);
+  ops.port.udp_port[MTL_SESSION_PORT_P] = st20p ? st20p->base.udp_port : (10000 + s->idx);
   if (ctx->has_tx_dst_mac[MTL_PORT_P]) {
-    memcpy(&ops.tx_dst_mac[MTL_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P], MTL_MAC_ADDR_LEN);
+    memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P],
+           MTL_MAC_ADDR_LEN);
     ops.flags |= ST20P_TX_FLAG_USER_P_MAC;
   }
   if (ops.port.num_port > 1) {
-    memcpy(ops.port.dip_addr[MTL_PORT_R],
-           st20p ? st20p->base.ip[MTL_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+    memcpy(ops.port.dip_addr[MTL_SESSION_PORT_R],
+           st20p ? st20p->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port.port[MTL_PORT_R],
-            st20p ? st20p->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.port.udp_port[MTL_PORT_R] = st20p ? st20p->base.udp_port : (10000 + s->idx);
+    strncpy(
+        ops.port.port[MTL_SESSION_PORT_R],
+        st20p ? st20p->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.port.udp_port[MTL_SESSION_PORT_R] =
+        st20p ? st20p->base.udp_port : (10000 + s->idx);
     if (ctx->has_tx_dst_mac[MTL_PORT_R]) {
-      memcpy(&ops.tx_dst_mac[MTL_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
+      memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
              MTL_MAC_ADDR_LEN);
       ops.flags |= ST20P_TX_FLAG_USER_R_MAC;
     }

--- a/app/src/tx_st22_app.c
+++ b/app/src/tx_st22_app.c
@@ -256,19 +256,21 @@ static int app_tx_st22_init(struct st_app_context* ctx, struct st22_app_tx_sessi
   ops.name = name;
   ops.priv = s;
   ops.num_port = ctx->para.num_ports;
-  memcpy(ops.dip_addr[MTL_PORT_P], ctx->tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = 15000 + s->idx;
+  memcpy(ops.dip_addr[MTL_SESSION_PORT_P], ctx->tx_dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  strncpy(ops.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops.udp_port[MTL_SESSION_PORT_P] = 15000 + s->idx;
   if (ctx->has_tx_dst_mac[MTL_PORT_P]) {
-    memcpy(&ops.tx_dst_mac[MTL_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P], MTL_MAC_ADDR_LEN);
+    memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P],
+           MTL_MAC_ADDR_LEN);
     ops.flags |= ST22_TX_FLAG_USER_P_MAC;
   }
   if (ops.num_port > 1) {
-    memcpy(ops.dip_addr[MTL_PORT_R], ctx->tx_dip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = 15000 + s->idx;
+    memcpy(ops.dip_addr[MTL_SESSION_PORT_R], ctx->tx_dip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops.port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops.udp_port[MTL_SESSION_PORT_R] = 15000 + s->idx;
     if (ctx->has_tx_dst_mac[MTL_PORT_R]) {
-      memcpy(&ops.tx_dst_mac[MTL_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
+      memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
              MTL_MAC_ADDR_LEN);
       ops.flags |= ST22_TX_FLAG_USER_R_MAC;
     }

--- a/app/src/tx_st22p_app.c
+++ b/app/src/tx_st22p_app.c
@@ -198,27 +198,30 @@ static int app_tx_st22p_init(struct st_app_context* ctx, st_json_st22p_session_t
   ops.name = name;
   ops.priv = s;
   ops.port.num_port = st22p ? st22p->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.port.dip_addr[MTL_PORT_P],
-         st22p ? st22p->base.ip[MTL_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+  memcpy(ops.port.dip_addr[MTL_SESSION_PORT_P],
+         st22p ? st22p->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port.port[MTL_PORT_P],
-          st22p ? st22p->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port.port[MTL_SESSION_PORT_P],
+          st22p ? st22p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.port.udp_port[MTL_PORT_P] = st22p ? st22p->base.udp_port : (10000 + s->idx);
+  ops.port.udp_port[MTL_SESSION_PORT_P] = st22p ? st22p->base.udp_port : (10000 + s->idx);
   if (ctx->has_tx_dst_mac[MTL_PORT_P]) {
-    memcpy(&ops.tx_dst_mac[MTL_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P], MTL_MAC_ADDR_LEN);
+    memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P],
+           MTL_MAC_ADDR_LEN);
     ops.flags |= ST22P_TX_FLAG_USER_P_MAC;
   }
   if (ops.port.num_port > 1) {
-    memcpy(ops.port.dip_addr[MTL_PORT_R],
-           st22p ? st22p->base.ip[MTL_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+    memcpy(ops.port.dip_addr[MTL_SESSION_PORT_R],
+           st22p ? st22p->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port.port[MTL_PORT_R],
-            st22p ? st22p->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.port.udp_port[MTL_PORT_R] = st22p ? st22p->base.udp_port : (10000 + s->idx);
+    strncpy(
+        ops.port.port[MTL_SESSION_PORT_R],
+        st22p ? st22p->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.port.udp_port[MTL_SESSION_PORT_R] =
+        st22p ? st22p->base.udp_port : (10000 + s->idx);
     if (ctx->has_tx_dst_mac[MTL_PORT_R]) {
-      memcpy(&ops.tx_dst_mac[MTL_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
+      memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
              MTL_MAC_ADDR_LEN);
       ops.flags |= ST22P_TX_FLAG_USER_R_MAC;
     }

--- a/app/src/tx_video_app.c
+++ b/app/src/tx_video_app.c
@@ -676,27 +676,29 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.dip_addr[MTL_PORT_P],
-         video ? video->base.ip[MTL_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+  memcpy(ops.dip_addr[MTL_SESSION_PORT_P],
+         video ? video->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops.port[MTL_PORT_P],
-          video ? video->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
+  strncpy(ops.port[MTL_SESSION_PORT_P],
+          video ? video->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
           MTL_PORT_MAX_LEN);
-  ops.udp_port[MTL_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
+  ops.udp_port[MTL_SESSION_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
   if (ctx->has_tx_dst_mac[MTL_PORT_P]) {
-    memcpy(&ops.tx_dst_mac[MTL_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P], MTL_MAC_ADDR_LEN);
+    memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_P][0], ctx->tx_dst_mac[MTL_PORT_P],
+           MTL_MAC_ADDR_LEN);
     ops.flags |= ST20_TX_FLAG_USER_P_MAC;
   }
   if (ops.num_port > 1) {
-    memcpy(ops.dip_addr[MTL_PORT_R],
-           video ? video->base.ip[MTL_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+    memcpy(ops.dip_addr[MTL_SESSION_PORT_R],
+           video ? video->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops.port[MTL_PORT_R],
-            video ? video->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],
-            MTL_PORT_MAX_LEN);
-    ops.udp_port[MTL_PORT_R] = video ? video->base.udp_port : (10000 + s->idx);
+    strncpy(
+        ops.port[MTL_SESSION_PORT_R],
+        video ? video->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],
+        MTL_PORT_MAX_LEN);
+    ops.udp_port[MTL_SESSION_PORT_R] = video ? video->base.udp_port : (10000 + s->idx);
     if (ctx->has_tx_dst_mac[MTL_PORT_R]) {
-      memcpy(&ops.tx_dst_mac[MTL_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
+      memcpy(&ops.tx_dst_mac[MTL_SESSION_PORT_R][0], ctx->tx_dst_mac[MTL_PORT_R],
              MTL_MAC_ADDR_LEN);
       ops.flags |= ST20_TX_FLAG_USER_R_MAC;
     }

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -58,7 +58,7 @@ extern "C" {
 #define MTL_BIT32(nr) (UINT32_C(1) << (nr))
 
 /**
- * Max length of a DPDK port name
+ * Max length of a DPDK port name and session logical port
  */
 #define MTL_PORT_MAX_LEN (64)
 /**
@@ -129,7 +129,22 @@ typedef struct mtl_dma_mem* mtl_dma_mem_handle;
 enum mtl_port {
   MTL_PORT_P = 0, /**< primary port */
   MTL_PORT_R,     /**< redundant port */
+  MTL_PORT_2,     /**< port index: 2 */
+  MTL_PORT_3,     /**< port index: 3 */
+  MTL_PORT_4,     /**< port index: 4 */
+  MTL_PORT_5,     /**< port index: 5 */
+  MTL_PORT_6,     /**< port index: 6 */
+  MTL_PORT_7,     /**< port index: 7 */
   MTL_PORT_MAX,   /**< max value of this enum */
+};
+
+/**
+ * Session port logical type
+ */
+enum mtl_session_port {
+  MTL_SESSION_PORT_P = 0, /**< primary session(logical) port */
+  MTL_SESSION_PORT_R,     /**< redundant session(logical) port */
+  MTL_SESSION_PORT_MAX,   /**< max value of this enum */
 };
 
 /**

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -843,13 +843,13 @@ struct st20_tx_ops {
   /** private data to the callback function */
   void* priv;
   /** destination IP address */
-  uint8_t dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t dip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
 
   /** Sender pacing type */
   enum st21_pacing pacing;
@@ -880,7 +880,7 @@ struct st20_tx_ops {
    * tx destination mac address.
    * Valid if ST20_TX_FLAG_USER_P(R)_MAC is enabled
    */
-  uint8_t tx_dst_mac[MTL_PORT_MAX][MTL_MAC_ADDR_LEN];
+  uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
 
   /**
    * the frame buffer count requested for one st20 tx session,
@@ -958,13 +958,13 @@ struct st22_tx_ops {
   /** private data to the callback function */
   void* priv;
   /** destination IP address */
-  uint8_t dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t dip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
 
   /** Session streaming type, frame or RTP */
   enum st22_type type;
@@ -987,7 +987,7 @@ struct st22_tx_ops {
    * tx destination mac address.
    * Valid if ST22_TX_FLAG_USER_P(R)_MAC is enabled
    */
-  uint8_t tx_dst_mac[MTL_PORT_MAX][MTL_MAC_ADDR_LEN];
+  uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
 
   /**
    * the frame buffer count requested for one st22 tx session,
@@ -1095,13 +1095,13 @@ struct st20_rx_ops {
   /** private data to the callback function */
   void* priv;
   /** source IP address of sender */
-  uint8_t sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
 
   /** Sender pacing type */
   enum st21_pacing pacing;
@@ -1235,13 +1235,13 @@ struct st22_rx_ops {
   /** private data to the callback function */
   void* priv;
   /** source IP address of sender */
-  uint8_t sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** flags, value in ST22_RX_FLAG_* */
   uint32_t flags;
 

--- a/include/st20_redundant_api.h
+++ b/include/st20_redundant_api.h
@@ -64,13 +64,13 @@ struct st20r_rx_ops {
   /** private data to the callback function */
   void* priv;
   /** source IP address of sender */
-  uint8_t sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** num of ports this session attached to, must be 2 */
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
 
   /** Sender pacing type */
   enum st21_pacing pacing;

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -234,13 +234,13 @@ struct st30_tx_ops {
   /** private data to the callback function */
   void* priv;
   /** destination IP address */
-  uint8_t dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t dip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
 
   /** Session payload format */
   enum st30_fmt fmt;
@@ -270,7 +270,7 @@ struct st30_tx_ops {
    * tx destination mac address.
    * Valid if ST30_TX_FLAG_USER_P(R)_MAC is enabled
    */
-  uint8_t tx_dst_mac[MTL_PORT_MAX][MTL_MAC_ADDR_LEN];
+  uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
 
   /**
    * the frame buffer count requested for one st30 tx session,
@@ -327,13 +327,13 @@ struct st30_rx_ops {
   /** private data to the callback function */
   void* priv;
   /** source IP address of sender */
-  uint8_t sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** flags, value in ST30_RX_FLAG_* */
   uint32_t flags;
 

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -219,13 +219,13 @@ struct st40_tx_ops {
   /** private data to the callback function */
   void* priv;
   /** destination IP address */
-  uint8_t dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t dip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** Session streaming type, frame or RTP */
   enum st40_type type;
   /** Session fps */
@@ -238,7 +238,7 @@ struct st40_tx_ops {
    * tx destination mac address.
    * Valid if ST40_TX_FLAG_USER_P(R)_MAC is enabled
    */
-  uint8_t tx_dst_mac[MTL_PORT_MAX][MTL_MAC_ADDR_LEN];
+  uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
 
   /**
    * the frame buffer count requested for one st40 tx session,
@@ -290,13 +290,13 @@ struct st40_rx_ops {
   /** private data to the callback function */
   void* priv;
   /** source IP address of sender */
-  uint8_t sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** flags, value in ST40_RX_FLAG_* */
   uint32_t flags;
 

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -599,13 +599,13 @@ struct st20_convert_frame_meta {
 /** The structure info for st tx port, used in creating session. */
 struct st_tx_port {
   /** destination IP address */
-  uint8_t dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t dip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** 7 bits payload type define in RFC3550 */
   uint8_t payload_type;
 };
@@ -613,13 +613,13 @@ struct st_tx_port {
 /** The structure info for st rx port, used in creating session. */
 struct st_rx_port {
   /** source IP address of sender */
-  uint8_t sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
+  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
   /** UDP port number */
-  uint16_t udp_port[MTL_PORT_MAX];
+  uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** 7 bits payload type define in RFC3550 */
   uint8_t payload_type;
 };
@@ -638,7 +638,7 @@ struct st20p_tx_ops {
    * tx destination mac address.
    * Valid if ST20P_TX_FLAG_USER_P(R)_MAC is enabled
    */
-  uint8_t tx_dst_mac[MTL_PORT_MAX][MTL_MAC_ADDR_LEN];
+  uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
   /** Session resolution width */
   uint32_t width;
   /** Session resolution height */
@@ -750,7 +750,7 @@ struct st22p_tx_ops {
    * tx destination mac address.
    * Valid if ST22P_TX_FLAG_USER_P(R)_MAC is enabled
    */
-  uint8_t tx_dst_mac[MTL_PORT_MAX][MTL_MAC_ADDR_LEN];
+  uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
   /** Session resolution width */
   uint32_t width;
   /** Session resolution height */

--- a/lib/src/mt_header.h
+++ b/lib/src/mt_header.h
@@ -35,12 +35,6 @@ enum mt_handle_type {
   MT_HANDLE_MAX,
 };
 
-enum mt_session_port {
-  MT_SESSION_PORT_P = 0, /* primary session(logical) port */
-  MT_SESSION_PORT_R,     /* redundant session(logical) port */
-  MT_SESSION_PORT_MAX,
-};
-
 /* total size: 42 */
 struct mt_udp_hdr {
   struct rte_ether_hdr eth; /* size: 14 */

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -404,7 +404,7 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
   mt_asan_init();
 #endif
 
-  RTE_BUILD_BUG_ON(MT_SESSION_PORT_MAX > (int)MTL_PORT_MAX);
+  RTE_BUILD_BUG_ON(MTL_SESSION_PORT_MAX > (int)MTL_PORT_MAX);
   RTE_BUILD_BUG_ON(sizeof(struct mt_udp_hdr) != 42);
 
   ret = mt_user_params_check(p);

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -64,7 +64,7 @@ int mt_build_port_map(struct mtl_main_impl* impl, char** ports, enum mtl_port* m
 
 /* logical session port to main(physical) port */
 static inline enum mtl_port mt_port_logic2phy(enum mtl_port* maps,
-                                              enum mt_session_port logic) {
+                                              enum mtl_session_port logic) {
   return maps[logic];
 }
 

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -317,7 +317,7 @@ static int rx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_rx
   memset(&ops_rx, 0, sizeof(ops_rx));
   ops_rx.name = ops->name;
   ops_rx.priv = ctx;
-  ops_rx.num_port = RTE_MIN(ops->port.num_port, MTL_PORT_MAX);
+  ops_rx.num_port = RTE_MIN(ops->port.num_port, MTL_SESSION_PORT_MAX);
   for (int i = 0; i < ops_rx.num_port; i++) {
     memcpy(ops_rx.sip_addr[i], ops->port.sip_addr[i], MTL_IP_ADDR_LEN);
     strncpy(ops_rx.port[i], ops->port.port[i], MTL_PORT_MAX_LEN);

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -228,20 +228,20 @@ static int tx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_tx
   memset(&ops_tx, 0, sizeof(ops_tx));
   ops_tx.name = ops->name;
   ops_tx.priv = ctx;
-  ops_tx.num_port = RTE_MIN(ops->port.num_port, MTL_PORT_MAX);
+  ops_tx.num_port = RTE_MIN(ops->port.num_port, MTL_SESSION_PORT_MAX);
   for (int i = 0; i < ops_tx.num_port; i++) {
     memcpy(ops_tx.dip_addr[i], ops->port.dip_addr[i], MTL_IP_ADDR_LEN);
     strncpy(ops_tx.port[i], ops->port.port[i], MTL_PORT_MAX_LEN);
     ops_tx.udp_port[i] = ops->port.udp_port[i];
   }
   if (ops->flags & ST20P_TX_FLAG_USER_P_MAC) {
-    memcpy(&ops_tx.tx_dst_mac[MTL_PORT_P][0], &ops->tx_dst_mac[MTL_PORT_P][0],
-           MTL_MAC_ADDR_LEN);
+    memcpy(&ops_tx.tx_dst_mac[MTL_SESSION_PORT_P][0],
+           &ops->tx_dst_mac[MTL_SESSION_PORT_P][0], MTL_MAC_ADDR_LEN);
     ops_tx.flags |= ST20_TX_FLAG_USER_P_MAC;
   }
   if (ops->flags & ST20P_TX_FLAG_USER_R_MAC) {
-    memcpy(&ops_tx.tx_dst_mac[MTL_PORT_R][0], &ops->tx_dst_mac[MTL_PORT_R][0],
-           MTL_MAC_ADDR_LEN);
+    memcpy(&ops_tx.tx_dst_mac[MTL_SESSION_PORT_R][0],
+           &ops->tx_dst_mac[MTL_SESSION_PORT_R][0], MTL_MAC_ADDR_LEN);
     ops_tx.flags |= ST20_TX_FLAG_USER_R_MAC;
   }
   ops_tx.pacing = ST21_PACING_NARROW;

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -192,7 +192,7 @@ static int rx_st22p_create_transport(struct mtl_main_impl* impl, struct st22p_rx
   memset(&ops_rx, 0, sizeof(ops_rx));
   ops_rx.name = ops->name;
   ops_rx.priv = ctx;
-  ops_rx.num_port = RTE_MIN(ops->port.num_port, MTL_PORT_MAX);
+  ops_rx.num_port = RTE_MIN(ops->port.num_port, MTL_SESSION_PORT_MAX);
   for (int i = 0; i < ops_rx.num_port; i++) {
     memcpy(ops_rx.sip_addr[i], ops->port.sip_addr[i], MTL_IP_ADDR_LEN);
     strncpy(ops_rx.port[i], ops->port.port[i], MTL_PORT_MAX_LEN);

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -225,19 +225,19 @@ static int tx_st22p_create_transport(struct mtl_main_impl* impl, struct st22p_tx
   memset(&ops_tx, 0, sizeof(ops_tx));
   ops_tx.name = ops->name;
   ops_tx.priv = ctx;
-  ops_tx.num_port = RTE_MIN(ops->port.num_port, MTL_PORT_MAX);
+  ops_tx.num_port = RTE_MIN(ops->port.num_port, MTL_SESSION_PORT_MAX);
   for (int i = 0; i < ops_tx.num_port; i++) {
     memcpy(ops_tx.dip_addr[i], ops->port.dip_addr[i], MTL_IP_ADDR_LEN);
     strncpy(ops_tx.port[i], ops->port.port[i], MTL_PORT_MAX_LEN);
     ops_tx.udp_port[i] = ops->port.udp_port[i];
   }
   if (ops->flags & ST22P_TX_FLAG_USER_P_MAC) {
-    memcpy(&ops_tx.tx_dst_mac[MTL_PORT_P][0], &ops->tx_dst_mac[MTL_PORT_P][0],
+    memcpy(&ops_tx.tx_dst_mac[MTL_SESSION_PORT_P][0], &ops->tx_dst_mac[MTL_PORT_P][0],
            MTL_MAC_ADDR_LEN);
     ops_tx.flags |= ST22_TX_FLAG_USER_P_MAC;
   }
   if (ops->flags & ST22P_TX_FLAG_USER_R_MAC) {
-    memcpy(&ops_tx.tx_dst_mac[MTL_PORT_R][0], &ops->tx_dst_mac[MTL_PORT_R][0],
+    memcpy(&ops_tx.tx_dst_mac[MTL_SESSION_PORT_R][0], &ops->tx_dst_mac[MTL_PORT_R][0],
            MTL_MAC_ADDR_LEN);
     ops_tx.flags |= ST22_TX_FLAG_USER_R_MAC;
   }

--- a/lib/src/st2110/redundant/st20_redundant_rx.c
+++ b/lib/src/st2110/redundant/st20_redundant_rx.c
@@ -120,7 +120,7 @@ static int rx_st20r_free_transport(struct st20r_rx_transport* transport) {
 }
 
 static int rx_st20r_create_transport(struct st20r_rx_ctx* ctx, struct st20r_rx_ops* ops,
-                                     enum mtl_port port) {
+                                     enum mtl_session_port port) {
   int idx = ctx->idx;
   struct mtl_main_impl* impl = ctx->impl;
   struct st20r_rx_transport* transport;
@@ -144,9 +144,9 @@ static int rx_st20r_create_transport(struct st20r_rx_ctx* ctx, struct st20r_rx_o
   ops_rx.name = ops->name;
   ops_rx.priv = transport;
   ops_rx.num_port = 1;
-  memcpy(ops_rx.sip_addr[MTL_PORT_P], ops->sip_addr[port], MTL_IP_ADDR_LEN);
-  strncpy(ops_rx.port[MTL_PORT_P], ops->port[port], MTL_PORT_MAX_LEN - 1);
-  ops_rx.udp_port[MTL_PORT_P] = ops->udp_port[port];
+  memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ops->sip_addr[port], MTL_IP_ADDR_LEN);
+  strncpy(ops_rx.port[MTL_SESSION_PORT_P], ops->port[port], MTL_PORT_MAX_LEN - 1);
+  ops_rx.udp_port[MTL_SESSION_PORT_P] = ops->udp_port[port];
 
   if (ops->flags & ST20R_RX_FLAG_DATA_PATH_ONLY)
     ops_rx.flags |= ST20_RX_FLAG_DATA_PATH_ONLY;
@@ -167,13 +167,14 @@ static int rx_st20r_create_transport(struct st20r_rx_ctx* ctx, struct st20r_rx_o
   ops_rx.type = ST20_TYPE_FRAME_LEVEL;
   ops_rx.framebuff_cnt = ops->framebuff_cnt;
   ops_rx.notify_frame_ready = rx_st20r_frame_ready;
-  if (port == MTL_PORT_P) /* only register vsync to p port now */
+  if (port == MTL_SESSION_PORT_P) /* only register vsync to p port now */
     ops_rx.notify_event = rx_st20r_notify_event;
 
   mt_sch_mask_t sch_mask = MT_SCH_MASK_ALL;
-  if (port == MTL_PORT_R) {
+  if (port == MTL_SESSION_PORT_R) {
     /* let R port select a different sch */
-    sch_mask &= ~(MTL_BIT64(st20_rx_get_sch_idx(ctx->transport[MTL_PORT_P]->handle)));
+    sch_mask &=
+        ~(MTL_BIT64(st20_rx_get_sch_idx(ctx->transport[MTL_SESSION_PORT_P]->handle)));
   }
   dbg("%s(%d,%d), sch_mask %" PRIx64 "\n", __func__, idx, port, sch_mask);
   transport->handle = st20_rx_create_with_mask(impl, &ops_rx, sch_mask);
@@ -199,7 +200,7 @@ int st20r_rx_free(st20r_rx_handle handle) {
 
   ctx->ready = false;
 
-  for (int i = 0; i < MTL_PORT_MAX; i++) {
+  for (int i = 0; i < MTL_SESSION_PORT_MAX; i++) {
     if (ctx->transport[i]) {
       rx_st20r_free_transport(ctx->transport[i]);
       ctx->transport[i] = NULL;
@@ -227,13 +228,13 @@ st20r_rx_handle st20r_rx_create(mtl_handle mt, struct st20r_rx_ops* ops) {
     err("%s, invalid st type %d\n", __func__, impl->type);
     return NULL;
   }
-  if (num_port != MTL_PORT_MAX) {
+  if (num_port != MTL_SESSION_PORT_MAX) {
     err("%s, invalid num_port %u\n", __func__, num_port);
     return NULL;
   }
-  if (0 ==
-      memcmp(ops->sip_addr[MTL_PORT_P], ops->sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN)) {
-    uint8_t* ip = ops->sip_addr[MTL_PORT_P];
+  if (0 == memcmp(ops->sip_addr[MTL_SESSION_PORT_P], ops->sip_addr[MTL_SESSION_PORT_R],
+                  MTL_IP_ADDR_LEN)) {
+    uint8_t* ip = ops->sip_addr[MTL_SESSION_PORT_P];
     err("%s, same %d.%d.%d.%d for both ip\n", __func__, ip[0], ip[1], ip[2], ip[3]);
     return NULL;
   }
@@ -299,7 +300,7 @@ size_t st20r_rx_get_framebuffer_size(st20r_rx_handle handle) {
     return -EIO;
   }
 
-  return st20_rx_get_framebuffer_size(ctx->transport[MTL_PORT_P]->handle);
+  return st20_rx_get_framebuffer_size(ctx->transport[MTL_SESSION_PORT_P]->handle);
 }
 
 int st20r_rx_get_framebuffer_count(st20r_rx_handle handle) {
@@ -310,7 +311,7 @@ int st20r_rx_get_framebuffer_count(st20r_rx_handle handle) {
     return -EIO;
   }
 
-  return st20_rx_get_framebuffer_count(ctx->transport[MTL_PORT_P]->handle);
+  return st20_rx_get_framebuffer_count(ctx->transport[MTL_SESSION_PORT_P]->handle);
 }
 
 int st20r_rx_pcapng_dump(st20r_rx_handle handle, uint32_t max_dump_packets, bool sync,
@@ -323,9 +324,9 @@ int st20r_rx_pcapng_dump(st20r_rx_handle handle, uint32_t max_dump_packets, bool
     return -EIO;
   }
 
-  ret += st20_rx_pcapng_dump(ctx->transport[MTL_PORT_P]->handle, max_dump_packets, sync,
-                             meta);
-  ret += st20_rx_pcapng_dump(ctx->transport[MTL_PORT_R]->handle, max_dump_packets, sync,
-                             meta);
+  ret += st20_rx_pcapng_dump(ctx->transport[MTL_SESSION_PORT_P]->handle, max_dump_packets,
+                             sync, meta);
+  ret += st20_rx_pcapng_dump(ctx->transport[MTL_SESSION_PORT_R]->handle, max_dump_packets,
+                             sync, meta);
   return ret;
 }

--- a/lib/src/st2110/redundant/st20_redundant_rx.c
+++ b/lib/src/st2110/redundant/st20_redundant_rx.c
@@ -22,7 +22,8 @@ static int rx_st20r_frame_pop(struct st20r_rx_ctx* ctx, void* frame) {
   return -EIO;
 }
 
-static int rx_st20r_frame_push(struct st20r_rx_ctx* ctx, void* frame, enum mtl_port port,
+static int rx_st20r_frame_push(struct st20r_rx_ctx* ctx, void* frame,
+                               enum mtl_session_port port,
                                struct st20_rx_frame_meta* meta) {
   struct st20r_rx_frame* rx_frame;
   int ret;
@@ -53,7 +54,7 @@ static int rx_st20r_frame_ready(void* priv, void* frame,
   struct st20r_rx_transport* transport = priv;
   struct st20r_rx_ctx* ctx = transport->parnet;
   int idx = ctx->idx;
-  enum mtl_port port = transport->port;
+  enum mtl_session_port port = transport->port;
   int ret = -EIO;
 
   if (!ctx->ready) return -EBUSY; /* not ready */
@@ -80,7 +81,7 @@ static int rx_st20r_frame_ready(void* priv, void* frame,
     if (st_is_frame_complete(meta->status)) {
       if (!ctx->cur_frame_complete) {
         /* full frame get at r session */
-        ret = rx_st20r_frame_push(ctx, frame, transport->port, meta);
+        ret = rx_st20r_frame_push(ctx, frame, port, meta);
         if (ret >= 0) {
           ctx->cur_frame_complete = true;
           info("%s(%d), push frame %p at r_port %d\n", __func__, idx, frame, port);

--- a/lib/src/st2110/redundant/st20_redundant_rx.h
+++ b/lib/src/st2110/redundant/st20_redundant_rx.h
@@ -13,13 +13,13 @@ struct st20r_rx_ctx;
 
 struct st20r_rx_transport {
   st20_rx_handle handle;
-  enum mtl_port port; /* port this handle attached */
+  enum mtl_session_port port; /* port this handle attached */
   struct st20r_rx_ctx* parnet;
 };
 
 struct st20r_rx_frame {
   void* frame;
-  enum mtl_port port;
+  enum mtl_session_port port;
   struct st20_rx_frame_meta meta;
 };
 

--- a/lib/src/st2110/redundant/st20_redundant_rx.h
+++ b/lib/src/st2110/redundant/st20_redundant_rx.h
@@ -33,7 +33,7 @@ struct st20r_rx_ctx {
 
   pthread_mutex_t lock;
   bool ready;
-  struct st20r_rx_transport* transport[MTL_PORT_MAX];
+  struct st20r_rx_transport* transport[MTL_SESSION_PORT_MAX];
 
   /* global status for current frame */
   void* cur_frame;

--- a/lib/src/st2110/st_ancillary_transmitter.c
+++ b/lib/src/st2110/st_ancillary_transmitter.c
@@ -141,7 +141,8 @@ int st_ancillary_transmitter_uinit(struct st_ancillary_transmitter_impl* trs) {
     trs->tasklet = NULL;
   }
 
-  info("%s(%d), succ, inflight %d:%d\n", __func__, idx, trs->inflight_cnt[MTL_PORT_P],
-       trs->inflight_cnt[MTL_PORT_R]);
+  for (int i = 0; i < mt_num_ports(trs->parnet); i++) {
+    info("%s(%d), succ, inflight %d:%d\n", __func__, idx, i, trs->inflight_cnt[i]);
+  }
   return 0;
 }

--- a/lib/src/st2110/st_audio_transmitter.c
+++ b/lib/src/st2110/st_audio_transmitter.c
@@ -140,7 +140,8 @@ int st_audio_transmitter_uinit(struct st_audio_transmitter_impl* trs) {
     trs->tasklet = NULL;
   }
 
-  info("%s(%d), succ, inflight %d:%d\n", __func__, idx, trs->inflight_cnt[MTL_PORT_P],
-       trs->inflight_cnt[MTL_PORT_R]);
+  for (int i = 0; i < mt_num_ports(trs->parnet); i++) {
+    info("%s(%d), succ, inflight %d:%d\n", __func__, idx, i, trs->inflight_cnt[i]);
+  }
   return 0;
 }

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -213,7 +213,7 @@ struct st22_tx_video_info {
   int (*notify_frame_done)(void* priv, uint16_t frame_idx,
                            struct st22_tx_frame_meta* meta);
 
-  struct st22_rfc9134_rtp_hdr rtp_hdr[MT_SESSION_PORT_MAX];
+  struct st22_rfc9134_rtp_hdr rtp_hdr[MTL_SESSION_PORT_MAX];
   int pkt_idx;           /* for P&F counter*/
   size_t cur_frame_size; /* size per frame */
   int frame_idx;         /* The Frame (F) counter */
@@ -230,20 +230,20 @@ struct st_vsync_info {
 };
 
 struct st_tx_video_session_impl {
-  enum mtl_port port_maps[MT_SESSION_PORT_MAX];
-  struct rte_mempool* mbuf_mempool_hdr[MT_SESSION_PORT_MAX];
-  bool mbuf_mempool_reuse_rx[MT_SESSION_PORT_MAX]; /* af_xdp zero copy */
+  enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
+  struct rte_mempool* mbuf_mempool_hdr[MTL_SESSION_PORT_MAX];
+  bool mbuf_mempool_reuse_rx[MTL_SESSION_PORT_MAX]; /* af_xdp zero copy */
   struct rte_mempool* mbuf_mempool_chain;
   bool tx_mono_pool; /* if reuse tx mono pool */
   /* if the eth dev support chain buff */
-  bool eth_has_chain[MT_SESSION_PORT_MAX];
+  bool eth_has_chain[MTL_SESSION_PORT_MAX];
   /* if the eth dev support ipv4 checksum offload */
-  bool eth_ipv4_cksum_offload[MT_SESSION_PORT_MAX];
+  bool eth_ipv4_cksum_offload[MTL_SESSION_PORT_MAX];
   unsigned int ring_count;
-  struct rte_ring* ring[MT_SESSION_PORT_MAX];
+  struct rte_ring* ring[MTL_SESSION_PORT_MAX];
   struct rte_ring* packet_ring; /* rtp ring */
-  uint16_t port_id[MT_SESSION_PORT_MAX];
-  struct mt_tx_queue* queue[MT_SESSION_PORT_MAX];
+  uint16_t port_id[MTL_SESSION_PORT_MAX];
+  struct mt_tx_queue* queue[MTL_SESSION_PORT_MAX];
   int idx; /* index for current tx_session */
   uint64_t advice_sleep_us;
 
@@ -251,15 +251,15 @@ struct st_tx_video_session_impl {
   struct st22_tx_video_session_handle_impl* st22_handle;
 
   uint16_t st20_ipv4_packet_id;
-  uint16_t st20_src_port[MT_SESSION_PORT_MAX]; /* udp port */
-  uint16_t st20_dst_port[MT_SESSION_PORT_MAX]; /* udp port */
-  struct st_rfc4175_video_hdr s_hdr[MT_SESSION_PORT_MAX];
+  uint16_t st20_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st20_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  struct st_rfc4175_video_hdr s_hdr[MTL_SESSION_PORT_MAX];
 
   struct st_tx_video_pacing pacing;
-  enum st21_tx_pacing_way pacing_way[MT_SESSION_PORT_MAX];
-  int (*pacing_tasklet_func[MT_SESSION_PORT_MAX])(struct mtl_main_impl* impl,
+  enum st21_tx_pacing_way pacing_way[MTL_SESSION_PORT_MAX];
+  int (*pacing_tasklet_func[MTL_SESSION_PORT_MAX])(struct mtl_main_impl* impl,
                                                   struct st_tx_video_session_impl* s,
-                                                  enum mt_session_port s_port);
+                                                  enum mtl_session_port s_port);
 
   struct st_vsync_info vsync;
 
@@ -268,21 +268,21 @@ struct st_tx_video_session_impl {
   enum mt_handle_type s_type; /* st22 or st20 */
 
   unsigned int bulk; /* Enqueue bulk objects on the ring */
-  struct rte_mbuf* inflight[MT_SESSION_PORT_MAX][ST_SESSION_MAX_BULK];
-  bool has_inflight[MT_SESSION_PORT_MAX];
-  int inflight_cnt[MT_SESSION_PORT_MAX]; /* for stats */
+  struct rte_mbuf* inflight[MTL_SESSION_PORT_MAX][ST_SESSION_MAX_BULK];
+  bool has_inflight[MTL_SESSION_PORT_MAX];
+  int inflight_cnt[MTL_SESSION_PORT_MAX]; /* for stats */
 
   /* info for transmitter */
-  uint64_t trs_target_tsc[MT_SESSION_PORT_MAX];
-  struct rte_mbuf* trs_inflight[MT_SESSION_PORT_MAX][ST_SESSION_MAX_BULK];
-  unsigned int trs_inflight_num[MT_SESSION_PORT_MAX];
-  unsigned int trs_inflight_idx[MT_SESSION_PORT_MAX];
-  unsigned int trs_pad_inflight_num[MT_SESSION_PORT_MAX]; /* inflight padding */
-  int trs_inflight_cnt[MT_SESSION_PORT_MAX];              /* for stats */
-  struct rte_mbuf* trs_inflight2[MT_SESSION_PORT_MAX][ST_SESSION_MAX_BULK];
-  unsigned int trs_inflight_num2[MT_SESSION_PORT_MAX];
-  unsigned int trs_inflight_idx2[MT_SESSION_PORT_MAX];
-  int trs_inflight_cnt2[MT_SESSION_PORT_MAX]; /* for stats */
+  uint64_t trs_target_tsc[MTL_SESSION_PORT_MAX];
+  struct rte_mbuf* trs_inflight[MTL_SESSION_PORT_MAX][ST_SESSION_MAX_BULK];
+  unsigned int trs_inflight_num[MTL_SESSION_PORT_MAX];
+  unsigned int trs_inflight_idx[MTL_SESSION_PORT_MAX];
+  unsigned int trs_pad_inflight_num[MTL_SESSION_PORT_MAX]; /* inflight padding */
+  int trs_inflight_cnt[MTL_SESSION_PORT_MAX];              /* for stats */
+  struct rte_mbuf* trs_inflight2[MTL_SESSION_PORT_MAX][ST_SESSION_MAX_BULK];
+  unsigned int trs_inflight_num2[MTL_SESSION_PORT_MAX];
+  unsigned int trs_inflight_idx2[MTL_SESSION_PORT_MAX];
+  int trs_inflight_cnt2[MTL_SESSION_PORT_MAX]; /* for stats */
 
   /* frame info */
   size_t st20_frame_size;   /* size per frame */
@@ -310,7 +310,7 @@ struct st_tx_video_session_impl {
   int st21_vrx_wide;         /* pass criteria for wide */
 
   struct st20_packet_group_info st20_pkt_info[ST20_PKT_TYPE_MAX];
-  struct rte_mbuf* pad[MT_SESSION_PORT_MAX][ST20_PKT_TYPE_MAX];
+  struct rte_mbuf* pad[MTL_SESSION_PORT_MAX][ST20_PKT_TYPE_MAX];
 
   /* the cpu resource to handle tx, 0: full, 100: cpu is very busy */
   float cpu_busy_score;
@@ -330,7 +330,7 @@ struct st_tx_video_session_impl {
   int stat_pkts_dummy;
   int stat_pkts_burst;
   int stat_pkts_burst_dummy;
-  int stat_trs_ret_code[MT_SESSION_PORT_MAX];
+  int stat_trs_ret_code[MTL_SESSION_PORT_MAX];
   int stat_build_ret_code;
   uint64_t stat_last_time;
   uint32_t stat_epoch_drop;
@@ -547,11 +547,11 @@ struct st_rx_video_session_impl {
   char ops_name[ST_MAX_NAME_LEN];
   uint64_t advice_sleep_us;
 
-  enum mtl_port port_maps[MT_SESSION_PORT_MAX];
-  struct mt_rx_queue* queue[MT_SESSION_PORT_MAX];
-  uint16_t port_id[MT_SESSION_PORT_MAX];
-  uint16_t st20_src_port[MT_SESSION_PORT_MAX]; /* udp port */
-  uint16_t st20_dst_port[MT_SESSION_PORT_MAX]; /* udp port */
+  enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
+  struct mt_rx_queue* queue[MTL_SESSION_PORT_MAX];
+  uint16_t port_id[MTL_SESSION_PORT_MAX];
+  uint16_t st20_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st20_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
 
   struct st_rx_video_session_handle_impl* st20_handle;
   struct st22_rx_video_session_handle_impl* st22_handle;
@@ -559,7 +559,7 @@ struct st_rx_video_session_impl {
   struct st22_rx_video_info* st22_info;
 
   bool is_hdr_split;
-  struct st_rx_video_hdr_split_info hdr_split_info[MT_SESSION_PORT_MAX];
+  struct st_rx_video_hdr_split_info hdr_split_info[MTL_SESSION_PORT_MAX];
 
   /* st20 detector info */
   struct st_rx_video_detector detector;
@@ -654,7 +654,7 @@ struct st_rx_video_session_impl {
 
   /* ret > 0 if it's handled by DMA */
   int (*pkt_handler)(struct st_rx_video_session_impl* s, struct rte_mbuf* mbuf,
-                     enum mt_session_port s_port, bool ctrl_thread);
+                     enum mtl_session_port s_port, bool ctrl_thread);
 };
 
 struct st_rx_video_sessions_mgr {
@@ -685,17 +685,17 @@ struct st_tx_audio_session_impl {
   struct st30_tx_ops ops;
   char ops_name[ST_MAX_NAME_LEN];
 
-  enum mtl_port port_maps[MT_SESSION_PORT_MAX];
-  struct rte_mempool* mbuf_mempool_hdr[MT_SESSION_PORT_MAX];
+  enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
+  struct rte_mempool* mbuf_mempool_hdr[MTL_SESSION_PORT_MAX];
   struct rte_mempool* mbuf_mempool_chain;
   bool tx_mono_pool; /* if reuse tx mono pool */
   /* if the eth dev support chain buff */
-  bool eth_has_chain[MT_SESSION_PORT_MAX];
+  bool eth_has_chain[MTL_SESSION_PORT_MAX];
   /* if the eth dev support ipv4 checksum offload */
-  bool eth_ipv4_cksum_offload[MT_SESSION_PORT_MAX];
-  struct rte_mbuf* inflight[MT_SESSION_PORT_MAX];
-  bool has_inflight[MT_SESSION_PORT_MAX];
-  int inflight_cnt[MT_SESSION_PORT_MAX]; /* for stats */
+  bool eth_ipv4_cksum_offload[MTL_SESSION_PORT_MAX];
+  struct rte_mbuf* inflight[MTL_SESSION_PORT_MAX];
+  bool has_inflight[MTL_SESSION_PORT_MAX];
+  int inflight_cnt[MTL_SESSION_PORT_MAX]; /* for stats */
   struct rte_ring* packet_ring;
 
   uint16_t st30_frames_cnt; /* numbers of frames requested */
@@ -705,9 +705,9 @@ struct st_tx_audio_session_impl {
   enum st30_tx_frame_status st30_frame_stat;
 
   uint16_t st30_ipv4_packet_id;
-  uint16_t st30_src_port[MT_SESSION_PORT_MAX]; /* udp port */
-  uint16_t st30_dst_port[MT_SESSION_PORT_MAX]; /* udp port */
-  struct st_rfc3550_audio_hdr hdr[MT_SESSION_PORT_MAX];
+  uint16_t st30_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st30_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  struct st_rfc3550_audio_hdr hdr[MTL_SESSION_PORT_MAX];
 
   struct st_tx_audio_session_pacing pacing;
 
@@ -804,12 +804,12 @@ struct st_rx_audio_session_impl {
   struct st30_rx_ops ops;
   char ops_name[ST_MAX_NAME_LEN];
 
-  enum mtl_port port_maps[MT_SESSION_PORT_MAX];
-  struct mt_rx_queue* queue[MT_SESSION_PORT_MAX];
-  uint16_t port_id[MT_SESSION_PORT_MAX];
+  enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
+  struct mt_rx_queue* queue[MTL_SESSION_PORT_MAX];
+  uint16_t port_id[MTL_SESSION_PORT_MAX];
 
-  uint16_t st30_src_port[MT_SESSION_PORT_MAX]; /* udp port */
-  uint16_t st30_dst_port[MT_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st30_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st30_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
 
   struct st_frame_trans* st30_frames;
   int st30_frames_cnt; /* numbers of frames requested */
@@ -870,17 +870,17 @@ struct st_tx_ancillary_session_impl {
   struct st40_tx_ops ops;
   char ops_name[ST_MAX_NAME_LEN];
 
-  enum mtl_port port_maps[MT_SESSION_PORT_MAX];
-  struct rte_mempool* mbuf_mempool_hdr[MT_SESSION_PORT_MAX];
+  enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
+  struct rte_mempool* mbuf_mempool_hdr[MTL_SESSION_PORT_MAX];
   struct rte_mempool* mbuf_mempool_chain;
   bool tx_mono_pool; /* if reuse tx mono pool */
   /* if the eth dev support chain buff */
-  bool eth_has_chain[MT_SESSION_PORT_MAX];
+  bool eth_has_chain[MTL_SESSION_PORT_MAX];
   /* if the eth dev support ipv4 checksum offload */
-  bool eth_ipv4_cksum_offload[MT_SESSION_PORT_MAX];
-  struct rte_mbuf* inflight[MT_SESSION_PORT_MAX];
-  bool has_inflight[MT_SESSION_PORT_MAX];
-  int inflight_cnt[MT_SESSION_PORT_MAX]; /* for stats */
+  bool eth_ipv4_cksum_offload[MTL_SESSION_PORT_MAX];
+  struct rte_mbuf* inflight[MTL_SESSION_PORT_MAX];
+  bool has_inflight[MTL_SESSION_PORT_MAX];
+  int inflight_cnt[MTL_SESSION_PORT_MAX]; /* for stats */
   struct rte_ring* packet_ring;
 
   uint32_t max_pkt_len; /* max data len(byte) for each pkt */
@@ -891,9 +891,9 @@ struct st_tx_ancillary_session_impl {
   enum st40_tx_frame_status st40_frame_stat;
 
   uint16_t st40_ipv4_packet_id;
-  uint16_t st40_src_port[MT_SESSION_PORT_MAX]; /* udp port */
-  uint16_t st40_dst_port[MT_SESSION_PORT_MAX]; /* udp port */
-  struct st_rfc8331_anc_hdr hdr[MT_SESSION_PORT_MAX];
+  uint16_t st40_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st40_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  struct st_rfc8331_anc_hdr hdr[MTL_SESSION_PORT_MAX];
 
   struct st_tx_ancillary_session_pacing pacing;
   struct st_fps_timing fps_tm;
@@ -941,13 +941,13 @@ struct st_rx_ancillary_session_impl {
   struct st40_rx_ops ops;
   char ops_name[ST_MAX_NAME_LEN];
 
-  enum mtl_port port_maps[MT_SESSION_PORT_MAX];
-  struct mt_rx_queue* queue[MT_SESSION_PORT_MAX];
-  uint16_t port_id[MT_SESSION_PORT_MAX];
+  enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
+  struct mt_rx_queue* queue[MTL_SESSION_PORT_MAX];
+  uint16_t port_id[MTL_SESSION_PORT_MAX];
   struct rte_ring* packet_ring;
 
-  uint16_t st40_src_port[MT_SESSION_PORT_MAX]; /* udp port */
-  uint16_t st40_dst_port[MT_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st40_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  uint16_t st40_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
 
   int st40_seq_id; /* seq id for each pkt */
 

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -258,8 +258,8 @@ struct st_tx_video_session_impl {
   struct st_tx_video_pacing pacing;
   enum st21_tx_pacing_way pacing_way[MTL_SESSION_PORT_MAX];
   int (*pacing_tasklet_func[MTL_SESSION_PORT_MAX])(struct mtl_main_impl* impl,
-                                                  struct st_tx_video_session_impl* s,
-                                                  enum mtl_session_port s_port);
+                                                   struct st_tx_video_session_impl* s,
+                                                   enum mtl_session_port s_port);
 
   struct st_vsync_info vsync;
 

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -551,7 +551,7 @@ static int rx_ancillary_ops_check(struct st40_rx_ops* ops) {
   int num_ports = ops->num_port, ret;
   uint8_t* ip;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }
@@ -771,7 +771,7 @@ int st40_rx_get_queue_meta(st40_rx_handle handle, struct st_queue_meta* meta) {
   impl = s_impl->parnet;
 
   memset(meta, 0x0, sizeof(*meta));
-  meta->num_port = RTE_MIN(s->ops.num_port, MTL_PORT_MAX);
+  meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
     port = mt_port_logic2phy(s->port_maps, i);
 

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -69,7 +69,7 @@ static int rx_ancillary_sessions_tasklet_stop(void* priv) {
 static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
                                            struct st_rx_ancillary_session_impl* s,
                                            struct rte_mbuf* mbuf,
-                                           enum mt_session_port s_port) {
+                                           enum mtl_session_port s_port) {
   struct st40_rx_ops* ops = &s->ops;
   size_t hdr_offset = sizeof(struct st_rfc3550_hdr) - sizeof(struct st_rfc3550_rtp_hdr);
   struct st_rfc3550_rtp_hdr* rtp =
@@ -239,7 +239,7 @@ static int rx_ancillary_session_init_sw(struct mtl_main_impl* impl,
   struct rte_ring* ring;
   unsigned int flags, count;
   int mgr_idx = mgr->idx, idx = s->idx;
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
   snprintf(ring_name, 32, "RX-ANC-PACKET-RING-M%d-R%d", mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
@@ -275,7 +275,7 @@ static int rx_ancillary_session_attach(struct mtl_main_impl* impl,
                                        struct st40_rx_ops* ops) {
   int ret;
   int idx = s->idx, num_port = ops->num_port;
-  char* ports[MT_SESSION_PORT_MAX];
+  char* ports[MTL_SESSION_PORT_MAX];
 
   for (int i = 0; i < num_port; i++) ports[i] = ops->port[i];
   ret = mt_build_port_map(impl, ports, s->port_maps, num_port);

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -977,7 +977,7 @@ static int rx_audio_ops_check(struct st30_rx_ops* ops) {
   int num_ports = ops->num_port, ret;
   uint8_t* ip;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }
@@ -1227,7 +1227,7 @@ int st30_rx_get_queue_meta(st30_rx_handle handle, struct st_queue_meta* meta) {
   impl = s_impl->parnet;
 
   memset(meta, 0x0, sizeof(*meta));
-  meta->num_port = RTE_MIN(s->ops.num_port, MTL_PORT_MAX);
+  meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
     port = mt_port_logic2phy(s->port_maps, i);
 

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -271,7 +271,7 @@ static int rx_audio_session_free_frames(struct st_rx_audio_session_impl* s) {
 
 static int rx_audio_session_alloc_frames(struct mtl_main_impl* impl,
                                          struct st_rx_audio_session_impl* s) {
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
   int soc_id = mt_socket_id(impl, port);
   int idx = s->idx;
   size_t size = s->st30_frame_size;
@@ -326,7 +326,7 @@ static int rx_audio_session_alloc_rtps(struct mtl_main_impl* impl,
   struct rte_ring* ring;
   unsigned int flags, count;
   int mgr_idx = mgr->idx, idx = s->idx;
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
   snprintf(ring_name, 32, "RX-AUDIO-RTP-RING-M%d-R%d", mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
@@ -364,7 +364,7 @@ static int rx_audio_sessions_tasklet_stop(void* priv) {
 static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
                                              struct st_rx_audio_session_impl* s,
                                              struct rte_mbuf* mbuf,
-                                             enum mt_session_port s_port) {
+                                             enum mtl_session_port s_port) {
   struct st30_rx_ops* ops = &s->ops;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
   struct mt_interface* inf = mt_if(impl, port);
@@ -448,7 +448,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
 static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
                                            struct st_rx_audio_session_impl* s,
                                            struct rte_mbuf* mbuf,
-                                           enum mt_session_port s_port) {
+                                           enum mtl_session_port s_port) {
   struct st30_rx_ops* ops = &s->ops;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
   struct mt_interface* inf = mt_if(impl, port);
@@ -664,7 +664,7 @@ static int rx_audio_session_attach(struct mtl_main_impl* impl,
                                    struct st30_rx_ops* ops) {
   int ret;
   int idx = s->idx, num_port = ops->num_port;
-  char* ports[MT_SESSION_PORT_MAX];
+  char* ports[MTL_SESSION_PORT_MAX];
 
   for (int i = 0; i < num_port; i++) ports[i] = ops->port[i];
   ret = mt_build_port_map(impl, ports, s->port_maps, num_port);

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3277,7 +3277,7 @@ static int rv_ops_check(struct st20_rx_ops* ops) {
   uint8_t* ip;
   enum st20_type type = ops->type;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }
@@ -3373,7 +3373,7 @@ static int rv_st22_ops_check(struct st22_rx_ops* ops) {
   int num_ports = ops->num_port, ret;
   uint8_t* ip;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }
@@ -3735,7 +3735,7 @@ int st20_rx_get_queue_meta(st20_rx_handle handle, struct st_queue_meta* meta) {
   impl = s_impl->parnet;
 
   memset(meta, 0x0, sizeof(*meta));
-  meta->num_port = RTE_MIN(s->ops.num_port, MTL_PORT_MAX);
+  meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
     port = mt_port_logic2phy(s->port_maps, i);
 
@@ -3820,13 +3820,10 @@ st22_rx_handle st22_rx_create(mtl_handle mt, struct st22_rx_ops* ops) {
   st20_ops.name = ops->name;
   st20_ops.priv = ops->priv;
   st20_ops.num_port = ops->num_port;
-  memcpy(st20_ops.sip_addr[MTL_PORT_P], ops->sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(st20_ops.port[MTL_PORT_P], ops->port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  st20_ops.udp_port[MTL_PORT_P] = ops->udp_port[MTL_PORT_P];
-  if (ops->num_port > 1) {
-    memcpy(st20_ops.sip_addr[MTL_PORT_R], ops->sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(st20_ops.port[MTL_PORT_R], ops->port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    st20_ops.udp_port[MTL_PORT_R] = ops->udp_port[MTL_PORT_R];
+  for (int i = 0; i < ops->num_port; i++) {
+    memcpy(st20_ops.sip_addr[i], ops->sip_addr[i], MTL_IP_ADDR_LEN);
+    strncpy(st20_ops.port[i], ops->port[i], MTL_PORT_MAX_LEN);
+    st20_ops.udp_port[i] = ops->udp_port[i];
   }
   if (ops->flags & ST22_RX_FLAG_DATA_PATH_ONLY)
     st20_ops.flags |= ST20_RX_FLAG_DATA_PATH_ONLY;
@@ -4057,7 +4054,7 @@ int st22_rx_get_queue_meta(st22_rx_handle handle, struct st_queue_meta* meta) {
   impl = s_impl->parnet;
 
   memset(meta, 0x0, sizeof(*meta));
-  meta->num_port = RTE_MIN(s->ops.num_port, MTL_PORT_MAX);
+  meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
     port = mt_port_logic2phy(s->port_maps, i);
 

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -621,7 +621,7 @@ static int rv_free_frames(struct st_rx_video_session_impl* s) {
 
 static int rv_alloc_frames(struct mtl_main_impl* impl,
                            struct st_rx_video_session_impl* s) {
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
   int soc_id = mt_socket_id(impl, port);
   int idx = s->idx;
   size_t size = s->st20_uframe_size ? s->st20_uframe_size : s->st20_fb_size;
@@ -699,7 +699,7 @@ static int rv_alloc_rtps(struct mtl_main_impl* impl, struct st_rx_video_sessions
   struct rte_ring* ring;
   unsigned int flags, count;
   int mgr_idx = mgr->idx, idx = s->idx;
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
   snprintf(ring_name, 32, "RX-VIDEO-RTP-RING-M%d-R%d", mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
@@ -719,7 +719,7 @@ static int rv_alloc_rtps(struct mtl_main_impl* impl, struct st_rx_video_sessions
 }
 
 static int rv_uinit_hdr_split(struct st_rx_video_session_impl* s) {
-  for (int i = 0; i < MT_SESSION_PORT_MAX; i++) {
+  for (int i = 0; i < MTL_SESSION_PORT_MAX; i++) {
     if (s->hdr_split_info[i].frames) {
       mt_rte_free(s->hdr_split_info[i].frames);
       s->hdr_split_info[i].frames = NULL;
@@ -775,7 +775,7 @@ static int rv_init_hdr_split(struct mtl_main_impl* impl,
 /* run within the context of receiver lcore */
 static int rv_hdrs_mbuf_callback_fn(void* priv, struct rte_eth_hdrs_mbuf* mbuf) {
   struct st_rx_video_session_impl* s = priv;
-  struct st_rx_video_hdr_split_info* hdr_split = &s->hdr_split_info[MT_SESSION_PORT_P];
+  struct st_rx_video_hdr_split_info* hdr_split = &s->hdr_split_info[MTL_SESSION_PORT_P];
   uint32_t alloc_idx = hdr_split->mbuf_alloc_idx;
   uint32_t cur_frame_mbuf_idx = hdr_split->cur_frame_mbuf_idx;
 
@@ -888,7 +888,7 @@ static int rv_uinit_slot(struct st_rx_video_session_impl* s) {
 }
 
 static int rv_init_slot(struct mtl_main_impl* impl, struct st_rx_video_session_impl* s) {
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
   int soc_id = mt_socket_id(impl, port);
   int idx = s->idx;
   size_t bitmap_size = s->st20_frame_bitmap_size;
@@ -1261,7 +1261,7 @@ static int rv_slice_dma_drop_mbuf(void* priv, struct rte_mbuf* mbuf) {
 }
 
 static int rv_init_dma(struct mtl_main_impl* impl, struct st_rx_video_session_impl* s) {
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
   int idx = s->idx;
   bool share_dma = true;
   enum st20_type type = s->ops.type;
@@ -1298,7 +1298,7 @@ static int rv_start_pcapng(struct mtl_main_impl* impl, struct st_rx_video_sessio
     return -EIO;
   }
 
-  enum mtl_port port = s->port_maps[MT_SESSION_PORT_P];
+  enum mtl_port port = s->port_maps[MTL_SESSION_PORT_P];
   int idx = s->idx;
   int pkt_len = ST_PKT_MAX_ETHER_BYTES;
 
@@ -1462,7 +1462,7 @@ static inline uint32_t rfc4175_rtp_seq_id(struct st20_rfc4175_rtp_hdr* rtp) {
 }
 
 static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf* mbuf,
-                               enum mt_session_port s_port, bool ctrl_thread) {
+                               enum mtl_session_port s_port, bool ctrl_thread) {
   struct st20_rx_ops* ops = &s->ops;
   // size_t hdr_offset = mbuf->l2_len + mbuf->l3_len + mbuf->l4_len;
   size_t hdr_offset =
@@ -1660,7 +1660,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
 }
 
 static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf* mbuf,
-                             enum mt_session_port s_port, bool ctrl_thread) {
+                             enum mtl_session_port s_port, bool ctrl_thread) {
   struct st20_rx_ops* ops = &s->ops;
   size_t hdr_offset = sizeof(struct st_rfc3550_hdr) - sizeof(struct st_rfc3550_rtp_hdr);
   struct st_rfc3550_rtp_hdr* rtp =
@@ -1787,7 +1787,7 @@ static int rv_parse_st22_boxes(struct st_rx_video_session_impl* s, void* boxes,
 }
 
 static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf* mbuf,
-                              enum mt_session_port s_port, bool ctrl_thread) {
+                              enum mtl_session_port s_port, bool ctrl_thread) {
   struct st20_rx_ops* ops = &s->ops;
   // size_t hdr_offset = mbuf->l2_len + mbuf->l3_len + mbuf->l4_len;
   size_t hdr_offset =
@@ -1923,7 +1923,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
 }
 
 static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
-                                   struct rte_mbuf* mbuf, enum mt_session_port s_port,
+                                   struct rte_mbuf* mbuf, enum mtl_session_port s_port,
                                    bool ctrl_thread) {
   struct st20_rx_ops* ops = &s->ops;
   // size_t hdr_offset = mbuf->l2_len + mbuf->l3_len + mbuf->l4_len;
@@ -2120,7 +2120,7 @@ static int rv_pkt_lcore_func(void* args) {
   while (rte_atomic32_read(&s->pkt_lcore_active)) {
     ret = rte_ring_sc_dequeue(s->pkt_lcore_ring, (void**)&pkt);
     if (ret >= 0) {
-      rv_handle_frame_pkt(s, pkt, MT_SESSION_PORT_P, true);
+      rv_handle_frame_pkt(s, pkt, MTL_SESSION_PORT_P, true);
       rte_pktmbuf_free(pkt);
     }
   }
@@ -2137,7 +2137,7 @@ static int rv_init_pkt_lcore(struct mtl_main_impl* impl,
   struct rte_ring* ring;
   unsigned int flags, count, lcore;
   int mgr_idx = mgr->idx, idx = s->idx, ret;
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MT_SESSION_PORT_P);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
   snprintf(ring_name, 32, "RX-VIDEO-PKT-RING-M%d-R%d", mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
@@ -2346,7 +2346,7 @@ static int rv_init_sw(struct mtl_main_impl* impl, struct st_rx_video_sessions_mg
 }
 
 static int rv_handle_detect_err(struct st_rx_video_session_impl* s, struct rte_mbuf* mbuf,
-                                enum mt_session_port s_port, bool ctrl_thread) {
+                                enum mtl_session_port s_port, bool ctrl_thread) {
   err_once("%s(%d,%d), detect fail, please choose the rigth format\n", __func__, s->idx,
            s_port);
   return 0;
@@ -2362,7 +2362,7 @@ static int rv_detect_change_status(struct st_rx_video_session_impl* s,
 }
 
 static int rv_handle_detect_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf* mbuf,
-                                enum mt_session_port s_port, bool ctrl_thread) {
+                                enum mtl_session_port s_port, bool ctrl_thread) {
   int ret;
   struct st20_rx_ops* ops = &s->ops;
   struct st_rx_video_detector* detector = &s->detector;
@@ -2669,7 +2669,7 @@ static int rv_attach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
                      struct st22_rx_ops* st22_ops) {
   int ret;
   int idx = s->idx, num_port = ops->num_port;
-  char* ports[MT_SESSION_PORT_MAX];
+  char* ports[MTL_SESSION_PORT_MAX];
 
   for (int i = 0; i < num_port; i++) ports[i] = ops->port[i];
   ret = mt_build_port_map(impl, ports, s->port_maps, num_port);

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -1278,8 +1278,9 @@ void st_tx_ancillary_sessions_stat(struct mtl_main_impl* impl) {
     mgr->st40_stat_pkts_burst = 0;
   } else {
     if (mgr->max_idx > 0) {
-      warn("TX_ANC_SESSION: trs ret %d:%d\n", mgr->stat_trs_ret_code[MTL_PORT_P],
-           mgr->stat_trs_ret_code[MTL_PORT_R]);
+      for (int i = 0; i < mt_num_ports(impl); i++) {
+        warn("TX_ANC_SESSION: trs ret %d:%d\n", i, mgr->stat_trs_ret_code[i]);
+      }
     }
   }
 }
@@ -1313,7 +1314,7 @@ static int tx_ancillary_ops_check(struct st40_tx_ops* ops) {
   int num_ports = ops->num_port, ret;
   uint8_t* ip;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -1088,8 +1088,8 @@ static void tx_audio_session_stat(struct st_tx_audio_session_impl* s) {
   rte_atomic32_set(&s->st30_stat_frame_cnt, 0);
 
   notice("TX_AUDIO_SESSION(%d:%s): frame cnt %d, pkt cnt %d, inflight count %d: %d\n",
-         idx, s->ops_name, frame_cnt, s->st30_stat_pkt_cnt, s->inflight_cnt[MTL_PORT_P],
-         s->inflight_cnt[MTL_PORT_R]);
+         idx, s->ops_name, frame_cnt, s->st30_stat_pkt_cnt,
+         s->inflight_cnt[MTL_SESSION_PORT_P], s->inflight_cnt[MTL_SESSION_PORT_R]);
   s->st30_stat_pkt_cnt = 0;
 
   if (s->st30_epoch_mismatch) {
@@ -1266,8 +1266,9 @@ void st_tx_audio_sessions_stat(struct mtl_main_impl* impl) {
     mgr->st30_stat_pkts_burst = 0;
   } else {
     if (mgr->max_idx > 0) {
-      warn("TX_AUDIO_SESSION: trs ret %d:%d\n", mgr->stat_trs_ret_code[MTL_PORT_P],
-           mgr->stat_trs_ret_code[MTL_PORT_R]);
+      for (int i = 0; i < mt_num_ports(impl); i++) {
+        warn("TX_AUDIO_SESSION: trs ret %d:%d\n", i, mgr->stat_trs_ret_code[i]);
+      }
     }
   }
 }
@@ -1276,7 +1277,7 @@ static int tx_audio_ops_check(struct st30_tx_ops* ops) {
   int num_ports = ops->num_port, ret;
   uint8_t* ip;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -1048,8 +1048,8 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
 
   /* check if any inflight pkts */
   if (s->has_inflight[MTL_SESSION_PORT_P]) {
-    n = rte_ring_sp_enqueue_bulk(ring_p, (void**)&s->inflight[MTL_SESSION_PORT_P][0], bulk,
-                                 NULL);
+    n = rte_ring_sp_enqueue_bulk(ring_p, (void**)&s->inflight[MTL_SESSION_PORT_P][0],
+                                 bulk, NULL);
     if (n > 0) {
       s->has_inflight[MTL_SESSION_PORT_P] = false;
     } else {
@@ -1058,8 +1058,8 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
     }
   }
   if (send_r && s->has_inflight[MTL_SESSION_PORT_R]) {
-    n = rte_ring_sp_enqueue_bulk(ring_r, (void**)&s->inflight[MTL_SESSION_PORT_R][0], bulk,
-                                 NULL);
+    n = rte_ring_sp_enqueue_bulk(ring_r, (void**)&s->inflight[MTL_SESSION_PORT_R][0],
+                                 bulk, NULL);
     if (n > 0) {
       s->has_inflight[MTL_SESSION_PORT_R] = false;
     } else {
@@ -1270,8 +1270,8 @@ static int tv_tasklet_rtp(struct mtl_main_impl* impl,
 
   /* check if any inflight pkts */
   if (s->has_inflight[MTL_SESSION_PORT_P]) {
-    n = rte_ring_sp_enqueue_bulk(ring_p, (void**)&s->inflight[MTL_SESSION_PORT_P][0], bulk,
-                                 NULL);
+    n = rte_ring_sp_enqueue_bulk(ring_p, (void**)&s->inflight[MTL_SESSION_PORT_P][0],
+                                 bulk, NULL);
     if (n > 0) {
       s->has_inflight[MTL_SESSION_PORT_P] = false;
     } else {
@@ -1280,8 +1280,8 @@ static int tv_tasklet_rtp(struct mtl_main_impl* impl,
     }
   }
   if (send_r && s->has_inflight[MTL_SESSION_PORT_R]) {
-    n = rte_ring_sp_enqueue_bulk(ring_r, (void**)&s->inflight[MTL_SESSION_PORT_R][0], bulk,
-                                 NULL);
+    n = rte_ring_sp_enqueue_bulk(ring_r, (void**)&s->inflight[MTL_SESSION_PORT_R][0],
+                                 bulk, NULL);
     if (n > 0) {
       s->has_inflight[MTL_SESSION_PORT_R] = false;
     } else {
@@ -1415,8 +1415,8 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
 
   /* check if any inflight pkts */
   if (s->has_inflight[MTL_SESSION_PORT_P]) {
-    n = rte_ring_sp_enqueue_bulk(ring_p, (void**)&s->inflight[MTL_SESSION_PORT_P][0], bulk,
-                                 NULL);
+    n = rte_ring_sp_enqueue_bulk(ring_p, (void**)&s->inflight[MTL_SESSION_PORT_P][0],
+                                 bulk, NULL);
     if (n > 0) {
       s->has_inflight[MTL_SESSION_PORT_P] = false;
     } else {
@@ -1425,8 +1425,8 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
     }
   }
   if (send_r && s->has_inflight[MTL_SESSION_PORT_R]) {
-    n = rte_ring_sp_enqueue_bulk(ring_r, (void**)&s->inflight[MTL_SESSION_PORT_R][0], bulk,
-                                 NULL);
+    n = rte_ring_sp_enqueue_bulk(ring_r, (void**)&s->inflight[MTL_SESSION_PORT_R][0],
+                                 bulk, NULL);
     if (n > 0) {
       s->has_inflight[MTL_SESSION_PORT_R] = false;
     } else {

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -2614,7 +2614,7 @@ static int tv_ops_check(struct st20_tx_ops* ops) {
   int num_ports = ops->num_port, ret;
   uint8_t* ip;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }
@@ -2682,7 +2682,7 @@ static int tv_st22_ops_check(struct st22_tx_ops* ops) {
   int num_ports = ops->num_port, ret;
   uint8_t* ip;
 
-  if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
+  if ((num_ports > MTL_SESSION_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);
     return -EINVAL;
   }
@@ -3146,21 +3146,20 @@ st22_tx_handle st22_tx_create(mtl_handle mt, struct st22_tx_ops* ops) {
   st20_ops.name = ops->name;
   st20_ops.priv = ops->priv;
   st20_ops.num_port = ops->num_port;
-  memcpy(st20_ops.dip_addr[MTL_PORT_P], ops->dip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(st20_ops.port[MTL_PORT_P], ops->port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  st20_ops.udp_port[MTL_PORT_P] = ops->udp_port[MTL_PORT_P];
+  for (int i = 0; i < ops->num_port; i++) {
+    memcpy(st20_ops.dip_addr[i], ops->dip_addr[i], MTL_IP_ADDR_LEN);
+    strncpy(st20_ops.port[i], ops->port[i], MTL_PORT_MAX_LEN);
+    st20_ops.udp_port[i] = ops->udp_port[i];
+  }
   if (ops->flags & ST22_TX_FLAG_USER_P_MAC) {
-    memcpy(&st20_ops.tx_dst_mac[MTL_PORT_P][0], &ops->tx_dst_mac[MTL_PORT_P][0],
-           MTL_MAC_ADDR_LEN);
+    memcpy(&st20_ops.tx_dst_mac[MTL_SESSION_PORT_P][0],
+           &ops->tx_dst_mac[MTL_SESSION_PORT_P][0], MTL_MAC_ADDR_LEN);
     st20_ops.flags |= ST20_TX_FLAG_USER_P_MAC;
   }
   if (ops->num_port > 1) {
-    memcpy(st20_ops.dip_addr[MTL_PORT_R], ops->dip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(st20_ops.port[MTL_PORT_R], ops->port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    st20_ops.udp_port[MTL_PORT_R] = ops->udp_port[MTL_PORT_R];
     if (ops->flags & ST22_TX_FLAG_USER_R_MAC) {
-      memcpy(&st20_ops.tx_dst_mac[MTL_PORT_R][0], &ops->tx_dst_mac[MTL_PORT_R][0],
-             MTL_MAC_ADDR_LEN);
+      memcpy(&st20_ops.tx_dst_mac[MTL_SESSION_PORT_R][0],
+             &ops->tx_dst_mac[MTL_SESSION_PORT_R][0], MTL_MAC_ADDR_LEN);
       st20_ops.flags |= ST20_TX_FLAG_USER_R_MAC;
     }
   }

--- a/lib/src/st2110/st_video_transmitter.c
+++ b/lib/src/st2110/st_video_transmitter.c
@@ -29,7 +29,7 @@ static int video_trs_tasklet_stop(void* priv) {
 /* warm start for the first packet */
 static int video_trs_rl_warm_up(struct mtl_main_impl* impl,
                                 struct st_tx_video_session_impl* s,
-                                enum mt_session_port s_port) {
+                                enum mtl_session_port s_port) {
   struct st_tx_video_pacing* pacing = &s->pacing;
   uint64_t target_tsc = s->trs_target_tsc[s_port];
   uint64_t cur_tsc, pre_tsc;
@@ -72,7 +72,7 @@ static int video_trs_rl_warm_up(struct mtl_main_impl* impl,
 }
 
 static int video_burst_packet(struct st_tx_video_session_impl* s,
-                              enum mt_session_port s_port, struct rte_mbuf** pkts,
+                              enum mtl_session_port s_port, struct rte_mbuf** pkts,
                               int bulk, bool use_two) {
   struct st_tx_video_pacing* pacing = &s->pacing;
   int tx = mt_dev_tx_burst(s->queue[s_port], &pkts[0], bulk);
@@ -117,7 +117,7 @@ static int video_burst_packet(struct st_tx_video_session_impl* s,
 
 static int _video_trs_rl_tasklet(struct mtl_main_impl* impl,
                                  struct st_tx_video_session_impl* s,
-                                 enum mt_session_port s_port, int* ret_status) {
+                                 enum mtl_session_port s_port, int* ret_status) {
   unsigned int bulk = s->bulk;
   struct rte_ring* ring = s->ring[s_port];
   int idx = s->idx;
@@ -261,7 +261,7 @@ static int _video_trs_rl_tasklet(struct mtl_main_impl* impl,
 
 static int video_trs_rl_tasklet(struct mtl_main_impl* impl,
                                 struct st_tx_video_session_impl* s,
-                                enum mt_session_port s_port) {
+                                enum mtl_session_port s_port) {
   int pending = MT_TASKLET_ALL_DONE;
   int ret_status = 0;
 
@@ -280,7 +280,7 @@ static int video_trs_rl_tasklet(struct mtl_main_impl* impl,
 
 static int video_trs_tsc_tasklet(struct mtl_main_impl* impl,
                                  struct st_tx_video_session_impl* s,
-                                 enum mt_session_port s_port) {
+                                 enum mtl_session_port s_port) {
   unsigned int bulk = 1; /* only one packet now for tsc */
   struct rte_ring* ring = s->ring[s_port];
   int idx = s->idx, tx;
@@ -398,7 +398,7 @@ static int video_trs_tsc_tasklet(struct mtl_main_impl* impl,
 
 static int video_trs_ptp_tasklet(struct mtl_main_impl* impl,
                                  struct st_tx_video_session_impl* s,
-                                 enum mt_session_port s_port) {
+                                 enum mtl_session_port s_port) {
   unsigned int bulk = 1; /* only one packet now for tsc */
   struct rte_ring* ring = s->ring[s_port];
   int idx = s->idx, tx;
@@ -536,7 +536,7 @@ static int video_trs_tasklet_handler(void* priv) {
 }
 
 int st_video_reslove_pacing_tasklet(struct st_tx_video_session_impl* s,
-                                    enum mt_session_port port) {
+                                    enum mtl_session_port port) {
   int idx = s->idx;
 
   switch (s->pacing_way[port]) {

--- a/lib/src/st2110/st_video_transmitter.h
+++ b/lib/src/st2110/st_video_transmitter.h
@@ -13,6 +13,6 @@ int st_video_transmitter_init(struct mtl_main_impl* impl, struct mt_sch_impl* sc
 int st_video_transmitter_uinit(struct st_video_transmitter_impl* trs);
 
 int st_video_reslove_pacing_tasklet(struct st_tx_video_session_impl* s,
-                                    enum mt_session_port port);
+                                    enum mtl_session_port port);
 
 #endif

--- a/tests/script/multi_port_json/multicast_1v_1a_1anc_4port.json
+++ b/tests/script/multi_port_json/multicast_1v_1a_1anc_4port.json
@@ -1,0 +1,198 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        },
+        {
+            "name": "0000:af:01.2",
+            "ip": "192.168.17.103"
+        },
+        {
+            "name": "0000:af:01.3",
+            "ip": "192.168.17.104"
+        },
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "239.168.17.101"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 1,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        },
+        {
+            "dip": [
+                "239.168.18.101"
+            ],
+            "interface": [
+                2
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 1,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "239.168.17.101",
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 1,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        },
+        {
+            "ip": [
+                "239.168.18.101",
+            ],
+            "interface": [
+                3
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 1,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/multi_port_json/multicast_2v_2a_2anc_4port.json
+++ b/tests/script/multi_port_json/multicast_2v_2a_2anc_4port.json
@@ -1,0 +1,198 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        },
+        {
+            "name": "0000:af:01.2",
+            "ip": "192.168.17.103"
+        },
+        {
+            "name": "0000:af:01.3",
+            "ip": "192.168.17.104"
+        },
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "239.168.17.101"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        },
+        {
+            "dip": [
+                "239.168.18.101"
+            ],
+            "interface": [
+                2
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "239.168.17.101",
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        },
+        {
+            "ip": [
+                "239.168.18.101",
+            ],
+            "interface": [
+                3
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/multi_port_json/unicast_2v_2a_2anc_4port.json
+++ b/tests/script/multi_port_json/unicast_2v_2a_2anc_4port.json
@@ -1,0 +1,198 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        },
+        {
+            "name": "0000:af:01.2",
+            "ip": "192.168.17.103"
+        },
+        {
+            "name": "0000:af:01.3",
+            "ip": "192.168.17.104"
+        },
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "192.168.17.102",
+            ],
+            "interface": [
+                0,
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        },
+        {
+            "dip": [
+                "192.168.17.104",
+            ],
+            "interface": [
+                2,
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "192.168.17.101", 
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        },
+        {
+            "ip": [
+                "192.168.17.103"
+            ],
+            "interface": [
+                3
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/multi_port_json/unicast_2v_2a_2anc_4port_redundant.json
+++ b/tests/script/multi_port_json/unicast_2v_2a_2anc_4port_redundant.json
@@ -1,0 +1,206 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        },
+        {
+            "name": "0000:af:01.2",
+            "ip": "192.168.17.103"
+        },
+        {
+            "name": "0000:af:01.3",
+            "ip": "192.168.17.104"
+        },
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "192.168.17.103",
+                "192.168.17.104"
+            ],
+            "interface": [
+                0,
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        },
+        {
+            "dip": [
+                "192.168.17.101",
+                "192.168.17.102"
+            ],
+            "interface": [
+                2,
+                3
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "192.168.17.103",
+                "192.168.17.104"
+            ],
+            "interface": [
+                0,
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        },
+        {
+            "ip": [
+                "192.168.17.101",
+                "192.168.17.102"
+            ],
+            "interface": [
+                2,
+                3
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/multi_port_test.sh
+++ b/tests/script/multi_port_test.sh
@@ -12,7 +12,7 @@ TEST_TIME_SEC=100
 #TEST_TIME_SEC=20
 TEST_LOOP=1
 
-TEST_JSON_LIST='loop_json/*.json'
+TEST_JSON_LIST='multi_port_json/*.json'
 #echo $TEST_JSON_LIST
 
 export KAHAWAI_CFG_PATH=../../kahawai.json

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -517,13 +517,15 @@ static void st20_tx_ops_init(tests_context* st20, struct st20_tx_ops* ops) {
   ops->name = "st20_test";
   ops->priv = st20;
   ops->num_port = ctx->para.num_ports;
-  memcpy(ops->dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops->port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops->udp_port[MTL_PORT_P] = 10000 + st20->idx;
+  memcpy(ops->dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops->port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops->udp_port[MTL_SESSION_PORT_P] = 10000 + st20->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->dip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops->port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops->udp_port[MTL_PORT_R] = 10000 + st20->idx;
+    memcpy(ops->dip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops->port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops->udp_port[MTL_SESSION_PORT_R] = 10000 + st20->idx;
   }
   ops->pacing = ST21_PACING_NARROW;
   ops->type = ST20_TYPE_FRAME_LEVEL;
@@ -546,13 +548,15 @@ static void st20_rx_ops_init(tests_context* st20, struct st20_rx_ops* ops) {
   ops->name = "st20_test";
   ops->priv = st20;
   ops->num_port = ctx->para.num_ports;
-  memcpy(ops->sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops->port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops->udp_port[MTL_PORT_P] = 10000 + st20->idx;
+  memcpy(ops->sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops->port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops->udp_port[MTL_SESSION_PORT_P] = 10000 + st20->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->sip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops->port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops->udp_port[MTL_PORT_R] = 10000 + st20->idx;
+    memcpy(ops->sip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops->port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops->udp_port[MTL_SESSION_PORT_R] = 10000 + st20->idx;
   }
   ops->pacing = ST21_PACING_NARROW;
   ops->type = ST20_TYPE_FRAME_LEVEL;
@@ -871,9 +875,11 @@ static void st20_rx_fps_test(enum st20_type type[], enum st_fps fps[], int width
     ops_tx.name = "st20_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.type = type[i];
     ops_tx.width = width[i];
@@ -935,9 +941,11 @@ static void st20_rx_fps_test(enum st20_type type[], enum st_fps fps[], int width
     ops_rx.name = "st20_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = type[i];
     ops_rx.width = width[i];
@@ -1289,16 +1297,17 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions) {
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
     if (2 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
     else if (1 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
     else
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.type = type;
     ops_tx.width = 1920;
@@ -1333,9 +1342,11 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions) {
     ops_rx.name = "st20_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = type;
     ops_rx.width = 1920;
@@ -1367,8 +1378,9 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions) {
   struct st_rx_source_info src;
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 10000 + 1;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 10000 + 1;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   test_ctx_tx[1]->seq_id = 0; /* reset seq id */
   for (int i = 0; i < rx_sessions; i++) {
     ret = st20_rx_update_source(rx_handle[i], &src);
@@ -1395,8 +1407,9 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions) {
   if (tx_sessions > 2) {
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
-    src.udp_port[MTL_PORT_P] = 10000 + 2;
-    memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
+    src.udp_port[MTL_SESSION_PORT_P] = 10000 + 2;
+    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
     test_ctx_tx[2]->seq_id = rand(); /* random seq id */
     for (int i = 0; i < rx_sessions; i++) {
       ret = st20_rx_update_source(rx_handle[i], &src);
@@ -1423,8 +1436,9 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions) {
 
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 10000 + 0;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 10000 + 0;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   test_ctx_tx[0]->seq_id = rand(); /* random seq id */
   for (int i = 0; i < rx_sessions; i++) {
     ret = st20_rx_update_source(rx_handle[i], &src);
@@ -1782,12 +1796,14 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
     ops_tx.name = "st20_digest_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
     if (hdr_split)
-      ops_tx.udp_port[MTL_PORT_P] = 6970 + i;
+      ops_tx.udp_port[MTL_SESSION_PORT_P] = 6970 + i;
     else
-      ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+      ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = packing[i];
     ops_tx.type = tx_type[i];
@@ -1864,12 +1880,14 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
     ops_rx.name = "st20_digest_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
     if (hdr_split)
-      ops_rx.udp_port[MTL_PORT_P] = 6970 + i;
+      ops_rx.udp_port[MTL_SESSION_PORT_P] = 6970 + i;
     else
-      ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+      ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = rx_type[i];
     ops_rx.width = width[i];
@@ -2632,9 +2650,11 @@ static void st20_rx_meta_test(enum st_fps fps[], int width[], int height[],
     ops_tx.name = "st20_meta_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = ST20_PACKING_BPM;
     ops_tx.type = ST20_TYPE_RTP_LEVEL;
@@ -2665,9 +2685,11 @@ static void st20_rx_meta_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st20_meta_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = ST20_TYPE_FRAME_LEVEL;
     ops_rx.width = width[i];
@@ -2801,10 +2823,11 @@ static void st20_rx_after_start_test(enum st20_type type[], enum st_fps fps[],
       ops_tx.name = "st20_test";
       ops_tx.priv = test_ctx_tx[i];
       ops_tx.num_port = 1;
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-      ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+      strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+              MTL_PORT_MAX_LEN);
+      ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
       ops_tx.pacing = ST21_PACING_NARROW;
       ops_tx.type = type[i];
       ops_tx.width = width[i];
@@ -2838,10 +2861,11 @@ static void st20_rx_after_start_test(enum st20_type type[], enum st_fps fps[],
       ops_rx.name = "st20_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-      ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+      strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+              MTL_PORT_MAX_LEN);
+      ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
       ops_rx.pacing = ST21_PACING_NARROW;
       ops_rx.type = type[i];
       ops_rx.width = width[i];
@@ -3011,9 +3035,11 @@ static void st20_rx_uframe_test(enum st20_type rx_type[], enum st20_packing pack
     ops_tx.name = "st20_uframe_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = packing[i];
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;
@@ -3080,9 +3106,11 @@ static void st20_rx_uframe_test(enum st20_type rx_type[], enum st20_packing pack
     ops_rx.name = "st20_uframe_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = rx_type[i];
     ops_rx.width = width[i];
@@ -3284,9 +3312,11 @@ static void st20_rx_detect_test(enum st20_type tx_type[], enum st20_type rx_type
     ops_tx.name = "st20_detect_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = packing[i];
     ops_tx.type = tx_type[i];
@@ -3367,9 +3397,11 @@ static void st20_rx_detect_test(enum st20_type tx_type[], enum st20_type rx_type
     ops_rx.name = "st20_detect_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = rx_type[i];
     ops_rx.width = 1920;
@@ -3579,9 +3611,11 @@ static void st20_rx_dump_test(enum st20_type type[], enum st_fps fps[], int widt
     ops_tx.name = "st20_dump_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.type = type[i];
     ops_tx.width = width[i];
@@ -3616,9 +3650,11 @@ static void st20_rx_dump_test(enum st20_type type[], enum st_fps fps[], int widt
     ops_rx.name = "st20_dump_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = type[i];
     ops_rx.width = width[i];
@@ -3782,9 +3818,11 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
     ops_tx.name = "st20_ext_frame_digest_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = packing[i];
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;
@@ -3888,9 +3926,11 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
     ops_rx.name = "st20_ext_frame_digest_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = ST20_TYPE_FRAME_LEVEL;
     ops_rx.width = width[i];
@@ -4114,9 +4154,11 @@ static void st20_tx_user_pacing_test(int width[], int height[], enum st20_fmt fm
     ops_tx.name = "st20_timestamp_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = ST20_PACKING_BPM;
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;
@@ -4170,9 +4212,11 @@ static void st20_tx_user_pacing_test(int width[], int height[], enum st20_fmt fm
     ops_rx.name = "st20_timestamp_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = ST20_TYPE_FRAME_LEVEL;
     ops_rx.width = width[i];
@@ -4306,9 +4350,11 @@ static void st20_linesize_digest_test(enum st20_packing packing[], enum st_fps f
     ops_tx.name = "st20_linesize_digest_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.packing = packing[i];
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;
@@ -4426,9 +4472,11 @@ static void st20_linesize_digest_test(enum st20_packing packing[], enum st_fps f
     ops_rx.name = "st20_linesize_digest_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.type = ST20_TYPE_FRAME_LEVEL;
     ops_rx.width = width[i];

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -247,10 +247,11 @@ static void st20p_tx_ops_init(tests_context* st20, struct st20p_tx_ops* ops_tx) 
   ops_tx->name = "st20p_test";
   ops_tx->priv = st20;
   ops_tx->port.num_port = 1;
-  memcpy(ops_tx->port.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops_tx->port.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops_tx->port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx->port.udp_port[MTL_PORT_P] = ST20P_TEST_UDP_PORT + st20->idx;
+  strncpy(ops_tx->port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_tx->port.udp_port[MTL_SESSION_PORT_P] = ST20P_TEST_UDP_PORT + st20->idx;
   ops_tx->port.payload_type = ST20P_TEST_PAYLOAD_TYPE;
   ops_tx->width = 1920;
   ops_tx->height = 1080;
@@ -271,10 +272,11 @@ static void st20p_rx_ops_init(tests_context* st20, struct st20p_rx_ops* ops_rx) 
   ops_rx->name = "st20p_test";
   ops_rx->priv = st20;
   ops_rx->port.num_port = 1;
-  memcpy(ops_rx->port.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops_rx->port.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops_rx->port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-  ops_rx->port.udp_port[MTL_PORT_P] = ST20P_TEST_UDP_PORT + st20->idx;
+  strncpy(ops_rx->port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+          MTL_PORT_MAX_LEN);
+  ops_rx->port.udp_port[MTL_SESSION_PORT_P] = ST20P_TEST_UDP_PORT + st20->idx;
   ops_rx->port.payload_type = ST20P_TEST_PAYLOAD_TYPE;
   ops_rx->width = 1920;
   ops_rx->height = 1080;
@@ -668,10 +670,11 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_tx.name = "st20p_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.port.num_port = 1;
-    memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+    memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.port.udp_port[MTL_PORT_P] = ST20P_TEST_UDP_PORT + i;
+    strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ST20P_TEST_UDP_PORT + i;
     ops_tx.port.payload_type = ST20P_TEST_PAYLOAD_TYPE;
     ops_tx.width = width[i];
     ops_tx.height = height[i];
@@ -875,10 +878,11 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st20p_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.port.udp_port[MTL_PORT_P] = ST20P_TEST_UDP_PORT + i;
+    strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ST20P_TEST_UDP_PORT + i;
     ops_rx.port.payload_type = ST20P_TEST_PAYLOAD_TYPE;
     ops_rx.width = width[i];
     ops_rx.height = height[i];

--- a/tests/src/st22_test.cpp
+++ b/tests/src/st22_test.cpp
@@ -95,13 +95,15 @@ static void st22_tx_ops_init(tests_context* st22, struct st22_tx_ops* ops) {
   ops->name = "st22_test";
   ops->priv = st22;
   ops->num_port = ctx->para.num_ports;
-  memcpy(ops->dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops->port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops->udp_port[MTL_PORT_P] = 10000 + st22->idx;
+  memcpy(ops->dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops->port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops->udp_port[MTL_SESSION_PORT_P] = 10000 + st22->idx;
   if (ops->num_port > 1) {
-    memcpy(ops->dip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops->port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops->udp_port[MTL_PORT_R] = 10000 + st22->idx;
+    memcpy(ops->dip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops->port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops->udp_port[MTL_SESSION_PORT_R] = 10000 + st22->idx;
   }
   ops->pacing = ST21_PACING_NARROW;
   ops->width = 1920;
@@ -125,12 +127,14 @@ static void st22_rx_ops_init(tests_context* st22, struct st22_rx_ops* ops) {
   ops->name = "st22_test";
   ops->priv = st22;
   ops->num_port = ctx->para.num_ports;
-  memcpy(ops->sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops->port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops->udp_port[MTL_PORT_P] = 10000 + st22->idx;
+  memcpy(ops->sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops->port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops->udp_port[MTL_SESSION_PORT_P] = 10000 + st22->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->sip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops->port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    memcpy(ops->sip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops->port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
     ops->udp_port[MTL_PORT_R] = 10000 + st22->idx;
   }
   ops->pacing = ST21_PACING_NARROW;
@@ -387,9 +391,11 @@ static void st22_rx_fps_test(enum st22_type type[], enum st_fps fps[], int width
     ops_tx.name = "st22_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.width = width[i];
     ops_tx.height = height[i];
@@ -439,9 +445,11 @@ static void st22_rx_fps_test(enum st22_type type[], enum st_fps fps[], int width
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.width = width[i];
     ops_rx.height = height[i];
@@ -580,16 +588,17 @@ static void st22_rx_update_src_test(int tx_sessions) {
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
     if (2 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
     else if (1 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
     else
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 10000 + i;
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.width = 1920;
     ops_tx.height = 1080;
@@ -633,9 +642,11 @@ static void st22_rx_update_src_test(int tx_sessions) {
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 10000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 10000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.width = 1920;
     ops_rx.height = 1080;
@@ -669,8 +680,9 @@ static void st22_rx_update_src_test(int tx_sessions) {
   struct st_rx_source_info src;
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 10000 + 1;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 10000 + 1;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st22_rx_update_source(rx_handle[i], &src);
     EXPECT_GE(ret, 0);
@@ -693,8 +705,9 @@ static void st22_rx_update_src_test(int tx_sessions) {
   if (tx_sessions > 2) {
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
-    src.udp_port[MTL_PORT_P] = 10000 + 2;
-    memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
+    src.udp_port[MTL_SESSION_PORT_P] = 10000 + 2;
+    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
     for (int i = 0; i < rx_sessions; i++) {
       ret = st22_rx_update_source(rx_handle[i], &src);
       EXPECT_GE(ret, 0);
@@ -717,8 +730,9 @@ static void st22_rx_update_src_test(int tx_sessions) {
 
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 10000 + 0;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 10000 + 0;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st22_rx_update_source(rx_handle[i], &src);
     EXPECT_GE(ret, 0);
@@ -804,10 +818,11 @@ static void st22_rx_after_start_test(enum st_fps fps[], int width[], int height[
       ops_tx.name = "st22_test";
       ops_tx.priv = test_ctx_tx[i];
       ops_tx.num_port = 1;
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-      ops_tx.udp_port[MTL_PORT_P] = 15000 + i;
+      strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+              MTL_PORT_MAX_LEN);
+      ops_tx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
       ops_tx.pacing = ST21_PACING_NARROW;
       ops_tx.width = width[i];
       ops_tx.height = height[i];
@@ -852,10 +867,11 @@ static void st22_rx_after_start_test(enum st_fps fps[], int width[], int height[
       ops_rx.name = "st22_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-      ops_rx.udp_port[MTL_PORT_P] = 15000 + i;
+      strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+              MTL_PORT_MAX_LEN);
+      ops_rx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
       ops_rx.pacing = ST21_PACING_NARROW;
       ops_rx.width = width[i];
       ops_rx.height = height[i];
@@ -964,9 +980,11 @@ static void st22_rx_dump_test(enum st_fps fps[], int width[], int height[],
     ops_tx.name = "st22_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.width = width[i];
     ops_tx.height = height[i];
@@ -1011,9 +1029,11 @@ static void st22_rx_dump_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.width = width[i];
     ops_rx.height = height[i];
@@ -1181,9 +1201,11 @@ static void st22_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_tx.name = "st22_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.width = width[i];
     ops_tx.height = height[i];
@@ -1240,9 +1262,11 @@ static void st22_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.width = width[i];
     ops_rx.height = height[i];
@@ -1372,9 +1396,11 @@ static void st22_tx_user_pacing_test(int width[], int height[], int pkt_data_len
     ops_tx.name = "st22_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_tx.pacing = ST21_PACING_NARROW;
     ops_tx.width = width[i];
     ops_tx.height = height[i];
@@ -1415,9 +1441,11 @@ static void st22_tx_user_pacing_test(int width[], int height[], int pkt_data_len
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 15000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 15000 + i;
     ops_rx.pacing = ST21_PACING_NARROW;
     ops_rx.width = width[i];
     ops_rx.height = height[i];

--- a/tests/src/st22p_test.cpp
+++ b/tests/src/st22p_test.cpp
@@ -447,10 +447,11 @@ static void st22p_tx_ops_init(tests_context* st22, struct st22p_tx_ops* ops_tx) 
   ops_tx->name = "st22p_test";
   ops_tx->priv = st22;
   ops_tx->port.num_port = 1;
-  memcpy(ops_tx->port.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops_tx->port.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops_tx->port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops_tx->port.udp_port[MTL_PORT_P] = ST22P_TEST_UDP_PORT + st22->idx;
+  strncpy(ops_tx->port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+          MTL_PORT_MAX_LEN);
+  ops_tx->port.udp_port[MTL_SESSION_PORT_P] = ST22P_TEST_UDP_PORT + st22->idx;
   ops_tx->port.payload_type = ST22P_TEST_PAYLOAD_TYPE;
   ops_tx->width = 1920;
   ops_tx->height = 1080;
@@ -474,10 +475,11 @@ static void st22p_rx_ops_init(tests_context* st22, struct st22p_rx_ops* ops_rx) 
   ops_rx->name = "st22p_test";
   ops_rx->priv = st22;
   ops_rx->port.num_port = 1;
-  memcpy(ops_rx->port.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops_rx->port.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
-  strncpy(ops_rx->port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-  ops_rx->port.udp_port[MTL_PORT_P] = ST22P_TEST_UDP_PORT + st22->idx;
+  strncpy(ops_rx->port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+          MTL_PORT_MAX_LEN);
+  ops_rx->port.udp_port[MTL_SESSION_PORT_P] = ST22P_TEST_UDP_PORT + st22->idx;
   ops_rx->port.payload_type = ST22P_TEST_PAYLOAD_TYPE;
   ops_rx->width = 1920;
   ops_rx->height = 1080;
@@ -731,10 +733,11 @@ static void st22p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_tx.name = "st22p_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.port.num_port = 1;
-    memcpy(ops_tx.port.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+    memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.port.udp_port[MTL_PORT_P] = ST22P_TEST_UDP_PORT + i;
+    strncpy(ops_tx.port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ST22P_TEST_UDP_PORT + i;
     ops_tx.port.payload_type = ST22P_TEST_PAYLOAD_TYPE;
     ops_tx.width = width[i];
     ops_tx.height = height[i];
@@ -806,10 +809,11 @@ static void st22p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st22p_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.port.udp_port[MTL_PORT_P] = ST22P_TEST_UDP_PORT + i;
+    strncpy(ops_rx.port.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ST22P_TEST_UDP_PORT + i;
     ops_rx.port.payload_type = ST22P_TEST_PAYLOAD_TYPE;
     ops_rx.width = width[i];
     ops_rx.height = height[i];

--- a/tests/src/st30_test.cpp
+++ b/tests/src/st30_test.cpp
@@ -214,13 +214,15 @@ static void st30_tx_ops_init(tests_context* st30, struct st30_tx_ops* ops) {
   ops->name = "st30_test";
   ops->priv = st30;
   ops->num_port = ctx->para.num_ports;
-  memcpy(ops->dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops->port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops->udp_port[MTL_PORT_P] = 20000 + st30->idx;
+  memcpy(ops->dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops->port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops->udp_port[MTL_SESSION_PORT_P] = 20000 + st30->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->dip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops->port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops->udp_port[MTL_PORT_R] = 20000 + st30->idx;
+    memcpy(ops->dip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops->port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops->udp_port[MTL_SESSION_PORT_R] = 20000 + st30->idx;
   }
   ops->type = ST30_TYPE_FRAME_LEVEL;
   ops->channel = 2;
@@ -436,9 +438,11 @@ static void st30_rx_fps_test(enum st30_type type[], enum st30_sampling sample[],
     ops_tx.name = "st30_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 20000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
     ops_tx.type = type[i];
     ops_tx.sampling = sample[i];
     ops_tx.channel = channel[i];
@@ -496,9 +500,11 @@ static void st30_rx_fps_test(enum st30_type type[], enum st30_sampling sample[],
     ops_rx.name = "st30_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 20000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
     ops_rx.type = type[i];
     ops_rx.sampling = sample[i];
     ops_rx.channel = channel[i];
@@ -825,16 +831,17 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
     if (2 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
     else if (1 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
     else
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 20000 + i;
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
     ops_tx.type = type;
     ops_tx.sampling = ST30_SAMPLING_48K;
     ops_tx.channel = 2;
@@ -872,9 +879,11 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
     ops_rx.name = "st30_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 20000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
     ops_rx.type = type;
     ops_rx.sampling = ST30_SAMPLING_48K;
     ops_rx.channel = 2;
@@ -906,8 +915,9 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
   struct st_rx_source_info src;
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 20000 + 1;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 20000 + 1;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st30_rx_update_source(rx_handle[i], &src);
     EXPECT_GE(ret, 0);
@@ -931,8 +941,9 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
   if (tx_sessions > 2) {
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
-    src.udp_port[MTL_PORT_P] = 20000 + 2;
-    memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
+    src.udp_port[MTL_SESSION_PORT_P] = 20000 + 2;
+    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
     for (int i = 0; i < rx_sessions; i++) {
       ret = st30_rx_update_source(rx_handle[i], &src);
       EXPECT_GE(ret, 0);
@@ -956,8 +967,9 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
 
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 20000 + 0;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 20000 + 0;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st30_rx_update_source(rx_handle[i], &src);
     EXPECT_GE(ret, 0);
@@ -1086,9 +1098,11 @@ static void st30_rx_meta_test(enum st30_fmt fmt[], enum st30_sampling sampling[]
     ops_tx.name = "st30_meta_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 20000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
     ops_tx.type = ST30_TYPE_FRAME_LEVEL;
     ops_tx.sampling = sampling[i];
     ops_tx.channel = channel[i];
@@ -1129,9 +1143,11 @@ static void st30_rx_meta_test(enum st30_fmt fmt[], enum st30_sampling sampling[]
     ops_rx.name = "st30_meta_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 20000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
     ops_rx.type = ST30_TYPE_FRAME_LEVEL;
     ops_rx.sampling = sampling[i];
     ops_rx.channel = channel[i];
@@ -1265,10 +1281,11 @@ static void st30_create_after_start_test(enum st30_type type[],
       ops_tx.name = "st30_test";
       ops_tx.priv = test_ctx_tx[i];
       ops_tx.num_port = 1;
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-      ops_tx.udp_port[MTL_PORT_P] = 20000 + i;
+      strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+              MTL_PORT_MAX_LEN);
+      ops_tx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
       ops_tx.type = type[i];
       ops_tx.sampling = sample[i];
       ops_tx.channel = channel[i];
@@ -1307,10 +1324,11 @@ static void st30_create_after_start_test(enum st30_type type[],
       ops_rx.name = "st30_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-      ops_rx.udp_port[MTL_PORT_P] = 20000 + i;
+      strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+              MTL_PORT_MAX_LEN);
+      ops_rx.udp_port[MTL_SESSION_PORT_P] = 20000 + i;
       ops_rx.type = type[i];
       ops_rx.sampling = sample[i];
       ops_rx.channel = channel[i];

--- a/tests/src/st40_test.cpp
+++ b/tests/src/st40_test.cpp
@@ -214,13 +214,15 @@ static void st40_rx_ops_init(tests_context* st40, struct st40_rx_ops* ops) {
   ops->name = "st40_test";
   ops->priv = st40;
   ops->num_port = ctx->para.num_ports;
-  memcpy(ops->sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops->port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops->udp_port[MTL_PORT_P] = 30000 + st40->idx;
+  memcpy(ops->sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops->port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops->udp_port[MTL_SESSION_PORT_P] = 30000 + st40->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->sip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops->port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops->udp_port[MTL_PORT_R] = 30000 + st40->idx;
+    memcpy(ops->sip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops->port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops->udp_port[MTL_SESSION_PORT_R] = 30000 + st40->idx;
   }
   ops->notify_rtp_ready = rx_rtp_ready;
   ops->rtp_ring_size = 1024;
@@ -234,13 +236,15 @@ static void st40_tx_ops_init(tests_context* st40, struct st40_tx_ops* ops) {
   ops->name = "st40_test";
   ops->priv = st40;
   ops->num_port = ctx->para.num_ports;
-  memcpy(ops->dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-  strncpy(ops->port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-  ops->udp_port[MTL_PORT_P] = 30000 + st40->idx;
+  memcpy(ops->dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  strncpy(ops->port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
+  ops->udp_port[MTL_SESSION_PORT_P] = 30000 + st40->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->dip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops->port[MTL_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops->udp_port[MTL_PORT_R] = 30000 + st40->idx;
+    memcpy(ops->dip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops->port[MTL_SESSION_PORT_R], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
+    ops->udp_port[MTL_SESSION_PORT_R] = 30000 + st40->idx;
   }
   ops->type = ST40_TYPE_FRAME_LEVEL;
   ops->fps = ST_FPS_P59_94;
@@ -480,9 +484,11 @@ static void st40_rx_fps_test(enum st40_type type[], enum st_fps fps[],
     ops_tx.name = "st40_test";
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
-    memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 30000 + i;
+    memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 30000 + i;
     ops_tx.type = type[i];
     ops_tx.fps = fps[i];
     ops_tx.payload_type = ST40_TEST_PAYLOAD_TYPE;
@@ -532,9 +538,11 @@ static void st40_rx_fps_test(enum st40_type type[], enum st_fps fps[],
     ops_rx.name = "st40_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 30000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 30000 + i;
     ops_rx.notify_rtp_ready = rx_rtp_ready;
     ops_rx.rtp_ring_size = 1024;
     ops_rx.payload_type = ST40_TEST_PAYLOAD_TYPE;
@@ -730,16 +738,17 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions) {
     ops_tx.priv = test_ctx_tx[i];
     ops_tx.num_port = 1;
     if (2 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
     else if (1 == i)
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
     else
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-    strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-    ops_tx.udp_port[MTL_PORT_P] = 30000 + i;
+    strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+            MTL_PORT_MAX_LEN);
+    ops_tx.udp_port[MTL_SESSION_PORT_P] = 30000 + i;
     ops_tx.type = type;
     ops_tx.fps = ST_FPS_P59_94;
     ops_tx.payload_type = ST40_TEST_PAYLOAD_TYPE;
@@ -773,9 +782,11 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions) {
     ops_rx.name = "st40_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
-    strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-    ops_rx.udp_port[MTL_PORT_P] = 30000 + i;
+    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+           MTL_IP_ADDR_LEN);
+    strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+            MTL_PORT_MAX_LEN);
+    ops_rx.udp_port[MTL_SESSION_PORT_P] = 30000 + i;
     ops_rx.notify_rtp_ready = rx_rtp_ready;
     ops_rx.rtp_ring_size = 1024;
     ops_rx.payload_type = ST40_TEST_PAYLOAD_TYPE;
@@ -792,8 +803,9 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions) {
   struct st_rx_source_info src;
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 30000 + 1;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 30000 + 1;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st40_rx_update_source(rx_handle[i], &src);
     EXPECT_GE(ret, 0);
@@ -817,8 +829,9 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions) {
   if (tx_sessions > 2) {
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
-    src.udp_port[MTL_PORT_P] = 30000 + 2;
-    memcpy(src.sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
+    src.udp_port[MTL_SESSION_PORT_P] = 30000 + 2;
+    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+           MTL_IP_ADDR_LEN);
     for (int i = 0; i < rx_sessions; i++) {
       ret = st40_rx_update_source(rx_handle[i], &src);
       EXPECT_GE(ret, 0);
@@ -842,8 +855,9 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions) {
 
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
-  src.udp_port[MTL_PORT_P] = 30000 + 0;
-  memcpy(src.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  src.udp_port[MTL_SESSION_PORT_P] = 30000 + 0;
+  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st40_rx_update_source(rx_handle[i], &src);
     EXPECT_GE(ret, 0);
@@ -942,10 +956,11 @@ static void st40_after_start_test(enum st40_type type[], enum st_fps fps[], int 
       ops_tx.name = "st40_test";
       ops_tx.priv = test_ctx_tx[i];
       ops_tx.num_port = 1;
-      memcpy(ops_tx.dip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+      memcpy(ops_tx.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_tx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_P], MTL_PORT_MAX_LEN);
-      ops_tx.udp_port[MTL_PORT_P] = 30000 + i;
+      strncpy(ops_tx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_P],
+              MTL_PORT_MAX_LEN);
+      ops_tx.udp_port[MTL_SESSION_PORT_P] = 30000 + i;
       ops_tx.type = type[i];
       ops_tx.fps = fps[i];
       ops_tx.payload_type = ST40_TEST_PAYLOAD_TYPE;
@@ -979,10 +994,11 @@ static void st40_after_start_test(enum st40_type type[], enum st_fps fps[], int 
       ops_rx.name = "st40_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
-      strncpy(ops_rx.port[MTL_PORT_P], ctx->para.port[MTL_PORT_R], MTL_PORT_MAX_LEN);
-      ops_rx.udp_port[MTL_PORT_P] = 30000 + i;
+      strncpy(ops_rx.port[MTL_SESSION_PORT_P], ctx->para.port[MTL_PORT_R],
+              MTL_PORT_MAX_LEN);
+      ops_rx.udp_port[MTL_SESSION_PORT_P] = 30000 + i;
       ops_rx.notify_rtp_ready = rx_rtp_ready;
       ops_rx.rtp_ring_size = 1024;
       ops_rx.payload_type = ST40_TEST_PAYLOAD_TYPE;

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -233,8 +233,8 @@ int tx_next_frame(void* priv, uint16_t* next_frame_idx);
     for (int i = 0; i < max; i++) {                         \
       handle[i] = A##_create(m_handle, &ops);               \
       if (!handle[i]) break;                                \
-      ops.udp_port[MTL_PORT_P]++;                           \
-      ops.udp_port[MTL_PORT_R]++;                           \
+      ops.udp_port[MTL_SESSION_PORT_P]++;                   \
+      ops.udp_port[MTL_SESSION_PORT_R]++;                   \
       expect_cnt++;                                         \
       A##_assert_cnt(expect_cnt);                           \
       st_usleep(100 * 1000);                                \
@@ -274,8 +274,8 @@ int tx_next_frame(void* priv, uint16_t* next_frame_idx);
     for (int i = 0; i < base; i++) {               \
       handle_base[i] = A##_create(m_handle, &ops); \
       ASSERT_TRUE(handle_base[i]);                 \
-      ops.udp_port[MTL_PORT_P]++;                  \
-      ops.udp_port[MTL_PORT_R]++;                  \
+      ops.udp_port[MTL_SESSION_PORT_P]++;          \
+      ops.udp_port[MTL_SESSION_PORT_R]++;          \
       expect_cnt++;                                \
       A##_assert_cnt(expect_cnt);                  \
     }                                              \
@@ -286,8 +286,8 @@ int tx_next_frame(void* priv, uint16_t* next_frame_idx);
       for (int j = 0; j < step; j++) {             \
         handle[j] = A##_create(m_handle, &ops);    \
         ASSERT_TRUE(handle[j] != NULL);            \
-        ops.udp_port[MTL_PORT_P]++;                \
-        ops.udp_port[MTL_PORT_R]++;                \
+        ops.udp_port[MTL_SESSION_PORT_P]++;        \
+        ops.udp_port[MTL_SESSION_PORT_R]++;        \
         expect_cnt++;                              \
         A##_assert_cnt(expect_cnt);                \
       }                                            \
@@ -549,8 +549,8 @@ int tx_next_frame(void* priv, uint16_t* next_frame_idx);
     for (int i = 0; i < base; i++) {                     \
       handle_base[i] = A##_create(m_handle, &ops);       \
       ASSERT_TRUE(handle_base[i]);                       \
-      ops.port.udp_port[MTL_PORT_P]++;                   \
-      ops.port.udp_port[MTL_PORT_R]++;                   \
+      ops.port.udp_port[MTL_SESSION_PORT_P]++;           \
+      ops.port.udp_port[MTL_SESSION_PORT_R]++;           \
       expect_cnt++;                                      \
       A##_assert_cnt(expect_cnt);                        \
     }                                                    \
@@ -561,8 +561,8 @@ int tx_next_frame(void* priv, uint16_t* next_frame_idx);
       for (int j = 0; j < step; j++) {                   \
         handle[j] = A##_create(m_handle, &ops);          \
         ASSERT_TRUE(handle[j] != NULL);                  \
-        ops.port.udp_port[MTL_PORT_P]++;                 \
-        ops.port.udp_port[MTL_PORT_R]++;                 \
+        ops.port.udp_port[MTL_SESSION_PORT_P]++;         \
+        ops.port.udp_port[MTL_SESSION_PORT_R]++;         \
         expect_cnt++;                                    \
         A##_assert_cnt(expect_cnt);                      \
       }                                                  \
@@ -607,8 +607,8 @@ int tx_next_frame(void* priv, uint16_t* next_frame_idx);
     for (int i = 0; i < max; i++) {                         \
       handle[i] = A##_create(m_handle, &ops);               \
       if (!handle[i]) break;                                \
-      ops.port.udp_port[MTL_PORT_P]++;                      \
-      ops.port.udp_port[MTL_PORT_R]++;                      \
+      ops.port.udp_port[MTL_SESSION_PORT_P]++;              \
+      ops.port.udp_port[MTL_SESSION_PORT_R]++;              \
       expect_cnt++;                                         \
       A##_assert_cnt(expect_cnt);                           \
     }                                                       \


### PR DESCRIPTION
User can initial MTL instance with up to 8 ports. 
See tests/script/multi_port_json/ for how to use from RxTxApp.