### PR TITLE
Init all rx session before rx packet

### DIFF
--- a/ecosystem/ffmpeg_plugin/kahawai_dec.c
+++ b/ecosystem/ffmpeg_plugin/kahawai_dec.c
@@ -305,6 +305,9 @@ static int kahawai_read_packet(AVFormatContext* ctx, AVPacket* pkt) {
   int ret = 0;
 
   av_log(ctx, AV_LOG_VERBOSE, "kahawai_read_packet triggered\n");
+  if (active_session_cnt != s->session_cnt) {
+    return 0;
+  }
 
   if (s->ext_frames_mode) {
     if (s->last_frame) {


### PR DESCRIPTION
Issue:
On multiple RX sessions, the second RX session initializes after the first packet is received on the first session. Fix:
Return from kahawai_read_packet() if session count doesn't match the active session count.