### PR TITLE
api: add api to get the ip/address/netmsk for dhcp

### DIFF
--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -568,4 +568,7 @@ static inline uint64_t st_app_get_monotonic_time() {
 int st_app_video_get_lcore(struct st_app_context* ctx, int sch_idx, bool rtp,
                            unsigned int* lcore);
 
+uint8_t* st_json_ip(struct st_app_context* ctx, st_json_session_base_t* base,
+                    enum mtl_session_port port);
+
 #endif

--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -1623,6 +1623,20 @@ static int parse_session_num(json_object* group, const char* name) {
   return num;
 }
 
+static int parse_session_ip(const char* str_ip, struct st_json_session_base* base,
+                            enum mtl_session_port port) {
+  int ret = inet_pton(AF_INET, str_ip, base->ip[port]);
+  if (ret == 1) return 0;
+
+  /* if it's local interface case for test */
+  ret = strtol(str_ip, NULL, 10);
+  if (ret < 0) return ret;
+  base->type[port] = ST_JSON_IP_LOCAL_IF;
+  base->local[port] = ret;
+  dbg("%s, local if port %d\n", __func__, ret);
+  return 0;
+}
+
 void st_app_free_json(st_json_context_t* ctx) {
   if (ctx->interfaces) {
     st_app_free(ctx->interfaces);
@@ -1878,12 +1892,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(dip_p),
-                      ctx->tx_video_sessions[num_video].base.ip[0]);
+            parse_session_ip(json_object_get_string(dip_p),
+                             &ctx->tx_video_sessions[num_video].base, MTL_SESSION_PORT_P);
             ctx->tx_video_sessions[num_video].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(dip_r),
-                        ctx->tx_video_sessions[num_video].base.ip[1]);
+              parse_session_ip(json_object_get_string(dip_r),
+                               &ctx->tx_video_sessions[num_video].base,
+                               MTL_SESSION_PORT_R);
               ctx->tx_video_sessions[num_video].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->tx_video_sessions[num_video].base.num_inf = num_inf;
@@ -1909,12 +1924,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(dip_p),
-                      ctx->tx_audio_sessions[num_audio].base.ip[0]);
+            parse_session_ip(json_object_get_string(dip_p),
+                             &ctx->tx_audio_sessions[num_audio].base, MTL_SESSION_PORT_P);
             ctx->tx_audio_sessions[num_audio].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(dip_r),
-                        ctx->tx_audio_sessions[num_audio].base.ip[1]);
+              parse_session_ip(json_object_get_string(dip_r),
+                               &ctx->tx_audio_sessions[num_audio].base,
+                               MTL_SESSION_PORT_R);
               ctx->tx_audio_sessions[num_audio].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->tx_audio_sessions[num_audio].base.num_inf = num_inf;
@@ -1939,12 +1955,12 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(dip_p),
-                      ctx->tx_anc_sessions[num_anc].base.ip[0]);
+            parse_session_ip(json_object_get_string(dip_p),
+                             &ctx->tx_anc_sessions[num_anc].base, MTL_SESSION_PORT_P);
             ctx->tx_anc_sessions[num_anc].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(dip_r),
-                        ctx->tx_anc_sessions[num_anc].base.ip[1]);
+              parse_session_ip(json_object_get_string(dip_r),
+                               &ctx->tx_anc_sessions[num_anc].base, MTL_SESSION_PORT_R);
               ctx->tx_anc_sessions[num_anc].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->tx_anc_sessions[num_anc].base.num_inf = num_inf;
@@ -1968,12 +1984,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(dip_p),
-                      ctx->tx_st22p_sessions[num_st22p].base.ip[0]);
+            parse_session_ip(json_object_get_string(dip_p),
+                             &ctx->tx_st22p_sessions[num_st22p].base, MTL_SESSION_PORT_P);
             ctx->tx_st22p_sessions[num_st22p].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(dip_r),
-                        ctx->tx_st22p_sessions[num_st22p].base.ip[1]);
+              parse_session_ip(json_object_get_string(dip_r),
+                               &ctx->tx_st22p_sessions[num_st22p].base,
+                               MTL_SESSION_PORT_R);
               ctx->tx_st22p_sessions[num_st22p].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->tx_st22p_sessions[num_st22p].base.num_inf = num_inf;
