### PR TITLE
stat: all stat use mt_stat_register

### DIFF
--- a/lib/src/mt_cni.h
+++ b/lib/src/mt_cni.h
@@ -18,6 +18,4 @@ static inline struct mt_cni_impl* mt_get_cni(struct mtl_main_impl* impl) {
   return &impl->cni;
 }
 
-void mt_cni_stat(struct mtl_main_impl* impl);
-
 #endif

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -15,13 +15,6 @@
 #include "mt_stat.h"
 #include "mt_util.h"
 
-#include "st2110/st_rx_ancillary_session.h"
-#include "st2110/st_rx_audio_session.h"
-#include "st2110/st_rx_video_session.h"
-#include "st2110/st_tx_ancillary_session.h"
-#include "st2110/st_tx_audio_session.h"
-#include "st2110/st_tx_video_session.h"
-
 static struct mt_rx_flow_rsp* dev_if_create_rx_flow(struct mt_interface* inf, uint16_t q,
                                                     struct mt_rx_flow* flow);
 static int dev_if_free_rx_flow(struct mt_interface* inf, struct mt_rx_flow_rsp* rsp);
@@ -183,14 +176,7 @@ static void dev_stat(struct mtl_main_impl* impl) {
   }
 
   notice("* *    M T    D E V   S T A T E   * * \n");
-  st_tx_video_sessions_stat(impl);
-  if (impl->tx_a_init) st_tx_audio_sessions_stat(impl);
-  if (impl->tx_anc_init) st_tx_ancillary_sessions_stat(impl);
-  st_rx_video_sessions_stat(impl);
-  if (impl->rx_a_init) st_rx_audio_sessions_stat(impl);
-  if (impl->rx_anc_init) st_rx_ancillary_sessions_stat(impl);
   if (p->stat_dump_cb_fn) p->stat_dump_cb_fn(p->priv);
-  /* todo: move all above to stat framework */
   mt_stat_dump(impl);
   notice("* *    E N D    S T A T E   * * \n\n");
 }

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -7,7 +7,6 @@
 #include "mt_arp.h"
 #include "mt_cni.h"
 #include "mt_dhcp.h"
-#include "mt_dma.h"
 #include "mt_log.h"
 #include "mt_mcast.h"
 #include "mt_sch.h"
