### PR TITLE
st/video: add best effort pacing

### DIFF
--- a/.github/workflows/ubuntu_build_with_gtest.yml
+++ b/.github/workflows/ubuntu_build_with_gtest.yml
@@ -127,6 +127,6 @@ jobs:
         run: |
           sudo ./build/tests/KahawaiTest --auto_start_stop --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --gtest_filter=-St22_?x.*
 
-      - name: Run st2110 st20p test case with rss in IOVA PA mode
+      - name: Run st2110 st20p test case with rss in IOVA PA mode with tsc pacing way
         run: |
-          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --iova_mode pa --gtest_filter=Main.*:St20p*:-*ext*
+          sudo ./build/tests/KahawaiTest --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --dma_dev ${{  env.TEST_DMA_PORT_P  }},${{  env.TEST_DMA_PORT_R  }} --rss_mode l3_l4_dst_port_only --pacing_way tsc --iova_mode pa --gtest_filter=Main.*:St20p*:-*ext*

--- a/app/sample/README.md
+++ b/app/sample/README.md
@@ -65,7 +65,7 @@ The dir include the simple sample code for how to develop application quickly ba
 [rx_st20p_tx_st20p_downsample_merge_fwd.c](fwd/rx_st20p_tx_st20p_merge_fwd.c): Receive 4 1080p sessions from rx, downsample and merge to single 1080p st20 stream and send out.
 
 ```bash
-./build/app/RxSt20pTxSt20pMergeFwd --p_port 0000:af:01.1 --p_sip 192.168.75.22 --p_rx_ip 239.168.75.20 --p_fwd_ip 239.168.75.21
+./build/app/RxSt20pTxSt20pDownsampleMergeFwd --p_port 0000:af:01.1 --p_sip 192.168.75.22 --p_rx_ip 239.168.75.20 --p_fwd_ip 239.168.75.21
 ```
 
 [rx_st20_tx_st20_split_fwd.c](fwd/rx_st20_tx_st20_split_fwd.c): Receive 4k frames from rx, do square quad division and send with 4 1080p sessions.

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -392,6 +392,8 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
           p->pacing = ST21_TX_PACING_WAY_TSC;
         else if (!strcmp(optarg, "ptp"))
           p->pacing = ST21_TX_PACING_WAY_PTP;
+        else if (!strcmp(optarg, "be"))
+          p->pacing = ST21_TX_PACING_WAY_BE;
         else
           err("%s, unknow pacing way %s\n", __func__, optarg);
         break;

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -254,6 +254,8 @@ enum st21_tx_pacing_way {
   ST21_TX_PACING_WAY_TSN,
   /** ptp based pacing */
   ST21_TX_PACING_WAY_PTP,
+  /** best effort sending */
+  ST21_TX_PACING_WAY_BE,
   /** Max value of this enum */
   ST21_TX_PACING_WAY_MAX,
 };

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -1478,7 +1478,7 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
       pacing_set_mbuf_time_stamp(pkts_r[i], pacing);
     }
 
-    pacing_forward_cursor(pacing); /* pkt foward */
+    pacing_forward_cursor(pacing); /* pkt forward */
     s->st20_pkt_idx++;
     s->stat_pkts_build++;
   }
@@ -1517,12 +1517,11 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
       tv_frame_free_cb(frame_info->addr, frame_info);
     }
 
-    uint64_t frame_build_end_time = mt_get_tsc(impl);
-    uint64_t frame_est_end_time = pacing->tsc_time_cursor;
-    if (frame_build_end_time > frame_est_end_time) {
+    uint64_t frame_end_time = mt_get_tsc(impl);
+    if (frame_end_time > pacing->tsc_time_cursor) {
       s->stat_exceed_frame_time++;
       dbg("%s(%d), frame %d build time out %fus\n", __func__, idx, s->st20_frame_idx,
-          (frame_build_end_time - frame_est_end_time) / NS_PER_US);
+          (frame_end_time - pacing->tsc_time_cursor) / NS_PER_US);
     }
   }
 
@@ -1631,7 +1630,7 @@ static int tv_tasklet_rtp(struct mtl_main_impl* impl,
       pacing_set_mbuf_time_stamp(pkts_r[i], pacing);
     }
 
-    pacing_forward_cursor(pacing); /* pkt foward */
+    pacing_forward_cursor(pacing); /* pkt forward */
     s->st20_pkt_idx++;
     s->stat_pkts_build++;
   }
@@ -1813,7 +1812,7 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
         st_tx_mbuf_set_idx(pkts_r[i], s->st20_pkt_idx);
       }
 
-      pacing_forward_cursor(pacing); /* pkt foward */
+      pacing_forward_cursor(pacing); /* pkt forward */
       s->st20_pkt_idx++;
       s->stat_pkts_build++;
       s->stat_pkts_dummy++;
@@ -1885,7 +1884,7 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
         pacing_set_mbuf_time_stamp(pkts_r[i], pacing);
       }
 