@@ -1999,12 +2016,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(dip_p),
-                      ctx->tx_st20p_sessions[num_st20p].base.ip[0]);
+            parse_session_ip(json_object_get_string(dip_p),
+                             &ctx->tx_st20p_sessions[num_st20p].base, MTL_SESSION_PORT_P);
             ctx->tx_st20p_sessions[num_st20p].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(dip_r),
-                        ctx->tx_st20p_sessions[num_st20p].base.ip[1]);
+              parse_session_ip(json_object_get_string(dip_r),
+                               &ctx->tx_st20p_sessions[num_st20p].base,
+                               MTL_SESSION_PORT_R);
               ctx->tx_st20p_sessions[num_st20p].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->tx_st20p_sessions[num_st20p].base.num_inf = num_inf;
@@ -2183,12 +2201,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(ip_p),
-                      ctx->rx_video_sessions[num_video].base.ip[0]);
+            parse_session_ip(json_object_get_string(ip_p),
+                             &ctx->rx_video_sessions[num_video].base, MTL_SESSION_PORT_P);
             ctx->rx_video_sessions[num_video].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(ip_r),
-                        ctx->rx_video_sessions[num_video].base.ip[1]);
+              parse_session_ip(json_object_get_string(ip_r),
+                               &ctx->rx_video_sessions[num_video].base,
+                               MTL_SESSION_PORT_R);
               ctx->rx_video_sessions[num_video].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->rx_video_sessions[num_video].base.num_inf = num_inf;
@@ -2214,12 +2233,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(ip_p),
-                      ctx->rx_audio_sessions[num_audio].base.ip[0]);
+            parse_session_ip(json_object_get_string(ip_p),
+                             &ctx->rx_audio_sessions[num_audio].base, MTL_SESSION_PORT_P);
             ctx->rx_audio_sessions[num_audio].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(ip_r),
-                        ctx->rx_audio_sessions[num_audio].base.ip[1]);
+              parse_session_ip(json_object_get_string(ip_r),
+                               &ctx->rx_audio_sessions[num_audio].base,
+                               MTL_SESSION_PORT_R);
               ctx->rx_audio_sessions[num_audio].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->rx_audio_sessions[num_audio].base.num_inf = num_inf;
@@ -2244,12 +2264,12 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(ip_p),
-                      ctx->rx_anc_sessions[num_anc].base.ip[0]);
+            parse_session_ip(json_object_get_string(ip_p),
+                             &ctx->rx_anc_sessions[num_anc].base, MTL_SESSION_PORT_P);
             ctx->rx_anc_sessions[num_anc].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(ip_r),
-                        ctx->rx_anc_sessions[num_anc].base.ip[1]);
+              parse_session_ip(json_object_get_string(ip_r),
+                               &ctx->rx_anc_sessions[num_anc].base, MTL_SESSION_PORT_R);
               ctx->rx_anc_sessions[num_anc].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->rx_anc_sessions[num_anc].base.num_inf = num_inf;
@@ -2273,12 +2293,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(ip_p),
-                      ctx->rx_st22p_sessions[num_st22p].base.ip[0]);
+            parse_session_ip(json_object_get_string(ip_p),
+                             &ctx->rx_st22p_sessions[num_st22p].base, MTL_SESSION_PORT_P);
             ctx->rx_st22p_sessions[num_st22p].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(ip_r),
-                        ctx->rx_st22p_sessions[num_st22p].base.ip[1]);
+              parse_session_ip(json_object_get_string(ip_r),
+                               &ctx->rx_st22p_sessions[num_st22p].base,
+                               MTL_SESSION_PORT_R);
               ctx->rx_st22p_sessions[num_st22p].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->rx_st22p_sessions[num_st22p].base.num_inf = num_inf;
@@ -2304,12 +2325,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(ip_p),
-                      ctx->rx_st20p_sessions[num_st20p].base.ip[0]);
+            parse_session_ip(json_object_get_string(ip_p),
+                             &ctx->rx_st20p_sessions[num_st20p].base, MTL_SESSION_PORT_P);
             ctx->rx_st20p_sessions[num_st20p].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(ip_r),
