### PR TITLE
arp/mcast/ptp: malloc context at runtime

### DIFF
--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -766,13 +766,11 @@ struct mtl_main_impl {
   struct mt_cni_impl cni;
 
   /* ptp context */
-  struct mt_ptp_impl ptp[MTL_PORT_MAX];
-
+  struct mt_ptp_impl* ptp[MTL_PORT_MAX];
   /* arp context */
-  struct mt_arp_impl arp[MTL_PORT_MAX];
-
+  struct mt_arp_impl* arp[MTL_PORT_MAX];
   /* mcast context */
-  struct mt_mcast_impl mcast[MTL_PORT_MAX];
+  struct mt_mcast_impl* mcast[MTL_PORT_MAX];
 
   /* sch context */
   struct mt_sch_mgr sch_mgr;
@@ -1286,7 +1284,8 @@ static inline uint32_t st_rx_mbuf_get_len(struct rte_mbuf* mbuf) {
   return priv->rx_priv.len;
 }
 
-uint64_t mt_mbuf_hw_time_stamp(struct mtl_main_impl* impl, struct rte_mbuf* mbuf);
+uint64_t mt_mbuf_hw_time_stamp(struct mtl_main_impl* impl, struct rte_mbuf* mbuf,
+                               enum mtl_port port);
 
 static inline uint64_t mt_get_ptp_time(struct mtl_main_impl* impl, enum mtl_port port) {
   return mt_if(impl, port)->ptp_get_time_fn(impl, port);

--- a/lib/src/mt_mcast.c
+++ b/lib/src/mt_mcast.c
@@ -13,7 +13,7 @@
 
 static inline struct mt_mcast_impl* get_mcast(struct mtl_main_impl* impl,
                                               enum mtl_port port) {
-  return &impl->mcast[port];
+  return impl->mcast[port];
 }
 
 /* Computing the Internet Checksum based on rfc1071 */
@@ -315,15 +315,25 @@ static int mcast_inf_remove_mac(struct mt_interface* inf,
 }
 
 int mt_mcast_init(struct mtl_main_impl* impl) {
-  int ret;
+  int num_ports = mt_num_ports(impl);
+  int socket = mt_socket_id(impl, MTL_PORT_P);
 
-  for (int port = 0; port < MTL_PORT_MAX; ++port) {
-    struct mt_mcast_impl* mcast = get_mcast(impl, port);
+  for (int i = 0; i < num_ports; i++) {
+    struct mt_mcast_impl* mcast = mt_rte_zmalloc_socket(sizeof(*mcast), socket);
+    if (!mcast) {
+      err("%s(%d), mcast malloc fail\n", __func__, i);
+      mt_mcast_uinit(impl);
+      return -ENOMEM;
+    }
 
     mt_pthread_mutex_init(&mcast->group_mutex, NULL);
+
+    /* assign arp instance */
+    impl->mcast[i] = mcast;
   }
 
-  ret = rte_eal_alarm_set(IGMP_JOIN_GROUP_PERIOD_US, mcast_membership_report_cb, impl);
+  int ret =
+      rte_eal_alarm_set(IGMP_JOIN_GROUP_PERIOD_US, mcast_membership_report_cb, impl);
   if (ret < 0) err("%s, set igmp alarm fail %d\n", __func__, ret);
 
   info("%s, report every %d seconds\n", __func__, IGMP_JOIN_GROUP_PERIOD_S);
@@ -331,18 +341,23 @@ int mt_mcast_init(struct mtl_main_impl* impl) {
 }
 
 int mt_mcast_uinit(struct mtl_main_impl* impl) {
-  int ret;
+  int num_ports = mt_num_ports(impl);
 
-  for (int port = 0; port < MTL_PORT_MAX; ++port) {
-    struct mt_mcast_impl* mcast = get_mcast(impl, port);
+  for (int i = 0; i < num_ports; i++) {
+    struct mt_mcast_impl* mcast = get_mcast(impl, i);
+    if (!mcast) continue;
 
     mt_pthread_mutex_destroy(&mcast->group_mutex);
+
+    /* free the memory */
+    mt_rte_free(mcast);
+    impl->mcast[i] = NULL;
   }
 
-  ret = rte_eal_alarm_cancel(mcast_membership_report_cb, impl);
+  int ret = rte_eal_alarm_cancel(mcast_membership_report_cb, impl);
   if (ret < 0) err("%s, alarm cancel fail %d\n", __func__, ret);
 
-  info("%s, succ\n", __func__);
+  dbg("%s, succ\n", __func__);
   return 0;
 }
 

--- a/lib/src/mt_ptp.h
+++ b/lib/src/mt_ptp.h
@@ -104,7 +104,7 @@ struct mt_ptp_delay_resp_msg {
 
 static inline struct mt_ptp_impl* mt_get_ptp(struct mtl_main_impl* impl,
                                              enum mtl_port port) {
-  return &impl->ptp[port];
+  return impl->ptp[port];
 }
 
 int mt_ptp_init(struct mtl_main_impl* impl);

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -416,7 +416,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   s->st30_pkt_idx++;
 
   if (mt_has_ebu(impl) && inf->feature & MT_IF_FEATURE_RX_OFFLOAD_TIMESTAMP) {
-    ra_ebu_on_packet(s, tmstamp, mt_mbuf_hw_time_stamp(impl, mbuf));
+    ra_ebu_on_packet(s, tmstamp, mt_mbuf_hw_time_stamp(impl, mbuf, port));
   }
 
   // notify frame done
@@ -489,7 +489,7 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   s->st30_stat_pkts_received++;
 
   if (mt_has_ebu(impl) && inf->feature & MT_IF_FEATURE_RX_OFFLOAD_TIMESTAMP) {
-    ra_ebu_on_packet(s, tmstamp, mt_mbuf_hw_time_stamp(impl, mbuf));
+    ra_ebu_on_packet(s, tmstamp, mt_mbuf_hw_time_stamp(impl, mbuf, port));
   }
 
   return 0;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1386,7 +1386,8 @@ static int rv_dump_pcapng(struct mtl_main_impl* impl, struct st_rx_video_session
   struct rte_mbuf* pcapng_mbuf[rv];
   int pcapng_mbuf_cnt = 0;
   ssize_t len;
-  struct mt_interface* inf = mt_if(impl, mt_port_logic2phy(s->port_maps, s_port));
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
+  struct mt_interface* inf = mt_if(impl, port);
   uint16_t queue_id = mt_dev_rx_queue_id(s->queue[s_port]);
 
   for (uint16_t i = 0; i < rv; i++) {
@@ -1394,7 +1395,7 @@ static int rv_dump_pcapng(struct mtl_main_impl* impl, struct st_rx_video_session
     uint64_t timestamp_cycle, timestamp_ns;
     if (mt_has_ebu(impl) && inf->feature & MT_IF_FEATURE_RX_OFFLOAD_TIMESTAMP) {
       timestamp_cycle = 0;
-      timestamp_ns = mt_mbuf_hw_time_stamp(impl, mbuf[i]);
+      timestamp_ns = mt_mbuf_hw_time_stamp(impl, mbuf[i], port);
     } else {
       timestamp_cycle = rte_get_tsc_cycles();
       timestamp_ns = 0;
@@ -1570,7 +1571,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
     enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
     struct mt_interface* inf = mt_if(impl, port);
     if (inf->feature & MT_IF_FEATURE_RX_OFFLOAD_TIMESTAMP) {
-      rv_ebu_on_packet(s, tmstamp, mt_mbuf_hw_time_stamp(impl, mbuf), pkt_idx);
+      rv_ebu_on_packet(s, tmstamp, mt_mbuf_hw_time_stamp(impl, mbuf, port), pkt_idx);
     }
   }
   if (s->st20_uframe_size) {


### PR DESCRIPTION
reduce memory usage since MTL_PORT_MAX is extent to 8 now