### PR TITLE
st/video: fix dma copy for IOVA PA mode

### DIFF
--- a/.github/workflows/ubuntu_build_with_gtest.yml
+++ b/.github/workflows/ubuntu_build_with_gtest.yml
@@ -120,4 +120,4 @@ jobs:
 
       - name: Run st2110 st20p test case with rss in IOVA PA mode
         run: |
-          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --iova_pa_mode --gtest_filter=Main.*:St20p*:-*ext*
+          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --iova_mode pa --gtest_filter=Main.*:St20p*:-*ext*

--- a/.github/workflows/ubuntu_build_with_gtest.yml
+++ b/.github/workflows/ubuntu_build_with_gtest.yml
@@ -118,6 +118,6 @@ jobs:
         run: |
           sudo ./build/tests/KahawaiTest --auto_start_stop --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --gtest_filter=-St22_?x.*
 
-      - name: Run st2110 st20p test case with rss and tx_no_chain
+      - name: Run st2110 st20p test case with rss in IOVA PA mode
         run: |
-          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --tx_no_chain --gtest_filter=Main.*:St20p.*
+          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --iova_pa_mode --gtest_filter=Main.*:St20*:-*ext*

--- a/.github/workflows/ubuntu_build_with_gtest.yml
+++ b/.github/workflows/ubuntu_build_with_gtest.yml
@@ -120,4 +120,4 @@ jobs:
 
       - name: Run st2110 st20p test case with rss in IOVA PA mode
         run: |
-          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --iova_pa_mode --gtest_filter=Main.*:St20*:-*ext*
+          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --iova_pa_mode --gtest_filter=Main.*:St20p*:-*ext*

--- a/doc/dma.md
+++ b/doc/dma.md
@@ -68,4 +68,4 @@ BTW, the gtest support --dma_dev also, pls pass the DMA setup for the DMA test.
 
 ## 3. DMA sample code for application usage
 
-Refer to [dma_sample.c](../app/sample/dma_sample.c) for how to use DMA in application side, use st_hp_virt2iova(for st_hp_malloc) or st_dma_map(for malloc) to get the IOVA address.
+Refer to [dma_sample.c](../app/sample/dma/dma_sample.c) for how to use DMA in application side, use st_hp_virt2iova(for st_hp_malloc) or st_dma_map(for malloc) to get the IOVA address.

--- a/ecosystem/librist/build_librist_mtl.sh
+++ b/ecosystem/librist/build_librist_mtl.sh
@@ -9,6 +9,7 @@ set -e
 rm librist -rf
 git clone https://code.videolan.org/rist/librist.git
 cd librist
+git checkout d364e491
 
 # apply the patches
 git am ../*.patch

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -503,6 +503,10 @@ struct mtl_init_params {
    * Suggest using rss (L3 or L4) for rx packets direction.
    */
   enum mt_rss_mode rss_mode;
