### PR TITLE
ld_preload: first version

### DIFF
--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -9,7 +9,7 @@
 
 /* include "struct sockaddr_in" define before include mudp_sockfd_api */
 // clang-format off
-#include <mtl/mudp_sockfd_api.h>
+#include <mtl/mudp_sockfd_internal.h>
 // clang-format on
 
 enum sample_args_cmd {

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,9 @@ if [ -n "$1" ];  then
            buildtype=debug
            enable_asan=true
            ;;
+      "debugonly")
+           buildtype=debug
+           ;;
       "debugoptimized")
            buildtype=debugoptimized
            ;;
@@ -74,6 +77,7 @@ LIB_BUILD_DIR=${WORKSPACE}/build
 APP_BUILD_DIR=${WORKSPACE}/build/app
 TEST_BUILD_DIR=${WORKSPACE}/build/tests
 PLUGINS_BUILD_DIR=${WORKSPACE}/build/plugins
+LD_PRELOAD_BUILD_DIR=${WORKSPACE}/build/ld_preload
 
 # build lib
 meson "${LIB_BUILD_DIR}" -Dbuildtype="$buildtype" -Ddisable_pcapng="$disable_pcapng" -Denable_asan="$enable_asan" -Denable_kni="$enable_kni" -Denable_tap="$enable_tap"
@@ -107,6 +111,19 @@ pushd plugins/
 meson "${PLUGINS_BUILD_DIR}" -Dbuildtype="$buildtype" -Denable_asan="$enable_asan"
 popd
 pushd "${PLUGINS_BUILD_DIR}"
+ninja
+if [ "$user" == "root" ]; then
+    ninja install
+else
+    sudo ninja install
+fi
+popd
+
+# build ld_preload
+pushd ld_preload/
+meson "${LD_PRELOAD_BUILD_DIR}" -Dbuildtype="$buildtype" -Denable_asan="$enable_asan"
+popd
+pushd "${LD_PRELOAD_BUILD_DIR}"
 ninja
 if [ "$user" == "root" ]; then
     ninja install

--- a/include/mudp_sockfd_api.h
+++ b/include/mudp_sockfd_api.h
@@ -292,30 +292,6 @@ static void inline mufd_init_sockaddr(struct sockaddr_in* saddr,
   saddr->sin_port = htons(port);
 }
 
-/**
- * All config should be parsed from MUFD_CFG_ENV_NAME json config file.
- * But we still need some runtime args(ex: log level) for debug usage.
- */
-struct mufd_override_params {
-  /** log level */
-  enum mtl_log_level log_level;
-  /** shared queue mode */
-  bool shared_queue;
-  /** lcore mode */
-  bool lcore_mode;
-};
-
-/**
- * Commit the runtime parameters of mufd instance.
- *
- * @param p
- *   The pointer to the rt parameters.
- * @return
- *   - >=0: Success.
- *   - <0: Error code.
- */
-int mufd_commit_override_params(struct mufd_override_params* p);
-
 #if defined(__cplusplus)
 }
 #endif

--- a/include/mudp_sockfd_internal.h
+++ b/include/mudp_sockfd_internal.h
@@ -14,9 +14,35 @@
 /** Marco for re-inculde protect */
 #define _MUDP_SOCKFD_INTERNAL_HEAD_H_
 
+#include "mtl_api.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
+
+/**
+ * All config should be parsed from MUFD_CFG_ENV_NAME json config file.
+ * But we still need some runtime args(ex: log level) for debug usage.
+ */
+struct mufd_override_params {
+  /** log level */
+  enum mtl_log_level log_level;
+  /** shared queue mode */
+  bool shared_queue;
+  /** lcore mode */
+  bool lcore_mode;
+};
+
+/**
+ * Commit the runtime parameters of mufd instance.
+ *
+ * @param p
+ *   The pointer to the rt parameters.
+ * @return
+ *   - >=0: Success.
+ *   - <0: Error code.
+ */
+int mufd_commit_override_params(struct mufd_override_params* p);
 
 /**
  * All init params should be parsed from MUFD_CFG_ENV_NAME json config file.
@@ -60,6 +86,24 @@ int mufd_commit_init_params(struct mufd_init_params* p);
  *   - <0: Error code.
  */
 int mufd_get_sessions_max_nb(void);