-      pacing_forward_cursor(pacing); /* pkt foward */
+      pacing_forward_cursor(pacing); /* pkt forward */
       s->st20_pkt_idx++;
       s->stat_pkts_build++;
     }
@@ -1921,14 +1920,11 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
     rte_atomic32_inc(&s->stat_frame_cnt);
     st22_info->frame_idx++;
 
-    uint64_t frame_build_end_time = mt_get_tsc(impl);
-    uint64_t frame_est_end_time = pacing->tsc_time_cursor;
-    if (s->pacing_way[MTL_SESSION_PORT_P] == ST21_TX_PACING_WAY_BE)
-      frame_est_end_time += (s->st20_total_pkts - 1) * pacing->trs;
-    if (frame_build_end_time > frame_est_end_time) {
+    uint64_t frame_end_time = mt_get_tsc(impl);
+    if (frame_end_time > pacing->tsc_time_cursor) {
       s->stat_exceed_frame_time++;
       dbg("%s(%d), frame %d build time out %fus\n", __func__, idx, s->st20_frame_idx,
-          (frame_build_end_time - frame_est_end_time) / NS_PER_US);
+          (frame_end_time - pacing->tsc_time_cursor) / NS_PER_US);
     }
   }
 

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -1478,8 +1478,7 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
       pacing_set_mbuf_time_stamp(pkts_r[i], pacing);
     }
 
-    if (s->pacing_way[MTL_SESSION_PORT_P] != ST21_TX_PACING_WAY_BE)
-      pacing_forward_cursor(pacing); /* pkt foward */
+    pacing_forward_cursor(pacing); /* pkt foward */
     s->st20_pkt_idx++;
     s->stat_pkts_build++;
   }
@@ -1520,8 +1519,6 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
 
     uint64_t frame_build_end_time = mt_get_tsc(impl);
     uint64_t frame_est_end_time = pacing->tsc_time_cursor;
-    if (s->pacing_way[MTL_SESSION_PORT_P] == ST21_TX_PACING_WAY_BE)
-      frame_est_end_time += (s->st20_total_pkts - 1) * pacing->trs;
     if (frame_build_end_time > frame_est_end_time) {
       s->stat_exceed_frame_time++;
       dbg("%s(%d), frame %d build time out %fus\n", __func__, idx, s->st20_frame_idx,
@@ -1634,8 +1631,7 @@ static int tv_tasklet_rtp(struct mtl_main_impl* impl,
       pacing_set_mbuf_time_stamp(pkts_r[i], pacing);
     }
 
-    if (s->pacing_way[MTL_SESSION_PORT_P] != ST21_TX_PACING_WAY_BE)
-      pacing_forward_cursor(pacing); /* pkt foward */
+    pacing_forward_cursor(pacing); /* pkt foward */
     s->st20_pkt_idx++;
     s->stat_pkts_build++;
   }
@@ -1817,8 +1813,7 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
         st_tx_mbuf_set_idx(pkts_r[i], s->st20_pkt_idx);
       }
 
-      if (s->pacing_way[MTL_SESSION_PORT_P] != ST21_TX_PACING_WAY_BE)
-        pacing_forward_cursor(pacing); /* pkt foward */
+      pacing_forward_cursor(pacing); /* pkt foward */
       s->st20_pkt_idx++;
       s->stat_pkts_build++;
       s->stat_pkts_dummy++;
@@ -1890,8 +1885,7 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
         pacing_set_mbuf_time_stamp(pkts_r[i], pacing);
       }
 
-      if (s->pacing_way[MTL_SESSION_PORT_P] != ST21_TX_PACING_WAY_BE)
-        pacing_forward_cursor(pacing); /* pkt foward */
+      pacing_forward_cursor(pacing); /* pkt foward */
       s->st20_pkt_idx++;
       s->stat_pkts_build++;
     }

