### PR TITLE
upl: add mix fd type support for epoll

### DIFF
--- a/doc/experimental/header_split.md
+++ b/doc/experimental/header_split.md
@@ -33,8 +33,10 @@ ln -s ice_wireless_edge-1.3.9.99_1.pkg ice.pkg
 ./build/app/RxTxApp --config_file tests/script/hdr_split/1080p59_1v.json --hdr_split
 ```
 
-Check status log to check how many pkts are with header split and still copied by CPU.
+Check log to see if header split is enabled.
 
 ```bash
-ST: RX_VIDEO_SESSION(1,0): hdr split pkts 2465924, copy 252341
+MT: rv_attach(0), hdr_split enabled in ops
+ice_hdrs_mbuf_set_cb(): RX queue 1 register hdrs mbuf cb at 0x7f59f0b2a310
+MT: dev_rx_queue_create_flow_raw(1), queue 1 succ
 ```

--- a/include/mudp_sockfd_internal.h
+++ b/include/mudp_sockfd_internal.h
@@ -190,6 +190,29 @@ int mufd_register_stat_dump_cb(int sockfd, int (*dump)(void* priv), void* priv);
  */
 int mufd_socket_check(int domain, int type, int protocol);
 
+/**
+ * Poll the udp transport socket, blocks until one of the events occurs.
+ * Only support POLLIN now.
+ *
+ * @param fds
+ *   Point to pollfd request, fd is by mufd_socket.
+ * @param nfds
+ *   The number of request in fds.
+ * @param timeout
+ *   timeout value in ms.
+ * @param query
+ *   query callback, return > 0 means it has ready data on the query.
+ * @param priv
+ *   priv data to the query callback.
+ * @return
+ *   - > 0: Success, returns a nonnegative value which is the number of elements
+ *          in the fds whose revents fields have been set to a nonzero value.
+ *   - =0: Timeosockfd.
+ *   - <0: Error code. -1 is returned, and errno is set appropriately.
+ */
+int mufd_poll_query(struct pollfd* fds, nfds_t nfds, int timeout,
+                    int (*query)(void* priv), void* priv);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/ld_preload/udp/udp_preload.h
+++ b/ld_preload/udp/udp_preload.h
@@ -103,7 +103,10 @@ enum upl_entry_type {
   UPL_ENTRY_MAX,
 };
 
+struct upl_ctx; /* forward declare */
+
 struct upl_base_entry {
+  struct upl_ctx* parent;
   enum upl_entry_type upl_type;
 };
 
@@ -142,6 +145,11 @@ struct upl_efd_entry {
   struct upl_efd_fd_list fds;
   int fds_cnt;
   atomic_int kfd_cnt;
+  /* for kfd query */
+  struct epoll_event* events;
+  int maxevents;
+  const sigset_t* sigmask;
+  int kfd_ret;
 };
 
 struct upl_ctx {

--- a/ld_preload/udp/udp_preload.h
+++ b/ld_preload/udp/udp_preload.h
@@ -125,6 +125,8 @@ struct upl_ufd_entry {
   int stat_rx_ufd_cnt;
   int stat_tx_kfd_cnt;
   int stat_rx_kfd_cnt;
+  int stat_epoll_cnt;
+  int stat_epoll_revents_cnt;
 };
 
 struct upl_efd_fd_item {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3126,6 +3126,11 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
            s->stat_mismatch_hdr_split_frame);
     s->stat_mismatch_hdr_split_frame = 0;
   }
+  if (s->stat_pkts_copy_hdr_split) {
+    notice("RX_VIDEO_SESSION(%d,%d): hdr split copied pkts %d\n", m_idx, idx,
+           s->stat_pkts_copy_hdr_split);
+    s->stat_pkts_copy_hdr_split = 0;
+  }
   if (s->stat_vsync_mismatch) {
     notice("RX_VIDEO_SESSION(%d,%d): vsync mismatch cnt %u\n", m_idx, idx,
            s->stat_vsync_mismatch);

--- a/lib/src/udp/udp_main.h
+++ b/lib/src/udp/udp_main.h
@@ -116,4 +116,7 @@ struct mudp_impl {
 
 int mudp_verify_socket_args(int domain, int type, int protocol);
 
+int mudp_poll_query(struct mudp_pollfd* fds, mudp_nfds_t nfds, int timeout,
+                    int (*query)(void* priv), void* priv);
+
 #endif

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -545,7 +545,8 @@ ssize_t mufd_sendmsg(int sockfd, const struct msghdr* msg, int flags) {
   return mudp_sendmsg(slot->handle, msg, flags);
 }
 
-int mufd_poll(struct pollfd* fds, nfds_t nfds, int timeout) {
+int mufd_poll_query(struct pollfd* fds, nfds_t nfds, int timeout,
+                    int (*query)(void* priv), void* priv) {
   struct mudp_pollfd mfds[nfds];
   struct ufd_slot* slot;
 
@@ -556,11 +557,15 @@ int mufd_poll(struct pollfd* fds, nfds_t nfds, int timeout) {
     mfds[i].events = fds[i].events;
   }
 
-  int ret = mudp_poll(mfds, nfds, timeout);
+  int ret = mudp_poll_query(mfds, nfds, timeout, query, priv);
   for (nfds_t i = 0; i < nfds; i++) {
     fds[i].revents = mfds[i].revents;
   }
   return ret;
+}
+
+int mufd_poll(struct pollfd* fds, nfds_t nfds, int timeout) {
+  return mufd_poll_query(fds, nfds, timeout, NULL, NULL);
 }
 
 ssize_t mufd_recvfrom(int sockfd, void* buf, size_t len, int flags,


### PR DESCRIPTION
query the libc epoll with zero timeout status for each poll.

todo: enable similar for poll and select.