### PR TITLE
upl: not use rte malloc for child process

### DIFF
--- a/ld_preload/preload_platform.h
+++ b/ld_preload/preload_platform.h
@@ -18,6 +18,8 @@
 
 #ifdef WINDOWSENV
 typedef unsigned long int nfds_t;
+
+static inline pid_t getpid() { return GetCurrentProcessId(); }
 #endif
 
 #endif

--- a/ld_preload/udp/udp_preload.h
+++ b/ld_preload/udp/udp_preload.h
@@ -62,6 +62,17 @@ enum mtl_log_level upl_get_log_level(void);
     return -1;            \
   } while (0)
 
+/* child only can't use rte malloc */
+static inline void* upl_malloc(size_t sz) { return malloc(sz); }
+
+static inline void* upl_zmalloc(size_t sz) {
+  void* p = malloc(sz);
+  if (p) memset(p, 0x0, sz);
+  return p;
+}
+
+static inline void upl_free(void* p) { free(p); }
+
 struct upl_functions {
   int (*socket)(int domain, int type, int protocol);
   int (*close)(int sockfd);

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -980,8 +980,9 @@ dequeue:
   unsigned int us = (mt_get_tsc(impl) - start_ts) / NS_PER_US;
   unsigned int timeout = s->rx_timeout_us;
   if ((us < timeout) && udp_alive(s)) {
-    mur_client_timedwait(s->rxq, timeout - us);
-    if (s->rx_poll_sleep_us) mt_sleep_us(s->rx_poll_sleep_us);
+    if (s->rx_poll_sleep_us) {
+      mur_client_timedwait(s->rxq, timeout - us, s->rx_poll_sleep_us);
+    }
     goto dequeue;
   }
 
@@ -1077,8 +1078,9 @@ dequeue:
   unsigned int us = (mt_get_tsc(impl) - start_ts) / NS_PER_US;
   unsigned int timeout = s->rx_timeout_us;
   if ((us < timeout) && udp_alive(s)) {
-    mur_client_timedwait(s->rxq, timeout - us);
-    if (s->rx_poll_sleep_us) mt_sleep_us(s->rx_poll_sleep_us);
+    if (s->rx_poll_sleep_us) {
+      mur_client_timedwait(s->rxq, timeout - us, s->rx_poll_sleep_us);
+    }
     goto dequeue;
   }
 
@@ -1141,10 +1143,8 @@ rx_poll:
   /* check if timeout */
   int ms = (mt_get_tsc(impl) - start_ts) / NS_PER_MS;
   if (((ms < timeout) || (timeout < 0)) && udp_alive(s)) {
-    mur_client_timedwait(s->rxq, timeout - ms);
     if (s->rx_poll_sleep_us) {
-      dbg("%s(%d), sleep %u us\n", __func__, s->idx, s->rx_poll_sleep_us);
-      mt_sleep_us(s->rx_poll_sleep_us);
+      mur_client_timedwait(s->rxq, (timeout - ms) * US_PER_MS, s->rx_poll_sleep_us);
     }
     goto rx_poll;
   }

--- a/lib/src/udp/udp_rxq.h
+++ b/lib/src/udp/udp_rxq.h
@@ -93,22 +93,23 @@ struct mur_client* mur_client_get(struct mur_client_create* create);
 uint16_t mur_client_rx(struct mur_client* q);
 int mur_client_dump(struct mur_client* q);
 
-int mur_client_timedwait(struct mur_client* q, unsigned int us);
+int mur_client_timedwait(struct mur_client* cq, unsigned int timedwait_us,
+                         unsigned int poll_sleep_us);
 
-static inline struct rte_ring* mur_client_ring(struct mur_client* q) { return q->ring; }
+static inline struct rte_ring* mur_client_ring(struct mur_client* c) { return c->ring; }
 
-static inline int mur_client_set_wake_thresh(struct mur_client* q, unsigned int count) {
-  q->wake_thresh_count = count;
+static inline int mur_client_set_wake_thresh(struct mur_client* c, unsigned int count) {
+  c->wake_thresh_count = count;
   return 0;
 }
 
-static inline int mur_client_set_wake_timeout(struct mur_client* q, unsigned int us) {
-  q->wake_timeout_us = us;
+static inline int mur_client_set_wake_timeout(struct mur_client* c, unsigned int us) {
+  c->wake_timeout_us = us;
   return 0;
 }
 
-static inline int mur_client_set_reuse(struct mur_client* q, int reuse) {
-  // q->reuse_port = reuse;
+static inline int mur_client_set_reuse(struct mur_client* c, int reuse) {
+  // c->reuse_port = reuse;
   return 0;
 }
 

--- a/lib/src/udp/ufd_main.h
+++ b/lib/src/udp/ufd_main.h
@@ -26,6 +26,7 @@ struct ufd_mt_ctx {
   struct mufd_init_params init_params;
   struct mtl_main_impl* mt;
   bool alloc_with_rte;
+  pid_t parent_pid;
 
   int slot_last_idx;
   struct ufd_slot** slots;    /* slots with init_params.slots_nb_max */

--- a/lib/windows/win_posix.h
+++ b/lib/windows/win_posix.h
@@ -106,9 +106,9 @@ struct shmid_ds {
   void* shm_unused3;
 };
 
-int inline flock(int fd, int operation) { return 0; }
+static int inline flock(int fd, int operation) { return 0; }
 
-key_t inline ftok(const char* path, int id) { return 0; }
+static key_t inline ftok(const char* path, int id) { return 0; }
 
 void* shmat(int shmid, const void* shmaddr, int shmflg);
 int shmctl(int shmid, int cmd, struct shmid_ds* buf);
@@ -117,10 +117,13 @@ int shmget(key_t key, size_t size, int shmflg);
 
 typedef intptr_t pthread_cond_t;
 typedef int pthread_condattr_t;
+
 #ifdef __MTL_LIB_BUILD__  // only lib need this typedef
 typedef rte_cpuset_t cpu_set_t;
 #endif
+
 #define localtime_r(T, Tm) (localtime_s(Tm, T) ? NULL : Tm)
+
 int pthread_cond_signal(pthread_cond_t* cv);
 int pthread_cond_init(pthread_cond_t* cv, const pthread_condattr_t* a);
 int pthread_cond_wait(pthread_cond_t* cv, pthread_mutex_t* external_mutex);
@@ -128,4 +131,7 @@ int pthread_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex,
                            const struct timespec* time);
 int pthread_cond_destroy(pthread_cond_t* cv);
 int pthread_mutex_trylock(pthread_mutex_t* mutex);
+
+static inline pid_t getpid() { return GetCurrentProcessId(); }
+
 #endif

--- a/lib/windows/win_posix.h
+++ b/lib/windows/win_posix.h
@@ -132,6 +132,8 @@ int pthread_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex,
 int pthread_cond_destroy(pthread_cond_t* cv);
 int pthread_mutex_trylock(pthread_mutex_t* mutex);
 
+#ifdef __MTL_LIB_BUILD__
 static inline pid_t getpid() { return GetCurrentProcessId(); }
+#endif
 
 #endif


### PR DESCRIPTION
Child can not alloc rte memory itself.