### PR TITLE
dev: add tx burst pkt check

### DIFF
--- a/app/src/args.c
+++ b/app/src/args.c
@@ -96,6 +96,7 @@ enum st_args_cmd {
   ST_ARG_MULTI_SRC_PORT,
   ST_ARG_AUDIO_BUILD_PACING,
   ST_ARG_AUDIO_FIFO_SIZE,
+  ST_ARG_TX_NO_BURST_CHECK,
   ST_ARG_MAX,
 };
 
@@ -193,6 +194,7 @@ static struct option st_app_args_options[] = {
     {"multi_src_port", no_argument, 0, ST_ARG_MULTI_SRC_PORT},
     {"audio_build_pacing", no_argument, 0, ST_ARG_AUDIO_BUILD_PACING},
     {"audio_fifo_size", required_argument, 0, ST_ARG_AUDIO_FIFO_SIZE},
+    {"tx_no_burst_check", no_argument, 0, ST_ARG_TX_NO_BURST_CHECK},
 
     {0, 0, 0, 0}};
 
@@ -571,6 +573,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_TX_NO_CHAIN:
         p->flags |= MTL_FLAG_TX_NO_CHAIN;
+        break;
+      case ST_ARG_TX_NO_BURST_CHECK:
+        p->flags |= MTL_FLAG_TX_NO_BURST_CHK;
         break;
       case ST_ARG_MULTI_SRC_PORT:
         p->flags |= MTL_FLAG_MULTI_SRC_PORT;

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -399,6 +399,11 @@ enum st21_tx_pacing_way {
  * Will do memcpy from framebuffer to packet payload.
  */
 #define MTL_FLAG_TX_NO_CHAIN (MTL_BIT64(30))
+/**
+ * Flag bit in flags of struct mtl_init_params, debug usage only.
+ * Disable the pkt check for TX burst API.
+ */
+#define MTL_FLAG_TX_NO_BURST_CHK (MTL_BIT64(31))
 
 /**
  * The structure describing how to init af_xdp interface.

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -1113,7 +1113,12 @@ static int dev_start_port(struct mt_interface* inf) {
           q);
       return ret;
     }
-    rte_eth_add_tx_callback(port_id, q, dev_tx_pkt_check, inf);
+  }
+  if (mt_get_user_params(impl)->flags & MTL_FLAG_TX_NO_BURST_CHK) {
+    info("%s(%d), no tx burst check\n", __func__, port);
+  } else {
+    for (uint16_t q = 0; q < nb_tx_q; q++)
+      rte_eth_add_tx_callback(port_id, q, dev_tx_pkt_check, inf);
   }
 
   ret = rte_eth_dev_start(port_id);
@@ -1133,7 +1138,7 @@ static int dev_start_port(struct mt_interface* inf) {
 
   if (mt_get_user_params(impl)->flags & MTL_FLAG_NIC_RX_PROMISCUOUS) {
     /* Enable RX in promiscuous mode if it's required. */
-    err("%s(%d), enable promiscuous\n", __func__, port);
+    warn("%s(%d), enable promiscuous\n", __func__, port);
     rte_eth_promiscuous_enable(port_id);
   }
   rte_eth_stats_reset(port_id); /* reset stats */

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -996,6 +996,39 @@ static int dev_config_port(struct mt_interface* inf) {
   return 0;
 }
 
+static bool dev_pkt_valid(struct mt_interface* inf, uint16_t queue,
+                          struct rte_mbuf* pkt) {
+  uint32_t pkt_len = pkt->pkt_len;
+  enum mtl_port port = inf->port;
+
+  if ((pkt_len <= 16) || (pkt_len > MTL_MTU_MAX_BYTES)) {
+    err("%s(%d:%u), invalid pkt_len %u at %p\n", __func__, port, queue, pkt_len, pkt);
+    return false;
+  }
+  if (pkt->nb_segs > 2) {
+    err("%s(%d:%u), invalid nb_segs %u at %p\n", __func__, port, queue, pkt->nb_segs,
+        pkt);
+    return false;
+  }
+
+  return true;
+}
+
+static uint16_t dev_tx_pkt_check(uint16_t port, uint16_t queue, struct rte_mbuf** pkts,
+                                 uint16_t nb_pkts, void* priv) {
+  struct mt_interface* inf = priv;
+
+  for (uint16_t i = 0; i < nb_pkts; i++) {
+    if (!dev_pkt_valid(inf, queue, pkts[i])) {
+      /* should never happen, replace with dummy pkt */
+      rte_pktmbuf_free(pkts[i]);
+      pkts[i] = inf->pad;
+    }
+  }
+
+  return nb_pkts;
+}
+
 static int dev_start_port(struct mt_interface* inf) {
   int ret;
   struct mtl_main_impl* impl = inf->parent;
@@ -1080,6 +1113,7 @@ static int dev_start_port(struct mt_interface* inf) {
           q);
       return ret;
     }
+    rte_eth_add_tx_callback(port_id, q, dev_tx_pkt_check, inf);
   }
 
   ret = rte_eth_dev_start(port_id);

--- a/lib/src/st2110/st_video_transmitter.c
+++ b/lib/src/st2110/st_video_transmitter.c
@@ -202,7 +202,7 @@ static int _video_trs_rl_tasklet(struct mtl_main_impl* impl,
     pkt_idx = st_tx_mbuf_get_idx(pkts[i]);
     if ((pkt_idx == 0) || (pkt_idx == ST_TX_DUMMY_PKT_IDX)) {
       valid_bulk = i;
-      break;
+      break; /* break if it's the first pkt of frame or it's the start of dummy */
     }
   }
   dbg("%s(%d), pkt_idx %u valid_bulk %d ts %" PRIu64 "\n", __func__, idx, pkt_idx,


### PR DESCRIPTION
To filter the invalid pkt which will cause "Malicious Driver Detection" on the NIC