+  /**
+   * Force to use DPDK IOVA PA mode.
+   */
+  bool iova_pa;
 };
 
 /**

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -192,6 +192,20 @@ enum mt_rss_mode {
 };
 
 /**
+ * IOVA mode
+ */
+enum mt_iova_mode {
+  /** let DPDK to choose IOVA mode */
+  MT_IOVA_MODE_AUTO = 0,
+  /** using IOVA VA mode */
+  MT_IOVA_MODE_VA,
+  /** using IOVA PA mode */
+  MT_IOVA_MODE_PA,
+  /** max value of this enum */
+  MT_IOVA_MODE_MAX,
+};
+
+/**
  * Transport type
  */
 enum mtl_transport_type {
@@ -504,9 +518,9 @@ struct mtl_init_params {
    */
   enum mt_rss_mode rss_mode;
   /**
-   * Force to use DPDK IOVA PA mode.
+   * Select default or force IOVA mode.
    */
-  bool iova_pa;
+  enum mt_iova_mode iova_mode;
 };
 
 /**

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -293,6 +293,13 @@ static int dev_eal_init(struct mtl_init_params* p, struct mt_kport_info* kport_i
     argc++;
   }
 
+  if (p->iova_pa) {
+    argv[argc] = "--iova-mode";
+    argc++;
+    argv[argc] = "pa";
+    argc++;
+  }
+
   argv[argc] = "--log-level";
   argc++;
   if (p->log_level == MTL_LOG_LEVEL_DEBUG) {

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -293,10 +293,13 @@ static int dev_eal_init(struct mtl_init_params* p, struct mt_kport_info* kport_i
     argc++;
   }
 
-  if (p->iova_pa) {
+  if (p->iova_mode > MT_IOVA_MODE_AUTO && p->iova_mode < MT_IOVA_MODE_MAX) {
     argv[argc] = "--iova-mode";
     argc++;
-    argv[argc] = "pa";
+    if (p->iova_mode == MT_IOVA_MODE_VA)
+      argv[argc] = "va";
+    else if (p->iova_mode == MT_IOVA_MODE_PA)
+      argv[argc] = "pa";
     argc++;
   }
 

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -721,7 +721,7 @@ struct mtl_main_impl {
   uint64_t tsc_hz;
   pthread_t tsc_cal_tid;
 
-  enum rte_iova_mode iova_mode;
+  enum rte_iova_mode iova_mode; /* current IOVA mode */
   size_t page_size;
 
   /* rss */

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -391,8 +391,7 @@ struct st_rx_video_slot_impl {
   uint16_t seq_id_base;     /* seq id for the first packt */
   uint32_t seq_id_base_u32; /* seq id for the first packt with u32 */
   bool seq_id_got;
-  void* frame; /* only for frame type */
-  rte_iova_t frame_iova;
+  struct st_frame_trans* frame; /* only for frame type */
   uint8_t* frame_bitmap;
   size_t frame_recv_size;           /* for frame type */
   size_t pkt_lcore_frame_recv_size; /* frame_recv_size for pkt lcore */

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -642,7 +642,7 @@ static int rv_frame_create_page_table(struct st_rx_video_session_impl* s,
   info("%s(%d,%d), hugepage size %" PRIu64 "\n", __func__, s->idx, frame_info->idx,
        hugepage_sz);
 
-  /* calculate num pages of 2m hp */
+  /* calculate num hugepages */
   uint16_t num_pages =
       RTE_PTR_DIFF(RTE_PTR_ALIGN(frame_info->addr + s->st20_fb_size, hugepage_sz),
                    RTE_PTR_ALIGN_FLOOR(frame_info->addr, hugepage_sz)) /

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -592,22 +592,11 @@ static struct st_frame_trans* rv_get_frame(struct st_rx_video_session_impl* s) {
   return NULL;
 }
 
-static int rv_put_frame(struct st_rx_video_session_impl* s, void* frame) {
-  int idx = s->idx;
-  struct st_frame_trans* st20_frame;
-
-  for (int i = 0; i < s->st20_frames_cnt; i++) {
-    st20_frame = &s->st20_frames[i];
-
-    if (st20_frame->addr == frame) {
-      dbg("%s(%d), put frame at %d\n", __func__, idx, i);
-      rte_atomic32_dec(&st20_frame->refcnt);
-      return 0;
-    }
-  }
-
-  err("%s(%d), invalid frame %p\n", __func__, idx, frame);
-  return -EIO;
+static int rv_put_frame(struct st_rx_video_session_impl* s,
+                        struct st_frame_trans* frame) {
+  dbg("%s(%d), put frame at %d\n", __func__, s->idx, frame->idx);
+  rte_atomic32_dec(&frame->refcnt);
+  return 0;
 }
 
 static int rv_free_frames(struct st_rx_video_session_impl* s) {
@@ -623,6 +612,68 @@ static int rv_free_frames(struct st_rx_video_session_impl* s) {
 
   dbg("%s(%d), succ\n", __func__, s->idx);
   return 0;
+}
+
+static rte_iova_t rv_frame_get_offset_iova(struct st_rx_video_session_impl* s,
+                                           struct st_frame_trans* frame_info,
+                                           size_t offset) {
+  if (rte_eal_iova_mode() != RTE_IOVA_PA) return frame_info->iova + offset;
+  void* addr = RTE_PTR_ADD(frame_info->addr, offset);
+  struct st_page_info* page;
+  for (uint16_t i = 0; i < frame_info->page_table_len; i++) {
+    page = &frame_info->page_table[i];
+    if (addr >= page->addr && addr < RTE_PTR_ADD(page->addr, page->len))
+      return page->iova + RTE_PTR_DIFF(addr, page->addr);
+  }
+
+  err("%s(%d,%d), offset %" PRIu64 " get iova fail\n", __func__, s->idx, frame_info->idx,
+      offset);
+  return MTL_BAD_IOVA;
+}
+
+static int rv_frame_create_page_table(struct st_rx_video_session_impl* s,
+                                      struct st_frame_trans* frame_info) {
+  if (rte_eal_iova_mode() != RTE_IOVA_PA) {
+    dbg("%s(%d,%d), no need to create IOVA table\n", __func__, s->idx, frame_info->idx);
+    return 0;
+  }
+
+  /* calculate num pages of 2m hp */
+  uint16_t num_pages =
+      RTE_PTR_DIFF(RTE_PTR_ALIGN(frame_info->addr + s->st20_fb_size, RTE_PGSIZE_2M),
+                   RTE_PTR_ALIGN_FLOOR(frame_info->addr, RTE_PGSIZE_2M)) /
+      RTE_PGSIZE_2M;
+
+  struct st_page_info* pages = mt_zmalloc(sizeof(*pages) * num_pages);
+  if (pages == NULL) {
+    err("%s(%d), pages info malloc fail\n", __func__, s->idx);
+    return -ENOMEM;
+  }
+
+  void* addr = frame_info->addr;
+  /* get IOVA start of each page */
+  for (uint16_t i = 0; i < num_pages; i++) {
+    /* touch the page before getting its IOVA */
+    *(volatile char*)addr = 0;
+    pages[i].addr = addr;
+    pages[i].iova = rte_mem_virt2iova(addr);
+    void* next_addr = RTE_PTR_ALIGN(RTE_PTR_ADD(addr, 1), RTE_PGSIZE_2M);
+    pages[i].len = RTE_PTR_DIFF(next_addr, addr);
+    addr = next_addr;
+    info("%s(%d,%d), va: %p, iova(pa): 0x%" PRIx64 ", len: %" PRIu64 "\n", __func__,
+         s->idx, frame_info->idx, pages[i].addr, pages[i].iova, pages[i].len);
+  }
+
+  frame_info->page_table = pages;
+  frame_info->page_table_len = num_pages;
+  return 0;
+}
+
+static inline bool rv_frame_payload_cross_page(struct st_rx_video_session_impl* s,
+                                               struct st_frame_trans* frame_info,
+                                               size_t offset, size_t len) {
+  return ((rv_frame_get_offset_iova(s, frame_info, offset + len - 1) -
+           rv_frame_get_offset_iova(s, frame_info, offset)) != len - 1);
 }
 
 static int rv_alloc_frames(struct mtl_main_impl* impl,
@@ -682,6 +733,7 @@ static int rv_alloc_frames(struct mtl_main_impl* impl,
       st20_frame->flags = ST_FT_FLAG_RTE_MALLOC;
       st20_frame->addr = frame;
       st20_frame->iova = rte_malloc_virt2iova(frame);
+      rv_frame_create_page_table(s, st20_frame);
     }
   }
 
@@ -967,7 +1019,7 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
     int ret = -EIO;
     dbg("%s(%d): tmstamp %u\n", __func__, s->idx, slot->tmstamp);
     if (ops->notify_frame_ready)
-      ret = ops->notify_frame_ready(ops->priv, slot->frame, meta);
+      ret = ops->notify_frame_ready(ops->priv, slot->frame->addr, meta);
     if (ret < 0) {
       err("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
       rv_put_frame(s, slot->frame);
@@ -981,7 +1033,7 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
     rte_atomic32_inc(&s->cbs_incomplete_frame_cnt);
     /* notify the incomplete frame if user required */
     if (ops->flags & ST20_RX_FLAG_RECEIVE_INCOMPLETE_FRAME) {
-      ops->notify_frame_ready(ops->priv, slot->frame, meta);
+      ops->notify_frame_ready(ops->priv, slot->frame->addr, meta);
     } else {
       rv_put_frame(s, slot->frame);
       slot->frame = NULL;
@@ -1007,7 +1059,7 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
   if (st_is_frame_complete(status)) {
     rte_atomic32_inc(&s->stat_frames_received);
     if (st22_info->notify_frame_ready)
-      ret = st22_info->notify_frame_ready(ops->priv, slot->frame, meta);
+      ret = st22_info->notify_frame_ready(ops->priv, slot->frame->addr, meta);
     if (ret < 0) {
       err("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
       rv_put_frame(s, slot->frame);
@@ -1018,7 +1070,7 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
     rte_atomic32_inc(&s->cbs_incomplete_frame_cnt);
     /* notify the incomplete frame if user required */
     if (ops->flags & ST20_RX_FLAG_RECEIVE_INCOMPLETE_FRAME) {
-      st22_info->notify_frame_ready(ops->priv, slot->frame, meta);
+      st22_info->notify_frame_ready(ops->priv, slot->frame->addr, meta);
     } else {
       rv_put_frame(s, slot->frame);
       slot->frame = NULL;
@@ -1037,7 +1089,7 @@ static void rv_slice_notify(struct st_rx_video_session_impl* s,
   meta->second_field = slot->second_field;
   meta->frame_recv_size = rv_slot_get_frame_size(s, slot);
   meta->frame_recv_lines = slice_info->ready_slices * s->slice_lines;
-  ops->notify_slice_ready(ops->priv, slot->frame, meta);
+  ops->notify_slice_ready(ops->priv, slot->frame->addr, meta);
   s->stat_slices_received++;
 }
 
@@ -1176,8 +1228,7 @@ static struct st_rx_video_slot_impl* rv_slot_by_tmstamp(
     frame_info->flags |= ST_FT_FLAG_EXT;
     meta->opaque = ext_frame.opaque;
   }
-  slot->frame = frame_info->addr;
-  slot->frame_iova = frame_info->iova;
+  slot->frame = frame_info;
 
   s->dma_slot = slot;
 
@@ -1187,8 +1238,8 @@ static struct st_rx_video_slot_impl* rv_slot_by_tmstamp(
 
   rte_atomic32_inc(&s->cbs_frame_slot_cnt);
 
-  dbg("%s(%d): assign slot %d frame %p for tmstamp %u\n", __func__, s->idx, slot_idx,
-      slot->frame, tmstamp);
+  dbg("%s(%d): assign slot %d framebuff %p for tmstamp %u\n", __func__, s->idx, slot_idx,
+      slot->frame->addr, tmstamp);
   return slot;
 }
 
@@ -1590,31 +1641,34 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
     pg_meta->row_offset = line1_offset;
     pg_meta->pg_cnt = line1_length / s->st20_pg.size;
     pg_meta->timestamp = tmstamp;
-    ops->uframe_pg_callback(ops->priv, slot->frame, pg_meta);
+    ops->uframe_pg_callback(ops->priv, slot->frame->addr, pg_meta);
     if (extra_rtp) {
       pg_meta->payload = payload + line1_length;
       pg_meta->row_length = ntohs(extra_rtp->row_length);
       pg_meta->row_number = ntohs(extra_rtp->row_number);
       pg_meta->row_offset = ntohs(extra_rtp->row_offset);
       pg_meta->pg_cnt = pg_meta->row_length / s->st20_pg.size;
-      ops->uframe_pg_callback(ops->priv, slot->frame, pg_meta);
+      ops->uframe_pg_callback(ops->priv, slot->frame->addr, pg_meta);
     }
   } else if (need_copy) {
     /* copy the payload to target frame by dma or cpu */
     if (extra_rtp && s->st20_linesize > s->st20_bytes_in_line) {
       /* packet acrosses line padding, copy two lines data */
-      rte_memcpy(slot->frame + offset, payload, line1_length);
-      rte_memcpy(slot->frame + (line1_number + 1) * s->st20_linesize,
+      rte_memcpy(slot->frame->addr + offset, payload, line1_length);
+      rte_memcpy(slot->frame->addr + (line1_number + 1) * s->st20_linesize,
                  payload + line1_length, payload_length - line1_length);
     } else if (dma_dev && (payload_length > ST_RX_VIDEO_DMA_MIN_SIZE) &&
-               !mt_dma_full(dma_dev)) {
+               !mt_dma_full(dma_dev) &&
+               !(rte_eal_iova_mode() == RTE_IOVA_PA &&
+                 rv_frame_payload_cross_page(s, slot->frame, offset, payload_length))) {
       rte_iova_t payload_iova =
           rte_pktmbuf_iova_offset(mbuf, sizeof(struct st_rfc4175_video_hdr));
       if (extra_rtp) payload_iova += sizeof(*extra_rtp);
-      ret = mt_dma_copy(dma_dev, slot->frame_iova + offset, payload_iova, payload_length);
+      ret = mt_dma_copy(dma_dev, rv_frame_get_offset_iova(s, slot->frame, offset),
+                        payload_iova, payload_length);
       if (ret < 0) {
         /* use cpu copy if dma copy fail */
-        rte_memcpy(slot->frame + offset, payload, payload_length);
+        rte_memcpy(slot->frame->addr + offset, payload, payload_length);
       } else {
         /* abstrct dma dev takes ownership of this mbuf */
         st_rx_mbuf_set_offset(mbuf, offset);
@@ -1626,7 +1680,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
         s->stat_pkts_dma++;
       }
     } else {
-      rte_memcpy(slot->frame + offset, payload, payload_length);
+      rte_memcpy(slot->frame->addr + offset, payload, payload_length);
     }
   }
 
@@ -1653,7 +1707,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
   }
   if (end_frame) {
     dbg("%s(%d,%d): full frame on %p(%" PRIu64 ")\n", __func__, s->idx, s_port,
-        slot->frame, frame_recv_size);
+        slot->frame->addr, frame_recv_size);
     dbg("%s(%d,%d): tmstamp %u slot %d\n", __func__, s->idx, s_port, slot->tmstamp,
         slot->idx);
     /* end of frame */
@@ -1907,7 +1961,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
     s->stat_pkts_offset_dropped++;
     return -EIO;
   }
-  rte_memcpy(slot->frame + offset, payload, payload_length);
+  rte_memcpy(slot->frame->addr + offset, payload, payload_length);
   rv_slot_add_frame_size(s, slot, payload_length);
   s->stat_pkts_received++;
   slot->pkts_received++;
@@ -2066,7 +2120,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
   }
 
   if (need_copy) {
-    rte_memcpy(slot->frame + offset, payload, payload_length);
+    rte_memcpy(slot->frame->addr + offset, payload, payload_length);
   }
 
   rv_slot_add_frame_size(s, slot, payload_length);
@@ -2081,7 +2135,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
   /* check if frame is full */
   size_t frame_recv_size = rv_slot_get_frame_size(s, slot);
   if (frame_recv_size >= s->st20_frame_size) {
-    dbg("%s(%d,%d): full frame on %p(%d)\n", __func__, s->idx, s_port, slot->frame,
+    dbg("%s(%d,%d): full frame on %p(%d)\n", __func__, s->idx, s_port, slot->frame->addr,
         frame_recv_size);
     dbg("%s(%d,%d): tmstamp %u slot %d\n", __func__, s->idx, s_port, slot->tmstamp,
         slot->idx);
@@ -3655,9 +3709,10 @@ int st20_rx_free(st20_rx_handle handle) {
   return 0;
 }
 
-int st20_rx_put_framebuff(st20_rx_handle handle, void* frame) {
+int st20_rx_put_framebuff(st20_rx_handle handle, void* framebuff) {
   struct st_rx_video_session_handle_impl* s_impl = handle;
   struct st_rx_video_session_impl* s;
+  struct st_frame_trans* st20_frame;
 
   if (s_impl->type != MT_HANDLE_RX_VIDEO) {
     err("%s, invalid type %d\n", __func__, s_impl->type);
@@ -3666,7 +3721,16 @@ int st20_rx_put_framebuff(st20_rx_handle handle, void* frame) {
 
   s = s_impl->impl;
 
-  return rv_put_frame(s, frame);
+  for (int i = 0; i < s->st20_frames_cnt; i++) {
+    st20_frame = &s->st20_frames[i];
+    if (st20_frame->addr == framebuff) {
+      dbg("%s(%d), put frame at %d\n", __func__, s->idx, i);
+      return rv_put_frame(s, st20_frame);
+    }
+  }
+
+  err("%s(%d), invalid frame %p\n", __func__, s->idx, framebuff);
+  return -EIO;
 }
 
 size_t st20_rx_get_framebuffer_size(st20_rx_handle handle) {
@@ -4033,9 +4097,10 @@ void st22_rx_put_mbuf(st22_rx_handle handle, void* mbuf) {
   if (pkt) rte_pktmbuf_free(pkt);
 }
 
-int st22_rx_put_framebuff(st22_rx_handle handle, void* frame) {
+int st22_rx_put_framebuff(st22_rx_handle handle, void* framebuff) {
   struct st22_rx_video_session_handle_impl* s_impl = handle;
   struct st_rx_video_session_impl* s;
+  struct st_frame_trans* st20_frame;
 
   if (s_impl->type != MT_ST22_HANDLE_RX_VIDEO) {
     err("%s, invalid type %d\n", __func__, s_impl->type);
@@ -4044,7 +4109,16 @@ int st22_rx_put_framebuff(st22_rx_handle handle, void* frame) {
 
   s = s_impl->impl;
 
-  return rv_put_frame(s, frame);
+  for (int i = 0; i < s->st20_frames_cnt; i++) {
+    st20_frame = &s->st20_frames[i];
+    if (st20_frame->addr == framebuff) {
+      dbg("%s(%d), put frame at %d\n", __func__, s->idx, i);
+      return rv_put_frame(s, st20_frame);
+    }
+  }
+
+  err("%s(%d), invalid frame %p\n", __func__, s->idx, framebuff);
+  return -EIO;
 }
 
 void* st22_rx_get_fb_addr(st22_rx_handle handle, uint16_t idx) {

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -107,7 +107,7 @@ static int tv_frame_create_page_table(struct st_tx_video_session_impl* s,
   info("%s(%d,%d), hugepage size %" PRIu64 "\n", __func__, s->idx, frame_info->idx,
        hugepage_sz);
 
-  /* calculate num pages of 2m hp */
+  /* calculate num hugepages */
   uint16_t num_pages =
       RTE_PTR_DIFF(RTE_PTR_ALIGN(frame_info->addr + s->st20_fb_size, hugepage_sz),
                    RTE_PTR_ALIGN_FLOOR(frame_info->addr, hugepage_sz)) /

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -82,7 +82,7 @@ static void tv_frame_free_cb(void* addr, void* opaque) {
 static rte_iova_t tv_frame_get_offset_iova(struct st_tx_video_session_impl* s,
                                            struct st_frame_trans* frame_info,
                                            size_t offset) {
-  if (rte_eal_iova_mode() != RTE_IOVA_PA) return frame_info->iova + offset;
+  if (frame_info->page_table_len == 0) return frame_info->iova + offset;
   void* addr = RTE_PTR_ADD(frame_info->addr, offset);
   struct st_page_info* page;
   for (uint16_t i = 0; i < frame_info->page_table_len; i++) {
@@ -98,45 +98,50 @@ static rte_iova_t tv_frame_get_offset_iova(struct st_tx_video_session_impl* s,
 
 static int tv_frame_create_page_table(struct st_tx_video_session_impl* s,
                                       struct st_frame_trans* frame_info) {
-  if (rte_eal_iova_mode() != RTE_IOVA_PA) {
-    dbg("%s(%d,%d), no need to create IOVA table\n", __func__, s->idx, frame_info->idx);
-    return 0;
+  struct rte_memseg* mseg = rte_mem_virt2memseg(frame_info->addr, NULL);
+  if (mseg == NULL) {
+    err("%s(%d,%d), get mseg fail\n", __func__, s->idx, frame_info->idx);
+    return -EIO;
   }
+  size_t hugepage_sz = mseg->hugepage_sz;
+  info("%s(%d,%d), hugepage size %" PRIu64 "\n", __func__, s->idx, frame_info->idx,
+       hugepage_sz);
 
   /* calculate num pages of 2m hp */
   uint16_t num_pages =
-      RTE_PTR_DIFF(RTE_PTR_ALIGN(frame_info->addr + s->st20_fb_size, RTE_PGSIZE_2M),
-                   RTE_PTR_ALIGN_FLOOR(frame_info->addr, RTE_PGSIZE_2M)) /
-      RTE_PGSIZE_2M;
+      RTE_PTR_DIFF(RTE_PTR_ALIGN(frame_info->addr + s->st20_fb_size, hugepage_sz),
+                   RTE_PTR_ALIGN_FLOOR(frame_info->addr, hugepage_sz)) /
+      hugepage_sz;
 
   struct st_page_info* pages = mt_zmalloc(sizeof(*pages) * num_pages);
   if (pages == NULL) {
-    err("%s(%d), pages info malloc fail\n", __func__, s->idx);
+    err("%s(%d,%d), pages info malloc fail\n", __func__, s->idx, frame_info->idx);
     return -ENOMEM;
   }
 
-  void* addr = frame_info->addr;
   /* get IOVA start of each page */
+  void* addr = frame_info->addr;
   for (uint16_t i = 0; i < num_pages; i++) {
     /* touch the page before getting its IOVA */
     *(volatile char*)addr = 0;
-    pages[i].addr = addr;
     pages[i].iova = rte_mem_virt2iova(addr);
-    void* next_addr = RTE_PTR_ALIGN(RTE_PTR_ADD(addr, 1), RTE_PGSIZE_2M);
+    pages[i].addr = addr;
+    void* next_addr = RTE_PTR_ALIGN(RTE_PTR_ADD(addr, 1), hugepage_sz);
     pages[i].len = RTE_PTR_DIFF(next_addr, addr);
     addr = next_addr;
-    info("%s(%d,%d), va: %p, iova(pa): 0x%" PRIx64 ", len: %" PRIu64 "\n", __func__,
-         s->idx, frame_info->idx, pages[i].addr, pages[i].iova, pages[i].len);
+    info("%s(%d,%d), seg %u, va %p, iova 0x%" PRIx64 ", len %" PRIu64 "\n", __func__,
+         s->idx, frame_info->idx, i, pages[i].addr, pages[i].iova, pages[i].len);
   }
-
   frame_info->page_table = pages;
   frame_info->page_table_len = num_pages;
+
   return 0;
 }
 
 static inline bool tv_frame_payload_cross_page(struct st_tx_video_session_impl* s,
                                                struct st_frame_trans* frame_info,
                                                size_t offset, size_t len) {
+  if (frame_info->page_table_len == 0) return false;
   return ((tv_frame_get_offset_iova(s, frame_info, offset + len - 1) -
            tv_frame_get_offset_iova(s, frame_info, offset)) != len - 1);
 }
@@ -187,7 +192,7 @@ static int tv_alloc_frames(struct mtl_main_impl* impl,
       frame_info->iova = rte_mem_virt2iova(frame);
       frame_info->addr = frame;
       frame_info->flags = ST_FT_FLAG_RTE_MALLOC;
-      tv_frame_create_page_table(s, frame_info);
+      if (impl->iova_mode == RTE_IOVA_PA) tv_frame_create_page_table(s, frame_info);
     }
     frame_info->priv = s;
   }
@@ -867,8 +872,7 @@ static int tv_build_st20_chain(struct st_tx_video_session_impl* s, struct rte_mb
     mtl_memcpy(payload, frame_info->addr + offset, line1_length);
     mtl_memcpy(payload + line1_length,
                frame_info->addr + s->st20_linesize * (line1_number + 1), line2_length);
-  } else if (rte_eal_iova_mode() == RTE_IOVA_PA &&
-             tv_frame_payload_cross_page(s, frame_info, offset, left_len)) {
+  } else if (tv_frame_payload_cross_page(s, frame_info, offset, left_len)) {
     /* do not attach extbuf, copy to data room */
     void* payload = rte_pktmbuf_mtod(pkt_chain, void*);
     mtl_memcpy(payload, frame_info->addr + offset, left_len);
@@ -1167,8 +1171,7 @@ static int tv_build_st22_chain(struct st_tx_video_session_impl* s, struct rte_mb
 
   /* attach payload to chainbuf */
   struct st_frame_trans* frame_info = &s->st20_frames[s->st20_frame_idx];
-  if (rte_eal_iova_mode() == RTE_IOVA_PA &&
-      tv_frame_payload_cross_page(s, frame_info, offset, left_len)) {
+  if (tv_frame_payload_cross_page(s, frame_info, offset, left_len)) {
     /* do not attach extbuf, copy to data room */
     void* payload = rte_pktmbuf_mtod(pkt_chain, void*);
     mtl_memcpy(payload, frame_info->addr + offset, left_len);
@@ -2119,7 +2122,7 @@ static int tv_mempool_init(struct mtl_main_impl* impl,
       hdr_room_size += sizeof(struct st20_rfc4175_extra_rtp_hdr);
     /* attach extbuf used, only placeholder mbuf */
     chain_room_size = 0;
-    if (rte_eal_iova_mode() == RTE_IOVA_PA) /* need copy for cross page pkts*/
+    if (impl->iova_mode == RTE_IOVA_PA) /* need copy for cross page pkts*/
       chain_room_size = s->st20_pkt_len;
   }
 

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -192,7 +192,8 @@ static int tv_alloc_frames(struct mtl_main_impl* impl,
       frame_info->iova = rte_mem_virt2iova(frame);
       frame_info->addr = frame;
       frame_info->flags = ST_FT_FLAG_RTE_MALLOC;
-      if (impl->iova_mode == RTE_IOVA_PA) tv_frame_create_page_table(s, frame_info);
+      if (impl->iova_mode == RTE_IOVA_PA && !s->tx_no_chain)
+        tv_frame_create_page_table(s, frame_info);
     }
     frame_info->priv = s;
   }

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -81,7 +81,9 @@ static struct option test_args_options[] = {
 
 static struct st_tests_context* g_test_ctx;
 
-struct st_tests_context* st_test_ctx(void) { return g_test_ctx; }
+struct st_tests_context* st_test_ctx(void) {
+  return g_test_ctx;
+}
 
 static int test_args_dma_dev(struct mtl_init_params* p, const char* in_dev) {
   if (!in_dev) return -EIO;

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -41,7 +41,7 @@ enum test_args_cmd {
   TEST_ARG_PACING_WAY,
   TEST_ARG_RSS_MODE,
   TEST_ARG_TX_NO_CHAIN,
-  TEST_ARG_IOVA_PA_MODE,
+  TEST_ARG_IOVA_MODE,
 };
 
 static struct option test_args_options[] = {
@@ -75,15 +75,13 @@ static struct option test_args_options[] = {
     {"pacing_way", required_argument, 0, TEST_ARG_PACING_WAY},
     {"rss_mode", required_argument, 0, TEST_ARG_RSS_MODE},
     {"tx_no_chain", no_argument, 0, TEST_ARG_TX_NO_CHAIN},
-    {"iova_pa_mode", no_argument, 0, TEST_ARG_IOVA_PA_MODE},
+    {"iova_mode", required_argument, 0, TEST_ARG_IOVA_MODE},
 
     {0, 0, 0, 0}};
 
 static struct st_tests_context* g_test_ctx;
 
-struct st_tests_context* st_test_ctx(void) {
-  return g_test_ctx;
-}
+struct st_tests_context* st_test_ctx(void) { return g_test_ctx; }
 
 static int test_args_dma_dev(struct mtl_init_params* p, const char* in_dev) {
   if (!in_dev) return -EIO;
@@ -249,8 +247,13 @@ static int test_parse_args(struct st_tests_context* ctx, struct mtl_init_params*
       case TEST_ARG_TX_NO_CHAIN:
         p->flags |= MTL_FLAG_TX_NO_CHAIN;
         break;
-      case TEST_ARG_IOVA_PA_MODE:
-        p->iova_pa = true;
+      case TEST_ARG_IOVA_MODE:
+        if (!strcmp(optarg, "va"))
+          p->iova_mode = MT_IOVA_MODE_VA;
+        else if (!strcmp(optarg, "pa"))
+          p->iova_mode = MT_IOVA_MODE_PA;
+        else
+          err("%s, unknow iova mode %s\n", __func__, optarg);
         break;
       default:
         break;

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -41,6 +41,7 @@ enum test_args_cmd {
   TEST_ARG_PACING_WAY,
   TEST_ARG_RSS_MODE,
   TEST_ARG_TX_NO_CHAIN,
+  TEST_ARG_IOVA_PA_MODE,
 };
 
 static struct option test_args_options[] = {
@@ -74,6 +75,7 @@ static struct option test_args_options[] = {
     {"pacing_way", required_argument, 0, TEST_ARG_PACING_WAY},
     {"rss_mode", required_argument, 0, TEST_ARG_RSS_MODE},
     {"tx_no_chain", no_argument, 0, TEST_ARG_TX_NO_CHAIN},
+    {"iova_pa_mode", no_argument, 0, TEST_ARG_IOVA_PA_MODE},
 
     {0, 0, 0, 0}};
 
@@ -246,6 +248,9 @@ static int test_parse_args(struct st_tests_context* ctx, struct mtl_init_params*
         break;
       case TEST_ARG_TX_NO_CHAIN:
         p->flags |= MTL_FLAG_TX_NO_CHAIN;
+        break;
+      case TEST_ARG_IOVA_PA_MODE:
+        p->iova_pa = true;
         break;
       default:
         break;


### PR DESCRIPTION
The best setup: IOMMU enabled, DPDK in IOVA VA mode, 2MB hugepages enabled.
The second choice: IOMMU not supported, enable no_iommu for vfio driver, DPDK in IOVA PA mode, 2MB hugepages enabled.
The third option(will be deprecated): IOMMU not supported, enable no_iommu for vfio driver, DPDK in IOVA PA mode, 1GB hugepages enabled.
Current windows setup: vfio not supported, use netuio driver, DPDK in IOVA PA mode, 1GB hugepages enabled.

The goal is to abandon 1GB hugepages setting for both Windows and AWS.
Add gtest argument to simulate IOVA PA environment. The test for IOVA PA may take extra long time.

[Notice] Features not supported in IOVA PA mode: st20 ext_frame, st20p ext_frame no convert mode, dma_map/unmap and others.