+
+/**
+ * Init mufd context with json config from MUFD_CFG_ENV_NAME env.
+ *
+ * @return
+ *   - >=0: Success.
+ *   - <0: Error code.
+ */
+int mufd_init_context(void);
+
+/**
+ * Get the base fd of mufd context.
+ *
+ * @return
+ *   - >=0: Success, the base fd.
+ *   - <0: Error code.
+ */
+int mufd_base_fd(void);
 
 #if defined(__cplusplus)
 }

--- a/ld_preload/meson.build
+++ b/ld_preload/meson.build
@@ -14,6 +14,7 @@ add_global_arguments('-DALLOW_EXPERIMENTAL_API', language : 'c')
 cc = meson.get_compiler('c')
 
 mtl_dep = dependency('mtl', required : true)
+libdl_dep = cc.find_library('dl', required : true)
 
 # build udp preload
 subdir('udp')

--- a/ld_preload/meson.build
+++ b/ld_preload/meson.build
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023 Intel Corporation
+
+project('mtl_preload', 'c', default_options: ['buildtype=release'],
+        version: run_command(find_program('cat', 'more'), files('../VERSION'), check: true).stdout().strip(),)
+
+#detect os
+exec_env = host_machine.system()
+set_variable('is_windows', exec_env == 'windows')
+
+# allow experimental api
+add_global_arguments('-DALLOW_EXPERIMENTAL_API', language : 'c')
+
+cc = meson.get_compiler('c')
+
+mtl_dep = dependency('mtl', required : true)
+
+# build udp preload
+subdir('udp')

--- a/ld_preload/meson_options.txt
+++ b/ld_preload/meson_options.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023 Intel Corporation
+
+option('enable_asan', type: 'boolean', value: false, description: 'enable/disable address sanitizer, debug usage only')

--- a/ld_preload/preload_platform.h
+++ b/ld_preload/preload_platform.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+#include <unistd.h>
+
+#ifndef _MT_UDP_PRELOAD_PLATFORM_H_
+#define _MT_UDP_PRELOAD_PLATFORM_H_
+
+#ifdef WINDOWSENV /* Windows */
+#include <Winsock2.h>
+#include <ws2tcpip.h>
+#else /* Linux */
+#include <arpa/inet.h>
+#include <poll.h>
+#include <sys/socket.h>
+#endif
+
+#ifdef WINDOWSENV
+typedef unsigned long int nfds_t;
+#endif
+
+#endif

--- a/ld_preload/udp/meson.build
+++ b/ld_preload/udp/meson.build
@@ -25,6 +25,6 @@ shared_library('mtl_udp_preload', udp_preload_sources,
   c_args : udp_preload_c_args,
   link_args : udp_preload_ld_args,
   # asan should be always the first dep
-  dependencies: [asan_dep, mtl_dep],
+  dependencies: [asan_dep, mtl_dep, libdl_dep],
   install: true
 )

--- a/ld_preload/udp/meson.build
+++ b/ld_preload/udp/meson.build
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023 Intel Corporation
+
+udp_preload_c_args = []
+# enable warning as error
+udp_preload_c_args += ['-Werror']
+udp_preload_c_args += ['-Wall']
+# simd build option, enable sse4.2 default, todo: do we need AVX2/AVX512 ?
+udp_preload_c_args += ['-msse4.2']
+
+udp_preload_ld_args = []
+
+udp_preload_sources = files('udp_preload.c')
+
+# default no asan dep
+asan_dep = []
+if get_option('enable_asan') == true
+  message('Enable -fsanitize=address')
+  udp_preload_c_args += ['-fsanitize=address']
+  asan_dep = cc.find_library('asan', required : true)
+endif
+
+# build mtl udp preload lib
+shared_library('mtl_udp_preload', udp_preload_sources,
+  c_args : udp_preload_c_args,
+  link_args : udp_preload_ld_args,
+  # asan should be always the first dep
+  dependencies: [asan_dep, mtl_dep],
+  install: true
+)

--- a/ld_preload/udp/udp_preload.c
+++ b/ld_preload/udp/udp_preload.c
@@ -202,6 +202,7 @@ ssize_t sendto(int sockfd, const void* buf, size_t len, int flags,
     return -EIO;
   }
 
+  dbg("%s(%d), len %d\n", __func__, sockfd, (int)len);
   if (upl_is_mtl_scoket(ctx, sockfd))
     return mufd_sendto(sockfd, buf, len, flags, dest_addr, addrlen);
   else
@@ -280,9 +281,15 @@ int fcntl(int sockfd, int cmd, va_list args) {
     err("%s, ctx init fail, pls check setup\n", __func__);
     return -EIO;
   }
