### PR TITLE
st/video: use memzone for frame alloc in pa mode

### DIFF
--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -591,12 +591,6 @@ int st_frame_trans_uinit(struct st_frame_trans* frame) {
   }
   frame->iova = 0;
 
-  if (frame->page_table) {
-    mt_rte_free(frame->page_table);
-    frame->page_table = NULL;
-    frame->page_table_len = 0;
-  }
-
   return 0;
 }
 

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -106,6 +106,8 @@ struct st_rx_muf_priv_data {
 #define ST_FT_FLAG_RTE_MALLOC (MTL_BIT32(0))
 /* ext frame by application */
 #define ST_FT_FLAG_EXT (MTL_BIT32(1))
+/* the frame is malloc by rte memzone */
+#define ST_FT_FLAG_RTE_MEMZONE (MTL_BIT32(2))
 
 /* IOVA mapping info of each page in frame, used for IOVA:PA mode */
 struct st_page_info {
@@ -118,12 +120,10 @@ struct st_page_info {
 struct st_frame_trans {
   /* todo: use struct st_frame as base */
   int idx;
-  void* addr;                      /* virtual address */
-  rte_iova_t iova;                 /* iova for hw */
-  struct st_page_info* page_table; /* page table for hw, used for IOVA:PA mode */
-  uint16_t page_table_len;         /* page table len for hw, used for IOVA:PA mode */
-  rte_atomic32_t refcnt;           /* 0 means it's free */
-  void* priv;                      /* private data for lib */
+  void* addr;            /* virtual address */
+  rte_iova_t iova;       /* iova for hw */
+  rte_atomic32_t refcnt; /* 0 means it's free */
+  void* priv;            /* private data for lib */
 
   uint32_t flags;                          /* ST_FT_FLAG_* */
   struct rte_mbuf_ext_shared_info sh_info; /* for st20 tx ext shared */
@@ -305,6 +305,7 @@ struct st_tx_video_session_impl {
   size_t st20_linesize;     /* line size including padding bytes */
   uint16_t st20_frames_cnt; /* numbers of frames requested */
   struct st_frame_trans* st20_frames;
+  const struct rte_memzone* st20_frames_mz; /* for pa mode allocation */
 
   uint16_t st20_frame_idx; /* current frame index */
   enum st21_tx_frame_status st20_frame_stat;
@@ -601,6 +602,7 @@ struct st_rx_video_session_impl {
   size_t st20_frame_bitmap_size; /* bitmap size per frame */
   int st20_frames_cnt;           /* numbers of frames requested */
   struct st_frame_trans* st20_frames;
+  const struct rte_memzone* st20_frames_mz; /* for pa mode allocation */
   struct st20_pgroup st20_pg;
 
   size_t st20_uframe_size; /* size per user frame */

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -747,12 +747,12 @@ static int rv_alloc_frames(struct mtl_main_impl* impl,
 
   if (impl->iova_mode == RTE_IOVA_PA && s->dma_dev) {
     /* use memzone to alloc physical continious memory */
-    const struct rte_memzone* mz =
-        rte_memzone_reserve(s->ops.name, s->st20_fb_size * s->st20_frames_cnt, soc_id,
-                            RTE_MEMZONE_2MB | RTE_MEMZONE_SIZE_HINT_ONLY);
+    const struct rte_memzone* mz = rte_memzone_reserve(
+        s->ops.name, s->st20_fb_size * s->st20_frames_cnt, soc_id,
+        RTE_MEMZONE_2MB | RTE_MEMZONE_SIZE_HINT_ONLY | RTE_MEMZONE_IOVA_CONTIG);
     if (!mz) {
-      err("%s(%d), rte_memzone_reserve %" PRIu64 " fail\n", __func__, idx,
-          s->st20_fb_size * s->st20_frames_cnt);
+      err("%s(%d), rte_memzone_reserve %" PRIu64 " fail, errno %s\n", __func__, idx,
+          s->st20_fb_size * s->st20_frames_cnt, strerror(errno));
       return -ENOMEM;
     }
     s->st20_frames_mz = mz;

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -115,12 +115,12 @@ static int tv_alloc_frames(struct mtl_main_impl* impl,
 
   if (impl->iova_mode == RTE_IOVA_PA && !s->tx_no_chain) {
     /* use memzone to alloc physical continious memory */
-    const struct rte_memzone* mz =
-        rte_memzone_reserve(s->ops.name, s->st20_fb_size * s->st20_frames_cnt, soc_id,
-                            RTE_MEMZONE_2MB | RTE_MEMZONE_SIZE_HINT_ONLY);
+    const struct rte_memzone* mz = rte_memzone_reserve(
+        s->ops.name, s->st20_fb_size * s->st20_frames_cnt, soc_id,
+        RTE_MEMZONE_2MB | RTE_MEMZONE_SIZE_HINT_ONLY | RTE_MEMZONE_IOVA_CONTIG);
     if (!mz) {
-      err("%s(%d), rte_memzone_reserve %" PRIu64 " fail\n", __func__, idx,
-          s->st20_fb_size * s->st20_frames_cnt);
+      err("%s(%d), rte_memzone_reserve %" PRIu64 " fail, errno %s\n", __func__, idx,
+          s->st20_fb_size * s->st20_frames_cnt, strerror(errno));
       return -ENOMEM;
     }
     s->st20_frames_mz = mz;

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -92,76 +92,6 @@ static void tv_frame_free_cb(void* addr, void* opaque) {
   dbg("%s(%d), succ frame_idx %d\n", __func__, s_idx, frame_idx);
 }
 
-static rte_iova_t tv_frame_get_offset_iova(struct st_tx_video_session_impl* s,
-                                           struct st_frame_trans* frame_info,
-                                           size_t offset) {
-  if (frame_info->page_table_len == 0) return frame_info->iova + offset;
-  void* addr = RTE_PTR_ADD(frame_info->addr, offset);
-  struct st_page_info* page;
-  for (uint16_t i = 0; i < frame_info->page_table_len; i++) {
-    page = &frame_info->page_table[i];
-    if (addr >= page->addr && addr < RTE_PTR_ADD(page->addr, page->len))
-      return page->iova + RTE_PTR_DIFF(addr, page->addr);
-  }
-
-  err("%s(%d,%d), offset %" PRIu64 " get iova fail\n", __func__, s->idx, frame_info->idx,
-      offset);
-  return MTL_BAD_IOVA;
-}
-
-static int tv_frame_create_page_table(struct mtl_main_impl* impl,
-                                      struct st_tx_video_session_impl* s,
-                                      struct st_frame_trans* frame_info) {
-  struct rte_memseg* mseg = rte_mem_virt2memseg(frame_info->addr, NULL);
-  if (mseg == NULL) {
-    err("%s(%d,%d), get mseg fail\n", __func__, s->idx, frame_info->idx);
-    return -EIO;
-  }
-  size_t hugepage_sz = mseg->hugepage_sz;
-  info("%s(%d,%d), hugepage size %" PRIu64 "\n", __func__, s->idx, frame_info->idx,
-       hugepage_sz);
-
-  /* calculate num hugepages */
-  uint16_t num_pages =
-      RTE_PTR_DIFF(RTE_PTR_ALIGN(frame_info->addr + s->st20_fb_size, hugepage_sz),
-                   RTE_PTR_ALIGN_FLOOR(frame_info->addr, hugepage_sz)) /
-      hugepage_sz;
-
-  enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
-  int soc_id = mt_socket_id(impl, port);
-  struct st_page_info* pages = mt_rte_zmalloc_socket(sizeof(*pages) * num_pages, soc_id);
-  if (pages == NULL) {
-    err("%s(%d,%d), pages info malloc fail\n", __func__, s->idx, frame_info->idx);
-    return -ENOMEM;
-  }
-
-  /* get IOVA start of each page */
-  void* addr = frame_info->addr;
-  for (uint16_t i = 0; i < num_pages; i++) {
-    /* touch the page before getting its IOVA */
-    *(volatile char*)addr = 0;
-    pages[i].iova = rte_mem_virt2iova(addr);
-    pages[i].addr = addr;
-    void* next_addr = RTE_PTR_ALIGN(RTE_PTR_ADD(addr, 1), hugepage_sz);
-    pages[i].len = RTE_PTR_DIFF(next_addr, addr);
-    addr = next_addr;
-    info("%s(%d,%d), seg %u, va %p, iova 0x%" PRIx64 ", len %" PRIu64 "\n", __func__,
-         s->idx, frame_info->idx, i, pages[i].addr, pages[i].iova, pages[i].len);
-  }
-  frame_info->page_table = pages;
-  frame_info->page_table_len = num_pages;
-
-  return 0;
-}
-
-static inline bool tv_frame_payload_cross_page(struct st_tx_video_session_impl* s,
-                                               struct st_frame_trans* frame_info,
-                                               size_t offset, size_t len) {
-  if (frame_info->page_table_len == 0) return false;
-  return ((tv_frame_get_offset_iova(s, frame_info, offset + len - 1) -
-           tv_frame_get_offset_iova(s, frame_info, offset)) != len - 1);
-}
-
 static int tv_alloc_frames(struct mtl_main_impl* impl,
                            struct st_tx_video_session_impl* s) {
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
@@ -183,6 +113,20 @@ static int tv_alloc_frames(struct mtl_main_impl* impl,
     frame_info->idx = i;
   }
 
+  if (impl->iova_mode == RTE_IOVA_PA && !s->tx_no_chain) {
+    /* use memzone to alloc physical continious memory */
+    const struct rte_memzone* mz =
+        rte_memzone_reserve(s->ops.name, s->st20_fb_size * s->st20_frames_cnt, soc_id,
+                            RTE_MEMZONE_2MB | RTE_MEMZONE_SIZE_HINT_ONLY);
+    if (!mz) {
+      err("%s(%d), rte_memzone_reserve %" PRIu64 " fail\n", __func__, idx,
+          s->st20_fb_size * s->st20_frames_cnt);
+      return -ENOMEM;
+    }
+    s->st20_frames_mz = mz;
+    info("%s(%d), use rte_memzone allocation\n", __func__, idx);
+  }
+
   for (int i = 0; i < s->st20_frames_cnt; i++) {
     frame_info = &s->st20_frames[i];
 
@@ -195,6 +139,10 @@ static int tv_alloc_frames(struct mtl_main_impl* impl,
       frame_info->addr = NULL;
       frame_info->flags = ST_FT_FLAG_EXT;
       info("%s(%d), use external framebuffer, skip allocation\n", __func__, idx);
+    } else if (s->st20_frames_mz) {
+      frame_info->addr = s->st20_frames_mz->addr + i * s->st20_fb_size;
+      frame_info->iova = s->st20_frames_mz->iova + i * s->st20_fb_size;
+      frame_info->flags = ST_FT_FLAG_RTE_MEMZONE;
     } else {
       void* frame = mt_rte_zmalloc_socket(s->st20_fb_size, soc_id);
       if (!frame) {
@@ -208,8 +156,6 @@ static int tv_alloc_frames(struct mtl_main_impl* impl,
       frame_info->iova = rte_mem_virt2iova(frame);
       frame_info->addr = frame;
       frame_info->flags = ST_FT_FLAG_RTE_MALLOC;
-      if (impl->iova_mode == RTE_IOVA_PA && !s->tx_no_chain)
-        tv_frame_create_page_table(impl, s, frame_info);
     }
     frame_info->priv = s;
   }
@@ -225,9 +171,13 @@ static int tv_free_frames(struct st_tx_video_session_impl* s) {
       frame = &s->st20_frames[i];
       st_frame_trans_uinit(frame);
     }
-
     mt_rte_free(s->st20_frames);
     s->st20_frames = NULL;
+  }
+
+  if (s->st20_frames_mz) {
+    rte_memzone_free(s->st20_frames_mz);
+    s->st20_frames_mz = NULL;
   }
 
   dbg("%s(%d), succ\n", __func__, s->idx);
@@ -975,15 +925,10 @@ static int tv_build_st20_chain(struct st_tx_video_session_impl* s, struct rte_mb
     mtl_memcpy(payload, frame_info->addr + offset, line1_length);
     mtl_memcpy(payload + line1_length,
                frame_info->addr + s->st20_linesize * (line1_number + 1), line2_length);
-  } else if (tv_frame_payload_cross_page(s, frame_info, offset, left_len)) {
-    /* do not attach extbuf, copy to data room */
-    void* payload = rte_pktmbuf_mtod(pkt_chain, void*);
-    mtl_memcpy(payload, frame_info->addr + offset, left_len);
   } else {
     /* attach payload to chainbuf */
     rte_pktmbuf_attach_extbuf(pkt_chain, frame_info->addr + offset,
-                              tv_frame_get_offset_iova(s, frame_info, offset), left_len,
-                              &frame_info->sh_info);
+                              frame_info->iova + offset, left_len, &frame_info->sh_info);
     rte_mbuf_ext_refcnt_update(&frame_info->sh_info, 1);
   }
   pkt_chain->data_len = pkt_chain->pkt_len = left_len;
@@ -1276,16 +1221,9 @@ static int tv_build_st22_chain(struct st_tx_video_session_impl* s, struct rte_mb
 
   /* attach payload to chainbuf */
   struct st_frame_trans* frame_info = &s->st20_frames[s->st20_frame_idx];
-  if (tv_frame_payload_cross_page(s, frame_info, offset, left_len)) {
-    /* do not attach extbuf, copy to data room */
-    void* payload = rte_pktmbuf_mtod(pkt_chain, void*);
-    mtl_memcpy(payload, frame_info->addr + offset, left_len);
-  } else { /* attach payload */
-    rte_pktmbuf_attach_extbuf(pkt_chain, frame_info->addr + offset,
-                              tv_frame_get_offset_iova(s, frame_info, offset), left_len,
-                              &frame_info->sh_info);
-    rte_mbuf_ext_refcnt_update(&frame_info->sh_info, 1);
-  }
+  rte_pktmbuf_attach_extbuf(pkt_chain, frame_info->addr + offset,
+                            frame_info->iova + offset, left_len, &frame_info->sh_info);
+  rte_mbuf_ext_refcnt_update(&frame_info->sh_info, 1);
 
   pkt_chain->data_len = pkt_chain->pkt_len = left_len;
 
@@ -2250,8 +2188,6 @@ static int tv_mempool_init(struct mtl_main_impl* impl,
       hdr_room_size += sizeof(struct st20_rfc4175_extra_rtp_hdr);
     /* attach extbuf used, only placeholder mbuf */
     chain_room_size = 0;
-    if (impl->iova_mode == RTE_IOVA_PA) /* need copy for cross page pkts*/
-      chain_room_size = s->st20_pkt_len;
   }
 
   for (int i = 0; i < num_port; i++) {


### PR DESCRIPTION
 Memzone is used to reserve contiguous portions of physical memory. This is used in PA mode instead of calculating page tables for frame allocation.