### PR TITLE
lib/mutex: default enable PTHREAD_PROCESS_SHARED

### DIFF
--- a/lib/src/mt_platform.h
+++ b/lib/src/mt_platform.h
@@ -71,7 +71,9 @@ typedef unsigned long int nfds_t;
 #define MT_FLOCK_PATH "/tmp/kahawai_lcore.lock"
 #endif
 
+#ifndef WINDOWSENV
 #define MT_ENABLE_P_SHARED /* default enable PTHREAD_PROCESS_SHARED */
+#endif
 
 static inline int mt_pthread_mutex_init(pthread_mutex_t* mutex,
                                         pthread_mutexattr_t* p_attr) {

--- a/lib/src/mt_platform.h
+++ b/lib/src/mt_platform.h
@@ -71,13 +71,30 @@ typedef unsigned long int nfds_t;
 #define MT_FLOCK_PATH "/tmp/kahawai_lcore.lock"
 #endif
 
+#define MT_ENABLE_P_SHARED /* default enable PTHREAD_PROCESS_SHARED */
+
 static inline int mt_pthread_mutex_init(pthread_mutex_t* mutex,
-                                        pthread_mutexattr_t* attr) {
-  return pthread_mutex_init(mutex, attr);
+                                        pthread_mutexattr_t* p_attr) {
+#ifdef MT_ENABLE_P_SHARED
+  if (p_attr) {
+    pthread_mutexattr_setpshared(p_attr, PTHREAD_PROCESS_SHARED);
+  } else {
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+    p_attr = &attr;
+  }
+#endif
+
+  return pthread_mutex_init(mutex, p_attr);
 }
 
 static inline int mt_pthread_mutex_lock(pthread_mutex_t* mutex) {
   return pthread_mutex_lock(mutex);
+}
+
+static inline int mt_pthread_mutex_try_lock(pthread_mutex_t* mutex) {
+  return pthread_mutex_trylock(mutex);
 }
 
 static inline int mt_pthread_mutex_unlock(pthread_mutex_t* mutex) {

--- a/lib/src/mt_rss.c
+++ b/lib/src/mt_rss.c
@@ -198,7 +198,7 @@ uint16_t mt_rss_burst(struct mt_rss_entry* entry, uint16_t nb_pkts) {
   struct mt_udp_hdr* hdr;
   struct rte_ipv4_hdr* ipv4;
 
-  mt_pthread_mutex_lock(&rss_queue->mutex);
+  if (0 != mt_pthread_mutex_try_lock(&rss_queue->mutex)) return 0;
   rx = rte_eth_rx_burst(rss_queue->port_id, q, pkts, nb_pkts);
   if (rx) dbg("%s(%u), rx pkts %u\n", __func__, q, rx);
   int rss_pkts_nb = 0;

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -178,7 +178,7 @@ uint16_t mt_rsq_burst(struct mt_rsq_entry* entry, uint16_t nb_pkts) {
   struct mt_udp_hdr* hdr;
   struct rte_udp_hdr* udp;
 
-  mt_pthread_mutex_lock(&rsq_queue->mutex);
+  if (0 != mt_pthread_mutex_try_lock(&rsq_queue->mutex)) return 0;
   rx = rte_eth_rx_burst(rsq_queue->port_id, q, pkts, nb_pkts);
   if (rx) dbg("%s(%u), rx pkts %u\n", __func__, q, rx);
   rsq_queue->stat_pkts_recv += rx;

--- a/lib/src/mt_stat.c
+++ b/lib/src/mt_stat.c
@@ -24,7 +24,8 @@ int mt_stat_dump(struct mtl_main_impl* impl) {
 
 int mt_stat_register(struct mtl_main_impl* impl, mt_stat_cb_t cb, void* priv) {
   struct mt_stat_mgr* mgr = get_stat_mgr(impl);
-  struct mt_stat_item* item = mt_zmalloc(sizeof(*item));
+  struct mt_stat_item* item =
+      mt_rte_zmalloc_socket(sizeof(*item), mt_socket_id(impl, MTL_PORT_P));
   if (!item) {
     err("%s, malloc fail\n", __func__);
     return -ENOMEM;
@@ -51,7 +52,7 @@ int mt_stat_unregister(struct mtl_main_impl* impl, mt_stat_cb_t cb, void* priv) 
       /* found the matched item, remove it */
       MT_TAILQ_REMOVE(&mgr->head, item, next);
       mt_pthread_mutex_unlock(&mgr->mutex);
-      mt_free(item);
+      mt_rte_free(item);
       dbg("%s, succ, priv %p\n", __func__, priv);
       return 0;
     }

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -592,7 +592,7 @@ int st_frame_trans_uinit(struct st_frame_trans* frame) {
   frame->iova = 0;
 
   if (frame->page_table) {
-    mt_free(frame->page_table);
+    mt_rte_free(frame->page_table);
     frame->page_table = NULL;
     frame->page_table_len = 0;
   }

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -726,7 +726,8 @@ static rte_iova_t rv_frame_get_offset_iova(struct st_rx_video_session_impl* s,
   return MTL_BAD_IOVA;
 }
 
-static int rv_frame_create_page_table(struct st_rx_video_session_impl* s,
+static int rv_frame_create_page_table(struct mtl_main_impl* impl,
+                                      struct st_rx_video_session_impl* s,
                                       struct st_frame_trans* frame_info) {
   struct rte_memseg* mseg = rte_mem_virt2memseg(frame_info->addr, NULL);
   if (mseg == NULL) {
@@ -743,7 +744,9 @@ static int rv_frame_create_page_table(struct st_rx_video_session_impl* s,
                    RTE_PTR_ALIGN_FLOOR(frame_info->addr, hugepage_sz)) /
       hugepage_sz;
 
-  struct st_page_info* pages = mt_zmalloc(sizeof(*pages) * num_pages);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
+  int soc_id = mt_socket_id(impl, port);
+  struct st_page_info* pages = mt_rte_zmalloc_socket(sizeof(*pages) * num_pages, soc_id);
   if (pages == NULL) {
     err("%s(%d,%d), pages info malloc fail\n", __func__, s->idx, frame_info->idx);
     return -ENOMEM;
@@ -784,6 +787,7 @@ static int rv_alloc_frames(struct mtl_main_impl* impl,
   size_t size = s->st20_uframe_size ? s->st20_uframe_size : s->st20_fb_size;
   struct st_frame_trans* st20_frame;
   void* frame;
+  int ret;
 
   s->st20_frames =
       mt_rte_zmalloc_socket(sizeof(*s->st20_frames) * s->st20_frames_cnt, soc_id);
@@ -799,7 +803,7 @@ static int rv_alloc_frames(struct mtl_main_impl* impl,
   }
 
   if (rv_is_hdr_split(s)) {
-    int ret = rv_init_hdr_split_frame(impl, s);
+    ret = rv_init_hdr_split_frame(impl, s);
     if (ret < 0) {
       rv_free_frames(s);
       return ret;
@@ -845,8 +849,13 @@ static int rv_alloc_frames(struct mtl_main_impl* impl,
       st20_frame->flags = ST_FT_FLAG_RTE_MALLOC;
       st20_frame->addr = frame;
       st20_frame->iova = rte_malloc_virt2iova(frame);
-      if (impl->iova_mode == RTE_IOVA_PA && s->dma_dev)
-        rv_frame_create_page_table(s, st20_frame);
+      if (impl->iova_mode == RTE_IOVA_PA && s->dma_dev) {
+        ret = rv_frame_create_page_table(impl, s, st20_frame);
+        if (ret < 0) {
+          rv_free_frames(s);
+          return ret;
+        }
+      }
     }
   }
 

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -450,6 +450,7 @@ static int udp_init_txq(struct mtl_main_impl* impl, struct mudp_impl* s,
   int idx = s->idx;
   uint16_t queue_id;
 
+  dbg("%s(%d), start\n", __func__, idx);
   if (mt_shared_queue(impl, port)) {
     struct mt_tsq_flow flow;
     memset(&flow, 0, sizeof(flow));
@@ -486,6 +487,7 @@ static int udp_init_txq(struct mtl_main_impl* impl, struct mudp_impl* s,
   }
 
   udp_set_flag(s, MUDP_TXQ_ALLOC);
+  dbg("%s(%d), succ\n", __func__, idx);
   return 0;
 }
 
@@ -527,10 +529,32 @@ static int udp_stat_dump(void* priv) {
   int idx = s->idx;
   enum mtl_port port = s->port;
 
-  if (s->stat_pkt_rx) {
-    notice("%s(%d,%d), pkt rx %u deliver %u\n", __func__, port, idx, s->stat_pkt_rx,
-           s->stat_pkt_deliver);
-    s->stat_pkt_rx = 0;
+  if (s->rxq) {
+    notice("%s(%d,%d), rx ring cnt %u\n", __func__, port, idx,
+           rte_ring_count(mur_client_ring(s->rxq)));
+  }
+  if (s->stat_rx_msg_cnt) {
+    notice("%s(%d,%d), rx_msg %u succ %u timeout %u again %u\n", __func__, port, idx,
+           s->stat_rx_msg_cnt, s->stat_rx_msg_succ_cnt, s->stat_rx_msg_timeout_cnt,
+           s->stat_rx_msg_again_cnt);
+    s->stat_rx_msg_cnt = 0;
+    s->stat_rx_msg_succ_cnt = 0;
+    s->stat_rx_msg_timeout_cnt = 0;
+    s->stat_rx_msg_again_cnt = 0;
+  }
+  if (s->stat_poll_cnt) {
+    notice("%s(%d,%d), poll %u succ %u timeout %u query_ret %u\n", __func__, port, idx,
+           s->stat_poll_cnt, s->stat_poll_succ_cnt, s->stat_poll_timeout_cnt,
+           s->stat_poll_query_ret_cnt);
+    s->stat_poll_cnt = 0;
+    s->stat_poll_succ_cnt = 0;
+    s->stat_poll_timeout_cnt = 0;
+    s->stat_poll_query_ret_cnt = 0;
+  }
+  if (s->stat_pkt_dequeue) {
+    notice("%s(%d,%d), pkt dequeue %u deliver %u\n", __func__, port, idx,
+           s->stat_pkt_dequeue, s->stat_pkt_deliver);
+    s->stat_pkt_dequeue = 0;
     s->stat_pkt_deliver = 0;
   }
   if (s->rxq) mur_client_dump(s->rxq);
@@ -887,7 +911,7 @@ static ssize_t udp_rx_dequeue(struct mudp_impl* s, void* buf, size_t len, int fl
   /* dequeue pkt from rx ring */
   ret = rte_ring_sc_dequeue(mur_client_ring(s->rxq), (void**)&pkt);
   if (ret < 0) return ret;
-  s->stat_pkt_rx++;
+  s->stat_pkt_dequeue++;
 
   struct mt_udp_hdr* hdr = rte_pktmbuf_mtod(pkt, struct mt_udp_hdr*);
   struct rte_udp_hdr* udp = &hdr->udp;
@@ -973,6 +997,7 @@ static ssize_t udp_rx_msg_dequeue(struct mudp_impl* s, struct msghdr* msg, int f
   /* dequeue pkt from rx ring */
   ret = rte_ring_sc_dequeue(mur_client_ring(s->rxq), (void**)&pkt);
   if (ret < 0) return ret;
+  s->stat_pkt_dequeue++;
 
   struct mt_udp_hdr* hdr = rte_pktmbuf_mtod(pkt, struct mt_udp_hdr*);
   struct rte_udp_hdr* udp = &hdr->udp;
@@ -1028,10 +1053,15 @@ static ssize_t udp_recvmsg(struct mudp_impl* s, struct msghdr* msg, int flags) {
   uint16_t rx;
   uint64_t start_ts = mt_get_tsc(impl);
 
+  s->stat_rx_msg_cnt++;
+
 dequeue:
   /* msg dequeue pkt from rx ring */
   copied = udp_rx_msg_dequeue(s, msg, flags);
-  if (copied > 0) return copied;
+  if (copied > 0) {
+    s->stat_rx_msg_succ_cnt++;
+    return copied;
+  }
 
   rx = mur_client_rx(s->rxq);
   if (rx) { /* dequeue again as rx succ */
@@ -1040,6 +1070,7 @@ dequeue:
 
   /* return EAGAIN if MSG_DONTWAIT is set */
   if (flags & MSG_DONTWAIT) {
+    s->stat_rx_msg_again_cnt++;
     MUDP_ERR_RET(EAGAIN);
   }
 
@@ -1051,6 +1082,7 @@ dequeue:
     goto dequeue;
   }
 
+  s->stat_rx_msg_timeout_cnt++;
   return udp_rx_ret_timeout(s);
 }
 
@@ -1061,14 +1093,20 @@ static int udp_poll(struct mudp_pollfd* fds, mudp_nfds_t nfds, int timeout,
   uint64_t start_ts = mt_get_tsc(impl);
   int rc;
 
-  dbg("%s(%d), nfds %d\n", __func__, s->idx, nfds);
+  dbg("%s(%d), nfds %d timeout %d\n", __func__, s->idx, (int)nfds, timeout);
+  for (mudp_nfds_t i = 0; i < nfds; i++) {
+    s = fds[i].fd;
+    s->stat_poll_cnt++;
+  }
 
   /* rx from nic firstly if no pending pkt for each fd */
 rx_poll:
   for (mudp_nfds_t i = 0; i < nfds; i++) {
     s = fds[i].fd;
     unsigned int count = rte_ring_count(mur_client_ring(s->rxq));
-    if (!count) mur_client_rx(s->rxq);
+    if (!count) {
+      mur_client_rx(s->rxq);
+    }
   }
 
   /* check the ready fds */
@@ -1079,14 +1117,25 @@ rx_poll:
     if (count > 0) {
       rc++;
       fds[i].revents = POLLIN;
+      s->stat_poll_succ_cnt++;
       dbg("%s(%d), ring count %u\n", __func__, s->idx, count);
     }
   }
-  if (rc > 0) return rc;
+  if (rc > 0) {
+    dbg("%s(%d), rc %d\n", __func__, s->idx, rc);
+    return rc;
+  }
 
   if (query) { /* check if any pending event on the user query callback */
     rc = query(priv);
-    if (rc != 0) return rc;
+    if (rc != 0) {
+      dbg("%s(%d), query rc %d\n", __func__, s->idx, rc);
+      for (mudp_nfds_t i = 0; i < nfds; i++) {
+        s = fds[i].fd;
+        s->stat_poll_query_ret_cnt++;
+      }
+      return rc;
+    }
   }
 
   /* check if timeout */
@@ -1101,6 +1150,7 @@ rx_poll:
   }
 
   dbg("%s(%d), timeout to %d ms\n", __func__, s->idx, timeout);
+  s->stat_poll_timeout_cnt++;
   return 0;
 }
 
@@ -1224,6 +1274,15 @@ int mudp_bind(mudp_handle ut, const struct sockaddr* addr, socklen_t addrlen) {
   if (ret < 0) {
     err("%s(%d), init rxq fail\n", __func__, idx);
     return ret;
+  }
+
+  /* init txq if not */
+  if (!udp_get_flag(s, MUDP_TXQ_ALLOC)) {
+    ret = udp_init_txq(impl, s, addr_in);
+    if (ret < 0) {
+      err("%s(%d), init txq fail\n", __func__, idx);
+      return ret;
+    }
   }
 
   udp_set_flag(s, MUDP_BIND);

--- a/lib/src/udp/udp_main.h
+++ b/lib/src/udp/udp_main.h
@@ -98,8 +98,16 @@ struct mudp_impl {
   uint32_t stat_tx_gso_count;
   uint32_t stat_tx_retry;
 
-  uint32_t stat_pkt_rx;
+  uint32_t stat_pkt_dequeue;
   uint32_t stat_pkt_deliver;
+  uint32_t stat_poll_cnt;
+  uint32_t stat_poll_succ_cnt;
+  uint32_t stat_poll_timeout_cnt;
+  uint32_t stat_poll_query_ret_cnt;
+  uint32_t stat_rx_msg_cnt;
+  uint32_t stat_rx_msg_succ_cnt;
+  uint32_t stat_rx_msg_timeout_cnt;
+  uint32_t stat_rx_msg_again_cnt;
 };
 
 int mudp_verify_socket_args(int domain, int type, int protocol);

--- a/lib/src/udp/udp_rxq.c
+++ b/lib/src/udp/udp_rxq.c
@@ -21,6 +21,12 @@ static inline void urq_mgr_unlock(struct mudp_rxq_mgr* mgr) {
 
 static inline void urq_lock(struct mur_queue* q) { mt_pthread_mutex_lock(&q->mutex); }
 
+/* return true if try lock succ */
+static inline bool urq_try_lock(struct mur_queue* q) {
+  int ret = mt_pthread_mutex_try_lock(&q->mutex);
+  return ret == 0 ? true : false;
+}
+
 static inline void urq_unlock(struct mur_queue* q) { mt_pthread_mutex_unlock(&q->mutex); }
 
 static uint16_t urq_rx_handle(struct mur_queue* q, struct rte_mbuf** pkts,
@@ -57,6 +63,7 @@ static uint16_t urq_rx_handle(struct mur_queue* q, struct rte_mbuf** pkts,
   /* enqueue the valid mbuf */
   if (clients == 1) {
     struct mur_client* c = MT_TAILQ_FIRST(&q->client_head);
+    c->stat_pkt_rx += valid_mbuf_cnt;
     n = rte_ring_sp_enqueue_bulk(c->ring, (void**)&valid_mbuf[0], valid_mbuf_cnt, NULL);
     if (!n) {
       dbg("%s(%d), %u pkts enqueue fail\n", __func__, idx, valid_mbuf_cnt);
@@ -76,16 +83,17 @@ static uint16_t urq_rx_handle(struct mur_queue* q, struct rte_mbuf** pkts,
 
   for (uint16_t i = 0; i < valid_mbuf_cnt; i++) {
     struct rte_mbuf* mbuf = valid_mbuf[i];
-    struct mt_udp_hdr* hdr = rte_pktmbuf_mtod(pkts[i], struct mt_udp_hdr*);
+    struct mt_udp_hdr* hdr = rte_pktmbuf_mtod(mbuf, struct mt_udp_hdr*);
     /* hash with ip and port of both src and dst */
     uint32_t tuple[3];
     rte_memcpy(tuple, &hdr->ipv4.src_addr, sizeof(tuple));
     uint32_t hash = mt_dev_softrss(tuple, 3);
     struct mur_client* c = cs[hash % clients];
-    if (!rte_ring_sp_enqueue(c->ring, mbuf)) {
+    c->stat_pkt_rx++;
+    if (0 != rte_ring_sp_enqueue(c->ring, mbuf)) {
       /* enqueue fail */
       rte_pktmbuf_free(mbuf);
-      c->stat_pkt_rx_enq_fail += 1;
+      c->stat_pkt_rx_enq_fail++;
     }
   }
 
@@ -111,7 +119,7 @@ static uint16_t urq_rx(struct mur_queue* q) {
 
   if (!q->rxq) return 0;
 
-  urq_lock(q);
+  if (!urq_try_lock(q)) return 0;
   uint16_t rx = mt_dev_rx_burst(q->rxq, pkts, rx_burst);
   urq_unlock(q);
 
@@ -482,14 +490,19 @@ int mur_client_put(struct mur_client* c) {
 int mur_client_dump(struct mur_client* c) {
   enum mtl_port port = c->port;
   uint16_t dst_port = c->dst_port;
+  int idx = c->idx;
 
+  if (c->stat_pkt_rx) {
+    notice("%s(%d,%u,%d), pkt rx %u\n", __func__, port, dst_port, idx, c->stat_pkt_rx);
+    c->stat_pkt_rx = 0;
+  }
   if (c->stat_pkt_rx_enq_fail) {
-    warn("%s(%d,%u), pkt rx %u enqueue fail\n", __func__, port, dst_port,
+    warn("%s(%d,%u,%d), pkt rx %u enqueue fail\n", __func__, port, dst_port, idx,
          c->stat_pkt_rx_enq_fail);
     c->stat_pkt_rx_enq_fail = 0;
   }
   if (c->stat_timedwait) {
-    notice("%s(%d,%u), timedwait %u timeout %u\n", __func__, port, dst_port,
+    notice("%s(%d,%u,%d), timedwait %u timeout %u\n", __func__, port, dst_port, idx,
            c->stat_timedwait, c->stat_timedwait_timeout);
     c->stat_timedwait = 0;
     c->stat_timedwait_timeout = 0;

--- a/lib/src/udp/udp_rxq.h
+++ b/lib/src/udp/udp_rxq.h
@@ -36,6 +36,7 @@ struct mur_client {
 
   uint32_t stat_timedwait;
   uint32_t stat_timedwait_timeout;
+  uint32_t stat_pkt_rx;
   uint32_t stat_pkt_rx_enq_fail;
 
   /* linked list for reuse port */

--- a/lib/src/udp/ufd_main.h
+++ b/lib/src/udp/ufd_main.h
@@ -25,6 +25,7 @@ struct ufd_slot {
 struct ufd_mt_ctx {
   struct mufd_init_params init_params;
   struct mtl_main_impl* mt;
+  bool alloc_with_rte;
 
   int slot_last_idx;
   struct ufd_slot** slots;    /* slots with init_params.slots_nb_max */


### PR DESCRIPTION
prepare for udp stack multi-process support, also memory should use rte_malloc which is shared between process.