+  info("%s, sockfd %d cmd %d\n", __func__, sockfd, cmd);
 
   if (upl_is_mtl_scoket(ctx, sockfd))
     return mufd_fcntl(sockfd, cmd, args);
   else
     return ctx->libc_fn.fcntl(sockfd, cmd, args);
+}
+
+int fcntl64(int sockfd, int cmd, va_list args) {
+  info("%s, sockfd %d cmd %d\n", __func__, sockfd, cmd);
+  return fcntl(sockfd, cmd, args);
 }

--- a/ld_preload/udp/udp_preload.c
+++ b/ld_preload/udp/udp_preload.c
@@ -39,51 +39,25 @@ static void* upl_open_libc(void) {
 }
 
 static int upl_get_libc_fn(struct upl_functions* fns, void* dl_handle) {
-  fns->socket = dlsym(dl_handle, "socket");
-  if (!fns->socket) {
-    err("%s, dlsym socket fail\n", __func__);
-    return -EIO;
-  }
-  fns->close = dlsym(dl_handle, "close");
-  if (!fns->close) {
-    err("%s, dlsym close fail\n", __func__);
-    return -EIO;
-  }
-  fns->bind = dlsym(dl_handle, "bind");
-  if (!fns->bind) {
-    err("%s, dlsym bind fail\n", __func__);
-    return -EIO;
-  }
-  fns->sendto = dlsym(dl_handle, "sendto");
-  if (!fns->sendto) {
-    err("%s, dlsym sendto fail\n", __func__);
-    return -EIO;
-  }
-  fns->poll = dlsym(dl_handle, "poll");
-  if (!fns->sendto) {
-    err("%s, dlsym sendto fail\n", __func__);
-    return -EIO;
-  }
-  fns->recvfrom = dlsym(dl_handle, "recvfrom");
-  if (!fns->recvfrom) {
-    err("%s, dlsym recvfrom fail\n", __func__);
-    return -EIO;
-  }
-  fns->getsockopt = dlsym(dl_handle, "getsockopt");
-  if (!fns->getsockopt) {
-    err("%s, dlsym getsockopt fail\n", __func__);
-    return -EIO;
-  }
-  fns->setsockopt = dlsym(dl_handle, "setsockopt");
-  if (!fns->setsockopt) {
-    err("%s, dlsym setsockopt fail\n", __func__);
-    return -EIO;
-  }
-  fns->fcntl = dlsym(dl_handle, "fcntl");
-  if (!fns->fcntl) {
-    err("%s, dlsym fcntl fail\n", __func__);
-    return -EIO;
-  }
+#define UPL_LIBC_FN(__name)                          \
+  do {                                               \
+    fns->__name = dlsym(dl_handle, #__name);         \
+    if (!fns->__name) {                              \
+      err("%s, dlsym %s fail\n", __func__, #__name); \
+      return -EIO;                                   \
+    }                                                \
+  } while (0)
+
+  UPL_LIBC_FN(socket);
+  UPL_LIBC_FN(close);
+  UPL_LIBC_FN(bind);
+  UPL_LIBC_FN(sendto);
+  UPL_LIBC_FN(poll);
+  UPL_LIBC_FN(recvfrom);
+  UPL_LIBC_FN(getsockopt);
+  UPL_LIBC_FN(setsockopt);
+  UPL_LIBC_FN(fcntl);
+  UPL_LIBC_FN(fcntl64);
 
   info("%s, succ\n", __func__);
   return 0;

--- a/ld_preload/udp/udp_preload.c
+++ b/ld_preload/udp/udp_preload.c
@@ -1,0 +1,288 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+#include "udp_preload.h"
+
+#include <dlfcn.h>
+
+static struct upl_ctx g_upl_ctx;
+
+static inline struct upl_ctx* upl_get_ctx(void) { return &g_upl_ctx; }
+
+static int upl_uinit_ctx(struct upl_ctx* ctx) {
+  if (ctx->libc_dl_handle) {
+    dlclose(ctx->libc_dl_handle);
+    ctx->libc_dl_handle = NULL;
+  }
+  info("%s, succ ctx %p\n", __func__, ctx);
+  return 0;
+}
+
+static const char* upl_libc_so_paths[] = {
+    "/lib/x86_64-linux-gnu/libc.so.6",
+};
+
+static void* upl_open_libc(void) {
+  void* handle = NULL;
+
+  for (int i = 0; i < MTL_ARRAY_SIZE(upl_libc_so_paths); i++) {
+    handle = dlopen(upl_libc_so_paths[i], RTLD_LAZY);
+    if (handle) {
+      info("%s, dlopen %s succ\n", __func__, upl_libc_so_paths[i]);
+      return handle;
+    }
+  }
+
+  err("%s, all libc path fail, pls add your libc to upl_libc_so_paths\n", __func__);
+  return NULL;
+}
+
+static int upl_get_libc_fn(struct upl_functions* fns, void* dl_handle) {
+  fns->socket = dlsym(dl_handle, "socket");
+  if (!fns->socket) {
+    err("%s, dlsym socket fail\n", __func__);
+    return -EIO;
+  }
+  fns->close = dlsym(dl_handle, "close");
+  if (!fns->close) {
+    err("%s, dlsym close fail\n", __func__);
+    return -EIO;
+  }
+  fns->bind = dlsym(dl_handle, "bind");
+  if (!fns->bind) {
+    err("%s, dlsym bind fail\n", __func__);
+    return -EIO;
+  }
+  fns->sendto = dlsym(dl_handle, "sendto");
+  if (!fns->sendto) {
+    err("%s, dlsym sendto fail\n", __func__);
+    return -EIO;
+  }
+  fns->poll = dlsym(dl_handle, "poll");
+  if (!fns->sendto) {
+    err("%s, dlsym sendto fail\n", __func__);
+    return -EIO;
+  }
+  fns->recvfrom = dlsym(dl_handle, "recvfrom");
+  if (!fns->recvfrom) {
+    err("%s, dlsym recvfrom fail\n", __func__);
+    return -EIO;
+  }
+  fns->getsockopt = dlsym(dl_handle, "getsockopt");
+  if (!fns->getsockopt) {
+    err("%s, dlsym getsockopt fail\n", __func__);
+    return -EIO;
+  }
+  fns->setsockopt = dlsym(dl_handle, "setsockopt");
+  if (!fns->setsockopt) {
+    err("%s, dlsym setsockopt fail\n", __func__);
+    return -EIO;
+  }
+  fns->fcntl = dlsym(dl_handle, "fcntl");
+  if (!fns->fcntl) {
+    err("%s, dlsym fcntl fail\n", __func__);
+    return -EIO;
+  }
+
+  info("%s, succ\n", __func__);
+  return 0;
+}
+
+static int upl_init_ctx(struct upl_ctx* ctx) {
+  int ret;
+
+  ctx->libc_dl_handle = upl_open_libc();
+  if (!ctx->libc_dl_handle) {
+    upl_uinit_ctx(ctx);
+    return -EIO;
+  }
+  ret = upl_get_libc_fn(&ctx->libc_fn, ctx->libc_dl_handle);
+  if (ret < 0) {
+    upl_uinit_ctx(ctx);
+    return -EIO;
+  }
+
+  info("%s, succ ctx %p\n", __func__, ctx);
+  return 0;
+}
+
+static void __attribute__((constructor)) upl_init() {
+  struct upl_ctx* ctx = upl_get_ctx();
+  int ret;
+
+  ret = upl_init_ctx(ctx);
+  if (ret < 0) {
+    err("%s, init ctx fail %d\n", __func__, ret);
+    return;
+  }
+  ctx->init_succ = true;
+
+  ret = mufd_init_context();
+  if (ret < 0) {
+    warn("%s, mufd init fail %d, fallback to kernel socket\n", __func__, ret);
+  } else {
+    ctx->mtl_fd_base = mufd_base_fd();
+    ctx->has_mtl_udp = true;
+    info("%s, mufd init succ, base fd %d\n", __func__, ctx->mtl_fd_base);
+  }
+}
+
+static void __attribute__((destructor)) upl_uinit() {
+  struct upl_ctx* ctx = upl_get_ctx();
+  upl_uinit_ctx(ctx);
+  ctx->has_mtl_udp = false;
+}
+
+static bool upl_is_mtl_scoket(struct upl_ctx* ctx, int fd) {
+  if (!ctx->has_mtl_udp) return false;
+  if (fd < ctx->mtl_fd_base) return false;
+  /* todo: add bitmap check */
+  return true;
+}
+
+int socket(int domain, int type, int protocol) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  int fd;
+
+  dbg("%s, domain %d type %d protocol %d\n", __func__, domain, type, protocol);
+
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (ctx->has_mtl_udp) {
+    fd = mufd_socket(domain, type, protocol);
+    if (fd >= 0) {
+      info("%s, mufd %d for domain %d type %d protocol %d\n", __func__, fd, domain, type,
+           protocol);
+      return fd;
+    }
+  }
+
+  /* the last option */
+  fd = ctx->libc_fn.socket(domain, type, protocol);
+  info("%s, libc fd %d for domain %d type %d protocol %d\n", __func__, fd, domain, type,
+       protocol);
+  return fd;
+}
+
+int close(int sockfd) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (upl_is_mtl_scoket(ctx, sockfd))
+    return mufd_close(sockfd);
+  else
+    return ctx->libc_fn.close(sockfd);
+}
+
+int bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (upl_is_mtl_scoket(ctx, sockfd))
+    return mufd_bind(sockfd, addr, addrlen);
+  else
+    return ctx->libc_fn.bind(sockfd, addr, addrlen);
+}
+
+ssize_t sendto(int sockfd, const void* buf, size_t len, int flags,
+               const struct sockaddr* dest_addr, socklen_t addrlen) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (upl_is_mtl_scoket(ctx, sockfd))
+    return mufd_sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+  else
+    return ctx->libc_fn.sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+int poll(struct pollfd* fds, nfds_t nfds, int timeout) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (nfds <= 0) {
+    err("%s, invalid nfds %d\n", __func__, (int)nfds);
+    return -EIO;
+  }
+  bool is_mtl = upl_is_mtl_scoket(ctx, fds[0].fd);
+  /* check if all fds are the same type */
+  for (nfds_t i = 1; i < nfds; i++) {
+    if (upl_is_mtl_scoket(ctx, fds[i].fd) != is_mtl) {
+      err("%s, not same type on %d, fd %d\n", __func__, (int)i, fds[i].fd);
+      return -EIO;
+    }
+  }
+  if (is_mtl) {
+    return mufd_poll(fds, nfds, timeout);
+  } else {
+    return ctx->libc_fn.poll(fds, nfds, timeout);
+  }
+}
+
+ssize_t recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr,
+                 socklen_t* addrlen) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (upl_is_mtl_scoket(ctx, sockfd))
+    return mufd_recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+  else
+    return ctx->libc_fn.recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+int getsockopt(int sockfd, int level, int optname, void* optval, socklen_t* optlen) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (upl_is_mtl_scoket(ctx, sockfd))
+    return mufd_getsockopt(sockfd, level, optname, optval, optlen);
+  else
+    return ctx->libc_fn.getsockopt(sockfd, level, optname, optval, optlen);
+}
+
+int setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (upl_is_mtl_scoket(ctx, sockfd))
+    return mufd_setsockopt(sockfd, level, optname, optval, optlen);
+  else
+    return ctx->libc_fn.setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+int fcntl(int sockfd, int cmd, va_list args) {
+  struct upl_ctx* ctx = upl_get_ctx();
+  if (!ctx->init_succ) {
+    err("%s, ctx init fail, pls check setup\n", __func__);
+    return -EIO;
+  }
+
+  if (upl_is_mtl_scoket(ctx, sockfd))
+    return mufd_fcntl(sockfd, cmd, args);
+  else
+    return ctx->libc_fn.fcntl(sockfd, cmd, args);
+}

