### PR TITLE
tx/video: add tx done cleanup if no next frame from user

### DIFF
--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -1885,6 +1885,13 @@ int mt_dev_flush_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue,
   return 0;
 }
 
+int mt_dev_tx_done_cleanup(struct mtl_main_impl* impl, struct mt_tx_queue* queue) {
+  uint16_t port_id = queue->port_id;
+  uint16_t queue_id = queue->queue_id;
+
+  return rte_eth_tx_done_cleanup(port_id, queue_id, 0);
+}
+
 int mt_dev_put_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue) {
   enum mtl_port port = queue->port;
   struct mt_interface* inf = mt_if(impl, port);

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -44,6 +44,7 @@ int mt_dev_set_tx_bps(struct mtl_main_impl* impl, enum mtl_port port, uint16_t q
                       uint64_t bytes_per_sec);
 int mt_dev_flush_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue,
                           struct rte_mbuf* pad);
+int mt_dev_tx_done_cleanup(struct mtl_main_impl* impl, struct mt_tx_queue* queue);
 static inline uint16_t mt_dev_tx_burst(struct mt_tx_queue* queue,
                                        struct rte_mbuf** tx_pkts, uint16_t nb_pkts) {
   return rte_eth_tx_burst(queue->port_id, queue->queue_id, tx_pkts, nb_pkts);

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -146,8 +146,10 @@ struct st_tx_video_pacing {
   uint32_t tr_offset_vrx; /* packets unit, VRX start value of each frame */
   double frame_time;      /* time of the frame in nanoseconds */
   double frame_time_sampling; /* time of the frame in sampling(90k) */
-  uint32_t warm_pkts;         /* pkts for RL pacing warm boot */
-  float pad_interval;         /* padding pkt interval(pkts level) for RL pacing */
+  /* in ns, idle time at the end of frame, frame_time - tr_offset - (trs * pkts) */
+  double frame_idle_time;
+  uint32_t warm_pkts; /* pkts for RL pacing warm boot */
+  float pad_interval; /* padding pkt interval(pkts level) for RL pacing */
 
   uint64_t cur_epochs; /* epoch of current frame */
   /* timestamp for rtp header */
@@ -256,6 +258,8 @@ struct st_tx_video_session_impl {
   struct mt_tx_queue* queue[MTL_SESSION_PORT_MAX];
   int idx; /* index for current tx_session */
   uint64_t advice_sleep_us;
+  uint16_t queue_burst_pkts[MTL_SESSION_PORT_MAX];
+  uint16_t tx_done_cleanup[MTL_SESSION_PORT_MAX];
 
   struct st_tx_video_session_handle_impl* st20_handle;
   struct st22_tx_video_session_handle_impl* st22_handle;
@@ -353,6 +357,7 @@ struct st_tx_video_session_impl {
   uint32_t stat_user_busy;       /* get_next_frame or dequeue_bulk from rtp ring fail */
   uint32_t stat_lines_not_ready; /* query app lines not ready */
   uint32_t stat_vsync_mismatch;
+  uint32_t stat_tx_done_cleanup;
 };
 
 struct st_tx_video_sessions_mgr {

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -1365,15 +1365,15 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
               s->tx_done_cleanup[MTL_SESSION_PORT_P]);
           for (int i = 0; i < num_port; i++) {
             struct rte_mbuf* pad = s->pad[i][ST20_PKT_TYPE_NORMAL];
-            if (pad) {
-              rte_mbuf_refcnt_update(pad, 1);
-              uint16_t tx = mt_dev_tx_burst(s->queue[i], &pad, 1);
-              if (tx < 1) {
-                rte_mbuf_refcnt_update(pad, -1);
-              } else {
-                s->tx_done_cleanup[i]--;
-                s->stat_tx_done_cleanup++;
-              }
+            if (!pad) continue;
+
+            rte_mbuf_refcnt_update(pad, 1);
+            uint16_t tx = mt_dev_tx_burst(s->queue[i], &pad, 1);
+            if (tx < 1) {
+              rte_mbuf_refcnt_update(pad, -1);
+            } else {
+              s->tx_done_cleanup[i]--;
+              s->stat_tx_done_cleanup++;
             }
           }
         }

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -371,6 +371,12 @@ static int tv_init_pacing(struct mtl_main_impl* impl,
     }
   }
   pacing->trs = frame_time * reactive / s->st20_total_pkts;
+  pacing->frame_idle_time = frame_time - pacing->tr_offset - frame_time * reactive;
+  dbg("%s[%02d], frame_idle_time %f\n", __func__, idx, pacing->frame_idle_time);
+  if (pacing->frame_idle_time < 0) {
+    warn("%s[%02d], error frame_idle_time %f\n", __func__, idx, pacing->frame_idle_time);
+    pacing->frame_idle_time = 0;
+  }
   /* always use MTL_PORT_P for ptp now */
   pacing->cur_epochs = mt_get_ptp_time(impl, MTL_PORT_P) / frame_time;
   pacing->tsc_time_cursor = mt_get_tsc(impl);
@@ -1299,13 +1305,14 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
   struct rte_mempool* chain_pool = s->mbuf_mempool_chain;
   struct rte_ring* ring_p = s->ring[MTL_SESSION_PORT_P];
   struct rte_ring* ring_r = NULL;
+  int num_port = ops->num_port;
 
   if (rte_ring_full(ring_p)) {
     s->stat_build_ret_code = -STI_FRAME_RING_FULL;
     return MT_TASKLET_ALL_DONE;
   }
 
-  if (s->ops.num_port > 1) {
+  if (num_port > 1) {
     send_r = true;
     hdr_pool_r = s->mbuf_mempool_hdr[MTL_SESSION_PORT_R];
     ring_r = s->ring[MTL_SESSION_PORT_R];
@@ -1351,6 +1358,25 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
           s->stat_user_busy_first = false;
           dbg("%s(%d), get_next_frame fail %d\n", __func__, idx, ret);
         }
+        if (s->tx_done_cleanup[MTL_SESSION_PORT_P] &&
+            (mt_get_tsc(impl) > pacing->tsc_time_cursor)) {
+          /* flush tx queue to cleanup all mbufs, for tv_frame_free_cb */
+          dbg("%s(%d), tx done cleanup %u\n", __func__, s->idx,
+              s->tx_done_cleanup[MTL_SESSION_PORT_P]);
+          for (int i = 0; i < num_port; i++) {
+            struct rte_mbuf* pad = s->pad[i][ST20_PKT_TYPE_NORMAL];
+            if (pad) {
+              rte_mbuf_refcnt_update(pad, 1);
+              uint16_t tx = mt_dev_tx_burst(s->queue[i], &pad, 1);
+              if (tx < 1) {
+                rte_mbuf_refcnt_update(pad, -1);
+              } else {
+                s->tx_done_cleanup[i]--;
+                s->stat_tx_done_cleanup++;
+              }
+            }
+          }
+        }
         s->stat_build_ret_code = -STI_FRAME_APP_GET_FRAME_BUSY;
         return MT_TASKLET_ALL_DONE;
       }
@@ -1370,6 +1396,9 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
       rte_atomic32_inc(&frame->refcnt);
       s->st20_frame_idx = next_frame_idx;
       s->st20_frame_lines_ready = 0;
+      for (int i = 0; i < num_port; i++) {
+        s->tx_done_cleanup[i] = s->queue_burst_pkts[i];
+      }
       dbg("%s(%d), next_frame_idx %d start\n", __func__, idx, next_frame_idx);
       s->st20_frame_stat = ST21_TX_STAT_SENDING_PKTS;
 
@@ -1523,6 +1552,8 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
       dbg("%s(%d), frame %d build time out %fus\n", __func__, idx, s->st20_frame_idx,
           (frame_end_time - pacing->tsc_time_cursor) / NS_PER_US);
     }
+    /* point to tsc time of next epoch */
+    pacing->tsc_time_cursor += pacing->frame_idle_time + pacing->tr_offset;
   }
 
   return done ? MT_TASKLET_ALL_DONE : MT_TASKLET_HAS_PENDING;
