### PR TITLE
app: build support without SDL2

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -20,7 +20,14 @@ libjson_c = dependency('json-c', required : true)
 if not is_windows
   libpcap = dependency('pcap', required: true)
 endif
-libsdl2 = dependency('sdl2', required: true)
+libsdl2 = dependency('sdl2', required: false)
+if libsdl2.found()
+  add_global_arguments('-DAPP_HAS_SDL2', language : 'c')
+  set_variable('app_has_sdl2', true)
+else
+  message('SDL2 not found')
+  set_variable('app_has_sdl2', false)
+endif
 libsdl2_ttf = dependency('SDL2_ttf', required: false)
 if libsdl2_ttf.found()
   add_global_arguments('-DAPP_HAS_SDL2_TTF', language : 'c')

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -2,7 +2,9 @@
  * Copyright(c) 2022 Intel Corporation
  */
 
+#ifdef APP_HAS_SDL2
 #include <SDL2/SDL.h>
+#endif
 #ifdef APP_HAS_SDL2_TTF
 #include <SDL2/SDL_ttf.h>
 #endif
@@ -50,14 +52,16 @@
 
 struct st_display {
   char name[36];
+#ifdef APP_HAS_SDL2
   SDL_Window* window;
   SDL_Renderer* renderer;
   SDL_Texture* texture;
   SDL_PixelFormatEnum fmt;
+  SDL_Rect msg_rect;
+#endif
 #ifdef APP_HAS_SDL2_TTF
   TTF_Font* font;
 #endif
-  SDL_Rect msg_rect;
   int window_w;
   int window_h;
   int pixel_w;

--- a/app/src/meson.build
+++ b/app/src/meson.build
@@ -2,7 +2,11 @@
 # Copyright 2022 Intel Corporation
 
 sources = files('rxtx_app.c', 'tx_ancillary_app.c', 'tx_audio_app.c',
-	'tx_video_app.c', 'args.c', 'parse_json.c', 'player.c', 'rx_video_app.c',
+	'tx_video_app.c', 'args.c', 'parse_json.c', 'rx_video_app.c',
 	'rx_audio_app.c', 'rx_ancillary_app.c', 'tx_st22_app.c', 'rx_st22_app.c',
 	'tx_st22p_app.c', 'rx_st22p_app.c', 'tx_st20p_app.c', 'rx_st20p_app.c',
 	'rx_st20r_app.c', 'fmt.c', )
+
+if app_has_sdl2
+  sources += files('player.c')
+endif

--- a/app/src/player.c
+++ b/app/src/player.c
@@ -4,6 +4,8 @@
 
 #include "player.h"
 
+#include <SDL2/SDL_thread.h>
+
 #define FPS_CALCULATE_INTERVAL (30)
 #define SCREEN_WIDTH (640)
 #define SCREEN_HEIGHT (360)

--- a/app/src/player.h
+++ b/app/src/player.h
@@ -2,7 +2,6 @@
  * Copyright(c) 2022 Intel Corporation
  */
 
-#include <SDL2/SDL_thread.h>
 #include <pthread.h>
 
 #include "app_base.h"
@@ -11,11 +10,31 @@
 #ifndef _PLAYER_HEAD_H_
 #define _PLAYER_HEAD_H_
 
+#ifdef APP_HAS_SDL2
 int st_app_player_uinit(struct st_app_context* ctx);
 int st_app_player_init(struct st_app_context* ctx);
 
 int st_app_init_display(struct st_display* d, char* name, int width, int height,
                         char* font);
 int st_app_uinit_display(struct st_display* d);
+#else
+static inline int st_app_player_uinit(struct st_app_context* ctx) {
+  warn("%s, not support as build without SDL2\n", __func__);
+  return -ENOTSUP;
+}
+static inline int st_app_player_init(struct st_app_context* ctx) {
+  warn("%s, not support as build without SDL2\n", __func__);
+  return -ENOTSUP;
+}
+static inline int st_app_init_display(struct st_display* d, char* name, int width,
+                                      int height, char* font) {
+  warn("%s, not support as build without SDL2\n", __func__);
+  return -ENOTSUP;
+}
+static inline int st_app_uinit_display(struct st_display* d) {
+  warn("%s, not support as build without SDL2\n", __func__);
+  return -ENOTSUP;
+}
+#endif
 
 #endif


### PR DESCRIPTION
SDL2 should be an optional dependency.