--- a/ld_preload/udp/udp_preload.c
+++ b/ld_preload/udp/udp_preload.c
@@ -120,7 +120,7 @@ static void __attribute__((constructor)) upl_init() {
 
   ret = mufd_init_context();
   if (ret < 0) {
-    warn("%s, mufd init fail %d, fallback to kernel socket\n", __func__, ret);
+    warn("%s, mufd init fail %d, fallback to posix socket\n", __func__, ret);
   } else {
     ctx->mtl_fd_base = mufd_base_fd();
     ctx->has_mtl_udp = true;

--- a/ld_preload/udp/udp_preload.h
+++ b/ld_preload/udp/udp_preload.h
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+#ifndef _MT_UDP_PRELOAD_H_
+#define _MT_UDP_PRELOAD_H_
+
+#include <errno.h>
+#include <mtl/mudp_sockfd_internal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../preload_platform.h"
+
+/* include "struct sockaddr_in" define before include mudp_sockfd_api */
+// clang-format off
+#include <mtl/mudp_sockfd_api.h>
+// clang-format on
+
+/* log define */
+#ifdef DEBUG
+#define dbg(...)                 \
+  do {                           \
+    printf("UPL: " __VA_ARGS__); \
+  } while (0)
+#else
+#define dbg(...) \
+  do {           \
+  } while (0)
+#endif
+#define info(...)                \
+  do {                           \
+    printf("UPL: " __VA_ARGS__); \
+  } while (0)
+#define warn(...)                     \
+  do {                                \
+    printf("UPL: Warn: "__VA_ARGS__); \
+  } while (0)
+#define err(...)                       \
+  do {                                 \
+    printf("UPL: Error: "__VA_ARGS__); \
+  } while (0)
+
+static inline void* upl_malloc(size_t sz) { return malloc(sz); }
+
+static inline void* upl_zmalloc(size_t sz) {
+  void* p = malloc(sz);
+  if (p) memset(p, 0x0, sz);
+  return p;
+}
+
+static inline void upl_free(void* p) { free(p); }
+
+struct upl_functions {
+  int (*socket)(int domain, int type, int protocol);
+  int (*close)(int sockfd);
+  int (*bind)(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+  ssize_t (*sendto)(int sockfd, const void* buf, size_t len, int flags,
+                    const struct sockaddr* dest_addr, socklen_t addrlen);
+  int (*poll)(struct pollfd* fds, nfds_t nfds, int timeout);
+  ssize_t (*recvfrom)(int sockfd, void* buf, size_t len, int flags,
+                      struct sockaddr* src_addr, socklen_t* addrlen);
+  int (*getsockopt)(int sockfd, int level, int optname, void* optval, socklen_t* optlen);
+  int (*setsockopt)(int sockfd, int level, int optname, const void* optval,
+                    socklen_t optlen);
+  int (*fcntl)(int sockfd, int cmd, ...);
+};
+
+struct upl_ctx {
+  bool init_succ;
+
+  bool has_mtl_udp;
+  int mtl_fd_base;
+
+  void* libc_dl_handle;
+  struct upl_functions libc_fn;
+};
+
+#endif

--- a/ld_preload/udp/udp_preload.h
+++ b/ld_preload/udp/udp_preload.h
@@ -64,6 +64,7 @@ struct upl_functions {
   int (*setsockopt)(int sockfd, int level, int optname, const void* optval,
                     socklen_t optlen);
   int (*fcntl)(int sockfd, int cmd, ...);
+  int (*fcntl64)(int sockfd, int cmd, ...);
 };
 
 struct upl_ctx {

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -31,15 +31,15 @@ static inline bool udp_alive(struct mudp_impl* s) {
 
 int mudp_verfiy_socket_args(int domain, int type, int protocol) {
   if (domain != AF_INET) {
-    err("%s, invalid domain %d\n", __func__, domain);
+    info("%s, invalid domain %d\n", __func__, domain);
     return -EINVAL;
   }
   if (type != SOCK_DGRAM) {
-    err("%s, invalid type %d\n", __func__, type);
+    info("%s, invalid type %d\n", __func__, type);
     return -EINVAL;
   }
   if (protocol != 0) {
-    err("%s, invalid protocol %d\n", __func__, protocol);
+    info("%s, invalid protocol %d\n", __func__, protocol);
     return -EINVAL;
   }
 

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -1261,6 +1261,9 @@ int mudp_setsockopt(mudp_handle ut, int level, int optname, const void* optval,
           return udp_set_rcvbuf(s, optval, optlen);
         case SO_RCVTIMEO:
           return udp_set_rcvtimeo(s, optval, optlen);
+        case SO_REUSEADDR: /* skip now */
+          info("%s(%d), skip SO_REUSEADDR\n", __func__, idx);
+          return 0;
         default:
           err("%s(%d), unknown optname %d for SOL_SOCKET\n", __func__, idx, optname);
           return -EINVAL;

--- a/script/dos2unix.sh
+++ b/script/dos2unix.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023 Intel Corporation
+
+set -e
+
+echo "dos2unix check"
+find . -regex '.*' -exec dos2unix {} \;


### PR DESCRIPTION
use LD_PRELOAD to load libmtl_udp_preload.so before libc, that mtl preload take over control the socket API.
Also udp_preload will dlopen libc and dlsym to get the libc socket api function pointer and use it as fallback path.

usage:

MUFD_CFG=app/udp/ufd_client.json
LD_PRELOAD=/usr/local/lib/x86_64-linux-gnu/libmtl_udp_preload.so ./build/app/UsocketClientSample

MUFD_CFG=app/udp/ufd_server.json
LD_PRELOAD=/usr/local/lib/x86_64-linux-gnu/libmtl_udp_preload.so ./build/app/UsocketServerSample