--- a/lib/src/st2110/st_video_transmitter.c
+++ b/lib/src/st2110/st_video_transmitter.c
@@ -544,6 +544,7 @@ int st_video_resolve_pacing_tasklet(struct st_tx_video_session_impl* s,
       s->pacing_tasklet_func[port] = video_trs_rl_tasklet;
       break;
     case ST21_TX_PACING_WAY_TSC:
+    case ST21_TX_PACING_WAY_BE:
       s->pacing_tasklet_func[port] = video_trs_tsc_tasklet;
       break;
     case ST21_TX_PACING_WAY_PTP:

--- a/lib/src/st2110/st_video_transmitter.c
+++ b/lib/src/st2110/st_video_transmitter.c
@@ -281,7 +281,8 @@ static int video_trs_rl_tasklet(struct mtl_main_impl* impl,
 static int video_trs_tsc_tasklet(struct mtl_main_impl* impl,
                                  struct st_tx_video_session_impl* s,
                                  enum mtl_session_port s_port) {
-  unsigned int bulk = 1; /* only one packet now for tsc */
+  unsigned int bulk = s->bulk;
+  if (s->pacing_way[s_port] == ST21_TX_PACING_WAY_BE) bulk = 1;
   struct rte_ring* ring = s->ring[s_port];
   int idx = s->idx, tx;
   unsigned int n;
@@ -344,7 +345,6 @@ static int video_trs_tsc_tasklet(struct mtl_main_impl* impl,
     rte_pktmbuf_free_bulk(&pkts[valid_bulk], bulk - valid_bulk);
     s->stat_pkts_burst_dummy += bulk - valid_bulk;
     s->stat_trs_ret_code[s_port] = -STI_TSCTRS_BURST_HAS_DUMMY;
-    return MT_TASKLET_ALL_DONE;
   }
 
   s->pri_nic_burst_cnt++;
@@ -357,26 +357,28 @@ static int video_trs_tsc_tasklet(struct mtl_main_impl* impl,
     s->pri_nic_inflight_cnt = 0;
   }
 
-  cur_tsc = mt_get_tsc(impl);
-  target_tsc = st_tx_mbuf_get_tsc(pkts[0]);
-  if (cur_tsc < target_tsc) {
-    unsigned int i;
-    uint64_t delta = target_tsc - cur_tsc;
+  if (s->pacing_way[s_port] != ST21_TX_PACING_WAY_BE || pkt_idx == 0) {
+    cur_tsc = mt_get_tsc(impl);
+    target_tsc = st_tx_mbuf_get_tsc(pkts[0]);
+    if (cur_tsc < target_tsc) {
+      unsigned int i;
+      uint64_t delta = target_tsc - cur_tsc;
 
-    if (likely(delta < NS_PER_S)) {
-      s->trs_target_tsc[s_port] = target_tsc;
-      /* save it on inflight */
-      s->trs_inflight_num[s_port] = valid_bulk;
-      s->trs_inflight_idx[s_port] = 0;
-      s->trs_inflight_cnt[s_port]++;
-      for (i = 0; i < valid_bulk; i++) s->trs_inflight[s_port][i] = pkts[i];
-      s->pri_nic_inflight_cnt++;
-      s->stat_trs_ret_code[s_port] = -STI_TSCTRS_TARGET_TSC_NOT_REACH;
-      return delta < mt_sch_schedule_ns(impl) ? MT_TASKLET_HAS_PENDING
-                                              : MT_TASKLET_ALL_DONE;
-    } else {
-      err("%s(%d), invalid tsc cur %" PRIu64 " target %" PRIu64 "\n", __func__, idx,
-          cur_tsc, target_tsc);
+      if (likely(delta < NS_PER_S)) {
+        s->trs_target_tsc[s_port] = target_tsc;
+        /* save it on inflight */
+        s->trs_inflight_num[s_port] = valid_bulk;
+        s->trs_inflight_idx[s_port] = 0;
+        s->trs_inflight_cnt[s_port]++;
+        for (i = 0; i < valid_bulk; i++) s->trs_inflight[s_port][i] = pkts[i];
+        s->pri_nic_inflight_cnt++;
+        s->stat_trs_ret_code[s_port] = -STI_TSCTRS_TARGET_TSC_NOT_REACH;
+        return delta < mt_sch_schedule_ns(impl) ? MT_TASKLET_HAS_PENDING
+                                                : MT_TASKLET_ALL_DONE;
+      } else {
+        err("%s(%d), invalid tsc cur %" PRIu64 " target %" PRIu64 "\n", __func__, idx,
+            cur_tsc, target_tsc);
+      }
     }
   }
 
@@ -399,7 +401,7 @@ static int video_trs_tsc_tasklet(struct mtl_main_impl* impl,
 static int video_trs_ptp_tasklet(struct mtl_main_impl* impl,
                                  struct st_tx_video_session_impl* s,
                                  enum mtl_session_port s_port) {
-  unsigned int bulk = 1; /* only one packet now for tsc */
+  unsigned int bulk = s->bulk;
   struct rte_ring* ring = s->ring[s_port];
   int idx = s->idx, tx;
   unsigned int n;
@@ -462,7 +464,6 @@ static int video_trs_ptp_tasklet(struct mtl_main_impl* impl,
     rte_pktmbuf_free_bulk(&pkts[valid_bulk], bulk - valid_bulk);
     s->stat_pkts_burst_dummy += bulk - valid_bulk;
     s->stat_trs_ret_code[s_port] = -STI_TSCTRS_BURST_HAS_DUMMY;
-    return MT_TASKLET_ALL_DONE;
   }
 
   s->pri_nic_burst_cnt++;

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -227,6 +227,8 @@ static int test_parse_args(struct st_tests_context* ctx, struct mtl_init_params*
           p->pacing = ST21_TX_PACING_WAY_TSC;
         else if (!strcmp(optarg, "ptp"))
           p->pacing = ST21_TX_PACING_WAY_PTP;
+        else if (!strcmp(optarg, "be"))
+          p->pacing = ST21_TX_PACING_WAY_BE;
         else
           err("%s, unknow pacing way %s\n", __func__, optarg);
         break;


### PR DESCRIPTION
Currently, reuse tsc way logic but only control the first packet sending time