### PR TITLE
dpdk: add patch for igc driver optimization.

### DIFF
--- a/patches/dpdk/23.03/0008-igc-optimize-LaunchTime-Tx-Qbv-configuration-and-PTP.patch
+++ b/patches/dpdk/23.03/0008-igc-optimize-LaunchTime-Tx-Qbv-configuration-and-PTP.patch
@@ -1,0 +1,1758 @@
+From baef8069110189b92406e2f65244da8d3124c3e1 Mon Sep 17 00:00:00 2001
+From: gongxiao-intel <xiaoyan.gong@intel.com>
+Date: Thu, 25 May 2023 13:22:23 +0000
+Subject: [PATCH 8/8] igc: optimize LaunchTime Tx, Qbv configuration and PTP
+ for SMPTE 2110-21 n-type transmission of 1080p 50fps video.
+
+1. Optimize LaunchTime Tx feature based on section 3.3.2.9.3.4 of doc#682924 rev-1.4.2 requirement.
+
+2. Configurate Qbv scheduler to isolate the video traffic and others traffic. The cycle time of
+the scheduler is the frame cycle time of 50fps. According SMPTE 2110-21 standard, the video packets
+transmission will end at the 784us from the end of cycle. The queue 0 is for video packets transmission.
+The other queues is for others traffic. So, the queue 0 is opened during the whole cycle, and the
+other queues is opened at the 784us from the end of cycle.
+
+3. Optimize time sync precision by adding clock freqency adjustment.
+
+4. Fix remote ptp4l NOT receiving DELAY_REQ message while send PTP message over UDP.
+---
+ drivers/net/igc/base/igc_defines.h |  29 +-
+ drivers/net/igc/base/igc_hw.h      |   2 +-
+ drivers/net/igc/base/igc_i225.c    |  16 +-
+ drivers/net/igc/base/igc_phy.c     |   6 +-
+ drivers/net/igc/base/igc_regs.h    |  29 +-
+ drivers/net/igc/igc_ethdev.c       | 412 +++++++++++++++-----------
+ drivers/net/igc/igc_ethdev.h       |   5 +-
+ drivers/net/igc/igc_flow.c         |   8 +-
+ drivers/net/igc/igc_txrx.c         | 455 ++++++++++++++++++++++-------
+ drivers/net/igc/igc_txrx.h         |  85 +-----
+ lib/ethdev/ethdev_driver.h         |   5 +
+ lib/ethdev/ethdev_trace.h          |   8 +
+ lib/ethdev/ethdev_trace_points.c   |   3 +
+ lib/ethdev/rte_ethdev.c            |  19 ++
+ lib/ethdev/rte_ethdev.h            |  19 ++
+ lib/ethdev/version.map             |   1 +
+ 16 files changed, 708 insertions(+), 394 deletions(-)
+
+diff --git a/drivers/net/igc/base/igc_defines.h b/drivers/net/igc/base/igc_defines.h
+index 280570b157..30fd7affda 100644
+--- a/drivers/net/igc/base/igc_defines.h
++++ b/drivers/net/igc/base/igc_defines.h
+@@ -171,6 +171,12 @@
+ #define IGC_RCTL_MO_SHIFT	12 /* multicast offset shift */
+ #define IGC_RCTL_MO_3		0x00003000 /* multicast offset 15:4 */
+ #define IGC_RCTL_BAM		0x00008000 /* broadcast enable */
++
++/* Split Replication Receive Control */
++#define IGC_SRRCTL_TIMESTAMP           0x40000000
++#define IGC_SRRCTL_TIMER1SEL(timer)    (((timer) & 0x3) << 14)
++#define IGC_SRRCTL_TIMER0SEL(timer)    (((timer) & 0x3) << 17)
++
+ /* these buffer sizes are valid if IGC_RCTL_BSEX is 0 */
+ #define IGC_RCTL_SZ_2048	0x00000000 /* Rx buffer size 2048 */
+ #define IGC_RCTL_SZ_1024	0x00010000 /* Rx buffer size 1024 */
+@@ -188,15 +194,6 @@
+ #define IGC_RCTL_BSEX		0x02000000 /* Buffer size extension */
+ #define IGC_RCTL_SECRC	0x04000000 /* Strip Ethernet CRC */
+ 
+-#define IGC_DTXMXPKTSZ_TSN     0x19 /* 1600 bytes of max TX DMA packet size */
+-#define IGC_TXPBSIZE_TSN       0x04145145 /* 5k bytes buffer for each queue */
+-
+-/* Transmit Scheduling */
+-#define IGC_TQAVCTRL_TRANSMIT_MODE_TSN 0x00000001
+-#define IGC_TQAVCTRL_ENHANCED_QAV      0x00000008
+-
+-#define IGC_TXQCTL_QUEUE_MODE_LAUNCHT  0x00000001
+-
+ /* Use byte values for the following shift parameters
+  * Usage:
+  *     psrctl |= (((ROUNDUP(value0, 128) >> IGC_PSRCTL_BSIZE0_SHIFT) &
+@@ -754,6 +751,7 @@
+ #define IGC_TSYNCTXCTL_SYNC_COMP_ERR		0x20000000 /* sync err */
+ #define IGC_TSYNCTXCTL_SYNC_COMP		0x40000000 /* sync complete */
+ #define IGC_TSYNCTXCTL_START_SYNC		0x80000000 /* initiate sync */
++#define IGC_TSYNCTXCTL_TXSYNSIG                 0x00000020  /* Sample TX tstamp in PHY sop */
+ 
+ #define IGC_TSYNCRXCTL_VALID		0x00000001 /* Rx timestamp valid */
+ #define IGC_TSYNCRXCTL_TYPE_MASK	0x0000000E /* Rx type mask */
+@@ -764,6 +762,7 @@
+ #define IGC_TSYNCRXCTL_TYPE_EVENT_V2	0x0A
+ #define IGC_TSYNCRXCTL_ENABLED	0x00000010 /* enable Rx timestamping */
+ #define IGC_TSYNCRXCTL_SYSCFI		0x00000020 /* Sys clock frequency */
++#define IGC_TSYNCRXCTL_RXSYNSIG         0x00000400  /* Sample RX tstamp in PHY sop */
+ 
+ #define IGC_RXMTRL_PTP_V1_SYNC_MESSAGE	0x00000000
+ #define IGC_RXMTRL_PTP_V1_DELAY_REQ_MESSAGE	0x00010000
+@@ -804,17 +803,6 @@
+ 
+ #define TSYNC_INTERRUPTS	TSINTR_TXTS
+ 
+-/* Split Replication Receive Control */
+-#define IGC_SRRCTL_TIMESTAMP           0x40000000
+-#define IGC_SRRCTL_TIMER1SEL(timer)    (((timer) & 0x3) << 14)
+-#define IGC_SRRCTL_TIMER0SEL(timer)    (((timer) & 0x3) << 17)
+-
+-/* Sample RX tstamp in PHY sop */
+-#define IGC_TSYNCRXCTL_RXSYNSIG         0x00000400
+-
+-/* Sample TX tstamp in PHY sop */
+-#define IGC_TSYNCTXCTL_TXSYNSIG         0x00000020
+-
+ /* TSAUXC Configuration Bits */
+ #define TSAUXC_EN_TT0	(1 << 0)  /* Enable target time 0. */
+ #define TSAUXC_EN_TT1	(1 << 1)  /* Enable target time 1. */
+@@ -1371,6 +1359,7 @@
+ #define IGP04IGC_E_PHY_ID	0x02A80391
+ #define M88_VENDOR		0x0141
+ #define I225_I_PHY_ID		0x67C9DC00
++#define I225_IT_PHY_ID		0x67C9DCC0
+ #define I226_LM_PHY_ID          0x67C9DC10
+ 
+ /* M88E1000 Specific Registers */
+diff --git a/drivers/net/igc/base/igc_hw.h b/drivers/net/igc/base/igc_hw.h
+index e919a11c02..10edd9b02b 100644
+--- a/drivers/net/igc/base/igc_hw.h
++++ b/drivers/net/igc/base/igc_hw.h
+@@ -164,7 +164,7 @@ struct igc_hw;
+ #define IGC_DEV_ID_I225_V			0x15F3
+ #define IGC_DEV_ID_I225_K			0x3100
+ #define IGC_DEV_ID_I225_I			0x15F8
+-#define IGC_DEV_ID_I225_IT			0x0D9F
++#define IGC_DEV_ID_I225_IT			0x0d9f
+ #define IGC_DEV_ID_I220_V			0x15F7
+ #define IGC_DEV_ID_I225_BLANK_NVM		0x15FD
+ #define IGC_DEV_ID_I226_K           0x3102
+diff --git a/drivers/net/igc/base/igc_i225.c b/drivers/net/igc/base/igc_i225.c
+index 180d3cf687..218b1db034 100644
+--- a/drivers/net/igc/base/igc_i225.c
++++ b/drivers/net/igc/base/igc_i225.c
+@@ -173,8 +173,20 @@ static s32 igc_init_phy_params_i225(struct igc_hw *hw)
+ 	phy->ops.write_reg = igc_write_phy_reg_gpy;
+ 
+ 	ret_val = igc_get_phy_id(hw);
+-	phy->type = igc_phy_i225;
+-
++	/* Verify phy id and set remaining function pointers */
++	switch (phy->id) {
++	case I225_I_PHY_ID:
++	case I225_IT_PHY_ID:
++	case I226_LM_PHY_ID:
++		phy->type		= igc_phy_i225;
++		phy->ops.set_d0_lplu_state = igc_set_d0_lplu_state_i225;
++		phy->ops.set_d3_lplu_state = igc_set_d3_lplu_state_i225;
++		/* TODO - complete with GPY PHY information */
++		break;
++	default:
++		ret_val = -IGC_ERR_PHY;
++		goto out;
++	}
+ 
+ out:
+ 	return ret_val;
+diff --git a/drivers/net/igc/base/igc_phy.c b/drivers/net/igc/base/igc_phy.c
+index 2906bae21a..43bbe69bca 100644
+--- a/drivers/net/igc/base/igc_phy.c
++++ b/drivers/net/igc/base/igc_phy.c
+@@ -1474,7 +1474,8 @@ s32 igc_phy_setup_autoneg(struct igc_hw *hw)
+ 			return ret_val;
+ 	}
+ 
+-	if (phy->autoneg_mask & ADVERTISE_2500_FULL) {
++	if ((phy->autoneg_mask & ADVERTISE_2500_FULL) &&
++	    hw->phy.id == I225_I_PHY_ID) {
+ 	/* Read the MULTI GBT AN Control Register - reg 7.32 */
+ 		ret_val = phy->ops.read_reg(hw, (STANDARD_AN_REG_MASK <<
+ 					    MMD_DEVADDR_SHIFT) |
+@@ -1614,7 +1615,8 @@ s32 igc_phy_setup_autoneg(struct igc_hw *hw)
+ 		ret_val = phy->ops.write_reg(hw, PHY_1000T_CTRL,
+ 					     mii_1000t_ctrl_reg);
+ 
+-	if (phy->autoneg_mask & ADVERTISE_2500_FULL)
++	if ((phy->autoneg_mask & ADVERTISE_2500_FULL) &&
++	    hw->phy.id == I225_I_PHY_ID)
+ 		ret_val = phy->ops.write_reg(hw,
+ 					     (STANDARD_AN_REG_MASK <<
+ 					     MMD_DEVADDR_SHIFT) |
+diff --git a/drivers/net/igc/base/igc_regs.h b/drivers/net/igc/base/igc_regs.h
+index e423814291..39d8649983 100644
+--- a/drivers/net/igc/base/igc_regs.h
++++ b/drivers/net/igc/base/igc_regs.h
+@@ -602,14 +602,6 @@
+ #define IGC_RXMTRL	0x0B634 /* Time sync Rx EtherType and Msg Type - RW */
+ #define IGC_RXUDP	0x0B638 /* Time Sync Rx UDP Port - RW */
+ 
+-#define IGC_QBVCYCLET	0x331C
+-#define IGC_QBVCYCLET_S 0x3320
+-#define IGC_STQT(_n)	(0x3324 + 0x4 * (_n))
+-#define IGC_ENDQT(_n)	(0x3334 + 0x4 * (_n))
+-#define IGC_TXQCTL(_n)	(0x3344 + 0x4 * (_n))
+-#define IGC_BASET_L	0x3314
+-#define IGC_BASET_H	0x3318
+-
+ /* Filtering Registers */
+ #define IGC_SAQF(_n)	(0x05980 + (4 * (_n))) /* Source Address Queue Fltr */
+ #define IGC_DAQF(_n)	(0x059A0 + (4 * (_n))) /* Dest Address Queue Fltr */
+@@ -729,4 +721,25 @@
+ #define IGC_MRQC_RSS_FIELD_IPV6_EX	0x00080000
+ #define IGC_RCTL_DTYP_MASK		0x00000C00 /* Descriptor type mask */
+ 
++/* Transmit Scheduling Registers */
++#define IGC_TQAVCTRL           0x3570
++#define IGC_TXQCTL(_n)         (0x3344 + 0x4 * (_n))
++#define IGC_BASET_L            0x3314
++#define IGC_BASET_H            0x3318
++#define IGC_QBVCYCLET          0x331C
++#define IGC_QBVCYCLET_S        0x3320
++
++#define IGC_STQT(_n)           (0x3324 + 0x4 * (_n))
++#define IGC_ENDQT(_n)          (0x3334 + 0x4 * (_n))
++
++#define IGC_TXQCTL_QAV_SEL_MASK           0x000000C0
++#define IGC_TXQCTL_QUEUE_MODE_LAUNCHT     0x00000001
++#define IGC_TQAVCC(_n)               (0x3004 + ((_n) * 0x40))
++#define IGC_TQAVHC(_n)               (0x300C + ((_n) * 0x40))
++#define IGC_GTXOFFSET                0x3310
++#define IGC_TXPBSIZE_TSN  0x0408208e
++#define IGC_ADVTXD_TSN_CNTX_FIRST 0x00000080
++#define IGC_TXQCTL_DATA_FETCH_TIM     0xC3508000
++#define I225_TXPBSIZE_DEFAULT     0x04000014 /* TXPBSIZE default */
++#define IGC_DTXMXPKTSZ_DEFAULT    0x98 /* 9728-byte Jumbo frames */
+ #endif
+diff --git a/drivers/net/igc/igc_ethdev.c b/drivers/net/igc/igc_ethdev.c
+index fab2ab6d1c..4e0044d5f0 100644
+--- a/drivers/net/igc/igc_ethdev.c
++++ b/drivers/net/igc/igc_ethdev.c
+@@ -7,7 +7,7 @@
+ 
+ #include <rte_string_fns.h>
+ #include <rte_pci.h>
+-#include <bus_pci_driver.h>
++#include <rte_bus_pci.h>
+ #include <ethdev_driver.h>
+ #include <ethdev_pci.h>
+ #include <rte_malloc.h>
+@@ -78,18 +78,9 @@
+ #define IGC_ALARM_INTERVAL	8000000u
+ /* us, about 13.6s some per-queue registers will wrap around back to 0. */
+ 
+-/* Transmit and receive latency (for PTP timestamps) */
+-#define IGC_I225_TX_LATENCY_10		240
+-#define IGC_I225_TX_LATENCY_100		58
+-#define IGC_I225_TX_LATENCY_1000	80
+-#define IGC_I225_TX_LATENCY_2500	1325
+-#define IGC_I225_RX_LATENCY_10		6450
+-#define IGC_I225_RX_LATENCY_100		185
+-#define IGC_I225_RX_LATENCY_1000	300
+-#define IGC_I225_RX_LATENCY_2500	1485
+-
+-uint64_t igc_tx_timestamp_dynflag;
+-int igc_tx_timestamp_dynfield_offset = -1;
++uint64_t igc_timestamp_dynflag;
++int igc_timestamp_dynfield_offset = -1;
++uint64_t rx_timestamp;
+ 
+ static const struct rte_eth_desc_lim rx_desc_lim = {
+ 	.nb_max = IGC_MAX_RXD,
+@@ -109,8 +100,8 @@ static const struct rte_pci_id pci_id_igc_map[] = {
+ 	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I225_LM) },
+ 	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I225_V)  },
+ 	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I225_I)  },
+-	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I225_IT)  },
+ 	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I225_K)  },
++	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I225_IT) },
+ 	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I226_K)  },
+ 	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I226_LMVP)  },
+ 	{ RTE_PCI_DEVICE(IGC_INTEL_VENDOR_ID, IGC_DEV_ID_I226_LM)  },
+@@ -258,19 +249,20 @@ eth_igc_vlan_filter_set(struct rte_eth_dev *dev, uint16_t vlan_id, int on);
+ static int eth_igc_vlan_offload_set(struct rte_eth_dev *dev, int mask);
+ static int eth_igc_vlan_tpid_set(struct rte_eth_dev *dev,
+ 		      enum rte_vlan_type vlan_type, uint16_t tpid);
+-static int eth_igc_timesync_enable(struct rte_eth_dev *dev);
+-static int eth_igc_timesync_disable(struct rte_eth_dev *dev);
+-static int eth_igc_timesync_read_rx_timestamp(struct rte_eth_dev *dev,
++static int eth_igc_read_clock(struct rte_eth_dev *dev, uint64_t *clock);
++static int igc_timesync_enable(struct rte_eth_dev *dev);
++static int igc_timesync_disable(struct rte_eth_dev *dev);
++static int igc_timesync_read_rx_timestamp(struct rte_eth_dev *dev,
+ 					  struct timespec *timestamp,
+ 					  uint32_t flags);
+-static int eth_igc_timesync_read_tx_timestamp(struct rte_eth_dev *dev,
++static int igc_timesync_read_tx_timestamp(struct rte_eth_dev *dev,
+ 					  struct timespec *timestamp);
+-static int eth_igc_timesync_adjust_time(struct rte_eth_dev *dev, int64_t delta);
+-static int eth_igc_timesync_read_time(struct rte_eth_dev *dev,
++static int igc_timesync_adjust_time(struct rte_eth_dev *dev, int64_t delta);
++static int igc_timesync_adjust_freq(struct rte_eth_dev *dev, int64_t ppm);
++static int igc_timesync_read_time(struct rte_eth_dev *dev,
+ 				  struct timespec *timestamp);
+-static int eth_igc_timesync_write_time(struct rte_eth_dev *dev,
++static int igc_timesync_write_time(struct rte_eth_dev *dev,
+ 				   const struct timespec *timestamp);
+-static int eth_igc_read_clock(struct rte_eth_dev *dev, uint64_t *clock);
+ 
+ static const struct eth_dev_ops eth_igc_ops = {
+ 	.dev_configure		= eth_igc_configure,
+@@ -324,14 +316,15 @@ static const struct eth_dev_ops eth_igc_ops = {
+ 	.vlan_tpid_set		= eth_igc_vlan_tpid_set,
+ 	.vlan_strip_queue_set	= eth_igc_vlan_strip_queue_set,
+ 	.flow_ops_get		= eth_igc_flow_ops_get,
+-	.timesync_enable	= eth_igc_timesync_enable,
+-	.timesync_disable	= eth_igc_timesync_disable,
+-	.timesync_read_rx_timestamp = eth_igc_timesync_read_rx_timestamp,
+-	.timesync_read_tx_timestamp = eth_igc_timesync_read_tx_timestamp,
+-	.timesync_adjust_time	= eth_igc_timesync_adjust_time,
+-	.timesync_read_time	= eth_igc_timesync_read_time,
+-	.timesync_write_time	= eth_igc_timesync_write_time,
+-	.read_clock             = eth_igc_read_clock,
++	.read_clock		= eth_igc_read_clock,
++	.timesync_enable      = igc_timesync_enable,
++	.timesync_disable     = igc_timesync_disable,
++	.timesync_read_rx_timestamp = igc_timesync_read_rx_timestamp,
++	.timesync_read_tx_timestamp = igc_timesync_read_tx_timestamp,
++	.timesync_adjust_time = igc_timesync_adjust_time,
++	.timesync_adjust_freq = igc_timesync_adjust_freq,
++	.timesync_read_time   = igc_timesync_read_time,
++	.timesync_write_time  = igc_timesync_write_time,
+ };
+ 
+ /*
+@@ -652,6 +645,7 @@ eth_igc_stop(struct rte_eth_dev *dev)
+ 	struct rte_pci_device *pci_dev = RTE_ETH_DEV_TO_PCI(dev);
+ 	struct rte_intr_handle *intr_handle = pci_dev->intr_handle;
+ 	struct rte_eth_link link;
++	uint32_t tqavctrl;
+ 
+ 	dev->data->dev_started = 0;
+ 	adapter->stopped = 1;
+@@ -673,6 +667,27 @@ eth_igc_stop(struct rte_eth_dev *dev)
+ 	/* disable intr eventfd mapping */
+ 	rte_intr_disable(intr_handle);
+ 
++	if (igc_timestamp_dynflag > 0) {
++		adapter->cycle_time = NSEC_PER_SEC;
++		adapter->base_time = 0;
++
++		IGC_WRITE_REG(hw, IGC_I350_DTXMXPKTSZ, IGC_DTXMXPKTSZ_DEFAULT);
++		IGC_WRITE_REG(hw, IGC_TXPBS, I225_TXPBSIZE_DEFAULT);
++
++		IGC_WRITE_REG(hw, IGC_QBVCYCLET_S, 0);
++		IGC_WRITE_REG(hw, IGC_QBVCYCLET, adapter->cycle_time);
++
++       for(uint8_t i = 0; i < IGC_QUEUE_PAIRS_NUM; i ++) {
++           IGC_WRITE_REG(hw, IGC_STQT(i), 0);
++           IGC_WRITE_REG(hw, IGC_ENDQT(i), adapter->cycle_time);
++           IGC_WRITE_REG(hw, IGC_TXQCTL(i), 0);
++       }
++
++		tqavctrl = IGC_READ_REG(hw, IGC_TQAVCTRL);
++		tqavctrl &= ~(0x1 | 0x8);
++		IGC_WRITE_REG(hw, IGC_TQAVCTRL, tqavctrl);
++	}
++
+ 	igc_reset_hw(hw);
+ 
+ 	/* disable all wake up */
+@@ -954,13 +969,13 @@ eth_igc_start(struct rte_eth_dev *dev)
+ 	struct igc_adapter *adapter = IGC_DEV_PRIVATE(dev);
+ 	struct rte_pci_device *pci_dev = RTE_ETH_DEV_TO_PCI(dev);
+ 	struct rte_intr_handle *intr_handle = pci_dev->intr_handle;
+-	uint32_t nsec, sec, baset_l, baset_h, tqavctrl;
+-	struct timespec system_time;
+-	int64_t n, systime;
+-	uint32_t txqctl = 0;
+ 	uint32_t *speeds;
+-	uint16_t i;
+ 	int ret;
++	uint32_t txqctl = 0;
++  uint32_t tqavcc = 0;
++	uint32_t sec, nsec, baset_l, baset_h, tqavctrl;
++	uint64_t n, systime;
++	struct timespec systime_ts;
+ 
+ 	PMD_INIT_FUNC_TRACE();
+ 
+@@ -988,6 +1003,80 @@ eth_igc_start(struct rte_eth_dev *dev)
+ 	}
+ 	adapter->stopped = 0;
+ 
++	if (igc_timestamp_dynflag > 0) {
++		adapter->cycle_time = NSEC_PER_SEC/50;
++    adapter->base_time = 0;
++
++		IGC_WRITE_REG(hw, IGC_TSAUXC, 0);
++		IGC_WRITE_REG(hw, IGC_I350_DTXMXPKTSZ, 0x19);
++		IGC_WRITE_REG(hw, IGC_TXPBS, IGC_TXPBSIZE_TSN);
++    IGC_WRITE_REG(hw, IGC_GTXOFFSET, 1500);
++
++		IGC_WRITE_REG(hw, IGC_QBVCYCLET_S, adapter->cycle_time);
++		IGC_WRITE_REG(hw, IGC_QBVCYCLET, adapter->cycle_time);
++
++		clock_gettime(CLOCK_REALTIME, &systime_ts);
++		IGC_WRITE_REG(hw, IGC_SYSTIML, systime_ts.tv_nsec);
++		IGC_WRITE_REG(hw, IGC_SYSTIMH, systime_ts.tv_sec);
++
++		nsec = IGC_READ_REG(hw, IGC_SYSTIML);
++		sec = IGC_READ_REG(hw, IGC_SYSTIMH);
++		systime = sec * NSEC_PER_SEC + nsec;
++
++		if (systime > adapter->base_time) {
++			n = (systime - adapter->base_time) / adapter->cycle_time;
++			adapter->base_time = adapter->base_time + (n + 1) * adapter->cycle_time;
++		}
++
++    baset_h = adapter->base_time / NSEC_PER_SEC;
++		baset_l = adapter->base_time % NSEC_PER_SEC;
++		IGC_WRITE_REG(hw, IGC_BASET_H, baset_h);
++		IGC_WRITE_REG(hw, IGC_BASET_L, baset_l);
++
++    for(uint8_t i = 0; i < IGC_QUEUE_PAIRS_NUM; i ++) {
++      txqctl = 0;
++      switch(i) {
++        case 0:
++          txqctl |= IGC_TXQCTL_QUEUE_MODE_LAUNCHT;
++          IGC_WRITE_REG(hw, IGC_STQT(i), 0);
++          IGC_WRITE_REG(hw, IGC_ENDQT(i), adapter->cycle_time);
++          break;
++        case 1:
++          IGC_WRITE_REG(hw, IGC_STQT(i), 0);
++          IGC_WRITE_REG(hw, IGC_ENDQT(i), 764000);
++          break;
++        case 2:
++          IGC_WRITE_REG(hw, IGC_STQT(i), 0);
++          IGC_WRITE_REG(hw, IGC_ENDQT(i), 764000);
++          break;
++        case 3:
++          IGC_WRITE_REG(hw, IGC_STQT(i), 0);
++          IGC_WRITE_REG(hw, IGC_ENDQT(i), 764000);
++          break;
++        default:
++          break;
++      }
++
++      txqctl |= (0x00000002 | 0x00000004);
++
++			if (i < 2) {
++        tqavcc = IGC_READ_REG(hw, IGC_TQAVCC(i));
++        tqavcc &= ~(IGC_TQAVCC_IDLE_SLOPE |
++              IGC_TQAVCC_KEEP_CREDITS);
++        IGC_WRITE_REG(hw, IGC_TQAVCC(i), tqavcc);
++
++        IGC_WRITE_REG(hw, IGC_TQAVHC(i), 0);
++
++        txqctl &= ~(IGC_TXQCTL_QAV_SEL_MASK);
++      }
++      IGC_WRITE_REG(hw, IGC_TXQCTL(i), txqctl);
++    }
++
++		tqavctrl = IGC_READ_REG(hw, IGC_TQAVCTRL);
++		tqavctrl |= 0x1 | 0x8;
++		IGC_WRITE_REG(hw, IGC_TQAVCTRL, tqavctrl);
++	}
++
+ 	/* check and configure queue intr-vector mapping */
+ 	if (rte_intr_cap_multiple(intr_handle) &&
+ 		dev->data->dev_conf.intr_conf.rxq) {
+@@ -1019,55 +1108,6 @@ eth_igc_start(struct rte_eth_dev *dev)
+ 		return ret;
+ 	}
+ 
+-	if (igc_tx_timestamp_dynflag > 0) {
+-		adapter->base_time = 0;
+-		adapter->cycle_time = NSEC_PER_SEC;
+-
+-		IGC_WRITE_REG(hw, IGC_TSSDP, 0);
+-		IGC_WRITE_REG(hw, IGC_TSIM, TSINTR_TXTS);
+-		IGC_WRITE_REG(hw, IGC_IMS, IGC_ICR_TS);
+-
+-		IGC_WRITE_REG(hw, IGC_TSAUXC, 0);
+-		IGC_WRITE_REG(hw, IGC_I350_DTXMXPKTSZ, IGC_DTXMXPKTSZ_TSN);
+-		IGC_WRITE_REG(hw, IGC_TXPBS, IGC_TXPBSIZE_TSN);
+-
+-		tqavctrl = IGC_READ_REG(hw, IGC_I210_TQAVCTRL);
+-		tqavctrl |= IGC_TQAVCTRL_TRANSMIT_MODE_TSN |
+-			    IGC_TQAVCTRL_ENHANCED_QAV;
+-		IGC_WRITE_REG(hw, IGC_I210_TQAVCTRL, tqavctrl);
+-
+-		IGC_WRITE_REG(hw, IGC_QBVCYCLET_S, adapter->cycle_time);
+-		IGC_WRITE_REG(hw, IGC_QBVCYCLET, adapter->cycle_time);
+-
+-		for (i = 0; i < dev->data->nb_tx_queues; i++) {
+-			IGC_WRITE_REG(hw, IGC_STQT(i), 0);
+-			IGC_WRITE_REG(hw, IGC_ENDQT(i), NSEC_PER_SEC);
+-
+-			txqctl |= IGC_TXQCTL_QUEUE_MODE_LAUNCHT;
+-			IGC_WRITE_REG(hw, IGC_TXQCTL(i), txqctl);
+-		}
+-
+-		clock_gettime(CLOCK_REALTIME, &system_time);
+-		IGC_WRITE_REG(hw, IGC_SYSTIML, system_time.tv_nsec);
+-		IGC_WRITE_REG(hw, IGC_SYSTIMH, system_time.tv_sec);
+-
+-		nsec = IGC_READ_REG(hw, IGC_SYSTIML);
+-		sec = IGC_READ_REG(hw, IGC_SYSTIMH);
+-		systime = (int64_t)sec * NSEC_PER_SEC + (int64_t)nsec;
+-
+-		if (systime > adapter->base_time) {
+-			n = (systime - adapter->base_time) /
+-			     adapter->cycle_time;
+-			adapter->base_time = adapter->base_time +
+-				(n + 1) * adapter->cycle_time;
+-		}
+-
+-		baset_h = adapter->base_time / NSEC_PER_SEC;
+-		baset_l = adapter->base_time % NSEC_PER_SEC;
+-		IGC_WRITE_REG(hw, IGC_BASET_H, baset_h);
+-		IGC_WRITE_REG(hw, IGC_BASET_L, baset_l);
+-	}
+-
+ 	igc_clear_hw_cntrs_base_generic(hw);
+ 
+ 	/* VLAN Offload Settings */
+@@ -1629,6 +1669,8 @@ eth_igc_infos_get(struct rte_eth_dev *dev, struct rte_eth_dev_info *dev_info)
+ 
+ 	dev_info->max_mtu = dev_info->max_rx_pktlen - IGC_ETH_OVERHEAD;
+ 	dev_info->min_mtu = RTE_ETHER_MIN_MTU;
++  dev_info->default_txconf.reserved_ptrs[0] = &igc_timestamp_dynflag;
++  dev_info->default_txconf.reserved_ptrs[1] = &igc_timestamp_dynfield_offset;
+ 	return 0;
+ }
+ 
+@@ -2670,15 +2712,45 @@ eth_igc_vlan_tpid_set(struct rte_eth_dev *dev,
+ }
+ 
+ static int
+-eth_igc_timesync_enable(struct rte_eth_dev *dev)
++eth_igc_read_clock(struct rte_eth_dev *dev, uint64_t *clock)
++{
++#if 0
++	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
++	uint32_t sec, nsec;
++
++	nsec = IGC_READ_REG(hw, IGC_SYSTIML);
++	sec = IGC_READ_REG(hw, IGC_SYSTIMH);
++	*clock = sec * 1000000000 + (int64_t)nsec;
++#endif
++	struct timespec system_time;
++
++	clock_gettime(CLOCK_REALTIME, &system_time);
++	*clock = system_time.tv_sec * NSEC_PER_SEC + system_time.tv_nsec;
++
++	return 0;
++}
++
++static int
++igc_timesync_enable(struct rte_eth_dev *dev)
+ {
+ 	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
++	uint32_t tsauxc, val;
+ 	struct timespec system_time;
+ 	struct igc_rx_queue *rxq;
+-	uint32_t val;
+ 	uint16_t i;
+ 
++	IGC_WRITE_REG(hw, IGC_TIMINCA, 0x0);
++	IGC_WRITE_REG(hw, IGC_SYSTIML, 0x0);
++	IGC_WRITE_REG(hw, IGC_SYSTIMH, 0x0);
++
++	tsauxc = IGC_READ_REG(hw, IGC_TSAUXC);
++	tsauxc &= ~0x80000000;
++	IGC_WRITE_REG(hw, IGC_TSAUXC, tsauxc);
++
+ 	IGC_WRITE_REG(hw, IGC_TSAUXC, 0x0);
++	IGC_WRITE_REG(hw, IGC_TSSDP, 0x0);
++	IGC_WRITE_REG(hw, IGC_TSIM, 0x10);
++	IGC_WRITE_REG(hw, IGC_IMS, 1 << 19);
+ 
+ 	clock_gettime(CLOCK_REALTIME, &system_time);
+ 	IGC_WRITE_REG(hw, IGC_SYSTIML, system_time.tv_nsec);
+@@ -2686,16 +2758,13 @@ eth_igc_timesync_enable(struct rte_eth_dev *dev)
+ 
+ 	/* Enable timestamping of received PTP packets. */
+ 	val = IGC_READ_REG(hw, IGC_RXPBS);
+-	val |= IGC_RXPBS_CFG_TS_EN;
++	val |= 0x80000000;
+ 	IGC_WRITE_REG(hw, IGC_RXPBS, val);
+ 
+-	for (i = 0; i < dev->data->nb_rx_queues; i++) {
+-		val = IGC_READ_REG(hw, IGC_SRRCTL(i));
+-		/* For now, only support retrieving Rx timestamp from timer0. */
+-		val |= IGC_SRRCTL_TIMER1SEL(0) | IGC_SRRCTL_TIMER0SEL(0) |
+-		       IGC_SRRCTL_TIMESTAMP;
+-		IGC_WRITE_REG(hw, IGC_SRRCTL(i), val);
+-	}
++	val = IGC_READ_REG(hw, IGC_SRRCTL(0));
++	val |= IGC_SRRCTL_TIMER1SEL(0) | IGC_SRRCTL_TIMER0SEL(0) |
++	       IGC_SRRCTL_TIMESTAMP;
++	IGC_WRITE_REG(hw, IGC_SRRCTL(0), val);
+ 
+ 	val = IGC_TSYNCRXCTL_ENABLED | IGC_TSYNCRXCTL_TYPE_ALL |
+ 	      IGC_TSYNCRXCTL_RXSYNSIG;
+@@ -2704,8 +2773,6 @@ eth_igc_timesync_enable(struct rte_eth_dev *dev)
+ 	/* Enable Timestamping of transmitted PTP packets. */
+ 	IGC_WRITE_REG(hw, IGC_TSYNCTXCTL, IGC_TSYNCTXCTL_ENABLED |
+ 		      IGC_TSYNCTXCTL_TXSYNSIG);
+-
+-	/* Read TXSTMP registers to discard any timestamp previously stored. */
+ 	IGC_READ_REG(hw, IGC_TXSTMPL);
+ 	IGC_READ_REG(hw, IGC_TXSTMPH);
+ 
+@@ -2718,7 +2785,7 @@ eth_igc_timesync_enable(struct rte_eth_dev *dev)
+ }
+ 
+ static int
+-eth_igc_timesync_read_time(struct rte_eth_dev *dev, struct timespec *ts)
++igc_timesync_read_time(struct rte_eth_dev *dev, struct timespec *ts)
+ {
+ 	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
+ 
+@@ -2729,7 +2796,7 @@ eth_igc_timesync_read_time(struct rte_eth_dev *dev, struct timespec *ts)
+ }
+ 
+ static int
+-eth_igc_timesync_write_time(struct rte_eth_dev *dev, const struct timespec *ts)
++igc_timesync_write_time(struct rte_eth_dev *dev, const struct timespec *ts)
+ {
+ 	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
+ 
+@@ -2740,18 +2807,18 @@ eth_igc_timesync_write_time(struct rte_eth_dev *dev, const struct timespec *ts)
+ }
+ 
+ static int
+-eth_igc_timesync_adjust_time(struct rte_eth_dev *dev, int64_t delta)
++igc_timesync_adjust_time(struct rte_eth_dev *dev, int64_t delta)
+ {
+ 	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
+-	uint32_t nsec, sec;
+-	uint64_t systime, ns;
++	uint64_t systime_cycles, ns;
+ 	struct timespec ts;
++	uint32_t sec, nsec;
+ 
+ 	nsec = (uint64_t)IGC_READ_REG(hw, IGC_SYSTIML);
+ 	sec = (uint64_t)IGC_READ_REG(hw, IGC_SYSTIMH);
+-	systime = sec * NSEC_PER_SEC + nsec;
++	systime_cycles = sec * NSEC_PER_SEC + nsec;
+ 
+-	ns = systime + delta;
++	ns = systime_cycles + delta;
+ 	ts = rte_ns_to_timespec(ns);
+ 
+ 	IGC_WRITE_REG(hw, IGC_SYSTIML, ts.tv_nsec);
+@@ -2761,86 +2828,106 @@ eth_igc_timesync_adjust_time(struct rte_eth_dev *dev, int64_t delta)
+ }
+ 
+ static int
+-eth_igc_timesync_read_rx_timestamp(__rte_unused struct rte_eth_dev *dev,
+-			       struct timespec *timestamp,
+-			       uint32_t flags)
++igc_timesync_adjust_freq(struct rte_eth_dev *dev, int64_t ppm)
+ {
+-	struct rte_eth_link link;
+-	int adjust = 0;
+-	struct igc_rx_queue *rxq;
+-	uint64_t rx_timestamp;
++	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
++	int neg_adj = 0;
++	uint64_t rate;
++	uint32_t inca;
+ 
+-	/* Get current link speed. */
+-	eth_igc_link_update(dev, 1);
+-	rte_eth_linkstatus_get(dev, &link);
++	if (ppm < 0) {
++		neg_adj = 1;
++		ppm = -ppm;
++	}
+ 
+-	switch (link.link_speed) {
+-	case SPEED_10:
+-		adjust = IGC_I225_RX_LATENCY_10;
+-		break;
+-	case SPEED_100:
+-		adjust = IGC_I225_RX_LATENCY_100;
+-		break;
+-	case SPEED_1000:
+-		adjust = IGC_I225_RX_LATENCY_1000;
+-		break;
+-	case SPEED_2500:
+-		adjust = IGC_I225_RX_LATENCY_2500;
+-		break;
++	rate = ppm;
++	rate <<= 14;
++	rate = rate / 78125;
++
++	inca = rate & 0x7fffffff;
++	if (neg_adj)
++		inca |= 0x80000000;
++
++	IGC_WRITE_REG(hw, IGC_TIMINCA, inca);
++
++	return 0;
++}
++
++static int
++igc_timesync_read_rx_timestamp(struct rte_eth_dev *dev,
++			       struct timespec *timestamp,
++			       uint32_t flags __rte_unused)
++{
++	uint32_t *speeds;
++	speeds = &dev->data->dev_conf.link_speeds;
++	if (*speeds & RTE_ETH_LINK_SPEED_10M_HD) {
++		rx_timestamp -= 6450;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_10M) {
++		rx_timestamp -= 6450;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_100M_HD) {
++		rx_timestamp -= 185;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_100M) {
++		rx_timestamp -= 185;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_1G) {
++		rx_timestamp -= 300;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_2_5G) {
++		rx_timestamp -= 1485;
+ 	}
+ 
+-	rxq = dev->data->rx_queues[flags];
+-	rx_timestamp = rxq->rx_timestamp - adjust;
+ 	*timestamp = rte_ns_to_timespec(rx_timestamp);
+ 
+ 	return 0;
+ }
+ 
+ static int
+-eth_igc_timesync_read_tx_timestamp(struct rte_eth_dev *dev,
++igc_timesync_read_tx_timestamp(struct rte_eth_dev *dev,
+ 			       struct timespec *timestamp)
+ {
+ 	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
+-	struct rte_eth_link link;
+-	uint32_t val, nsec, sec;
+ 	uint64_t tx_timestamp;
+-	int adjust = 0;
++	uint64_t sec, nsec;
++	uint32_t tsynctxctl;
+ 
+-	val = IGC_READ_REG(hw, IGC_TSYNCTXCTL);
+-	if (!(val & IGC_TSYNCTXCTL_VALID))
+-		return -EINVAL;
++	tsynctxctl = IGC_READ_REG(hw, IGC_TSYNCTXCTL);
++	if (!(tsynctxctl & 0x1))
++		return -1;
+ 
+ 	nsec = (uint64_t)IGC_READ_REG(hw, IGC_TXSTMPL);
+ 	sec = (uint64_t)IGC_READ_REG(hw, IGC_TXSTMPH);
+ 	tx_timestamp = sec * NSEC_PER_SEC + nsec;
+ 
+-	/* Get current link speed. */
+-	eth_igc_link_update(dev, 1);
+-	rte_eth_linkstatus_get(dev, &link);
+-
+-	switch (link.link_speed) {
+-	case SPEED_10:
+-		adjust = IGC_I225_TX_LATENCY_10;
+-		break;
+-	case SPEED_100:
+-		adjust = IGC_I225_TX_LATENCY_100;
+-		break;
+-	case SPEED_1000:
+-		adjust = IGC_I225_TX_LATENCY_1000;
+-		break;
+-	case SPEED_2500:
+-		adjust = IGC_I225_TX_LATENCY_2500;
+-		break;
++	uint32_t *speeds;
++	speeds = &dev->data->dev_conf.link_speeds;
++	if (*speeds & RTE_ETH_LINK_SPEED_10M_HD) {
++		tx_timestamp += 240;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_10M) {
++		tx_timestamp += 240;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_100M_HD) {
++		tx_timestamp += 58;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_100M) {
++		tx_timestamp += 58;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_1G) {
++		tx_timestamp += 80;
++	}
++	if (*speeds & RTE_ETH_LINK_SPEED_2_5G) {
++		tx_timestamp += 1325;
+ 	}
+-
+-	tx_timestamp += adjust;
+ 	*timestamp = rte_ns_to_timespec(tx_timestamp);
+ 
+ 	return 0;
+ }
+ 
+ static int
+-eth_igc_timesync_disable(struct rte_eth_dev *dev)
++igc_timesync_disable(struct rte_eth_dev *dev)
+ {
+ 	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
+ 	uint32_t val;
+@@ -2852,23 +2939,14 @@ eth_igc_timesync_disable(struct rte_eth_dev *dev)
+ 	IGC_WRITE_REG(hw, IGC_TSYNCRXCTL, 0);
+ 
+ 	val = IGC_READ_REG(hw, IGC_RXPBS);
+-	val &= IGC_RXPBS_CFG_TS_EN;
++	val &= ~0x80000000;
+ 	IGC_WRITE_REG(hw, IGC_RXPBS, val);
+ 
+ 	val = IGC_READ_REG(hw, IGC_SRRCTL(0));
+-	val &= ~IGC_SRRCTL_TIMESTAMP;
++	val &= ~0x40000000;
+ 	IGC_WRITE_REG(hw, IGC_SRRCTL(0), val);
+ 
+-	return 0;
+-}
+-
+-static int
+-eth_igc_read_clock(__rte_unused struct rte_eth_dev *dev, uint64_t *clock)
+-{
+-	struct timespec system_time;
+-
+-	clock_gettime(CLOCK_REALTIME, &system_time);
+-	*clock = system_time.tv_sec * NSEC_PER_SEC + system_time.tv_nsec;
++	IGC_WRITE_REG(hw, IGC_TIMINCA, 0);
+ 
+ 	return 0;
+ }
+diff --git a/drivers/net/igc/igc_ethdev.h b/drivers/net/igc/igc_ethdev.h
+index 8d7eb5458b..94da5b5c0c 100644
+--- a/drivers/net/igc/igc_ethdev.h
++++ b/drivers/net/igc/igc_ethdev.h
+@@ -241,9 +241,8 @@ struct igc_adapter {
+ 	struct igc_syn_filter syn_filter;
+ 	struct igc_rss_filter rss_filter;
+ 	struct igc_flow_list flow_list;
+-
+-	int64_t base_time;
+-	uint32_t cycle_time;
++  uint64_t base_time;
++  uint32_t cycle_time;
+ };
+ 
+ #define IGC_DEV_PRIVATE(_dev)	((_dev)->data->dev_private)
+diff --git a/drivers/net/igc/igc_flow.c b/drivers/net/igc/igc_flow.c
+index b677a0d613..58a6a8a539 100644
+--- a/drivers/net/igc/igc_flow.c
++++ b/drivers/net/igc/igc_flow.c
+@@ -327,14 +327,14 @@ igc_parse_pattern_ether(const struct rte_flow_item *item,
+ 	IGC_SET_FILTER_MASK(filter, IGC_FILTER_MASK_ETHER);
+ 
+ 	/* destination and source MAC address are not supported */
+-	if (!rte_is_zero_ether_addr(&mask->hdr.src_addr) ||
+-		!rte_is_zero_ether_addr(&mask->hdr.dst_addr))
++	if (!rte_is_zero_ether_addr(&mask->src) ||
++		!rte_is_zero_ether_addr(&mask->dst))
+ 		return rte_flow_error_set(error, EINVAL,
+ 				RTE_FLOW_ERROR_TYPE_ITEM_MASK, item,
+ 				"Only support ether-type");
+ 
+ 	/* ether-type mask bits must be all 1 */
+-	if (IGC_NOT_ALL_BITS_SET(mask->hdr.ether_type))
++	if (IGC_NOT_ALL_BITS_SET(mask->type))
+ 		return rte_flow_error_set(error, EINVAL,
+ 				RTE_FLOW_ERROR_TYPE_ITEM_MASK, item,
+ 				"Ethernet type mask bits must be all 1");
+@@ -342,7 +342,7 @@ igc_parse_pattern_ether(const struct rte_flow_item *item,
+ 	ether = &filter->ethertype;
+ 
+ 	/* get ether-type */
+-	ether->ether_type = rte_be_to_cpu_16(spec->hdr.ether_type);
++	ether->ether_type = rte_be_to_cpu_16(spec->type);
+ 
+ 	/* ether-type should not be IPv4 and IPv6 */
+ 	if (ether->ether_type == RTE_ETHER_TYPE_IPV4 ||
+diff --git a/drivers/net/igc/igc_txrx.c b/drivers/net/igc/igc_txrx.c
+index c11b6f7f25..95aa9659a0 100644
+--- a/drivers/net/igc/igc_txrx.c
++++ b/drivers/net/igc/igc_txrx.c
+@@ -53,6 +53,8 @@
+ #define IGC_RXD_ETQF_SHIFT		12
+ #define IGC_RXD_ETQF_MSK		(0xfu << IGC_RXD_ETQF_SHIFT)
+ #define IGC_RXD_VPKT			(1u << 16)
++#define IGC_LAUNCH_TIME_OFFLOAD     (1ULL << 23)
++#define IGC_EMPTY_FRAME_SIZE 60
+ 
+ /* TXD control bits */
+ #define IGC_TXDCTL_PTHRESH_SHIFT	0
+@@ -82,7 +84,8 @@
+ 		RTE_MBUF_F_TX_L4_MASK |	\
+ 		RTE_MBUF_F_TX_TCP_SEG |	\
+ 		RTE_MBUF_F_TX_UDP_SEG | \
+-		RTE_MBUF_F_TX_IEEE1588_TMST)
++		RTE_MBUF_F_TX_IEEE1588_TMST | \
++    IGC_LAUNCH_TIME_OFFLOAD)
+ 
+ #define IGC_TX_OFFLOAD_SEG	(RTE_MBUF_F_TX_TCP_SEG | RTE_MBUF_F_TX_UDP_SEG)
+ 
+@@ -95,6 +98,129 @@
+ #define IGC_TX_OFFLOAD_NOTSUP_MASK (RTE_MBUF_F_TX_OFFLOAD_MASK ^ IGC_TX_OFFLOAD_MASK)
+ 
+ #define IGC_TS_HDR_LEN 16
++#if 0
++/**
++ * Structure associated with each descriptor of the RX ring of a RX queue.
++ */
++struct igc_rx_entry {
++	struct rte_mbuf *mbuf; /**< mbuf associated with RX descriptor. */
++};
++
++/**
++ * Structure associated with each RX queue.
++ */
++struct igc_rx_queue {
++	struct rte_mempool  *mb_pool;   /**< mbuf pool to populate RX ring. */
++	volatile union igc_adv_rx_desc *rx_ring;
++	/**< RX ring virtual address. */
++	uint64_t            rx_ring_phys_addr; /**< RX ring DMA address. */
++	volatile uint32_t   *rdt_reg_addr; /**< RDT register address. */
++	volatile uint32_t   *rdh_reg_addr; /**< RDH register address. */
++	struct igc_rx_entry *sw_ring;   /**< address of RX software ring. */
++	struct rte_mbuf *pkt_first_seg; /**< First segment of current packet. */
++	struct rte_mbuf *pkt_last_seg;  /**< Last segment of current packet. */
++	uint16_t            nb_rx_desc; /**< number of RX descriptors. */
++	uint16_t            rx_tail;    /**< current value of RDT register. */
++	uint16_t            nb_rx_hold; /**< number of held free RX desc. */
++	uint16_t            rx_free_thresh; /**< max free RX desc to hold. */
++	uint16_t            queue_id;   /**< RX queue index. */
++	uint16_t            reg_idx;    /**< RX queue register index. */
++	uint16_t            port_id;    /**< Device port identifier. */
++	uint8_t             pthresh;    /**< Prefetch threshold register. */
++	uint8_t             hthresh;    /**< Host threshold register. */
++	uint8_t             wthresh;    /**< Write-back threshold register. */
++	uint8_t             crc_len;    /**< 0 if CRC stripped, 4 otherwise. */
++	uint8_t             drop_en;	/**< If not 0, set SRRCTL.Drop_En. */
++	uint32_t            flags;      /**< RX flags. */
++	uint64_t	    offloads;   /**< offloads of RTE_ETH_RX_OFFLOAD_* */
++};
++
++/** Offload features */
++union igc_tx_offload {
++	uint64_t data;
++	struct {
++		uint64_t l3_len:9; /**< L3 (IP) Header Length. */
++		uint64_t l2_len:7; /**< L2 (MAC) Header Length. */
++		uint64_t vlan_tci:16;
++		/**< VLAN Tag Control Identifier(CPU order). */
++		uint64_t l4_len:8; /**< L4 (TCP/UDP) Header Length. */
++		uint64_t tso_segsz:16; /**< TCP TSO segment size. */
++		/* uint64_t unused:8; */
++	};
++};
++#endif
++/*
++ * Compare mask for igc_tx_offload.data,
++ * should be in sync with igc_tx_offload layout.
++ */
++#define TX_MACIP_LEN_CMP_MASK	0x000000000000FFFFULL /**< L2L3 header mask. */
++#define TX_VLAN_CMP_MASK	0x00000000FFFF0000ULL /**< Vlan mask. */
++#define TX_TCP_LEN_CMP_MASK	0x000000FF00000000ULL /**< TCP header mask. */
++#define TX_TSO_MSS_CMP_MASK	0x00FFFF0000000000ULL /**< TSO segsz mask. */
++/** Mac + IP + TCP + Mss mask. */
++#define TX_TSO_CMP_MASK	\
++	(TX_MACIP_LEN_CMP_MASK | TX_TCP_LEN_CMP_MASK | TX_TSO_MSS_CMP_MASK)
++
++/**
++ * Structure to check if new context need be built
++ */
++struct igc_advctx_info {
++	uint64_t flags;           /**< ol_flags related to context build. */
++	/** tx offload: vlan, tso, l2-l3-l4 lengths. */
++	union igc_tx_offload tx_offload;
++	/** compare mask for tx offload. */
++	union igc_tx_offload tx_offload_mask;
++};
++
++/**
++ * Hardware context number
++ */
++enum {
++	IGC_CTX_0    = 0, /**< CTX0    */
++	IGC_CTX_1    = 1, /**< CTX1    */
++	IGC_CTX_NUM  = 2, /**< CTX_NUM */
++};
++
++/**
++ * Structure associated with each descriptor of the TX ring of a TX queue.
++ */
++struct igc_tx_entry {
++	struct rte_mbuf *mbuf; /**< mbuf associated with TX desc, if any. */
++	uint16_t next_id; /**< Index of next descriptor in ring. */
++	uint16_t last_id; /**< Index of last scattered descriptor. */
++};
++
++/**
++ * Structure associated with each TX queue.
++ */
++struct igc_tx_queue {
++	volatile union igc_adv_tx_desc *tx_ring; /**< TX ring address */
++	uint64_t               tx_ring_phys_addr; /**< TX ring DMA address. */
++	struct igc_tx_entry    *sw_ring; /**< virtual address of SW ring. */
++	volatile uint32_t      *tdt_reg_addr; /**< Address of TDT register. */
++	uint32_t               txd_type;      /**< Device-specific TXD type */
++	uint16_t               nb_tx_desc;    /**< number of TX descriptors. */
++	uint16_t               tx_tail;  /**< Current value of TDT register. */
++	uint16_t               tx_head;
++	/**< Index of first used TX descriptor. */
++	uint16_t               queue_id; /**< TX queue index. */
++	uint16_t               reg_idx;  /**< TX queue register index. */
++	uint16_t               port_id;  /**< Device port identifier. */
++	uint8_t                pthresh;  /**< Prefetch threshold register. */
++	uint8_t                hthresh;  /**< Host threshold register. */
++	uint8_t                wthresh;  /**< Write-back threshold register. */
++	uint8_t                ctx_curr;
++
++	/**< Start context position for transmit queue. */
++	struct igc_advctx_info ctx_cache[IGC_CTX_NUM];
++	/**< Hardware context history.*/
++	uint64_t	       offloads; /**< offloads of RTE_ETH_TX_OFFLOAD_* */
++	uint32_t	       start_time;
++	uint32_t	       end_time;
++  struct rte_eth_dev *dev;
++	uint64_t last_tx_cycle;          /* end of the cycle with a launchtime transmission */
++	uint64_t last_ff_cycle;          /* Last cycle with an active first flag */
++};
+ 
+ static inline uint64_t
+ rx_desc_statuserr_to_pkt_flags(uint32_t statuserr)
+@@ -225,12 +351,11 @@ rx_desc_get_pkt_info(struct igc_rx_queue *rxq, struct rte_mbuf *rxm,
+ 
+ 	pkt_flags |= rx_desc_statuserr_to_pkt_flags(staterr);
+ 
+-	if (rxq->offloads & RTE_ETH_RX_OFFLOAD_TIMESTAMP)
+-		pkt_flags |= RTE_MBUF_F_RX_IEEE1588_PTP;
+-
+ 	rxm->ol_flags = pkt_flags;
+ 	pkt_info = rte_le_to_cpu_16(rxd->wb.lower.lo_dword.hs_rss.pkt_info);
+ 	rxm->packet_type = rx_desc_pkt_info_to_pkt_type(pkt_info);
++
++	rxm->ol_flags |= RTE_MBUF_F_RX_IEEE1588_PTP;
+ }
+ 
+ uint16_t
+@@ -334,15 +459,13 @@ igc_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts, uint16_t nb_pkts)
+ 		rxm = rxe->mbuf;
+ 		rxe->mbuf = nmb;
+ 		rxdp->read.hdr_addr = 0;
+-
+-		if (rxq->offloads & RTE_ETH_RX_OFFLOAD_TIMESTAMP)
++		if (rxq->offloads == RTE_ETH_RX_OFFLOAD_TIMESTAMP)
+ 			rxdp->read.pkt_addr =
+-			rte_cpu_to_le_64(rte_mbuf_data_iova_default(nmb)) -
+-			IGC_TS_HDR_LEN;
++				rte_cpu_to_le_64(rte_mbuf_data_iova_default(nmb)) -
++				IGC_TS_HDR_LEN;
+ 		else
+ 			rxdp->read.pkt_addr =
+-			rte_cpu_to_le_64(rte_mbuf_data_iova_default(nmb));
+-
++				rte_cpu_to_le_64(rte_mbuf_data_iova_default(nmb));
+ 		rxm->next = NULL;
+ 
+ 		rxm->data_off = RTE_PKTMBUF_HEADROOM;
+@@ -353,13 +476,9 @@ igc_recv_pkts(void *rx_queue, struct rte_mbuf **rx_pkts, uint16_t nb_pkts)
+ 
+ 		rx_desc_get_pkt_info(rxq, rxm, &rxd, staterr);
+ 
+-		if (rxq->offloads & RTE_ETH_RX_OFFLOAD_TIMESTAMP) {
+-			uint32_t *ts = rte_pktmbuf_mtod_offset(rxm,
+-					uint32_t *, -IGC_TS_HDR_LEN);
+-			rxq->rx_timestamp = (uint64_t)ts[3] * NSEC_PER_SEC +
+-					ts[2];
+-			rxm->timesync = rxq->queue_id;
+-		}
++		uint32_t *ts = rte_pktmbuf_mtod_offset(rxm, uint32_t *, -IGC_TS_HDR_LEN);
++		uint64_t time = (uint64_t)ts[3] * 1000000000 + ts[2];
++		rx_timestamp = time;
+ 
+ 		/*
+ 		 * Store the mbuf address into the next entry of the array
+@@ -493,15 +612,8 @@ igc_recv_scattered_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 		rxm = rxe->mbuf;
+ 		rxe->mbuf = nmb;
+ 		rxdp->read.hdr_addr = 0;
+-
+-		if (rxq->offloads & RTE_ETH_RX_OFFLOAD_TIMESTAMP)
+-			rxdp->read.pkt_addr =
+-			rte_cpu_to_le_64(rte_mbuf_data_iova_default(nmb)) -
+-				IGC_TS_HDR_LEN;
+-		else
+-			rxdp->read.pkt_addr =
++		rxdp->read.pkt_addr =
+ 			rte_cpu_to_le_64(rte_mbuf_data_iova_default(nmb));
+-
+ 		rxm->next = NULL;
+ 
+ 		/*
+@@ -565,14 +677,6 @@ igc_recv_scattered_pkts(void *rx_queue, struct rte_mbuf **rx_pkts,
+ 
+ 		rx_desc_get_pkt_info(rxq, first_seg, &rxd, staterr);
+ 
+-		if (rxq->offloads & RTE_ETH_RX_OFFLOAD_TIMESTAMP) {
+-			uint32_t *ts = rte_pktmbuf_mtod_offset(first_seg,
+-					uint32_t *, -IGC_TS_HDR_LEN);
+-			rxq->rx_timestamp = (uint64_t)ts[3] * NSEC_PER_SEC +
+-					ts[2];
+-			rxm->timesync = rxq->queue_id;
+-		}
+-
+ 		/*
+ 		 * Store the mbuf address into the next entry of the array
+ 		 * of returned packets.
+@@ -1411,17 +1515,52 @@ what_advctx_update(struct igc_tx_queue *txq, uint64_t flags,
+ 	return IGC_CTX_NUM;
+ }
+ 
+-static uint32_t igc_tx_launchtime(uint64_t txtime, uint16_t port_id)
++static int32_t igc_tx_launchtime(struct igc_tx_queue *txq, uint64_t txtime,
++                                  bool *first_flag, bool *insert_empty,
++                                  uint64_t *last_ff_cycle,
++                                  uint64_t *last_tx_cycle,
++                                  bool *early_deadline)
+ {
+-	struct rte_eth_dev *dev = &rte_eth_devices[port_id];
+-	struct igc_adapter *adapter = IGC_DEV_PRIVATE(dev);
+-	uint64_t base_time = adapter->base_time;
+-	uint64_t cycle_time = adapter->cycle_time;
+-	uint32_t launchtime;
+-
+-	launchtime = (txtime - base_time) % cycle_time;
+-
+-	return rte_cpu_to_le_32(launchtime);
++	int32_t launchtime;
++  uint64_t n, now, base_est, end_of_cycle;
++  struct timespec now_ts;
++
++  struct igc_adapter *adapter = IGC_DEV_PRIVATE(txq->dev);
++  uint64_t base_time = adapter->base_time;
++  uint64_t cycle_time = adapter->cycle_time;
++
++  clock_gettime(CLOCK_REALTIME, &now_ts);
++  now = now_ts.tv_sec*NSEC_PER_SEC+now_ts.tv_nsec;
++
++  *early_deadline = (now + 600000 < txtime);
++  if (*early_deadline)
++    return 0;
++
++  n = (now - base_time) / cycle_time;
++  base_est = base_time + cycle_time * n;
++  end_of_cycle = base_est + cycle_time;
++
++  if (txtime >= end_of_cycle) {
++    if (base_est != *last_ff_cycle) {
++      *first_flag = true;
++      *last_ff_cycle = base_est;
++      if (txtime > *last_tx_cycle) {
++        *insert_empty = true;
++      }
++    }
++  }
++
++  *last_tx_cycle = end_of_cycle;
++  launchtime = txtime - base_est;
++
++  if (launchtime > 0) {
++    launchtime = launchtime % cycle_time;
++  }
++  else {
++    launchtime = 0;
++  }
++
++	return launchtime;
+ }
+ 
+ /*
+@@ -1432,7 +1571,7 @@ static inline void
+ igc_set_xmit_ctx(struct igc_tx_queue *txq,
+ 		volatile struct igc_adv_tx_context_desc *ctx_txd,
+ 		uint64_t ol_flags, union igc_tx_offload tx_offload,
+-		uint64_t txtime)
++		int32_t launch_time, bool first_flag)
+ {
+ 	uint32_t type_tucmd_mlhl;
+ 	uint32_t mss_l4len_idx;
+@@ -1506,23 +1645,25 @@ igc_set_xmit_ctx(struct igc_tx_queue *txq,
+ 		}
+ 	}
+ 
+-	if (!txtime) {
+-		txq->ctx_cache[ctx_curr].flags = ol_flags;
+-		txq->ctx_cache[ctx_curr].tx_offload.data =
+-			tx_offload_mask.data & tx_offload.data;
+-		txq->ctx_cache[ctx_curr].tx_offload_mask = tx_offload_mask;
++#if 0
++	txq->ctx_cache[ctx_curr].flags = ol_flags;
++	txq->ctx_cache[ctx_curr].tx_offload.data =
++		tx_offload_mask.data & tx_offload.data;
++	txq->ctx_cache[ctx_curr].tx_offload_mask = tx_offload_mask;
++#endif
++	if (igc_timestamp_dynflag > 0 && (ol_flags & IGC_LAUNCH_TIME_OFFLOAD)) {
++		ctx_txd->u.launch_time = rte_cpu_to_le_32(launch_time);
++    type_tucmd_mlhl |= IGC_ADVTXD_DTYP_CTXT | IGC_ADVTXD_DCMD_DEXT;
++    if (first_flag)
++      mss_l4len_idx |= IGC_ADVTXD_TSN_CNTX_FIRST;
++	} else {
++		ctx_txd->u.launch_time = 0;
+ 	}
+ 
+ 	ctx_txd->type_tucmd_mlhl = rte_cpu_to_le_32(type_tucmd_mlhl);
+ 	vlan_macip_lens = (uint32_t)tx_offload.data;
+ 	ctx_txd->vlan_macip_lens = rte_cpu_to_le_32(vlan_macip_lens);
+ 	ctx_txd->mss_l4len_idx = rte_cpu_to_le_32(mss_l4len_idx);
+-
+-	if (txtime)
+-		ctx_txd->u.launch_time = igc_tx_launchtime(txtime,
+-							   txq->port_id);
+-	else
+-		ctx_txd->u.launch_time = 0;
+ }
+ 
+ static inline uint32_t
+@@ -1570,7 +1711,6 @@ igc_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
+ 	uint16_t tx_last;
+ 	uint16_t nb_tx;
+ 	uint64_t tx_ol_req;
+-	uint32_t new_ctx = 0;
+ 	union igc_tx_offload tx_offload = {0};
+ 	uint64_t ts;
+ 
+@@ -1583,6 +1723,97 @@ igc_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
+ 
+ 		RTE_MBUF_PREFETCH_TO_FREE(txe->mbuf);
+ 
++		ol_flags = tx_pkt->ol_flags;
++		tx_ol_req = ol_flags & IGC_TX_OFFLOAD_MASK;
++
++    ts = 0;
++    bool first_flag = false;
++    bool insert_empty = false;
++    bool early_deadline = false;
++    int32_t launch_time = 0;
++    uint64_t last_ff_cycle = txq->last_ff_cycle;
++    uint64_t last_tx_cycle = txq->last_tx_cycle;
++    if (igc_timestamp_dynflag > 0 && (tx_ol_req & IGC_LAUNCH_TIME_OFFLOAD)) {
++      ts = *RTE_MBUF_DYNFIELD(tx_pkt,
++        igc_timestamp_dynfield_offset,
++        uint64_t *);
++
++      launch_time = igc_tx_launchtime(txq, ts, &first_flag, &insert_empty,
++                                      &last_ff_cycle, &last_tx_cycle, &early_deadline);
++
++      if (early_deadline) {
++        if (nb_tx == 0)
++          return 0;
++        goto end_of_tx;
++      }
++
++      if (insert_empty) {
++        /* FIX-ME: sending the empty packet.*/
++        /*
++        struct rte_mbuf * empty = rte_pktmbuf_alloc(tx_pkt->pool);
++        struct rte_ether_hdr *empty_frame = rte_pktmbuf_mtod(empty, struct rte_ether_hdr *);
++        memset(empty_frame, 0, IGC_EMPTY_FRAME_SIZE);
++        empty->pkt_len = IGC_EMPTY_FRAME_SIZE;
++        empty->data_len = IGC_EMPTY_FRAME_SIZE;
++
++        volatile struct igc_adv_tx_context_desc *
++          empty_ctx = (volatile struct igc_adv_tx_context_desc *)&txr[tx_id];
++
++        tx_last = (uint16_t)(tx_id + 1);
++        if (tx_last >= txq->nb_tx_desc)
++          tx_last = (uint16_t)(tx_last - txq->nb_tx_desc);
++
++        tx_end = sw_ring[tx_last].last_id;
++        tx_end = sw_ring[tx_end].next_id;
++        tx_end = sw_ring[tx_end].last_id;
++        if (!(txr[tx_end].wb.status & IGC_TXD_STAT_DD)) {
++          if (nb_tx == 0)
++            return 0;
++          goto end_of_tx;
++        }
++
++        txn = &sw_ring[txe->next_id];
++        RTE_MBUF_PREFETCH_TO_FREE(txn->mbuf);
++
++        if (txe->mbuf != NULL) {
++          rte_pktmbuf_free_seg(txe->mbuf);
++          txe->mbuf = NULL;
++        }
++
++        empty_ctx->type_tucmd_mlhl = rte_cpu_to_le_32(IGC_TXD_CMD_DEXT | IGC_ADVTXD_DTYP_CTXT);
++        empty_ctx->vlan_macip_lens = 0;
++        empty_ctx->mss_l4len_idx = 0;
++        empty_ctx->u.launch_time = 0;
++
++        txe->last_id = tx_last;
++        tx_id = txe->next_id;
++        txe = txn;
++
++        txn = &sw_ring[txe->next_id];
++        RTE_MBUF_PREFETCH_TO_FREE(txn->mbuf);
++        txd = &txr[tx_id];
++
++        if (txe->mbuf != NULL)
++          rte_pktmbuf_free_seg(txe->mbuf);
++        txe->mbuf = empty;
++
++        slen = (uint16_t)empty->data_len;
++        buf_dma_addr = rte_mbuf_data_iova(empty);
++        txd->read.buffer_addr =
++          rte_cpu_to_le_64(buf_dma_addr);
++        txd->read.cmd_type_len =
++          rte_cpu_to_le_32(IGC_ADVTXD_DTYP_DATA | IGC_ADVTXD_DCMD_DEXT |
++                            IGC_ADVTXD_DCMD_IFCS |
++                            (IGC_TXD_CMD_RS | IGC_TXD_CMD_EOP) | slen);
++        txd->read.olinfo_status =
++          rte_cpu_to_le_32(slen << IGC_ADVTXD_PAYLEN_SHIFT);
++        txe->last_id = tx_last;
++        tx_id = txe->next_id;
++        txe = txn;
++        */
++      }
++    }
++
+ 		/*
+ 		 * The number of descriptors that must be allocated for a
+ 		 * packet is the number of segments of that packet, plus 1
+@@ -1593,9 +1824,6 @@ igc_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
+ 		 */
+ 		tx_last = (uint16_t)(tx_id + tx_pkt->nb_segs - 1);
+ 
+-		ol_flags = tx_pkt->ol_flags;
+-		tx_ol_req = ol_flags & IGC_TX_OFFLOAD_MASK;
+-
+ 		/* If a Context Descriptor need be built . */
+ 		if (tx_ol_req) {
+ 			tx_offload.l2_len = tx_pkt->l2_len;
+@@ -1604,12 +1832,7 @@ igc_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
+ 			tx_offload.vlan_tci = tx_pkt->vlan_tci;
+ 			tx_offload.tso_segsz = tx_pkt->tso_segsz;
+ 			tx_ol_req = check_tso_para(tx_ol_req, tx_offload);
+-
+-			new_ctx = what_advctx_update(txq, tx_ol_req,
+-					tx_offload);
+-			/* Only allocate context descriptor if required*/
+-			new_ctx = (new_ctx >= IGC_CTX_NUM);
+-			tx_last = (uint16_t)(tx_last + new_ctx);
++			tx_last = (uint16_t)(tx_last + 1);
+ 		}
+ 		if (tx_last >= txq->nb_tx_desc)
+ 			tx_last = (uint16_t)(tx_last - txq->nb_tx_desc);
+@@ -1664,11 +1887,24 @@ igc_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
+ 		/*
+ 		 * Check that this descriptor is free.
+ 		 */
+-		if (!(txr[tx_end].wb.status & IGC_TXD_STAT_DD)) {
+-			if (nb_tx == 0)
+-				return 0;
+-			goto end_of_tx;
+-		}
++
++
++
++
++
++
++
++
++
++      if (!(txr[tx_end].wb.status & rte_cpu_to_le_32(IGC_TXD_STAT_DD))) {
++        if (nb_tx == 0)
++          return 0;
++        goto end_of_tx;
++      }
++
++
++    txq->last_ff_cycle = last_ff_cycle;
++    txq->last_tx_cycle = last_tx_cycle;
+ 
+ 		/*
+ 		 * Set common flags of all TX Data Descriptors.
+@@ -1706,35 +1942,25 @@ igc_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
+ 			cmd_type_len |= IGC_ADVTXD_MAC_TSTAMP;
+ 
+ 		if (tx_ol_req) {
+-			/* Setup TX Advanced context descriptor if required */
+-			if (new_ctx) {
+-				volatile struct igc_adv_tx_context_desc *
+-					ctx_txd = (volatile struct
+-					igc_adv_tx_context_desc *)&txr[tx_id];
+-
+-				txn = &sw_ring[txe->next_id];
+-				RTE_MBUF_PREFETCH_TO_FREE(txn->mbuf);
+-
+-				if (txe->mbuf != NULL) {
+-					rte_pktmbuf_free_seg(txe->mbuf);
+-					txe->mbuf = NULL;
+-				}
+-
+-				if (igc_tx_timestamp_dynflag > 0) {
+-					ts = *RTE_MBUF_DYNFIELD(tx_pkt,
+-						igc_tx_timestamp_dynfield_offset,
+-						uint64_t *);
+-					igc_set_xmit_ctx(txq, ctx_txd,
+-						tx_ol_req, tx_offload, ts);
+-				} else {
+-					igc_set_xmit_ctx(txq, ctx_txd,
+-						tx_ol_req, tx_offload, 0);
+-				}
+-
+-				txe->last_id = tx_last;
+-				tx_id = txe->next_id;
+-				txe = txn;
+-			}
++      /* Setup TX Advanced context descriptor if required */
++      volatile struct igc_adv_tx_context_desc *
++        ctx_txd = (volatile struct
++        igc_adv_tx_context_desc *)&txr[tx_id];
++
++      txn = &sw_ring[txe->next_id];
++      RTE_MBUF_PREFETCH_TO_FREE(txn->mbuf);
++
++      if (txe->mbuf != NULL) {
++        rte_pktmbuf_free_seg(txe->mbuf);
++        txe->mbuf = NULL;
++      }
++
++      igc_set_xmit_ctx(txq, ctx_txd, tx_ol_req,
++          tx_offload, launch_time, first_flag);
++
++      txe->last_id = tx_last;
++      tx_id = txe->next_id;
++      txe = txn;
+ 
+ 			/* Setup the TX Advanced Data Descriptor */
+ 			cmd_type_len |=
+@@ -1862,7 +2088,7 @@ igc_reset_tx_queue(struct igc_tx_queue *txq)
+ 	for (i = 0; i < txq->nb_tx_desc; i++) {
+ 		volatile union igc_adv_tx_desc *txd = &txq->tx_ring[i];
+ 
+-		txd->wb.status = IGC_TXD_STAT_DD;
++		txd->wb.status = rte_cpu_to_le_32(IGC_TXD_STAT_DD);
+ 		txe[i].mbuf = NULL;
+ 		txe[i].last_id = i;
+ 		txe[prev].next_id = i;
+@@ -1908,6 +2134,8 @@ int eth_igc_tx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_idx,
+ 	struct igc_tx_queue *txq;
+ 	struct igc_hw *hw;
+ 	uint32_t size;
++	int err;
++	uint64_t offloads;
+ 
+ 	if (nb_desc % IGC_TX_DESCRIPTOR_MULTIPLE != 0 ||
+ 		nb_desc > IGC_MAX_TXD || nb_desc < IGC_MIN_TXD) {
+@@ -1920,6 +2148,8 @@ int eth_igc_tx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_idx,
+ 
+ 	hw = IGC_DEV_PRIVATE_HW(dev);
+ 
++	offloads = tx_conf->offloads | dev->data->dev_conf.txmode.offloads;
++
+ 	/*
+ 	 * The tx_free_thresh and tx_rs_thresh values are not used in the 2.5G
+ 	 * driver.
+@@ -1988,6 +2218,19 @@ int eth_igc_tx_queue_setup(struct rte_eth_dev *dev, uint16_t queue_idx,
+ 	dev->tx_pkt_prepare = &eth_igc_prep_pkts;
+ 	dev->data->tx_queues[queue_idx] = txq;
+ 	txq->offloads = tx_conf->offloads;
++	txq->offloads |= offloads;
++  txq->dev = dev;
++
++	if (txq->offloads & RTE_ETH_TX_OFFLOAD_SEND_ON_TIMESTAMP) {
++		err = rte_mbuf_dyn_tx_timestamp_register(
++				&igc_timestamp_dynfield_offset,
++				&igc_timestamp_dynflag);
++		if (err) {
++			PMD_DRV_LOG(ERR,
++				"Cannot register mbuf field/flag for timestamp");
++			return -EINVAL;
++		}
++	}
+ 
+ 	return 0;
+ }
+@@ -2111,11 +2354,9 @@ void
+ igc_tx_init(struct rte_eth_dev *dev)
+ {
+ 	struct igc_hw *hw = IGC_DEV_PRIVATE_HW(dev);
+-	uint64_t offloads = dev->data->dev_conf.txmode.offloads;
+ 	uint32_t tctl;
+ 	uint32_t txdctl;
+ 	uint16_t i;
+-	int err;
+ 
+ 	/* Setup the Base and Length of the Tx Descriptor Rings. */
+ 	for (i = 0; i < dev->data->nb_tx_queues; i++) {
+@@ -2145,16 +2386,6 @@ igc_tx_init(struct rte_eth_dev *dev)
+ 		IGC_WRITE_REG(hw, IGC_TXDCTL(txq->reg_idx), txdctl);
+ 	}
+ 
+-	if (offloads & RTE_ETH_TX_OFFLOAD_SEND_ON_TIMESTAMP) {
+-		err = rte_mbuf_dyn_tx_timestamp_register
+-			(&igc_tx_timestamp_dynfield_offset,
+-			 &igc_tx_timestamp_dynflag);
+-		if (err) {
+-			PMD_DRV_LOG(ERR,
+-				"Cannot register mbuf field/flag for timestamp");
+-		}
+-	}
+-
+ 	igc_config_collision_dist(hw);
+ 
+ 	/* Program the Transmit Control Register. */
+diff --git a/drivers/net/igc/igc_txrx.h b/drivers/net/igc/igc_txrx.h
+index ad7d3b4ca5..f261043538 100644
+--- a/drivers/net/igc/igc_txrx.h
++++ b/drivers/net/igc/igc_txrx.h
+@@ -11,16 +11,20 @@
+ extern "C" {
+ #endif
+ 
+-extern uint64_t igc_tx_timestamp_dynflag;
+-extern int igc_tx_timestamp_dynfield_offset;
++extern uint64_t igc_timestamp_dynflag;
++extern int igc_timestamp_dynfield_offset;
++extern uint64_t rx_timestamp;
+ 
++/**
++ *  * Structure associated with each descriptor of the RX ring of a RX queue.
++ *   */
+ struct igc_rx_entry {
+ 	struct rte_mbuf *mbuf; /**< mbuf associated with RX descriptor. */
+ };
+ 
+ /**
+- * Structure associated with each RX queue.
+- */
++ *  * Structure associated with each RX queue.
++ *   */
+ struct igc_rx_queue {
+ 	struct rte_mempool  *mb_pool;   /**< mbuf pool to populate RX ring. */
+ 	volatile union igc_adv_rx_desc *rx_ring;
+@@ -42,10 +46,9 @@ struct igc_rx_queue {
+ 	uint8_t             hthresh;    /**< Host threshold register. */
+ 	uint8_t             wthresh;    /**< Write-back threshold register. */
+ 	uint8_t             crc_len;    /**< 0 if CRC stripped, 4 otherwise. */
+-	uint8_t             drop_en;    /**< If not 0, set SRRCTL.Drop_En. */
++	uint8_t             drop_en;	/**< If not 0, set SRRCTL.Drop_En. */
+ 	uint32_t            flags;      /**< RX flags. */
+-	uint64_t            offloads;   /**< offloads of RTE_ETH_RX_OFFLOAD_* */
+-	uint64_t            rx_timestamp;
++	uint64_t	    offloads;   /**< offloads of RTE_ETH_RX_OFFLOAD_* */
+ };
+ 
+ /** Offload features */
+@@ -62,74 +65,6 @@ union igc_tx_offload {
+ 	};
+ };
+ 
+-/**
+- * Compare mask for igc_tx_offload.data,
+- * should be in sync with igc_tx_offload layout.
+- */
+-#define TX_MACIP_LEN_CMP_MASK  0x000000000000FFFFULL /**< L2L3 header mask. */
+-#define TX_VLAN_CMP_MASK       0x00000000FFFF0000ULL /**< Vlan mask. */
+-#define TX_TCP_LEN_CMP_MASK    0x000000FF00000000ULL /**< TCP header mask. */
+-#define TX_TSO_MSS_CMP_MASK    0x00FFFF0000000000ULL /**< TSO segsz mask. */
+-/** Mac + IP + TCP + Mss mask. */
+-#define TX_TSO_CMP_MASK        \
+-	(TX_MACIP_LEN_CMP_MASK | TX_TCP_LEN_CMP_MASK | TX_TSO_MSS_CMP_MASK)
+-
+-/**
+- * Structure to check if new context need be built
+- */
+-struct igc_advctx_info {
+-	uint64_t flags;           /**< ol_flags related to context build. */
+-	/** tx offload: vlan, tso, l2-l3-l4 lengths. */
+-	union igc_tx_offload tx_offload;
+-	/** compare mask for tx offload. */
+-	union igc_tx_offload tx_offload_mask;
+-};
+-
+-/**
+- * Hardware context number
+- */
+-enum {
+-	IGC_CTX_0    = 0, /**< CTX0    */
+-	IGC_CTX_1    = 1, /**< CTX1    */
+-	IGC_CTX_NUM  = 2, /**< CTX_NUM */
+-};
+-
+-/**
+- * Structure associated with each descriptor of the TX ring of a TX queue.
+- */
+-struct igc_tx_entry {
+-	struct rte_mbuf *mbuf; /**< mbuf associated with TX desc, if any. */
+-	uint16_t next_id; /**< Index of next descriptor in ring. */
+-	uint16_t last_id; /**< Index of last scattered descriptor. */
+-};
+-
+-/**
+- * Structure associated with each TX queue.
+- */
+-struct igc_tx_queue {
+-	volatile union igc_adv_tx_desc *tx_ring; /**< TX ring address */
+-	uint64_t               tx_ring_phys_addr; /**< TX ring DMA address. */
+-	struct igc_tx_entry    *sw_ring; /**< virtual address of SW ring. */
+-	volatile uint32_t      *tdt_reg_addr; /**< Address of TDT register. */
+-	uint32_t               txd_type;      /**< Device-specific TXD type */
+-	uint16_t               nb_tx_desc;    /**< number of TX descriptors. */
+-	uint16_t               tx_tail;  /**< Current value of TDT register. */
+-	uint16_t               tx_head;
+-	/**< Index of first used TX descriptor. */
+-	uint16_t               queue_id; /**< TX queue index. */
+-	uint16_t               reg_idx;  /**< TX queue register index. */
+-	uint16_t               port_id;  /**< Device port identifier. */
+-	uint8_t                pthresh;  /**< Prefetch threshold register. */
+-	uint8_t                hthresh;  /**< Host threshold register. */
+-	uint8_t                wthresh;  /**< Write-back threshold register. */
+-	uint8_t                ctx_curr;
+-
+-	/**< Start context position for transmit queue. */
+-	struct igc_advctx_info ctx_cache[IGC_CTX_NUM];
+-	/**< Hardware context history.*/
+-	uint64_t               offloads; /**< offloads of RTE_ETH_TX_OFFLOAD_* */
+-};
+-
+ /*
+  * RX/TX function prototypes
+  */
+diff --git a/lib/ethdev/ethdev_driver.h b/lib/ethdev/ethdev_driver.h
+index 2c9d615fb5..ee0393fd2a 100644
+--- a/lib/ethdev/ethdev_driver.h
++++ b/lib/ethdev/ethdev_driver.h
+@@ -633,6 +633,9 @@ typedef int (*eth_timesync_read_tx_timestamp_t)(struct rte_eth_dev *dev,
+ /** @internal Function used to adjust the device clock. */
+ typedef int (*eth_timesync_adjust_time)(struct rte_eth_dev *dev, int64_t);
+ 
++/** @internal Function used to adjust the clock frequency. */
++typedef int (*eth_timesync_adjust_freq)(struct rte_eth_dev *dev, int64_t);
++
+ /** @internal Function used to get time from the device clock. */
+ typedef int (*eth_timesync_read_time)(struct rte_eth_dev *dev,
+ 				      struct timespec *timestamp);
+@@ -1346,6 +1349,8 @@ struct eth_dev_ops {
+ 	eth_timesync_adjust_time   timesync_adjust_time;
+ 	/** Get the device clock time */
+ 	eth_timesync_read_time     timesync_read_time;
++	/** Adjust the clock frequency */
++	eth_timesync_adjust_freq   timesync_adjust_freq;
+ 	/** Set the device clock time */
+ 	eth_timesync_write_time    timesync_write_time;
+ 
+diff --git a/lib/ethdev/ethdev_trace.h b/lib/ethdev/ethdev_trace.h
+index 3dc7d028b8..810904dec0 100644
+--- a/lib/ethdev/ethdev_trace.h
++++ b/lib/ethdev/ethdev_trace.h
+@@ -2196,6 +2196,14 @@ RTE_TRACE_POINT_FP(
+ 	rte_trace_point_emit_int(ret);
+ )
+ 
++RTE_TRACE_POINT_FP(
++	rte_eth_trace_timesync_adjust_freq,
++	RTE_TRACE_POINT_ARGS(uint16_t port_id, int64_t ppm, int ret),
++	rte_trace_point_emit_u16(port_id);
++	rte_trace_point_emit_i64(ppm);
++	rte_trace_point_emit_int(ret);
++)
++
+ /* Called in loop in app/test-flow-perf */
+ RTE_TRACE_POINT_FP(
+ 	rte_flow_trace_create,
+diff --git a/lib/ethdev/ethdev_trace_points.c b/lib/ethdev/ethdev_trace_points.c
+index 61010cae56..c01b5d30c0 100644
+--- a/lib/ethdev/ethdev_trace_points.c
++++ b/lib/ethdev/ethdev_trace_points.c
+@@ -406,6 +406,9 @@ RTE_TRACE_POINT_REGISTER(rte_eth_trace_timesync_read_tx_timestamp,
+ RTE_TRACE_POINT_REGISTER(rte_eth_trace_timesync_adjust_time,
+ 	lib.ethdev.timesync_adjust_time)
+ 
++RTE_TRACE_POINT_REGISTER(rte_eth_trace_timesync_adjust_freq,
++	lib.ethdev.timesync_adjust_freq)
++
+ RTE_TRACE_POINT_REGISTER(rte_eth_trace_timesync_read_time,
+ 	lib.ethdev.timesync_read_time)
+ 
+diff --git a/lib/ethdev/rte_ethdev.c b/lib/ethdev/rte_ethdev.c
+index 4d03255683..2ae0dfed53 100644
+--- a/lib/ethdev/rte_ethdev.c
++++ b/lib/ethdev/rte_ethdev.c
+@@ -6016,6 +6016,25 @@ rte_eth_timesync_adjust_time(uint16_t port_id, int64_t delta)
+ 	return ret;
+ }
+ 
++int
++rte_eth_timesync_adjust_freq(uint16_t port_id, int64_t ppm)
++{
++	struct rte_eth_dev *dev;
++	int ret;
++
++	RTE_ETH_VALID_PORTID_OR_ERR_RET(port_id, -ENODEV);
++	dev = &rte_eth_devices[port_id];
++	
++	if (*dev->dev_ops->timesync_adjust_freq == NULL)
++		return -ENOTSUP;
++
++	ret = eth_err(port_id, (*dev->dev_ops->timesync_adjust_freq)(dev, ppm));
++	
++	rte_eth_trace_timesync_adjust_freq(port_id, ppm, ret);
++	
++	return ret;
++}
++
+ int
+ rte_eth_timesync_read_time(uint16_t port_id, struct timespec *timestamp)
+ {
+diff --git a/lib/ethdev/rte_ethdev.h b/lib/ethdev/rte_ethdev.h
+index 99fe9e238b..9fb7d51488 100644
+--- a/lib/ethdev/rte_ethdev.h
++++ b/lib/ethdev/rte_ethdev.h
+@@ -5101,6 +5101,25 @@ int rte_eth_timesync_read_tx_timestamp(uint16_t port_id,
+  */
+ int rte_eth_timesync_adjust_time(uint16_t port_id, int64_t delta);
+ 
++/**
++ * Adjust the clock increment rate on an Ethernet device.
++ *
++ * This is usually used in conjunction with other Ethdev timesync functions to
++ * synchronize the device time using the IEEE1588/802.1AS protocol.
++ *
++ * @param port_id
++ *   The port identifier of the Ethernet device.
++ * @param ppm
++ *   Parts per million with 16-bit fractional field
++ *
++ * @return
++ *   - 0: Success.
++ *   - -ENODEV: The port ID is invalid.
++ *   - -EIO: if device is removed.
++ *   - -ENOTSUP: The function is not supported by the Ethernet driver.
++ */
++int rte_eth_timesync_adjust_freq(uint16_t port_id, int64_t ppm);
++
+ /**
+  * Read the time from the timesync clock on an Ethernet device.
+  *
+diff --git a/lib/ethdev/version.map b/lib/ethdev/version.map
+index 357d1a88c0..4434a57c2f 100644
+--- a/lib/ethdev/version.map
++++ b/lib/ethdev/version.map
+@@ -106,6 +106,7 @@ DPDK_23 {
+ 	rte_eth_stats_get;
+ 	rte_eth_stats_reset;
+ 	rte_eth_timesync_adjust_time;
++	rte_eth_timesync_adjust_freq;
+ 	rte_eth_timesync_disable;
+ 	rte_eth_timesync_enable;
+ 	rte_eth_timesync_read_rx_timestamp;
+-- 
+2.25.1
+


### PR DESCRIPTION
1. Optimize LaunchTime Tx feature based on section 3.3.2.9.3.4 of doc#682924 rev-1.4.2 requirement.

2. Configurate Qbv scheduler to isolate the video traffic and others traffic. The cycle time of the scheduler is the frame cycle time of 50fps. According SMPTE 2110-21 standard, the video packets transmission will end at the 784us from the end of cycle. The queue 0 is for video packets transmission. The other queues is for others traffic. So, the queue 0 is opened during the whole cycle, and the other queues is opened at the 784us from the end of cycle.

3. Optimize time sync precision by adding clock freqency adjustment.

4. Fix remote ptp4l NOT receiving DELAY_REQ message while send PTP message over UDP.