### PR TITLE
Added flags to st22_rx_ops to disable boxes

### DIFF
--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -72,7 +72,7 @@ extern "C" {
  */
 #define ST22_TX_FLAG_USER_R_MAC (MTL_BIT32(1))
 /**
- * Flag bit in flags of struct st20_tx_ops.
+ * Flag bit in flags of struct st22_tx_ops.
  * Disable ST22 boxes, for ST22_TYPE_FRAME_LEVEL
  */
 #define ST22_TX_FLAG_DISABLE_BOXES (MTL_BIT32(2))
@@ -154,6 +154,11 @@ extern "C" {
  * If enabled, lib will pass ST_EVENT_VSYNC by the notify_event on every epoch start.
  */
 #define ST22_RX_FLAG_ENABLE_VSYNC (MTL_BIT32(1))
+/**
+ * Flag bit in flags of struct st22_rx_ops.
+ * Disable ST22 boxes, for ST22_TYPE_FRAME_LEVEL
+ */
+#define ST22_RX_FLAG_DISABLE_BOXES (MTL_BIT32(2))
 
 /**
  * Flag bit in flags of struct st22_rx_ops.

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -598,6 +598,8 @@ struct st_rx_video_session_impl {
   size_t st20_uframe_size; /* size per user frame */
   struct st20_rx_uframe_pg_meta pg_meta;
 
+  uint32_t st22_ops_flags; /* copy of st22_rx_ops->flags */
+
   /* rtp info */
   struct rte_ring* rtps_ring;
 

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1922,10 +1922,14 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
   } else {
     /* first packet */
     if (!pkt_counter) { /* first packet */
-      ret = rv_parse_st22_boxes(s, payload, slot);
-      if (ret < 0) {
-        s->stat_pkts_idx_dropped++;
-        return -EIO;
+      if (s->st22_ops_flags & ST22_RX_FLAG_DISABLE_BOXES) {
+        slot->st22_box_hdr_length = 0;
+      } else {
+        ret = rv_parse_st22_boxes(s, payload, slot);
+        if (ret < 0) {
+          s->stat_pkts_idx_dropped++;
+          return -EIO;
+        }
       }
       slot->seq_id_base = seq_id;
       slot->st22_payload_length = payload_length;
@@ -2795,6 +2799,7 @@ static int rv_attach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
   if (st22_ops) {
     s->st20_frame_size = st22_ops->framebuff_max_size;
     s->st20_fb_size = s->st20_frame_size;
+    s->st22_ops_flags = st22_ops->flags;
   } else
     s->st20_frame_size = ops->width * ops->height * s->st20_pg.size / s->st20_pg.coverage;
   s->st20_uframe_size = ops->uframe_size;


### PR DESCRIPTION
Closes #204 

I opted for the disable flag since boxes are not part of st2110-22, but rather part of the underlying RFCs. Since we may encounter other codestream that do not use boxes but still use 2110-22 in the future, it's safer to allow to ignore them.