@@ -188,7 +187,6 @@ static void dev_stat(struct mtl_main_impl* impl) {
   if (impl->tx_a_init) st_tx_audio_sessions_stat(impl);
   if (impl->tx_anc_init) st_tx_ancillary_sessions_stat(impl);
   st_rx_video_sessions_stat(impl);
-  mt_dma_stat(impl);
   if (impl->rx_a_init) st_rx_audio_sessions_stat(impl);
   if (impl->rx_anc_init) st_rx_ancillary_sessions_stat(impl);
   st_plugins_dump(impl);

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -14,7 +14,7 @@
 #include "mt_socket.h"
 #include "mt_stat.h"
 #include "mt_util.h"
-#include "st2110/pipeline/st_plugin.h"
+
 #include "st2110/st_rx_ancillary_session.h"
 #include "st2110/st_rx_audio_session.h"
 #include "st2110/st_rx_video_session.h"
@@ -189,7 +189,6 @@ static void dev_stat(struct mtl_main_impl* impl) {
   st_rx_video_sessions_stat(impl);
   if (impl->rx_a_init) st_rx_audio_sessions_stat(impl);
   if (impl->rx_anc_init) st_rx_ancillary_sessions_stat(impl);
-  st_plugins_dump(impl);
   if (p->stat_dump_cb_fn) p->stat_dump_cb_fn(p->priv);
   /* todo: move all above to stat framework */
   mt_stat_dump(impl);

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -184,7 +184,6 @@ static void dev_stat(struct mtl_main_impl* impl) {
   }
 
   notice("* *    M T    D E V   S T A T E   * * \n");
-  mt_cni_stat(impl);
   mt_sch_stat(impl);
   st_tx_video_sessions_stat(impl);
   if (impl->tx_a_init) st_tx_audio_sessions_stat(impl);

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -184,7 +184,6 @@ static void dev_stat(struct mtl_main_impl* impl) {
   }
 
   notice("* *    M T    D E V   S T A T E   * * \n");
-  mt_sch_stat(impl);
   st_tx_video_sessions_stat(impl);
   if (impl->tx_a_init) st_tx_audio_sessions_stat(impl);
   if (impl->tx_anc_init) st_tx_ancillary_sessions_stat(impl);

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -10,7 +10,6 @@
 #include "mt_dma.h"
 #include "mt_log.h"
 #include "mt_mcast.h"
-#include "mt_ptp.h"
 #include "mt_sch.h"
 #include "mt_shared_queue.h"
 #include "mt_socket.h"
@@ -185,7 +184,6 @@ static void dev_stat(struct mtl_main_impl* impl) {
   }
 
   notice("* *    M T    D E V   S T A T E   * * \n");
-  mt_ptp_stat(impl);
   mt_cni_stat(impl);
   mt_sch_stat(impl);
   st_tx_video_sessions_stat(impl);

--- a/lib/src/mt_dma.c
+++ b/lib/src/mt_dma.c
@@ -5,6 +5,7 @@
 #include "mt_dma.h"
 
 #include "mt_log.h"
+#include "mt_stat.h"
 
 static inline struct mt_map_mgr* mt_get_map_mgr(struct mtl_main_impl* impl) {
   return &impl->map_mgr;
@@ -266,8 +267,28 @@ static int dma_hw_stop(struct mt_dma_dev* dev) {
   return 0;
 }
 
+static int dma_stat(void* priv) {
+  struct mt_dma_dev* dev = priv;
+  int16_t dev_id = dev->dev_id;
+  int idx = dev->idx;
+  struct rte_dma_stats stats;
+  uint64_t avg_nb_inflight = 0;
+
+  rte_dma_stats_get(dev_id, 0, &stats);
+  rte_dma_stats_reset(dev_id, 0);
+  if (dev->stat_commit_sum)
+    avg_nb_inflight = dev->stat_inflight_sum / dev->stat_commit_sum;
+  dev->stat_inflight_sum = 0;
+  dev->stat_commit_sum = 0;
+  notice("DMA(%d), s %" PRIu64 " c %" PRIu64 " e %" PRIu64 " avg q %" PRIu64 "\n", idx,
+         stats.submitted, stats.completed, stats.errors, avg_nb_inflight);
+
+  return 0;
+}
+
 static int dma_sw_init(struct mtl_main_impl* impl, struct mt_dma_dev* dev) {
   int idx = dev->idx;
+
 #if MT_DMA_RTE_RING
   char ring_name[32];
   struct rte_ring* ring;
@@ -294,11 +315,15 @@ static int dma_sw_init(struct mtl_main_impl* impl, struct mt_dma_dev* dev) {
 #endif
   dev->nb_inflight = 0;
 
+  mt_stat_register(impl, dma_stat, dev);
+
   return 0;
 }
 
-static int dma_sw_uinit(struct mt_dma_dev* dev) {
+static int dma_sw_uinit(struct mtl_main_impl* impl, struct mt_dma_dev* dev) {
   uint16_t nb_inflight = 0;
+
+  mt_stat_unregister(impl, dma_stat, dev);
 
 #if MT_DMA_RTE_RING
   if (dev->borrow_queue) {
@@ -325,24 +350,6 @@ static int dma_sw_uinit(struct mt_dma_dev* dev) {
   return 0;
 }
 
-static int dma_stat(struct mtl_main_impl* impl, struct mt_dma_dev* dev) {
-  int16_t dev_id = dev->dev_id;
-  int idx = dev->idx;
-  struct rte_dma_stats stats;
-  uint64_t avg_nb_inflight = 0;
-
-  rte_dma_stats_get(dev_id, 0, &stats);
-  rte_dma_stats_reset(dev_id, 0);
-  if (dev->stat_commit_sum)
-    avg_nb_inflight = dev->stat_inflight_sum / dev->stat_commit_sum;
-  dev->stat_inflight_sum = 0;
-  dev->stat_commit_sum = 0;
-  notice("DMA(%d), s %" PRIu64 " c %" PRIu64 " e %" PRIu64 " avg q %" PRIu64 "\n", idx,
-         stats.submitted, stats.completed, stats.errors, avg_nb_inflight);
-
-  return 0;
-}
-
 static int dma_free(struct mtl_main_impl* impl, struct mt_dma_dev* dev) {
   if (!dev->active) {
     err("%s(%d), not active\n", __func__, dev->idx);
@@ -350,7 +357,7 @@ static int dma_free(struct mtl_main_impl* impl, struct mt_dma_dev* dev) {
   }
 
   dma_hw_stop(dev);
-  dma_sw_uinit(dev);
+  dma_sw_uinit(impl, dev);
   dev->active = false;
 
   return 0;
@@ -571,18 +578,6 @@ int mt_dma_uinit(struct mtl_main_impl* impl) {
   return 0;
 }
 
-int mt_dma_stat(struct mtl_main_impl* impl) {
-  struct mt_dma_mgr* mgr = mt_get_dma_mgr(impl);
-  int idx;
-  struct mt_dma_dev* dev;
-
-  for (idx = 0; idx < MTL_DMA_DEV_MAX; idx++) {
-    dev = &mgr->devs[idx];
-    if (dev->active) dma_stat(impl, dev);
-  }
-
-  return 0;
-}
 #else
 int mt_dma_init(struct mtl_main_impl* impl) {
   struct mtl_init_params* p = mt_get_user_params(impl);
@@ -596,8 +591,6 @@ int mt_dma_init(struct mtl_main_impl* impl) {
 }
 
 int mt_dma_uinit(struct mtl_main_impl* impl) { return -EINVAL; }
-
-int mt_dma_stat(struct mtl_main_impl* impl) { return -EINVAL; }
 
 struct mtl_dma_lender_dev* mt_dma_request_dev(struct mtl_main_impl* impl,
                                               struct mt_dma_request_req* req) {

--- a/lib/src/mt_dma.h
+++ b/lib/src/mt_dma.h
@@ -9,7 +9,6 @@
 
 int mt_dma_init(struct mtl_main_impl* impl);
 int mt_dma_uinit(struct mtl_main_impl* impl);
-int mt_dma_stat(struct mtl_main_impl* impl);
 
 struct mt_dma_request_req {
   uint16_t nb_desc;

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -388,6 +388,7 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
   int socket[MTL_PORT_MAX], ret;
   int num_ports = p->num_ports;
   struct mt_kport_info kport_info;
+  struct mt_interface* inf;
 
   RTE_BUILD_BUG_ON(MTL_SESSION_PORT_MAX > (int)MTL_PORT_MAX);
   RTE_BUILD_BUG_ON(sizeof(struct mt_udp_hdr) != 42);
@@ -446,6 +447,9 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
   rte_memcpy(&impl->kport_info, &kport_info, sizeof(kport_info));
   impl->type = MT_HANDLE_MAIN;
   for (int i = 0; i < num_ports; i++) {
+    inf = mt_if(impl, i);
+    inf->parent = impl;
+
     if (p->pmd[i] != MTL_PMD_DPDK_USER) {
       uint8_t if_ip[MTL_IP_ADDR_LEN];
       uint8_t if_netmask[MTL_IP_ADDR_LEN];

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -211,6 +211,7 @@ struct mt_cni_priv {
 
 struct mt_cni_impl {
   bool used; /* if enable cni */
+  int num_ports;
 
   struct mt_rx_queue* rx_q[MTL_PORT_MAX];   /* cni rx queue */
   struct mt_rsq_entry* rsq[MTL_PORT_MAX];   /* cni rsq queue */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -64,7 +64,7 @@
 /* Rx queue support hdr split */
 #define MT_IF_FEATURE_RXQ_OFFLOAD_BUFFER_SPLIT (MTL_BIT32(6))
 
-#define MT_IF_STAT_PORT_CONFIGED (MTL_BIT32(0))
+#define MT_IF_STAT_PORT_CONFIGURED (MTL_BIT32(0))
 #define MT_IF_STAT_PORT_STARTED (MTL_BIT32(1))
 
 #define NS_PER_MS (1000 * 1000)
@@ -466,6 +466,7 @@ struct mt_tx_queue {
 };
 
 struct mt_interface {
+  struct mtl_main_impl* parent;
   enum mtl_port port;
   uint16_t port_id;
   struct rte_eth_dev_info dev_info;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -526,6 +526,8 @@ struct mt_interface {
   /* time base for MTL_FLAG_PTP_SOURCE_TSC*/
   uint64_t tsc_time_base;
   uint64_t real_time_base;
+
+  struct mt_dev_stats* dev_stats; /* for nic without reset func */
 };
 
 struct mt_lcore_shm {
@@ -796,7 +798,6 @@ struct mtl_main_impl {
   pthread_mutex_t stat_wake_mutex;
   rte_atomic32_t stat_stop;
   struct mt_stat_mgr stat_mgr;
-  struct mt_dev_stats* dev_stats[MTL_PORT_MAX]; /* for nic without reset func */
 
   /* dev context */
   rte_atomic32_t instance_started;  /* if mt instance is started */

--- a/lib/src/mt_ptp.h
+++ b/lib/src/mt_ptp.h
@@ -114,6 +114,4 @@ int mt_ptp_parse(struct mt_ptp_impl* ptp, struct mt_ptp_header* hdr, bool vlan,
                  enum mt_ptp_l_mode mode, uint16_t timesync,
                  struct mt_ptp_ipv4_udp* ipv4_hdr);
 
-void mt_ptp_stat(struct mtl_main_impl* impl);
-
 #endif

--- a/lib/src/mt_sch.h
+++ b/lib/src/mt_sch.h
@@ -61,8 +61,6 @@ int mt_sch_put(struct mt_sch_impl* sch, int quota_mbs);
 int mt_sch_start_all(struct mtl_main_impl* impl);
 int mt_sch_stop_all(struct mtl_main_impl* impl);
 
-void mt_sch_stat(struct mtl_main_impl* impl);
-
 static inline void mt_sch_set_cpu_busy(struct mt_sch_impl* sch, bool busy) {
   sch->cpu_busy = busy;
 }

--- a/lib/src/mt_stat.c
+++ b/lib/src/mt_stat.c
@@ -58,7 +58,7 @@ int mt_stat_unregister(struct mtl_main_impl* impl, mt_stat_cb_t cb, void* priv) 
   }
   mt_pthread_mutex_unlock(&mgr->mutex);
 
-  err("%s, priv %p not found\n", __func__, priv);
+  warn("%s, cb %p priv %p not found\n", __func__, cb, priv);
   return -EIO;
 }
 

--- a/lib/src/st2110/pipeline/st_plugin.h
+++ b/lib/src/st2110/pipeline/st_plugin.h
@@ -28,6 +28,4 @@ int st20_put_converter(struct mtl_main_impl* impl,
 int st_plugins_init(struct mtl_main_impl* impl);
 int st_plugins_uinit(struct mtl_main_impl* impl);
 
-int st_plugins_dump(struct mtl_main_impl* impl);
-
 #endif

--- a/lib/src/st2110/st_rx_ancillary_session.h
+++ b/lib/src/st2110/st_rx_ancillary_session.h
@@ -11,6 +11,4 @@
 
 int st_rx_ancillary_sessions_mgr_uinit(struct st_rx_ancillary_sessions_mgr* mgr);
 
-void st_rx_ancillary_sessions_stat(struct mtl_main_impl* impl);
-
 #endif

--- a/lib/src/st2110/st_rx_audio_session.h
+++ b/lib/src/st2110/st_rx_audio_session.h
@@ -11,6 +11,4 @@
 
 int st_rx_audio_sessions_mgr_uinit(struct st_rx_audio_sessions_mgr* mgr);
 
-void st_rx_audio_sessions_stat(struct mtl_main_impl* impl);
-
 #endif

--- a/lib/src/st2110/st_rx_video_session.h
+++ b/lib/src/st2110/st_rx_video_session.h
@@ -18,8 +18,6 @@ int st_rx_video_sessions_sch_init(struct mtl_main_impl* impl, struct mt_sch_impl
 
 int st_rx_video_sessions_sch_uinit(struct mtl_main_impl* impl, struct mt_sch_impl* sch);
 
-void st_rx_video_sessions_stat(struct mtl_main_impl* impl);
-
 /* call rx_video_session_put always if get successfully */
 static inline struct st_rx_video_session_impl* rx_video_session_get(
     struct st_rx_video_sessions_mgr* mgr, int idx) {

--- a/lib/src/st2110/st_tx_ancillary_session.h
+++ b/lib/src/st2110/st_tx_ancillary_session.h
@@ -9,6 +9,4 @@
 
 int st_tx_ancillary_sessions_mgr_uinit(struct st_tx_ancillary_sessions_mgr* mgr);
 
-void st_tx_ancillary_sessions_stat(struct mtl_main_impl* impl);
-
 #endif

--- a/lib/src/st2110/st_tx_audio_session.h
+++ b/lib/src/st2110/st_tx_audio_session.h
@@ -9,6 +9,4 @@
 
 int st_tx_audio_sessions_mgr_uinit(struct st_tx_audio_sessions_mgr* mgr);
 
-void st_tx_audio_sessions_stat(struct mtl_main_impl* impl);
-
 #endif

--- a/lib/src/st2110/st_tx_video_session.h
+++ b/lib/src/st2110/st_tx_video_session.h
@@ -7,8 +7,6 @@
 
 #include "st_main.h"
 
-void st_tx_video_sessions_stat(struct mtl_main_impl* impl);
-
 int st_tx_video_sessions_sch_init(struct mtl_main_impl* impl, struct mt_sch_impl* sch);
 
 int st_tx_video_sessions_sch_uinit(struct mtl_main_impl* impl, struct mt_sch_impl* sch);


### PR DESCRIPTION
stat: eth stat use mt_stat_register
dev: use struct mt_interface for internal function
ptp: use mt_stat_register for stat
cni: use mt_stat_register for stat
sch: use mt_stat_register for stat
dma: use mt_stat_register for stat
plugin: use mt_stat_register for stat
st2110: use mt_stat_register for stat