### PR TITLE
Fix fps set wrongly in ffmpeg plugin

### DIFF
--- a/ecosystem/ffmpeg_plugin/kahawai_common.c
+++ b/ecosystem/ffmpeg_plugin/kahawai_common.c
@@ -24,26 +24,14 @@
 
 #include "libavutil/common.h"
 
-const KahawaiFpsDecs fps_table[] = {
-    {ST_FPS_P50, 5000 - 100, 5000 + 100},    {ST_FPS_P29_97, 2997 - 100, 2997 + 100},
-    {ST_FPS_P25, 2500 - 100, 2500 + 100},    {ST_FPS_P60, 6000 - 100, 6000 + 100},
-    {ST_FPS_P30, 3000 - 100, 3000 + 100},    {ST_FPS_P24, 2400 - 100, 2400 + 100},
-    {ST_FPS_P23_98, 2398 - 100, 2398 + 100}, {ST_FPS_P119_88, 11988 - 100, 11988 + 100}};
-
 static mtl_handle shared_st_handle = NULL;
 unsigned int active_session_cnt = 0;
 static struct mtl_init_params param = {0};
 
-enum st_fps get_fps_table(AVRational framerate) {
-  int ret;
-  unsigned int fps = framerate.num * 100 / framerate.den;
+enum st_fps kahawai_fps_to_st_fps(AVRational framerate) {
+  double fps = framerate.num / framerate.den;
 
-  for (ret = 0; ret < sizeof(fps_table) / sizeof(KahawaiFpsDecs); ++ret) {
-    if ((fps >= fps_table[ret].min) && (fps <= fps_table[ret].max)) {
-      return fps_table[ret].st_fps;
-    }
-  }
-  return ST_FPS_MAX;
+  return st_frame_rate_to_st_fps(fps);
 }
 
 mtl_handle kahawai_init(char* port, char* local_addr, int enc_session_cnt,

--- a/ecosystem/ffmpeg_plugin/kahawai_common.h
+++ b/ecosystem/ffmpeg_plugin/kahawai_common.h
@@ -27,7 +27,7 @@ typedef struct KahawaiFpsDecs {
   unsigned int max;
 } KahawaiFpsDecs;
 
-enum st_fps get_fps_table(AVRational framerate);
+enum st_fps kahawai_fps_to_st_fps(AVRational framerate);
 mtl_handle kahawai_init(char* port, char* local_addr, int enc_session_cnt,
                         int dec_session_cnt, char* dma_dev);
 mtl_handle kahawai_get_handle();

--- a/ecosystem/ffmpeg_plugin/kahawai_dec.c
+++ b/ecosystem/ffmpeg_plugin/kahawai_dec.c
@@ -126,7 +126,9 @@ static int kahawai_read_header(AVFormatContext* ctx) {
   }
   ops_rx.height = s->height;
 
-  switch ((pix_fmt = av_get_pix_fmt(s->pixel_format))) {
+  pix_fmt = av_get_pix_fmt(s->pixel_format);
+  const AVPixFmtDescriptor* pix_fmt_desc = av_pix_fmt_desc_get(pix_fmt);
+  switch (pix_fmt) {
     case AV_PIX_FMT_YUV422P10LE:
       ops_rx.transport_fmt = ST20_FMT_YUV_422_10BIT;
       if (s->ext_frames_mode) {
@@ -140,7 +142,7 @@ static int kahawai_read_header(AVFormatContext* ctx) {
       ops_rx.output_fmt = ST_FRAME_FMT_RGB8;
       break;
     default:
-      av_log(ctx, AV_LOG_ERROR, "Unsupported pixel format: %s.\n", s->pixel_format);
+      av_log(ctx, AV_LOG_ERROR, "Unsupported pixel format: %s.\n", pix_fmt_desc->name);
       return AVERROR(EINVAL);
   }
 
@@ -150,7 +152,7 @@ static int kahawai_read_header(AVFormatContext* ctx) {
     return packet_size;
   }
   av_log(ctx, AV_LOG_VERBOSE, "packet size: %d\n", packet_size);
-  ops_rx.fps = get_fps_table(s->framerate);
+  ops_rx.fps = kahawai_fps_to_st_fps(s->framerate);
   if (ops_rx.fps == ST_FPS_MAX) {
     av_log(ctx, AV_LOG_ERROR, "Frame rate %0.2f is not supported\n",
            av_q2d(s->framerate));

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -207,6 +207,15 @@ static inline bool st_is_frame_complete(enum st_frame_status status) {
 double st_frame_rate(enum st_fps fps);
 
 /**
+ * Helper function returning enum st_fps from frame rate
+ * @param framerate
+ *   frame rate number
+ * @return
+ *   enum st_fps fps.
+ */
+enum st_fps st_frame_rate_to_st_fps(double framerate);
+
+/**
  * Helper function to convert ST10_TIMESTAMP_FMT_TAI to ST10_TIMESTAMP_FMT_MEDIA_CLK.
  *
  * @param tai_ns

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -122,6 +122,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 120,
         .den = 1,
+        .framerate = 120.00,
+        .lower_limit = 0.00,
+        .upper_limit = 1.00,
     },
     {
         /* ST_FPS_P119_88 */
@@ -129,6 +132,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 60000 * 2,
         .den = 1001,
+        .framerate = 119.88,
+        .lower_limit = 1.00,
+        .upper_limit = 0.11,
     },
     {
         /* ST_FPS_P100 */
@@ -136,6 +142,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 100,
         .den = 1,
+        .framerate = 100.00,
+        .lower_limit = 1.00,
+        .upper_limit = 1.00,
     },
     {
         /* ST_FPS_P60 */
@@ -143,6 +152,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 60,
         .den = 1,
+        .framerate = 60.00,
+        .lower_limit = 0.00,
+        .upper_limit = 1.00,
     },
     {
         /* ST_FPS_P59_94 */
@@ -150,6 +162,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 60000,
         .den = 1001,
+        .framerate = 59.94,
+        .lower_limit = 1.00,
+        .upper_limit = 0.06,
     },
     {
         /* ST_FPS_P50 */
@@ -157,6 +172,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 50,
         .den = 1,
+        .framerate = 50.00,
+        .lower_limit = 1.00,
+        .upper_limit = 1.00,
     },
     {
         /* ST_FPS_P30 */
@@ -164,6 +182,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 30,
         .den = 1,
+        .framerate = 30.00,
+        .lower_limit = 0.00,
+        .upper_limit = 1.00,
     },
     {
         /* ST_FPS_P29_97 */
@@ -171,6 +192,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 30000,
         .den = 1001,
+        .framerate = 29.97,
+        .lower_limit = 1.00,
+        .upper_limit = 0.02,
     },
     {
         /* ST_FPS_P25 */
@@ -178,6 +202,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 25,
         .den = 1,
+        .framerate = 25.00,
+        .lower_limit = 0.00,
+        .upper_limit = 1.00,
     },
     {
         /* ST_FPS_P24 */
@@ -185,6 +212,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 24,
         .den = 1,
+        .framerate = 24.00,
+        .lower_limit = 0.0,
+        .upper_limit = 0.99,
     },
     {
         /* ST_FPS_P23.98 */
@@ -192,6 +222,9 @@ static const struct st_fps_timing st_fps_timings[] = {
         .sampling_clock_rate = 90 * 1000,
         .mul = 24000,
         .den = 1001,
+        .framerate = 23.98,
+        .lower_limit = 1.00,
+        .upper_limit = 0.01,
     },
 };
 
@@ -596,6 +629,21 @@ double st_frame_rate(enum st_fps fps) {
 
   err("%s, invalid fps %d\n", __func__, fps);
   return 0;
+}
+
+enum st_fps st_frame_rate_to_st_fps(double framerate) {
+  int i;
+
+  for (i = 0; i < MTL_ARRAY_SIZE(st_fps_timings); i++) {
+    if (framerate == st_fps_timings[i].framerate ||
+        ((framerate >= st_fps_timings[i].framerate - st_fps_timings[i].lower_limit) &&
+         (framerate <= st_fps_timings[i].framerate + st_fps_timings[i].upper_limit))) {
+      return st_fps_timings[i].fps;
+    }
+  }
+
+  err("%s, invalid fps %f\n", __func__, framerate);
+  return ST_FPS_MAX;
 }
 
 const char* st_frame_fmt_name(enum st_frame_fmt fmt) {

--- a/lib/src/st2110/st_fmt.h
+++ b/lib/src/st2110/st_fmt.h
@@ -13,6 +13,9 @@ struct st_fps_timing {
   int sampling_clock_rate; /* 90k of sampling clock rate */
   int mul;                 /* 60000 for ST_FPS_P59_94 */
   int den;                 /* 1001 for ST_FPS_P59_94 */
+  double framerate;
+  double lower_limit;
+  double upper_limit;
 };
 
 enum st_frame_sampling {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,6 +30,13 @@ test_c_args = []
 test_cpp_args = []
 test_ld_args = []
 
+is_gtest_newer_than_1_9_0 = gtest.version().version_compare('>=1.9.0')
+if is_gtest_newer_than_1_9_0
+  message('Gtest version: > 1.9.0; ' +  gtest.version())
+  test_c_args += ['-DMTL_GTEST_AFTER_1_9_0']
+  test_cpp_args += ['-DMTL_GTEST_AFTER_1_9_0']
+endif
+
 # enable warning as error for non debug build
 if get_option('buildtype') != 'debug'
   test_c_args += ['-Werror']

--- a/tests/src/st_test.cpp
+++ b/tests/src/st_test.cpp
@@ -479,3 +479,155 @@ TEST(Main, rss) {
 
   rss_mode_test(ctx);
 }
+
+class fps_23_98 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+TEST_P(fps_23_98, conv_fps_to_st_fps_23_98_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+PARAMETERIZED_TEST(Main, fps_23_98,
+                   ::testing::Values(std::make_tuple(ST_FPS_MAX, 22.00),
+                                     std::make_tuple(ST_FPS_MAX, 22.97),
+                                     std::make_tuple(ST_FPS_P23_98, 22.98),
+                                     std::make_tuple(ST_FPS_P23_98, 23.98),
+                                     std::make_tuple(ST_FPS_P23_98, 23.99),
+                                     std::make_tuple(ST_FPS_P24, 24.00)));
+
+class fps_24 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+TEST_P(fps_24, conv_fps_to_st_fps_24_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+PARAMETERIZED_TEST(Main, fps_24,
+                   ::testing::Values(std::make_tuple(ST_FPS_P23_98, 23.00),
+                                     std::make_tuple(ST_FPS_P24, 24.00),
+                                     std::make_tuple(ST_FPS_P24, 24.99),
+                                     std::make_tuple(ST_FPS_P25, 25.00)));
+
+class fps_25 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+TEST_P(fps_25, conv_fps_to_st_fps_25_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+PARAMETERIZED_TEST(Main, fps_25,
+                   ::testing::Values(std::make_tuple(ST_FPS_P25, 25.00),
+                                     std::make_tuple(ST_FPS_P25, 26.00),
+                                     std::make_tuple(ST_FPS_MAX, 27.00)));
+
+class fps_29_97 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+TEST_P(fps_29_97, conv_fps_to_st_fps_29_97_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+PARAMETERIZED_TEST(Main, fps_29_97,
+                   ::testing::Values(std::make_tuple(ST_FPS_MAX, 28.00),
+                                     std::make_tuple(ST_FPS_MAX, 28.50),
+                                     std::make_tuple(ST_FPS_P29_97, 29.97),
+                                     std::make_tuple(ST_FPS_P29_97, 29.99),
+                                     std::make_tuple(ST_FPS_P30, 30.00)));
+
+class fps_30 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+TEST_P(fps_30, conv_fps_to_st_fps_30_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+PARAMETERIZED_TEST(Main, fps_30,
+                   ::testing::Values(std::make_tuple(ST_FPS_P30, 30.00),
+                                     std::make_tuple(ST_FPS_P30, 31.00),
+                                     std::make_tuple(ST_FPS_MAX, 31.01),
+                                     std::make_tuple(ST_FPS_MAX, 32.00)));
+
+class fps_50 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+TEST_P(fps_50, conv_fps_to_st_fps_50_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+PARAMETERIZED_TEST(Main, fps_50,
+                   ::testing::Values(std::make_tuple(ST_FPS_MAX, 48.00),
+                                     std::make_tuple(ST_FPS_P50, 49.00),
+                                     std::make_tuple(ST_FPS_P50, 49.50),
+                                     std::make_tuple(ST_FPS_P50, 50.00),
+                                     std::make_tuple(ST_FPS_P50, 50.50),
+                                     std::make_tuple(ST_FPS_P50, 51.00),
+                                     std::make_tuple(ST_FPS_MAX, 52.00)));
+
+class fps_59_94 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+PARAMETERIZED_TEST(Main, fps_59_94,
+                   ::testing::Values(std::make_tuple(ST_FPS_MAX, 58.93),
+                                     std::make_tuple(ST_FPS_P59_94, 58.94),
+                                     std::make_tuple(ST_FPS_P59_94, 59.94),
+                                     std::make_tuple(ST_FPS_P59_94, 59.99),
+                                     std::make_tuple(ST_FPS_P60, 60.00)));
+
+TEST_P(fps_59_94, conv_fps_to_st_fps_50_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+class fps_60 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+PARAMETERIZED_TEST(Main, fps_60,
+                   ::testing::Values(std::make_tuple(ST_FPS_P60, 60.00),
+                                     std::make_tuple(ST_FPS_P60, 61.00),
+                                     std::make_tuple(ST_FPS_MAX, 61.01),
+                                     std::make_tuple(ST_FPS_MAX, 62.00)));
+
+TEST_P(fps_60, conv_fps_to_st_fps_60_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+class fps_100 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+PARAMETERIZED_TEST(Main, fps_100,
+                   ::testing::Values(std::make_tuple(ST_FPS_MAX, 98.99),
+                                     std::make_tuple(ST_FPS_P100, 99.00),
+                                     std::make_tuple(ST_FPS_P100, 100.00),
+                                     std::make_tuple(ST_FPS_P100, 101.00),
+                                     std::make_tuple(ST_FPS_MAX, 101.01)));
+
+TEST_P(fps_100, conv_fps_to_st_fps_100_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+class fps_119_98 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+PARAMETERIZED_TEST(Main, fps_119_98,
+                   ::testing::Values(std::make_tuple(ST_FPS_MAX, 118.87),
+                                     std::make_tuple(ST_FPS_P119_88, 118.88),
+                                     std::make_tuple(ST_FPS_P119_88, 119.88),
+                                     std::make_tuple(ST_FPS_P119_88, 119.99),
+                                     std::make_tuple(ST_FPS_P120, 120.00)));
+
+TEST_P(fps_119_98, conv_fps_to_st_fps_119_98_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}
+
+class fps_120 : public ::testing::TestWithParam<std::tuple<enum st_fps, double>> {};
+
+PARAMETERIZED_TEST(Main, fps_120,
+                   ::testing::Values(std::make_tuple(ST_FPS_P120, 120.00),
+                                     std::make_tuple(ST_FPS_P120, 120.01),
+                                     std::make_tuple(ST_FPS_P120, 121.00),
+                                     std::make_tuple(ST_FPS_MAX, 121.01),
+                                     std::make_tuple(ST_FPS_MAX, 122.00)));
+
+TEST_P(fps_120, conv_fps_to_st_fps_120_test) {
+  enum st_fps expect = st_frame_rate_to_st_fps(std::get<1>(GetParam()));
+  EXPECT_EQ(expect, std::get<0>(GetParam()));
+}

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -23,6 +23,12 @@
 #define MAX_TEST_DECODER_SESSIONS (8)
 #define MAX_TEST_CONVERTER_SESSIONS (8)
 
+#ifdef MTL_GTEST_AFTER_1_9_0
+#define PARAMETERIZED_TEST INSTANTIATE_TEST_SUITE_P
+#else
+#define PARAMETERIZED_TEST INSTANTIATE_TEST_CASE_P
+#endif
+
 struct test_converter_session {
   int idx;
 


### PR DESCRIPTION
Bugs:
1) FPS set in libmtl is always 60fps no matter the value set in filter graph
2) Existing FPS table has an overlap causing wrong enum returned to ffmpeg plugin

Root cause:
1) Existing code works this way: comparing result of get_fps_table() against ST_FPS_MAX and set the result to ops.tx->fps / ops.rx->fps
Fix: Move the code out to set ops.tx->fps / ops.rx->fps before comparing against ST_FPS_MAX.
2) Add API to get fps from st_fps_timings table