### PR TITLE
tx/pacing: add user vrx support

### DIFF
--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -487,6 +487,7 @@ struct st_app_context {
   struct st_app_tx_video_session* tx_video_sessions;
   int tx_video_session_cnt;
   int tx_video_rtp_ring_size; /* the ring size for tx video rtp type */
+  uint16_t tx_vrx;
 
   struct st_app_tx_audio_session* tx_audio_sessions;
   char tx_audio_url[ST_APP_URL_MAX_LEN];

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -97,6 +97,7 @@ enum st_args_cmd {
   ST_ARG_AUDIO_BUILD_PACING,
   ST_ARG_AUDIO_FIFO_SIZE,
   ST_ARG_TX_NO_BURST_CHECK,
+  ST_ARG_VRX,
   ST_ARG_MAX,
 };
 
@@ -195,6 +196,7 @@ static struct option st_app_args_options[] = {
     {"audio_build_pacing", no_argument, 0, ST_ARG_AUDIO_BUILD_PACING},
     {"audio_fifo_size", required_argument, 0, ST_ARG_AUDIO_FIFO_SIZE},
     {"tx_no_burst_check", no_argument, 0, ST_ARG_TX_NO_BURST_CHECK},
+    {"vrx", required_argument, 0, ST_ARG_VRX},
 
     {0, 0, 0, 0}};
 
@@ -587,6 +589,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_AUDIO_FIFO_SIZE:
         ctx->tx_audio_fifo_size = atoi(optarg);
+        break;
+      case ST_ARG_VRX:
+        ctx->tx_vrx = atoi(optarg);
         break;
       case '?':
         break;

--- a/app/src/tx_video_app.c
+++ b/app/src/tx_video_app.c
@@ -722,6 +722,7 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.notify_event = app_tx_notify_event;
   ops.framebuff_cnt = 2;
   ops.payload_type = video ? video->base.payload_type : ST_APP_PAYLOAD_TYPE_VIDEO;
+  ops.vrx = ctx->tx_vrx;
   if (s->enable_vsync) ops.flags |= ST20_TX_FLAG_ENABLE_VSYNC;
 
   ret = st20_get_pgroup(ops.fmt, &s->st20_pg);

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -892,6 +892,14 @@ struct st20_tx_ops {
    * Valid if ST20_TX_FLAG_USER_P(R)_MAC is enabled
    */
   uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
+  /**
+   * vrx buffer for tx.
+   * Leave to zero if not know detail, lib will assign vrx(narrow) based on resolution and
+   * timing.
+   * Refer to st21 spec for the possible vrx value, lib will follow this VRX if it's not a
+   * zero value, and also fine tune is required since network setup difference.
+   */
+  uint16_t vrx;
 
   /**
    * the frame buffer count requested for one st20 tx session,

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -143,19 +143,17 @@ struct st_frame_trans {
 struct st_tx_video_pacing {
   double trs;             /* in ns for of 2 consecutive packets, T-Frame / N-Packets */
   double tr_offset;       /* in ns, tr offset time of each frame */
-  uint32_t tr_offset_vrx; /* packets unit, VRX start value of each frame */
+  uint32_t vrx; /* packets unit, VRX start value of each frame */
+  uint32_t warm_pkts; /* packets unit, pkts for RL pacing warm boot */
   double frame_time;      /* time of the frame in nanoseconds */
   double frame_time_sampling; /* time of the frame in sampling(90k) */
   /* in ns, idle time at the end of frame, frame_time - tr_offset - (trs * pkts) */
   double frame_idle_time;
-  uint32_t warm_pkts; /* pkts for RL pacing warm boot */
   float pad_interval; /* padding pkt interval(pkts level) for RL pacing */
 
   uint64_t cur_epochs; /* epoch of current frame */
   /* timestamp for rtp header */
   uint32_t rtp_time_stamp;
-  /* timestamp for pacing */
-  uint32_t pacing_time_stamp;
   uint64_t cur_epoch_time;
   double tsc_time_cursor; /* in ns, tsc time cursor for packet pacing */
   double ptp_time_cursor; /* in ns, ptp time cursor for packet pacing */
@@ -439,7 +437,7 @@ struct st_rx_video_ebu_stat {
   bool compliant_narrow;
 
   /* Cinst, packet level check */
-  uint64_t cinmtl_initial_time;
+  uint64_t cinst_initial_time;
   int32_t cinst_max;
   int32_t cinst_min;
   uint32_t cinst_cnt;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -252,9 +252,11 @@ static void rv_ebu_on_frame(struct st_rx_video_session_impl* s, uint32_t rtp_tms
     if (!ebu_info->dropped_results) {
       rv_ebu_result(s);
       if (ebu_result->ebu_result_num) {
-        info("%s(%d), Compliance Rate Narrow %.2f%%, total %d narrow %d\n\n", __func__,
-             s->idx, rv_ebu_pass_rate(ebu_result, ebu_result->compliance_narrow),
-             ebu_result->ebu_result_num, ebu_result->compliance_narrow);
+        double pass_narrow = rv_ebu_pass_rate(ebu_result, ebu_result->compliance_narrow);
+        double pass_wide = rv_ebu_pass_rate(ebu_result, ebu_result->compliance - ebu_result->compliance_narrow);
+        info("%s(%d), Compliance Rate Narrow %.2f%% Wide %.2f%%, total %d narrow %d\n\n",
+             __func__, s->idx, pass_narrow, pass_wide, ebu_result->ebu_result_num,
+             ebu_result->compliance_narrow);
       }
     } else {
       if (ebu_result->ebu_result_num > ebu_info->dropped_results) {
@@ -268,7 +270,7 @@ static void rv_ebu_on_frame(struct st_rx_video_session_impl* s, uint32_t rtp_tms
   ebu->cur_epochs = epochs;
   ebu->vrx_drained_prev = 0;
   ebu->vrx_prev = 0;
-  ebu->cinmtl_initial_time = pkt_tmstamp;
+  ebu->cinst_initial_time = pkt_tmstamp;
   ebu->prev_rtp_ipt_ts = 0;
 
   /* calculate fpt */
@@ -337,7 +339,7 @@ static void rv_ebu_on_packet(struct st_rx_video_session_impl* s, uint32_t rtp_tm
 
   /* Calculate C-inst */
   int exp_cin_pkts =
-      ((pkt_tmstamp - ebu->cinmtl_initial_time) / trs) * ST_EBU_CINST_DRAIN_FACTOR;
+      ((pkt_tmstamp - ebu->cinst_initial_time) / trs) * ST_EBU_CINST_DRAIN_FACTOR;
   int cinst = RTE_MAX(0, pkt_idx - exp_cin_pkts);
 
   ebu->cinst_sum += cinst;


### PR DESCRIPTION
Ex: use "--vrx 30" to set the vrx buffer to 30 pkts for a wide pacing. 
Also fix the rtp time stamp to not include the warmup pkts