-                        ctx->rx_st20p_sessions[num_st20p].base.ip[1]);
+              parse_session_ip(json_object_get_string(ip_r),
+                               &ctx->rx_st20p_sessions[num_st20p].base,
+                               MTL_SESSION_PORT_R);
               ctx->rx_st20p_sessions[num_st20p].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->rx_st20p_sessions[num_st20p].base.num_inf = num_inf;
@@ -2340,12 +2362,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             goto error;
           }
           for (int k = 0; k < replicas; ++k) {
-            inet_pton(AF_INET, json_object_get_string(ip_p),
-                      ctx->rx_st20r_sessions[num_st20r].base.ip[0]);
+            parse_session_ip(json_object_get_string(ip_p),
+                             &ctx->rx_st20r_sessions[num_st20r].base, MTL_SESSION_PORT_P);
             ctx->rx_st20r_sessions[num_st20r].base.inf[0] = &ctx->interfaces[inf_p];
             if (num_inf == 2) {
-              inet_pton(AF_INET, json_object_get_string(ip_r),
-                        ctx->rx_st20r_sessions[num_st20r].base.ip[1]);
+              parse_session_ip(json_object_get_string(ip_r),
+                               &ctx->rx_st20r_sessions[num_st20r].base,
+                               MTL_SESSION_PORT_R);
               ctx->rx_st20r_sessions[num_st20r].base.inf[1] = &ctx->interfaces[inf_r];
             }
             ctx->rx_st20r_sessions[num_st20r].base.num_inf = num_inf;
@@ -2417,5 +2440,15 @@ bool st_app_get_interlaced(enum video_format fmt) {
       return true;
     default:
       return false;
+  }
+}
+
+uint8_t* st_json_ip(struct st_app_context* ctx, st_json_session_base_t* base,
+                    enum mtl_session_port port) {
+  if (base->type[port] == ST_JSON_IP_LOCAL_IF) {
+    mtl_port_ip_info(ctx->st, base->local[port], base->local_ip[port], NULL, NULL);
+    return base->local_ip[port];
+  } else {
+    return base->ip[port];
   }
 }

--- a/app/src/parse_json.h
+++ b/app/src/parse_json.h
@@ -124,12 +124,22 @@ typedef struct st_json_interface {
   uint8_t gateway[MTL_IP_ADDR_LEN];
 } st_json_interface_t;
 