@@ -2055,6 +2086,8 @@ static int tv_init_hw(struct mtl_main_impl* impl, struct st_tx_video_sessions_mg
       }
       s->pad[i][j] = pad;
     }
+
+    s->queue_burst_pkts[i] = mt_if_nb_tx_burst(impl, port);
   }
 
   return 0;
@@ -2689,6 +2722,11 @@ static void tv_stat(struct st_tx_video_sessions_mgr* mgr,
     notice("TX_VIDEO_SESSION(%d,%d): busy as no ready frame from user %u\n", m_idx, idx,
            s->stat_user_busy);
     s->stat_user_busy = 0;
+  }
+  if (s->stat_tx_done_cleanup) {
+    notice("TX_VIDEO_SESSION(%d,%d): tx done for cleanup %u\n", m_idx, idx,
+           s->stat_tx_done_cleanup);
+    s->stat_tx_done_cleanup = 0;
   }
   if (s->stat_lines_not_ready) {
     notice("TX_VIDEO_SESSION(%d,%d): query new lines but app not ready %u\n", m_idx, idx,

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -709,7 +709,7 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ret = mtl_sch_enable_sleep(st, sch, false);
     EXPECT_GE(ret, 0);
 
-    /* sha caculate */
+    /* sha calculate */
     size_t frame_size = test_ctx_tx[i]->frame_size;
     uint8_t* fb;
 
@@ -928,8 +928,10 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
   ret = mtl_start(st);
   EXPECT_GE(ret, 0);
   sleep(10);
-  ret = mtl_stop(st);
-  EXPECT_GE(ret, 0);
+  if (!para->send_done_check) {
+    ret = mtl_stop(st);
+    EXPECT_GE(ret, 0);
+  }
 
   for (int i = 0; i < sessions; i++) {
     uint64_t cur_time_ns = st_test_get_monotonic_time();
@@ -951,6 +953,10 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
       st_usleep(1000 * 100); /* wait all fb done */
       EXPECT_EQ(test_ctx_tx[i]->fb_send, test_ctx_tx[i]->fb_send_done);
     }
+  }
+  if (para->send_done_check) {
+    ret = mtl_stop(st);
+    EXPECT_GE(ret, 0);
   }
   for (int i = 0; i < sessions; i++) {
     uint64_t cur_time_ns = st_test_get_monotonic_time();

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -218,6 +218,8 @@ static int test_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
 
   if (!s->handle) return -EIO; /* not ready */
 
+  s->fb_send_done++;
+
   if (!(frame->flags & ST_FRAME_FLAG_EXT_BUF)) return 0;
 
   for (int i = 0; i < s->fb_cnt; ++i) {
@@ -578,6 +580,7 @@ struct st20p_rx_digest_test_para {
   bool vsync;
   bool pkt_convert;
   size_t line_padding_size;
+  bool send_done_check;
 };
 
 static void test_st20p_init_rx_digest_para(struct st20p_rx_digest_test_para* para) {
@@ -596,6 +599,7 @@ static void test_st20p_init_rx_digest_para(struct st20p_rx_digest_test_para* par
   para->vsync = true;
   para->pkt_convert = false;
   para->line_padding_size = 0;
+  para->send_done_check = false;
 }
 
 static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
@@ -686,8 +690,8 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_tx.framebuff_cnt = test_ctx_tx[i]->fb_cnt;
     ops_tx.notify_frame_available = test_st20p_tx_frame_available;
     ops_tx.notify_event = test_ctx_notify_event;
+    ops_tx.notify_frame_done = test_st20p_tx_frame_done;
     if (para->tx_ext) {
-      ops_tx.notify_frame_done = test_st20p_tx_frame_done;
       ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
     }
     if (para->user_timestamp) ops_tx.flags |= ST20P_TX_FLAG_USER_TIMESTAMP;
@@ -943,6 +947,10 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     test_ctx_tx[i]->stop = true;
     test_ctx_tx[i]->cv.notify_all();
     tx_thread[i].join();
+    if (para->send_done_check) {
+      st_usleep(1000 * 100); /* wait all fb done */
+      EXPECT_EQ(test_ctx_tx[i]->fb_send, test_ctx_tx[i]->fb_send_done);
+    }
   }
   for (int i = 0; i < sessions; i++) {
     uint64_t cur_time_ns = st_test_get_monotonic_time();
@@ -1138,6 +1146,7 @@ TEST(St20p, digest_1080p_packet_convert_s2) {
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
   para.check_fps = false;
   para.pkt_convert = true;
+  para.send_done_check = true;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -143,6 +143,7 @@ class tests_context {
   int fb_cnt = 0;
   uint16_t fb_idx = 0;
   int fb_send = 0;
+  int fb_send_done = 0;
   int fb_rec = 0;
   int vsync_cnt = 0;
   uint64_t first_vsync_time = 0;


### PR DESCRIPTION
Trigger the notify_frame_done for last frame to fix issue below:
Some app expect notify_frame_done callback for all TX frames before the destroy process.