+enum st_json_ip_type {
+  ST_JSON_IP_ADDR = 0,
+  ST_JSON_IP_LOCAL_IF,
+  ST_JSON_IP_MAX,
+};
+
 typedef struct st_json_session_base {
   uint8_t ip[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
   st_json_interface_t* inf[MTL_SESSION_PORT_MAX];
   int num_inf;
   uint16_t udp_port;
   uint8_t payload_type;
+  enum st_json_ip_type type[MTL_SESSION_PORT_MAX];
+  enum mtl_port local[MTL_SESSION_PORT_MAX]; /* if use ST_JSON_IP_LOCAL_IF */
+  uint8_t local_ip[MTL_SESSION_PORT_MAX]
+                  [MTL_IP_ADDR_LEN]; /* if use ST_JSON_IP_LOCAL_IF */
 } st_json_session_base_t;
 
 typedef struct st_json_video_info {
@@ -263,4 +273,5 @@ enum st_fps st_app_get_fps(enum video_format fmt);
 uint32_t st_app_get_width(enum video_format fmt);
 uint32_t st_app_get_height(enum video_format fmt);
 bool st_app_get_interlaced(enum video_format fmt);
+
 #endif

--- a/app/src/rx_ancillary_app.c
+++ b/app/src/rx_ancillary_app.c
@@ -127,7 +127,8 @@ static int app_rx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   ops.priv = s;
   ops.num_port = anc ? anc->base.num_inf : ctx->para.num_ports;
   memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
-         anc ? anc->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+         anc ? st_json_ip(ctx, &anc->base, MTL_SESSION_PORT_P)
+             : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port[MTL_SESSION_PORT_P],
           anc ? anc->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -135,7 +136,8 @@ static int app_rx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   ops.udp_port[MTL_SESSION_PORT_P] = anc ? anc->base.udp_port : (10200 + s->idx);
   if (ops.num_port > 1) {
     memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
-           anc ? anc->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+           anc ? st_json_ip(ctx, &anc->base, MTL_SESSION_PORT_R)
+               : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(ops.port[MTL_SESSION_PORT_R],
             anc ? anc->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],

--- a/app/src/rx_audio_app.c
+++ b/app/src/rx_audio_app.c
@@ -218,7 +218,8 @@ static int app_rx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   ops.priv = s;
   ops.num_port = audio ? audio->base.num_inf : ctx->para.num_ports;
   memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
-         audio ? audio->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+         audio ? st_json_ip(ctx, &audio->base, MTL_SESSION_PORT_P)
+               : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port[MTL_SESSION_PORT_P],
           audio ? audio->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -226,7 +227,8 @@ static int app_rx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   ops.udp_port[MTL_SESSION_PORT_P] = audio ? audio->base.udp_port : (10100 + s->idx);
   if (ops.num_port > 1) {
     memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
-           audio ? audio->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+           audio ? st_json_ip(ctx, &audio->base, MTL_SESSION_PORT_R)
+                 : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(ops.port[MTL_SESSION_PORT_R],
             audio ? audio->base.inf[MTL_PORT_R]->name : ctx->para.port[MTL_PORT_R],

--- a/app/src/rx_st20p_app.c
+++ b/app/src/rx_st20p_app.c
@@ -137,7 +137,8 @@ static int app_rx_st20p_init(struct st_app_context* ctx,
   ops.priv = s;
   ops.port.num_port = st20p ? st20p->base.num_inf : ctx->para.num_ports;
   memcpy(ops.port.sip_addr[MTL_SESSION_PORT_P],
-         st20p ? st20p->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+         st20p ? st_json_ip(ctx, &st20p->base, MTL_SESSION_PORT_P)
+               : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port.port[MTL_SESSION_PORT_P],
           st20p ? st20p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -145,7 +146,8 @@ static int app_rx_st20p_init(struct st_app_context* ctx,
   ops.port.udp_port[MTL_SESSION_PORT_P] = st20p ? st20p->base.udp_port : (10000 + s->idx);
   if (ops.port.num_port > 1) {
     memcpy(ops.port.sip_addr[MTL_SESSION_PORT_R],
-           st20p ? st20p->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+           st20p ? st_json_ip(ctx, &st20p->base, MTL_SESSION_PORT_R)
+                 : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port.port[MTL_SESSION_PORT_R],

--- a/app/src/rx_st20r_app.c
+++ b/app/src/rx_st20r_app.c
@@ -252,7 +252,8 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
   memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
-         video ? video->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+         video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_P)
+               : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port[MTL_SESSION_PORT_P],
           video ? video->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -260,7 +261,8 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
   ops.udp_port[MTL_SESSION_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
   if (ops.num_port > 1) {
     memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
-           video ? video->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+           video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_R)
+                 : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port[MTL_SESSION_PORT_R],

--- a/app/src/rx_st22p_app.c
+++ b/app/src/rx_st22p_app.c
@@ -137,7 +137,8 @@ static int app_rx_st22p_init(struct st_app_context* ctx,
   ops.priv = s;
   ops.port.num_port = st22p ? st22p->base.num_inf : ctx->para.num_ports;
   memcpy(ops.port.sip_addr[MTL_SESSION_PORT_P],
-         st22p ? st22p->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+         st22p ? st_json_ip(ctx, &st22p->base, MTL_SESSION_PORT_P)
+               : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port.port[MTL_SESSION_PORT_P],
           st22p ? st22p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -145,7 +146,8 @@ static int app_rx_st22p_init(struct st_app_context* ctx,
   ops.port.udp_port[MTL_SESSION_PORT_P] = st22p ? st22p->base.udp_port : (10000 + s->idx);
   if (ops.port.num_port > 1) {
     memcpy(ops.port.sip_addr[MTL_SESSION_PORT_R],
-           st22p ? st22p->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+           st22p ? st_json_ip(ctx, &st22p->base, MTL_SESSION_PORT_R)
+                 : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port.port[MTL_SESSION_PORT_R],

--- a/app/src/rx_video_app.c
+++ b/app/src/rx_video_app.c
@@ -437,7 +437,8 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
   memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
-         video ? video->base.ip[MTL_SESSION_PORT_P] : ctx->rx_sip_addr[MTL_PORT_P],
+         video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_P)
+               : ctx->rx_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port[MTL_SESSION_PORT_P],
           video ? video->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -445,7 +446,8 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.udp_port[MTL_SESSION_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
   if (ops.num_port > 1) {
     memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
-           video ? video->base.ip[MTL_SESSION_PORT_R] : ctx->rx_sip_addr[MTL_PORT_R],
+           video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_R)
+                 : ctx->rx_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port[MTL_SESSION_PORT_R],

--- a/app/src/tx_ancillary_app.c
+++ b/app/src/tx_ancillary_app.c
@@ -413,7 +413,8 @@ static int app_tx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   ops.priv = s;
   ops.num_port = anc ? anc->base.num_inf : ctx->para.num_ports;
   memcpy(ops.dip_addr[MTL_SESSION_PORT_P],
-         anc ? anc->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+         anc ? st_json_ip(ctx, &anc->base, MTL_SESSION_PORT_P)
+             : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port[MTL_SESSION_PORT_P],
           anc ? anc->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -426,7 +427,8 @@ static int app_tx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   }
   if (ops.num_port > 1) {
     memcpy(ops.dip_addr[MTL_SESSION_PORT_R],
-           anc ? anc->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+           anc ? st_json_ip(ctx, &anc->base, MTL_SESSION_PORT_R)
+               : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(ops.port[MTL_SESSION_PORT_R],
             anc ? anc->base.inf[MTL_SESSION_PORT_R]->name : ctx->para.port[MTL_PORT_R],

--- a/app/src/tx_audio_app.c
+++ b/app/src/tx_audio_app.c
@@ -382,7 +382,8 @@ static int app_tx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   ops.priv = s;
   ops.num_port = audio ? audio->base.num_inf : ctx->para.num_ports;
   memcpy(ops.dip_addr[MTL_SESSION_PORT_P],
-         audio ? audio->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+         audio ? st_json_ip(ctx, &audio->base, MTL_SESSION_PORT_P)
+               : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port[MTL_SESSION_PORT_P],
           audio ? audio->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -397,7 +398,8 @@ static int app_tx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   if (ctx->tx_audio_fifo_size) ops.fifo_size = ctx->tx_audio_fifo_size;
   if (ops.num_port > 1) {
     memcpy(ops.dip_addr[MTL_SESSION_PORT_R],
-           audio ? audio->base.ip[MTL_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+           audio ? st_json_ip(ctx, &audio->base, MTL_SESSION_PORT_R)
+                 : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port[MTL_SESSION_PORT_R],

--- a/app/src/tx_st20p_app.c
+++ b/app/src/tx_st20p_app.c
@@ -199,7 +199,8 @@ static int app_tx_st20p_init(struct st_app_context* ctx, st_json_st20p_session_t
   ops.priv = s;
   ops.port.num_port = st20p ? st20p->base.num_inf : ctx->para.num_ports;
   memcpy(ops.port.dip_addr[MTL_SESSION_PORT_P],
-         st20p ? st20p->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+         st20p ? st_json_ip(ctx, &st20p->base, MTL_SESSION_PORT_P)
+               : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port.port[MTL_SESSION_PORT_P],
           st20p ? st20p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -212,7 +213,8 @@ static int app_tx_st20p_init(struct st_app_context* ctx, st_json_st20p_session_t
   }
   if (ops.port.num_port > 1) {
     memcpy(ops.port.dip_addr[MTL_SESSION_PORT_R],
-           st20p ? st20p->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+           st20p ? st_json_ip(ctx, &st20p->base, MTL_SESSION_PORT_R)
+                 : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port.port[MTL_SESSION_PORT_R],

--- a/app/src/tx_st22p_app.c
+++ b/app/src/tx_st22p_app.c
@@ -199,7 +199,8 @@ static int app_tx_st22p_init(struct st_app_context* ctx, st_json_st22p_session_t
   ops.priv = s;
   ops.port.num_port = st22p ? st22p->base.num_inf : ctx->para.num_ports;
   memcpy(ops.port.dip_addr[MTL_SESSION_PORT_P],
-         st22p ? st22p->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+         st22p ? st_json_ip(ctx, &st22p->base, MTL_SESSION_PORT_P)
+               : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port.port[MTL_SESSION_PORT_P],
           st22p ? st22p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -212,7 +213,8 @@ static int app_tx_st22p_init(struct st_app_context* ctx, st_json_st22p_session_t
   }
   if (ops.port.num_port > 1) {
     memcpy(ops.port.dip_addr[MTL_SESSION_PORT_R],
-           st22p ? st22p->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+           st22p ? st_json_ip(ctx, &st22p->base, MTL_SESSION_PORT_R)
+                 : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port.port[MTL_SESSION_PORT_R],

--- a/app/src/tx_video_app.c
+++ b/app/src/tx_video_app.c
@@ -681,7 +681,8 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
   memcpy(ops.dip_addr[MTL_SESSION_PORT_P],
-         video ? video->base.ip[MTL_SESSION_PORT_P] : ctx->tx_dip_addr[MTL_PORT_P],
+         video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_P)
+               : ctx->tx_dip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   strncpy(ops.port[MTL_SESSION_PORT_P],
           video ? video->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P],
@@ -694,7 +695,8 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   }
   if (ops.num_port > 1) {
     memcpy(ops.dip_addr[MTL_SESSION_PORT_R],
-           video ? video->base.ip[MTL_SESSION_PORT_R] : ctx->tx_dip_addr[MTL_PORT_R],
+           video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_R)
+                 : ctx->tx_dip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     strncpy(
         ops.port[MTL_SESSION_PORT_R],

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -1138,6 +1138,24 @@ enum mtl_rss_mode mtl_rss_mode_get(mtl_handle mt);
 enum mtl_iova_mode mtl_iova_mode_get(mtl_handle mt);
 
 /**
+ * Get the ip info(address, netmask, gateway) for one mtl port.
+ *
+ * @param handle
+ *   The handle to the st user dma dev.
+ * @param ip
+ *   The buffer for IP address.
+ * @param netmask
+ *   The buffer for netmask address.
+ * @param gateway
+ *   The buffer for gateway address.
+ * @return
+ *   - 0: Success.
+ *   - <0: Error code.
+ */
+int mtl_port_ip_info(mtl_handle mt, enum mtl_port port, uint8_t ip[MTL_IP_ADDR_LEN],
+                     uint8_t netmask[MTL_IP_ADDR_LEN], uint8_t gateway[MTL_IP_ADDR_LEN]);
+
+/**
  * Get SIMD level current cpu supported.
  *
  * @return

--- a/include/mudp_sockfd_internal.h
+++ b/include/mudp_sockfd_internal.h
@@ -264,6 +264,22 @@ int mufd_socket_check(int domain, int type, int protocol);
 int mufd_poll_query(struct pollfd* fds, nfds_t nfds, int timeout,
                     int (*query)(void* priv), void* priv);
 
+/**
+ * Get the ip info(address, netmask, gateway) for mufd port.
+ *
+ * @param ip
+ *   The buffer for IP address.
+ * @param netmask
+ *   The buffer for netmask address.
+ * @param gateway
+ *   The buffer for gateway address.
+ * @return
+ *   - 0: Success.
+ *   - <0: Error code.
+ */
+int mufd_port_ip_info(enum mtl_port port, uint8_t ip[MTL_IP_ADDR_LEN],
+                      uint8_t netmask[MTL_IP_ADDR_LEN], uint8_t gateway[MTL_IP_ADDR_LEN]);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -348,7 +348,7 @@ int mt_cni_init(struct mtl_main_impl* impl) {
 
   ret = mt_cni_start(impl);
   if (ret < 0) {
-    info("%s, mt_cni_start fail %d\n", __func__, ret);
+    err("%s, mt_cni_start fail %d\n", __func__, ret);
     mt_cni_uinit(impl);
     return ret;
   }

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -1149,6 +1149,25 @@ enum mtl_iova_mode mtl_iova_mode_get(mtl_handle mt) {
   }
 }
 
+int mtl_port_ip_info(mtl_handle mt, enum mtl_port port, uint8_t ip[MTL_IP_ADDR_LEN],
+                     uint8_t netmask[MTL_IP_ADDR_LEN], uint8_t gateway[MTL_IP_ADDR_LEN]) {
+  struct mtl_main_impl* impl = mt;
+
+  if (impl->type != MT_HANDLE_MAIN) {
+    err("%s, invalid type %d\n", __func__, impl->type);
+    return -EINVAL;
+  }
+  if (port < 0 || port >= mt_num_ports(impl)) {
+    err("%s, invalid port %d\n", __func__, port);
+    return -EINVAL;
+  }
+
+  if (ip) rte_memcpy(ip, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
+  if (netmask) rte_memcpy(netmask, mt_sip_netmask(impl, port), MTL_IP_ADDR_LEN);
+  if (gateway) rte_memcpy(gateway, mt_sip_gateway(impl, port), MTL_IP_ADDR_LEN);
+  return 0;
+}
+
 enum mtl_simd_level mtl_get_simd_level(void) {
   if (rte_cpu_get_flag_enabled(RTE_CPUFLAG_AVX512VBMI2))
     return MTL_SIMD_LEVEL_AVX512_VBMI2;

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -840,3 +840,14 @@ int mufd_register_stat_dump_cb(int sockfd, int (*dump)(void* priv), void* priv) 
 int mufd_socket_check(int domain, int type, int protocol) {
   return mudp_verify_socket_args(domain, type, protocol);
 }
+
+int mufd_port_ip_info(enum mtl_port port, uint8_t ip[MTL_IP_ADDR_LEN],
+                      uint8_t netmask[MTL_IP_ADDR_LEN],
+                      uint8_t gateway[MTL_IP_ADDR_LEN]) {
+  struct ufd_mt_ctx* ctx = ufd_get_mt_ctx(false);
+  if (!ctx) {
+    err("%s, ctx get fail\n", __func__);
+    return -EIO;
+  }
+  return mtl_port_ip_info(ctx->mt, port, ip, netmask, gateway);
+}

--- a/tests/script/dhcp_loop_json/1080p59_1v.json
+++ b/tests/script/dhcp_loop_json/1080p59_1v.json
@@ -1,0 +1,60 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "proto": "dhcp"
+        },
+        {
+            "name": "0000:af:01.1",
+            "proto": "dhcp"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "1"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "0"
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false,
+                    "measure_latency": true,
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/dhcp_loop_json/unicast_1v_1a_1anc.json
+++ b/tests/script/dhcp_loop_json/unicast_1v_1a_1anc.json
@@ -1,0 +1,102 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "proto": "dhcp"
+        },
+        {
+            "name": "0000:af:01.1",
+            "proto": "dhcp"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "1"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 1,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "0",
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 1,
+                    "payload_type": 113,
+                    "start_port": 40000
+                }
+            ]
+        }
+    ]
+}

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -269,6 +269,7 @@ static int test_parse_args(struct st_tests_context* ctx, struct mtl_init_params*
       case TEST_ARG_DHCP:
         for (int port = 0; port < MTL_PORT_MAX; ++port)
           p->net_proto[port] = MTL_PROTO_DHCP;
+        ctx->dhcp = true;
         break;
       default:
         break;
@@ -584,6 +585,14 @@ GTEST_API_ int main(int argc, char** argv) {
   if (!ctx->handle) {
     err("%s, mtl_init fail\n", __func__);
     return -EIO;
+  }
+
+  if (ctx->dhcp) {
+    for (int i = 0; i < ctx->para.num_ports; i++) {
+      /* get the assigned dhcp ip */
+      mtl_port_ip_info(ctx->handle, (enum mtl_port)i, ctx->para.sip_addr[i],
+                       ctx->para.netmask[i], ctx->para.gateway[i]);
+    }
   }
 
   st_test_st22_plugin_register(ctx);

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -92,6 +92,7 @@ struct st_tests_context {
   uint64_t ptp_time;
   enum st_test_level level;
   bool hdr_split;
+  bool dhcp;
 
   st22_encoder_dev_handle encoder_dev_handle;
   st22_decoder_dev_handle decoder_dev_handle;

--- a/tests/src/ufd_test.h
+++ b/tests/src/ufd_test.h
@@ -20,6 +20,7 @@
 struct utest_ctx {
   struct mufd_init_params init_params;
   uint8_t mcast_ip_addr[MTL_IP_ADDR_LEN];
+  bool dhcp;
 };
 
 struct utest_ctx* utest_get_ctx(void);


### PR DESCRIPTION
Add dhcp_loop_json for app dhcp loop test, use interface idx as the dip/sip, refer to tests/script/dhcp_loop_json/ for usage. Also add --dhcp support for test.