### PR TITLE
rxq: use mt_rxq_get for all rxq request

### DIFF
--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -4,6 +4,7 @@
 sources = files(
   'mt_main.c',
   'mt_dev.c',
+  'mt_queue.c',
   'mt_sch.c',
   'mt_cni.c',
   'mt_ptp.c',

--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -88,8 +88,8 @@ static int cni_traffic(struct mtl_main_impl* impl) {
     ptp = mt_get_ptp(impl, i);
 
     /* rx from ptp rx queue */
-    if (ptp && ptp->rx_queue) {
-      rx = mt_dev_rx_burst(ptp->rx_queue, pkts_rx, ST_CNI_RX_BURST_SIZE);
+    if (ptp && ptp->rxq) {
+      rx = mt_rxq_burst(ptp->rxq, pkts_rx, ST_CNI_RX_BURST_SIZE);
       if (rx > 0) {
         cni->eth_rx_cnt[i] += rx;
         for (uint16_t ri = 0; ri < rx; ri++) cni_rx_handle(impl, pkts_rx[ri], i);

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -57,7 +57,7 @@ uint16_t mt_dev_tx_sys_queue_burst(struct mtl_main_impl* impl, enum mtl_port por
                                    struct rte_mbuf** tx_pkts, uint16_t nb_pkts);
 
 struct mt_rx_queue* mt_dev_get_rx_queue(struct mtl_main_impl* impl, enum mtl_port port,
-                                        struct mt_rx_flow* flow);
+                                        struct mt_rxq_flow* flow);
 int mt_dev_put_rx_queue(struct mtl_main_impl* impl, struct mt_rx_queue* queue);
 static inline uint16_t mt_dev_rx_queue_id(struct mt_rx_queue* queue) {
   return queue->queue_id;
@@ -86,7 +86,7 @@ uint16_t mt_dev_rss_hash_queue(struct mtl_main_impl* impl, enum mtl_port port,
 
 struct mt_rx_flow_rsp* mt_dev_create_rx_flow(struct mtl_main_impl* impl,
                                              enum mtl_port port, uint16_t q,
-                                             struct mt_rx_flow* flow);
+                                             struct mt_rxq_flow* flow);
 int mt_dev_free_rx_flow(struct mtl_main_impl* impl, enum mtl_port port,
                         struct mt_rx_flow_rsp* rsp);
 

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -17,16 +17,31 @@
 #include <rte_version.h>
 #include <rte_vfio.h>
 #include <sys/file.h>
+#include <sys/queue.h>
 #include <unistd.h>
 
 #include "mt_mem.h"
 #include "mt_platform.h"
-#include "mt_queue.h"
 #include "mt_quirk.h"
 #include "st2110/st_header.h"
 
 #ifndef _MT_LIB_MAIN_HEAD_H_
 #define _MT_LIB_MAIN_HEAD_H_
+
+/* Macros compatible with system's sys/queue.h */
+#define MT_TAILQ_HEAD(name, type) RTE_TAILQ_HEAD(name, type)
+#define MT_TAILQ_ENTRY(type) RTE_TAILQ_ENTRY(type)
+#define MT_TAILQ_FOREACH(var, head, field) RTE_TAILQ_FOREACH(var, head, field)
+#define MT_TAILQ_FIRST(head) RTE_TAILQ_FIRST(head)
+#define MT_TAILQ_NEXT(elem, field) RTE_TAILQ_NEXT(elem, field)
+
+#define MT_TAILQ_INSERT_TAIL(head, elem, filed) TAILQ_INSERT_TAIL(head, elem, filed)
+#define MT_TAILQ_INSERT_HEAD(head, elem, filed) TAILQ_INSERT_HEAD(head, elem, filed)
+#define MT_TAILQ_REMOVE(head, elem, filed) TAILQ_REMOVE(head, elem, filed)
+#define MT_TAILQ_INIT(head) TAILQ_INIT(head)
+
+#define MT_STAILQ_HEAD(name, type) RTE_STAILQ_HEAD(name, type)
+#define MT_STAILQ_ENTRY(type) RTE_STAILQ_ENTRY(type)
 
 #define MT_MAY_UNUSED(x) (void)(x)
 

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -772,6 +772,7 @@ struct mt_tsq_impl {
 struct mt_srss_entry {
   struct mt_rxq_flow flow;
   struct mt_srss_impl* srss;
+  uint16_t queue_id;
   /* linked list */
   MT_TAILQ_ENTRY(mt_srss_entry) next;
 };

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -150,7 +150,7 @@ struct mt_ptp_impl {
   enum mtl_port port;
   uint16_t port_id;
 
-  struct mt_rx_queue* rx_queue;
+  struct mt_rxq_entry* rxq;
   struct rte_mempool* mbuf_pool;
 
   uint8_t mcast_group_addr[MTL_IP_ADDR_LEN]; /* 224.0.1.129 */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -228,10 +228,7 @@ struct mt_cni_impl {
   bool used; /* if enable cni */
   int num_ports;
 
-  struct mt_rx_queue* rx_q[MTL_PORT_MAX];   /* cni rx queue */
-  struct mt_rsq_entry* rsq[MTL_PORT_MAX];   /* cni rsq queue */
-  struct mt_rss_entry* rss[MTL_PORT_MAX];   /* cni rss queue */
-  struct mt_srss_entry* srss[MTL_PORT_MAX]; /* cni srss queue */
+  struct mt_rxq_entry* rxq[MTL_PORT_MAX];
   struct mt_cni_priv cni_priv[MTL_PORT_MAX];
   pthread_t tid; /* thread id for rx */
   rte_atomic32_t stop_thread;
@@ -430,8 +427,8 @@ struct mt_rl_shaper {
 
 typedef int (*mt_rsq_mbuf_cb)(void* priv, struct rte_mbuf** mbuf, uint16_t nb);
 
-/* request of rx flow */
-struct mt_rx_flow {
+/* request of rx queue flow */
+struct mt_rxq_flow {
   /* for cni queue */
   bool sys_queue;
   bool no_ip_flow; /* no ip flow, only use port flow, for udp transport */
@@ -465,7 +462,7 @@ struct mt_rx_queue {
   uint16_t port_id;
   uint16_t queue_id;
   bool active;
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   struct mt_rx_flow_rsp* flow_rsp;
   struct rte_mempool* mbuf_pool;
   unsigned int mbuf_elements;
@@ -674,7 +671,7 @@ struct mt_rss_impl; /* forward delcare */
 
 struct mt_rss_entry {
   uint16_t queue_id;
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   struct mt_rss_impl* rss;
   uint32_t hash;
   /* linked list */
@@ -701,7 +698,7 @@ struct mt_rsq_impl; /* forward delcare */
 
 struct mt_rsq_entry {
   uint16_t queue_id;
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   uint16_t dst_port_net;
   struct mt_rx_flow_rsp* flow_rsp;
   struct mt_rsq_impl* parent;
@@ -730,8 +727,8 @@ struct mt_rsq_impl {
   struct mt_rsq_queue* rsq_queues;
 };
 
-/* request of tx shared queue flow */
-struct mt_tsq_flow {
+/* request of tx queue flow */
+struct mt_txq_flow {
   bool sys_queue;
   /* mandatory if not sys_queue */
   uint8_t dip_addr[MTL_IP_ADDR_LEN]; /* tx destination IP */
@@ -742,7 +739,7 @@ struct mt_tsq_impl; /* forward delcare */
 
 struct mt_tsq_entry {
   uint16_t queue_id;
-  struct mt_tsq_flow flow;
+  struct mt_txq_flow flow;
   struct mt_tsq_impl* parent;
   struct rte_mempool* tx_pool;
   /* linked list */
@@ -773,7 +770,7 @@ struct mt_tsq_impl {
 };
 
 struct mt_srss_entry {
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   struct mt_srss_impl* srss;
   /* linked list */
   MT_TAILQ_ENTRY(mt_srss_entry) next;

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -5,7 +5,7 @@
 #include "mt_ptp.h"
 
 #include "mt_cni.h"
-#include "mt_dev.h"
+#include "mt_queue.h"
 // #define DEBUG
 #include "mt_log.h"
 #include "mt_mcast.h"
@@ -717,10 +717,11 @@ static int ptp_init(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp,
   rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
   flow.no_port_flow = true;
   flow.dst_port = MT_PTP_UDP_GEN_PORT;
-  ptp->rx_queue = mt_dev_get_rx_queue(impl, port, &flow);
-  if (!ptp->rx_queue) {
-    err("%s(%d), ptp rx q create fail\n", __func__, port);
-    return -EIO;
+  ptp->rxq = mt_rxq_get(impl, port, &flow);
+  if (ptp->rxq) {
+    info("%s(%d), rx queue %d\n", __func__, port, mt_rxq_queue_id(ptp->rxq));
+  } else {
+    warn("%s(%d), fall back to cni path\n", __func__, port);
   }
 
   /* join mcast */
@@ -731,8 +732,7 @@ static int ptp_init(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp,
   }
   mt_mcast_l2_join(impl, &ptp_l2_multicast_eaddr, port);
 
-  info("%s(%d), rx queue %d, sip: %d.%d.%d.%d\n", __func__, port,
-       mt_dev_rx_queue_id(ptp->rx_queue), ip[0], ip[1], ip[2], ip[3]);
+  info("%s(%d), sip: %d.%d.%d.%d\n", __func__, port, ip[0], ip[1], ip[2], ip[3]);
   return 0;
 }
 
@@ -751,9 +751,9 @@ static int ptp_uinit(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp) {
   mt_mcast_l2_leave(impl, &ptp_l2_multicast_eaddr, port);
   mt_mcast_leave(impl, mt_ip_to_u32(ptp->mcast_group_addr), port);
 
-  if (ptp->rx_queue) {
-    mt_dev_put_rx_queue(impl, ptp->rx_queue);
-    ptp->rx_queue = NULL;
+  if (ptp->rxq) {
+    mt_rxq_put(ptp->rxq);
+    ptp->rxq = NULL;
   }
 
   info("%s(%d), succ\n", __func__, port);

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -711,7 +711,7 @@ static int ptp_init(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp,
   inet_pton(AF_INET, "224.0.1.129", ptp->mcast_group_addr);
 
   /* create rx queue */
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   memset(&flow, 0, sizeof(flow));
   rte_memcpy(flow.dip_addr, ptp->mcast_group_addr, MTL_IP_ADDR_LEN);
   rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);

--- a/lib/src/mt_queue.c
+++ b/lib/src/mt_queue.c
@@ -19,7 +19,7 @@ struct mt_rxq_entry* mt_rxq_get(struct mtl_main_impl* impl, enum mtl_port port,
   if (mt_has_srss(impl, port)) {
     entry->srss = mt_srss_get(impl, port, flow);
     if (!entry->srss) goto fail;
-    entry->queue_id = 0; /* not known the queue id */
+    entry->queue_id = mt_srss_queue_id(entry->srss);
   } else if (mt_has_rss(impl, port)) {
     entry->rss = mt_rss_get(impl, port, flow);
     if (!entry->rss) goto fail;

--- a/lib/src/mt_queue.c
+++ b/lib/src/mt_queue.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+#include "mt_queue.h"
+
+#include "mt_log.h"
+
+struct mt_rxq_entry* mt_rxq_get(struct mtl_main_impl* impl, enum mtl_port port,
+                                struct mt_rxq_flow* flow) {
+  struct mt_rxq_entry* entry =
+      mt_rte_zmalloc_socket(sizeof(*entry), mt_socket_id(impl, port));
+  if (!entry) {
+    err("%s(%d), entry malloc fail\n", __func__, port);
+    return NULL;
+  }
+  entry->parent = impl;
+
+  if (mt_has_srss(impl, port)) {
+    entry->srss = mt_srss_get(impl, port, flow);
+    if (!entry->srss) goto fail;
+    entry->queue_id = 0; /* not known the queue id */
+  } else if (mt_has_rss(impl, port)) {
+    entry->rss = mt_rss_get(impl, port, flow);
+    if (!entry->rss) goto fail;
+    entry->queue_id = mt_rss_queue_id(entry->rss);
+  } else if (mt_shared_queue(impl, port)) {
+    entry->rsq = mt_rsq_get(impl, port, flow);
+    if (!entry->rsq) goto fail;
+    entry->queue_id = mt_rsq_queue_id(entry->rsq);
+  } else {
+    entry->rxq = mt_dev_get_rx_queue(impl, port, flow);
+    if (!entry->rxq) goto fail;
+    entry->queue_id = mt_dev_rx_queue_id(entry->rxq);
+  }
+
+  return entry;
+
+fail:
+  mt_rxq_put(entry);
+  return NULL;
+}
+
+int mt_rxq_put(struct mt_rxq_entry* entry) {
+  if (entry->rxq) {
+    mt_dev_put_rx_queue(entry->parent, entry->rxq);
+    entry->rxq = NULL;
+  }
+  if (entry->rsq) {
+    mt_rsq_put(entry->rsq);
+    entry->rsq = NULL;
+  }
+  if (entry->rss) {
+    mt_rss_put(entry->rss);
+    entry->rss = NULL;
+  }
+  if (entry->srss) {
+    mt_srss_put(entry->srss);
+    entry->srss = NULL;
+  }
+  mt_rte_free(entry);
+  return 0;
+}
+
+uint16_t mt_rxq_burst(struct mt_rxq_entry* entry, struct rte_mbuf** rx_pkts,
+                      const uint16_t nb_pkts) {
+  uint16_t rx;
+  if (entry->srss) {
+    rx = 0; /* srss rx on the srss tasklet */
+  } else if (entry->rsq) {
+    mt_rsq_burst(entry->rsq, nb_pkts);
+    rx = 0; /* the buf is handled in the callback */
+  } else if (entry->rss) {
+    mt_rss_burst(entry->rss, nb_pkts);
+    rx = 0; /* the buf is handled in the callback */
+  } else {
+    rx = mt_dev_rx_burst(entry->rxq, rx_pkts, nb_pkts);
+  }
+
+  return rx;
+}

--- a/lib/src/mt_queue.h
+++ b/lib/src/mt_queue.h
@@ -5,21 +5,6 @@
 #ifndef _MT_LIB_QUEUE_HEAD_H_
 #define _MT_LIB_QUEUE_HEAD_H_
 
-#include <sys/queue.h>
-
-/* Macros compatible with system's sys/queue.h */
-#define MT_TAILQ_HEAD(name, type) RTE_TAILQ_HEAD(name, type)
-#define MT_TAILQ_ENTRY(type) RTE_TAILQ_ENTRY(type)
-#define MT_TAILQ_FOREACH(var, head, field) RTE_TAILQ_FOREACH(var, head, field)
-#define MT_TAILQ_FIRST(head) RTE_TAILQ_FIRST(head)
-#define MT_TAILQ_NEXT(elem, field) RTE_TAILQ_NEXT(elem, field)
-
-#define MT_TAILQ_INSERT_TAIL(head, elem, filed) TAILQ_INSERT_TAIL(head, elem, filed)
-#define MT_TAILQ_INSERT_HEAD(head, elem, filed) TAILQ_INSERT_HEAD(head, elem, filed)
-#define MT_TAILQ_REMOVE(head, elem, filed) TAILQ_REMOVE(head, elem, filed)
-#define MT_TAILQ_INIT(head) TAILQ_INIT(head)
-
-#define MT_STAILQ_HEAD(name, type) RTE_STAILQ_HEAD(name, type)
-#define MT_STAILQ_ENTRY(type) RTE_STAILQ_ENTRY(type)
+1
 
 #endif

--- a/lib/src/mt_queue.h
+++ b/lib/src/mt_queue.h
@@ -10,10 +10,6 @@
 #ifndef _MT_LIB_QUEUE_HEAD_H_
 #define _MT_LIB_QUEUE_HEAD_H_
 
-struct mt_txq_entry {
-  uint16_t queue_id;
-};
-
 struct mt_rxq_entry {
   struct mtl_main_impl* parent;
   uint16_t queue_id;
@@ -31,25 +27,5 @@ static inline uint16_t mt_rxq_queue_id(struct mt_rxq_entry* entry) {
 uint16_t mt_rxq_burst(struct mt_rxq_entry* entry, struct rte_mbuf** rx_pkts,
                       const uint16_t nb_pkts);
 int mt_rxq_put(struct mt_rxq_entry* entry);
-
-#if 0
-struct mt_txq_entry* mt_txq_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                struct mt_txq_flow* flow);
-static inline uint16_t mt_txq_queue_id(struct mt_txq_entry* entry) {
-  return entry->queue_id;
-}
-static inline struct rte_mempool* mt_txq_mempool(struct mt_txq_entry* entry) {
-  return entry->tx_pool;
-}
-int mt_txq_set_bps(struct mtl_main_impl* impl, struct mt_txq_entry* entry,
-                   uint64_t bytes_per_sec);
-uint16_t mt_txq_burst(struct mt_txq_entry* entry, struct rte_mbuf** tx_pkts,
-                      uint16_t nb_pkts);
-uint16_t mt_txq_burst_busy(struct mtl_main_impl* impl, struct mt_txq_entry* entry,
-                           struct rte_mbuf** tx_pkts, uint16_t nb_pkts, int timeout_ms);
-int mt_txq_flush(struct mtl_main_impl* impl, struct mt_txq_entry* entry,
-                 struct rte_mbuf* pad);
-int mt_txq_put(struct mt_txq_entry* entry);
-#endif
 
 #endif

--- a/lib/src/mt_queue.h
+++ b/lib/src/mt_queue.h
@@ -1,10 +1,55 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(c) 2022 Intel Corporation
+ * Copyright(c) 2023 Intel Corporation
  */
+
+#include "mt_dev.h"
+#include "mt_rss.h"
+#include "mt_shared_queue.h"
+#include "mt_shared_rss.h"
 
 #ifndef _MT_LIB_QUEUE_HEAD_H_
 #define _MT_LIB_QUEUE_HEAD_H_
 
-1
+struct mt_txq_entry {
+  uint16_t queue_id;
+};
+
+struct mt_rxq_entry {
+  struct mtl_main_impl* parent;
+  uint16_t queue_id;
+  struct mt_rx_queue* rxq;
+  struct mt_rsq_entry* rsq;
+  struct mt_rss_entry* rss;
+  struct mt_srss_entry* srss;
+};
+
+struct mt_rxq_entry* mt_rxq_get(struct mtl_main_impl* impl, enum mtl_port port,
+                                struct mt_rxq_flow* flow);
+static inline uint16_t mt_rxq_queue_id(struct mt_rxq_entry* entry) {
+  return entry->queue_id;
+}
+uint16_t mt_rxq_burst(struct mt_rxq_entry* entry, struct rte_mbuf** rx_pkts,
+                      const uint16_t nb_pkts);
+int mt_rxq_put(struct mt_rxq_entry* entry);
+
+#if 0
+struct mt_txq_entry* mt_txq_get(struct mtl_main_impl* impl, enum mtl_port port,
+                                struct mt_txq_flow* flow);
+static inline uint16_t mt_txq_queue_id(struct mt_txq_entry* entry) {
+  return entry->queue_id;
+}
+static inline struct rte_mempool* mt_txq_mempool(struct mt_txq_entry* entry) {
+  return entry->tx_pool;
+}
+int mt_txq_set_bps(struct mtl_main_impl* impl, struct mt_txq_entry* entry,
+                   uint64_t bytes_per_sec);
+uint16_t mt_txq_burst(struct mt_txq_entry* entry, struct rte_mbuf** tx_pkts,
+                      uint16_t nb_pkts);
+uint16_t mt_txq_burst_busy(struct mtl_main_impl* impl, struct mt_txq_entry* entry,
+                           struct rte_mbuf** tx_pkts, uint16_t nb_pkts, int timeout_ms);
+int mt_txq_flush(struct mtl_main_impl* impl, struct mt_txq_entry* entry,
+                 struct rte_mbuf* pad);
+int mt_txq_put(struct mt_txq_entry* entry);
+#endif
 
 #endif

--- a/lib/src/mt_rss.c
+++ b/lib/src/mt_rss.c
@@ -72,7 +72,7 @@ static int rss_uinit(struct mt_rss_impl* rss) {
   return 0;
 }
 
-static enum mtl_rss_mode rss_flow_mode(struct mt_rx_flow* flow) {
+static enum mtl_rss_mode rss_flow_mode(struct mt_rxq_flow* flow) {
   if (flow->no_port_flow)
     return MTL_RSS_MODE_L3;
   else if (flow->no_ip_flow)
@@ -84,7 +84,7 @@ static enum mtl_rss_mode rss_flow_mode(struct mt_rx_flow* flow) {
 }
 
 static int rss_flow_check(struct mtl_main_impl* impl, enum mtl_port port,
-                          struct mt_rx_flow* flow) {
+                          struct mt_rxq_flow* flow) {
   enum mtl_rss_mode sys_rss_mode = mt_get_rss_mode(impl, port);
   enum mtl_rss_mode flow_rss_mode = rss_flow_mode(flow);
 
@@ -97,7 +97,7 @@ static int rss_flow_check(struct mtl_main_impl* impl, enum mtl_port port,
   return 0;
 }
 
-static uint32_t rss_flow_hash(struct mt_rx_flow* flow, enum mtl_rss_mode rss) {
+static uint32_t rss_flow_hash(struct mt_rxq_flow* flow, enum mtl_rss_mode rss) {
   uint32_t tuple[4];
   uint32_t len = 0;
 
@@ -140,7 +140,7 @@ static uint32_t rss_flow_hash(struct mt_rx_flow* flow, enum mtl_rss_mode rss) {
 }
 
 struct mt_rss_entry* mt_rss_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                struct mt_rx_flow* flow) {
+                                struct mt_rxq_flow* flow) {
   if (!mt_has_rss(impl, port)) {
     err("%s(%d), rss not enabled\n", __func__, port);
     return NULL;

--- a/lib/src/mt_rss.c
+++ b/lib/src/mt_rss.c
@@ -145,6 +145,10 @@ struct mt_rss_entry* mt_rss_get(struct mtl_main_impl* impl, enum mtl_port port,
     err("%s(%d), rss not enabled\n", __func__, port);
     return NULL;
   }
+  if (!flow->cb) {
+    err("%s(%d), no cb in the flow\n", __func__, port);
+    return NULL;
+  }
   if (rss_flow_check(impl, port, flow) < 0) return NULL;
 
   struct mt_rss_impl* rss = rss_ctx_get(impl, port);

--- a/lib/src/mt_rss.h
+++ b/lib/src/mt_rss.h
@@ -11,7 +11,7 @@ int mt_rss_init(struct mtl_main_impl* impl);
 int mt_rss_uinit(struct mtl_main_impl* impl);
 
 struct mt_rss_entry* mt_rss_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                struct mt_rx_flow* flow);
+                                struct mt_rxq_flow* flow);
 static inline uint16_t mt_rss_queue_id(struct mt_rss_entry* entry) {
   return entry->queue_id;
 }

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -97,7 +97,7 @@ static int rsq_init(struct mtl_main_impl* impl, struct mt_rsq_impl* rsq) {
   return 0;
 }
 
-static uint32_t rsq_flow_hash(struct mt_rx_flow* flow) {
+static uint32_t rsq_flow_hash(struct mt_rxq_flow* flow) {
   struct rte_ipv4_tuple tuple;
   uint32_t len;
 
@@ -114,7 +114,7 @@ static uint32_t rsq_flow_hash(struct mt_rx_flow* flow) {
 }
 
 struct mt_rsq_entry* mt_rsq_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                struct mt_rx_flow* flow) {
+                                struct mt_rxq_flow* flow) {
   if (!mt_shared_queue(impl, port)) {
     err("%s(%d), shared queue not enabled\n", __func__, port);
     return NULL;
@@ -335,7 +335,7 @@ static int tsq_init(struct mtl_main_impl* impl, struct mt_tsq_impl* tsq) {
   return 0;
 }
 
-static uint32_t tsq_flow_hash(struct mt_tsq_flow* flow) {
+static uint32_t tsq_flow_hash(struct mt_txq_flow* flow) {
   struct rte_ipv4_tuple tuple;
   uint32_t len;
 
@@ -351,7 +351,7 @@ static uint32_t tsq_flow_hash(struct mt_tsq_flow* flow) {
 }
 
 struct mt_tsq_entry* mt_tsq_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                struct mt_tsq_flow* flow) {
+                                struct mt_txq_flow* flow) {
   if (!mt_shared_queue(impl, port)) {
     err("%s(%d), shared queue not enabled\n", __func__, port);
     return NULL;

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -119,6 +119,10 @@ struct mt_rsq_entry* mt_rsq_get(struct mtl_main_impl* impl, enum mtl_port port,
     err("%s(%d), shared queue not enabled\n", __func__, port);
     return NULL;
   }
+  if (!flow->cb) {
+    err("%s(%d), no cb in the flow\n", __func__, port);
+    return NULL;
+  }
 
   struct mt_rsq_impl* rsqm = rsq_ctx_get(impl, port);
   uint32_t hash = rsq_flow_hash(flow);

--- a/lib/src/mt_shared_queue.h
+++ b/lib/src/mt_shared_queue.h
@@ -11,7 +11,7 @@ int mt_rsq_init(struct mtl_main_impl* impl);
 int mt_rsq_uinit(struct mtl_main_impl* impl);
 
 struct mt_rsq_entry* mt_rsq_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                struct mt_rx_flow* flow);
+                                struct mt_rxq_flow* flow);
 static inline uint16_t mt_rsq_queue_id(struct mt_rsq_entry* entry) {
   return entry->queue_id;
 }
@@ -22,7 +22,7 @@ int mt_tsq_init(struct mtl_main_impl* impl);
 int mt_tsq_uinit(struct mtl_main_impl* impl);
 
 struct mt_tsq_entry* mt_tsq_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                struct mt_tsq_flow* flow);
+                                struct mt_txq_flow* flow);
 static inline uint16_t mt_tsq_queue_id(struct mt_tsq_entry* entry) {
   return entry->queue_id;
 }

--- a/lib/src/mt_shared_rss.c
+++ b/lib/src/mt_shared_rss.c
@@ -141,7 +141,7 @@ static int srss_tasklet_stop(void* priv) {
 }
 
 struct mt_srss_entry* mt_srss_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                  struct mt_rx_flow* flow) {
+                                  struct mt_rxq_flow* flow) {
   struct mt_srss_impl* srss = impl->srss[port];
   struct mt_srss_entry* entry;
   MT_TAILQ_FOREACH(entry, &srss->head, next) {

--- a/lib/src/mt_shared_rss.c
+++ b/lib/src/mt_shared_rss.c
@@ -144,6 +144,17 @@ struct mt_srss_entry* mt_srss_get(struct mtl_main_impl* impl, enum mtl_port port
                                   struct mt_rxq_flow* flow) {
   struct mt_srss_impl* srss = impl->srss[port];
   struct mt_srss_entry* entry;
+  static uint16_t srss_queue_id;
+
+  if (!mt_has_srss(impl, port)) {
+    err("%s(%d), shared rss not enabled\n", __func__, port);
+    return NULL;
+  }
+  if (!flow->cb) {
+    err("%s(%d), no cb in the flow\n", __func__, port);
+    return NULL;
+  }
+
   MT_TAILQ_FOREACH(entry, &srss->head, next) {
     if (entry->flow.dst_port == flow->dst_port &&
         *(uint32_t*)entry->flow.dip_addr == *(uint32_t*)flow->dip_addr) {
@@ -152,6 +163,7 @@ struct mt_srss_entry* mt_srss_get(struct mtl_main_impl* impl, enum mtl_port port
       return NULL;
     }
   }
+
   entry = mt_rte_zmalloc_socket(sizeof(*entry), mt_socket_id(impl, port));
   if (!entry) {
     err("%s(%d), malloc fail\n", __func__, port);
@@ -159,6 +171,8 @@ struct mt_srss_entry* mt_srss_get(struct mtl_main_impl* impl, enum mtl_port port
   }
   entry->flow = *flow;
   entry->srss = srss;
+  entry->queue_id = srss_queue_id; /* use a dummy queue id */
+  srss_queue_id++;
   pthread_mutex_lock(&srss->mutex);
   MT_TAILQ_INSERT_TAIL(&srss->head, entry, next);
   if (flow->sys_queue) srss->cni_entry = entry;

--- a/lib/src/mt_shared_rss.h
+++ b/lib/src/mt_shared_rss.h
@@ -12,7 +12,7 @@ int mt_srss_init(struct mtl_main_impl* impl);
 int mt_srss_uinit(struct mtl_main_impl* impl);
 
 struct mt_srss_entry* mt_srss_get(struct mtl_main_impl* impl, enum mtl_port port,
-                                  struct mt_rx_flow* flow);
+                                  struct mt_rxq_flow* flow);
 
 int mt_srss_put(struct mt_srss_entry* entry);
 

--- a/lib/src/mt_shared_rss.h
+++ b/lib/src/mt_shared_rss.h
@@ -13,7 +13,9 @@ int mt_srss_uinit(struct mtl_main_impl* impl);
 
 struct mt_srss_entry* mt_srss_get(struct mtl_main_impl* impl, enum mtl_port port,
                                   struct mt_rxq_flow* flow);
-
+static inline uint16_t mt_srss_queue_id(struct mt_srss_entry* entry) {
+  return entry->queue_id;
+}
 int mt_srss_put(struct mt_srss_entry* entry);
 
 #endif

--- a/lib/src/mt_socket.c
+++ b/lib/src/mt_socket.c
@@ -283,7 +283,7 @@ int mt_socket_get_mac(struct mtl_main_impl* impl, char* if_name,
 }
 
 int mt_socket_add_flow(struct mtl_main_impl* impl, enum mtl_port port, uint16_t queue_id,
-                       struct mt_rx_flow* flow) {
+                       struct mt_rxq_flow* flow) {
   char cmd[256];
   char out[128]; /* Added rule with ID 15871 */
   int ret;
@@ -359,7 +359,7 @@ int mt_socket_get_mac(struct mtl_main_impl* impl, char* if_name,
 }
 
 int mt_socket_add_flow(struct mtl_main_impl* impl, enum mtl_port port, uint16_t queue_id,
-                       struct mt_rx_flow* flow) {
+                       struct mt_rxq_flow* flow) {
   return -ENOTSUP;
 }
 

--- a/lib/src/mt_socket.h
+++ b/lib/src/mt_socket.h
@@ -23,7 +23,7 @@ int mt_socket_get_mac(struct mtl_main_impl* impl, char* if_name,
                       int timeout_ms);
 
 int mt_socket_add_flow(struct mtl_main_impl* impl, enum mtl_port port, uint16_t queue_id,
-                       struct mt_rx_flow* flow);
+                       struct mt_rxq_flow* flow);
 
 int mt_socket_remove_flow(struct mtl_main_impl* impl, enum mtl_port port, int flow_id);
 

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -565,6 +565,7 @@ struct st_rx_session_priv {
 
 struct st_rx_video_session_impl {
   int idx; /* index for current session */
+  bool attached;
   struct st_rx_video_sessions_mgr* parent;
   struct st_rx_session_priv priv[MTL_SESSION_PORT_MAX];
 
@@ -857,6 +858,7 @@ struct st_rx_audio_ebu_result {
 
 struct st_rx_audio_session_impl {
   int idx; /* index for current session */
+  bool attached;
   struct st30_rx_ops ops;
   char ops_name[ST_MAX_NAME_LEN];
   struct st_rx_session_priv priv[MTL_SESSION_PORT_MAX];
@@ -1008,6 +1010,7 @@ struct st_tx_ancillary_sessions_mgr {
 
 struct st_rx_ancillary_session_impl {
   int idx; /* index for current session */
+  bool attached;
   struct st40_rx_ops ops;
   char ops_name[ST_MAX_NAME_LEN];
   struct st_rx_session_priv priv[MTL_SESSION_PORT_MAX];

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -573,9 +573,7 @@ struct st_rx_video_session_impl {
   uint64_t advice_sleep_us;
 
   enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
-  struct mt_rx_queue* queue[MTL_SESSION_PORT_MAX];
-  struct mt_rss_entry* rss[MTL_SESSION_PORT_MAX];
-  struct mt_srss_entry* srss[MTL_SESSION_PORT_MAX];
+  struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
   uint16_t port_id[MTL_SESSION_PORT_MAX];
   uint16_t st20_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
   uint16_t st20_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
@@ -865,9 +863,7 @@ struct st_rx_audio_session_impl {
   struct st_rx_audio_session_handle_impl* st30_handle;
 
   enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
-  struct mt_rx_queue* queue[MTL_SESSION_PORT_MAX];
-  struct mt_rss_entry* rss[MTL_SESSION_PORT_MAX];
-  struct mt_srss_entry* srss[MTL_SESSION_PORT_MAX];
+  struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
   uint16_t port_id[MTL_SESSION_PORT_MAX];
 
   uint16_t st30_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
@@ -1018,9 +1014,7 @@ struct st_rx_ancillary_session_impl {
   struct st_rx_ancillary_session_handle_impl* st40_handle;
 
   enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
-  struct mt_rx_queue* queue[MTL_SESSION_PORT_MAX];
-  struct mt_rss_entry* rss[MTL_SESSION_PORT_MAX];
-  struct mt_srss_entry* srss[MTL_SESSION_PORT_MAX];
+  struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
   uint16_t port_id[MTL_SESSION_PORT_MAX];
   struct rte_ring* packet_ring;
 

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -129,7 +129,7 @@ static int rx_ancillary_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf,
   struct mtl_main_impl* impl = s_priv->impl;
   enum mtl_session_port s_port = s_priv->s_port;
 
-  if (!s->st40_handle) {
+  if (!s->attached) {
     dbg("%s(%d,%d), session not ready\n", __func__, s->idx, s_port);
     return -EIO;
   }
@@ -351,6 +351,7 @@ static int rx_ancillary_session_attach(struct mtl_main_impl* impl,
     return -EIO;
   }
 
+  s->attached = true;
   info("%s(%d), succ\n", __func__, idx);
   return 0;
 }
@@ -382,6 +383,7 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
 
 static int rx_ancillary_session_detach(struct mtl_main_impl* impl,
                                        struct st_rx_ancillary_session_impl* s) {
+  s->attached = false;
   rx_ancillary_session_stat(s);
   rx_ancillary_session_uinit_mcast(impl, s);
   rx_ancillary_session_uinit_sw(impl, s);

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -209,7 +209,7 @@ static int rx_ancillary_session_uinit_hw(struct mtl_main_impl* impl,
 static int rx_ancillary_session_init_hw(struct mtl_main_impl* impl,
                                         struct st_rx_ancillary_session_impl* s) {
   int idx = s->idx, num_port = s->ops.num_port;
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   enum mtl_port port;
 
   for (int i = 0; i < num_port; i++) {

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -605,7 +605,7 @@ static int rx_audio_session_uinit_hw(struct mtl_main_impl* impl,
 static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
                                     struct st_rx_audio_session_impl* s) {
   int idx = s->idx, num_port = s->ops.num_port;
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   enum mtl_port port;
 
   for (int i = 0; i < num_port; i++) {

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -518,7 +518,7 @@ static int rx_audio_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf, uint
   enum mtl_session_port s_port = s_priv->s_port;
   enum st30_type st30_type = s->ops.type;
 
-  if (!s->st30_handle) {
+  if (!s->attached) {
     dbg("%s(%d,%d), session not ready\n", __func__, s->idx, s_port);
     return -EIO;
   }
@@ -768,6 +768,7 @@ static int rx_audio_session_attach(struct mtl_main_impl* impl,
     return -EIO;
   }
 
+  s->attached = true;
   info("%s(%d), pkt_len %u frame_size %" PRId64 "\n", __func__, idx, s->pkt_len,
        s->st30_frame_size);
   return 0;
@@ -807,6 +808,7 @@ static void rx_audio_session_stat(struct st_rx_audio_session_impl* s) {
 
 static int rx_audio_session_detach(struct mtl_main_impl* impl,
                                    struct st_rx_audio_session_impl* s) {
+  s->attached = false;
   if (mt_has_ebu(impl)) rx_audio_session_ebu_result(s);
   rx_audio_session_stat(s);
   rx_audio_session_uinit_mcast(impl, s);

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -7,7 +7,7 @@
 #include <math.h>
 
 #include "../mt_log.h"
-#include "../mt_shared_rss.h"
+#include "../mt_queue.h"
 #include "../mt_stat.h"
 
 static inline double ra_ebu_pass_rate(struct st_rx_audio_ebu_result* ebu_result,
@@ -17,12 +17,7 @@ static inline double ra_ebu_pass_rate(struct st_rx_audio_ebu_result* ebu_result,
 
 static inline uint16_t rx_audio_queue_id(struct st_rx_audio_session_impl* s,
                                          enum mtl_session_port s_port) {
-  if (s->srss[s_port])
-    return 0;
-  else if (s->rss[s_port])
-    return mt_rss_queue_id(s->rss[s_port]);
-  else
-    return mt_dev_rx_queue_id(s->queue[s_port]);
+  return mt_rxq_queue_id(s->rxq[s_port]);
 }
 
 static void rx_audio_session_ebu_result(struct st_rx_audio_session_impl* s) {
@@ -549,16 +544,12 @@ static int rx_audio_session_tasklet(struct mtl_main_impl* impl,
   bool done = true;
 
   for (int s_port = 0; s_port < num_port; s_port++) {
-    if (s->rss[s_port]) {
-      rv = mt_rss_burst(s->rss[s_port], ST_RX_AUDIO_BURST_SIZE);
-    } else if (s->queue[s_port]) {
-      rv = mt_dev_rx_burst(s->queue[s_port], &mbuf[0], ST_RX_AUDIO_BURST_SIZE);
-      if (rv) {
-        rx_audio_session_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
-        rte_pktmbuf_free_bulk(&mbuf[0], rv);
-      }
-    } else {
-      continue;
+    if (!s->rxq[s_port]) continue;
+
+    rv = mt_rxq_burst(s->rxq[s_port], &mbuf[0], ST_RX_AUDIO_BURST_SIZE);
+    if (rv) {
+      rx_audio_session_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
+      rte_pktmbuf_free_bulk(&mbuf[0], rv);
     }
 
     if (rv) done = false;
@@ -589,13 +580,9 @@ static int rx_audio_session_uinit_hw(struct mtl_main_impl* impl,
   int num_port = s->ops.num_port;
 
   for (int i = 0; i < num_port; i++) {
-    if (s->queue[i]) {
-      mt_dev_put_rx_queue(impl, s->queue[i]);
-      s->queue[i] = NULL;
-    }
-    if (s->rss[i]) {
-      mt_rss_put(s->rss[i]);
-      s->rss[i] = NULL;
+    if (s->rxq[i]) {
+      mt_rxq_put(s->rxq[i]);
+      s->rxq[i] = NULL;
     }
   }
 
@@ -626,12 +613,10 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST30_RX_FLAG_DATA_PATH_ONLY))
-      s->queue[i] = mt_dev_get_rx_queue(impl, port, NULL);
-    else if (mt_has_rss(impl, port))
-      s->rss[i] = mt_rss_get(impl, port, &flow);
+      s->rxq[i] = mt_rxq_get(impl, port, NULL);
     else
-      s->queue[i] = mt_dev_get_rx_queue(impl, port, &flow);
-    if (!s->queue[i] && !s->rss[i]) {
+      s->rxq[i] = mt_rxq_get(impl, port, &flow);
+    if (!s->rxq[i]) {
       rx_audio_session_uinit_hw(impl, s);
       return -EIO;
     }
@@ -783,19 +768,6 @@ static int rx_audio_session_attach(struct mtl_main_impl* impl,
     return -EIO;
   }
 
-  for (int i = 0; i < num_port; i++) {
-    enum mtl_port port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_has_srss(impl, port)) {
-      s->srss[i] = mt_srss_get(impl, port, &s->rss[i]->flow);
-      if (!s->srss[i]) {
-        err("%s(%d), mt_srss_get fail\n", __func__, idx);
-        rx_audio_session_uinit_sw(impl, s);
-        rx_audio_session_uinit_hw(impl, s);
-        return -EIO;
-      }
-    }
-  }
-
   info("%s(%d), pkt_len %u frame_size %" PRId64 "\n", __func__, idx, s->pkt_len,
        s->st30_frame_size);
   return 0;
@@ -837,12 +809,6 @@ static int rx_audio_session_detach(struct mtl_main_impl* impl,
                                    struct st_rx_audio_session_impl* s) {
   if (mt_has_ebu(impl)) rx_audio_session_ebu_result(s);
   rx_audio_session_stat(s);
-  for (int i = 0; i < s->ops.num_port; i++) {
-    if (s->srss[i]) {
-      mt_srss_put(s->srss[i]);
-      s->srss[i] = NULL;
-    }
-  }
   rx_audio_session_uinit_mcast(impl, s);
   rx_audio_session_uinit_sw(impl, s);
   rx_audio_session_uinit_hw(impl, s);

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2796,7 +2796,7 @@ static int rv_uinit_hw(struct mtl_main_impl* impl, struct st_rx_video_session_im
 static int rv_init_hw(struct mtl_main_impl* impl, struct st_rx_video_session_impl* s) {
   struct st20_rx_ops* ops = &s->ops;
   int idx = s->idx, num_port = ops->num_port;
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   enum mtl_port port;
 
   for (int i = 0; i < num_port; i++) {

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -452,7 +452,7 @@ static int udp_init_txq(struct mtl_main_impl* impl, struct mudp_impl* s,
 
   dbg("%s(%d), start\n", __func__, idx);
   if (mt_shared_queue(impl, port)) {
-    struct mt_tsq_flow flow;
+    struct mt_txq_flow flow;
     memset(&flow, 0, sizeof(flow));
     mtl_memcpy(&flow.dip_addr, &addr_in->sin_addr, MTL_IP_ADDR_LEN);
     flow.dst_port = ntohs(addr_in->sin_port);

--- a/lib/src/udp/udp_rxq.c
+++ b/lib/src/udp/udp_rxq.c
@@ -113,14 +113,11 @@ static uint16_t urq_rx(struct mur_queue* q) {
   uint16_t rx_burst = q->rx_burst_pkts;
   struct rte_mbuf* pkts[rx_burst];
 
-  /* no lock need as rsq/rss has lock already */
-  if (q->rsq) return mt_rsq_burst(q->rsq, rx_burst);
-  if (q->rss) return mt_rss_burst(q->rss, rx_burst);
-
-  if (!q->rxq) return 0;
+  /* no lock need as rsq/rss/srss has lock already */
+  if (!q->rxq->rxq) return mt_rxq_burst(q->rxq, NULL, rx_burst);
 
   if (!urq_try_lock(q)) return 0;
-  uint16_t rx = mt_dev_rx_burst(q->rxq, pkts, rx_burst);
+  uint16_t rx = mt_rxq_burst(q->rxq, pkts, rx_burst);
   urq_unlock(q);
 
   uint16_t n = urq_rx_handle(q, pkts, rx);
@@ -188,16 +185,8 @@ static int urq_put(struct mur_queue* q) {
 
   urq_mgr_del(mgr, q);
   if (q->rxq) {
-    mt_dev_put_rx_queue(impl, q->rxq);
+    mt_rxq_put(q->rxq);
     q->rxq = NULL;
-  }
-  if (q->rsq) {
-    mt_rsq_put(q->rsq);
-    q->rsq = NULL;
-  }
-  if (q->rss) {
-    mt_rss_put(q->rss);
-    q->rss = NULL;
   }
 
   urq_mgr_unlock(mgr);
@@ -249,7 +238,6 @@ static struct mur_queue* urq_get(struct mudp_rxq_mgr* mgr,
   MT_TAILQ_INIT(&q->client_head);
   mt_pthread_mutex_init(&q->mutex, NULL);
 
-  uint16_t queue_id;
   /* create flow */
   struct mt_rxq_flow flow;
   memset(&flow, 0, sizeof(flow));
@@ -257,32 +245,14 @@ static struct mur_queue* urq_get(struct mudp_rxq_mgr* mgr,
   flow.dst_port = dst_port;
   flow.priv = q;
   flow.cb = urq_rsq_mbuf_cb; /* for rss and rsq */
-  if (mt_has_rss(impl, port)) {
-    q->rss = mt_rss_get(impl, port, &flow);
-    if (!q->rss) {
-      err("%s(%d,%u), get rss fail\n", __func__, port, dst_port);
-      urq_put(q);
-      goto out_unlock_fail;
-    }
-    queue_id = mt_rss_queue_id(q->rss);
-  } else if (mt_shared_queue(impl, port)) {
-    q->rsq = mt_rsq_get(impl, port, &flow);
-    if (!q->rsq) {
-      err("%s(%d,%u), get rsq fail\n", __func__, port, dst_port);
-      urq_put(q);
-      goto out_unlock_fail;
-    }
-    queue_id = mt_rsq_queue_id(q->rsq);
-  } else {
-    q->rxq = mt_dev_get_rx_queue(impl, port, &flow);
-    if (!q->rxq) {
-      err("%s(%d,%u), get rx queue fail\n", __func__, port, dst_port);
-      urq_put(q);
-      goto out_unlock_fail;
-    }
-    queue_id = mt_dev_rx_queue_id(q->rxq);
+
+  q->rxq = mt_rxq_get(impl, port, &flow);
+  if (!q->rxq) {
+    err("%s(%d,%u), get rxq fail\n", __func__, port, dst_port);
+    urq_put(q);
+    goto out_unlock_fail;
   }
-  q->rxq_id = queue_id;
+  q->rxq_id = mt_rxq_queue_id(q->rxq);
 
   ret = urq_mgr_add(mgr, q);
   if (ret < 0) {

--- a/lib/src/udp/udp_rxq.c
+++ b/lib/src/udp/udp_rxq.c
@@ -251,7 +251,7 @@ static struct mur_queue* urq_get(struct mudp_rxq_mgr* mgr,
 
   uint16_t queue_id;
   /* create flow */
-  struct mt_rx_flow flow;
+  struct mt_rxq_flow flow;
   memset(&flow, 0, sizeof(flow));
   flow.no_ip_flow = true;
   flow.dst_port = dst_port;

--- a/lib/src/udp/udp_rxq.h
+++ b/lib/src/udp/udp_rxq.h
@@ -5,11 +5,9 @@
 #ifndef _MT_LIB_UDP_RXQ_H_
 #define _MT_LIB_UDP_RXQ_H_
 
-#include "../mt_dev.h"
 #include "../mt_main.h"
-#include "../mt_rss.h"
+#include "../mt_queue.h"
 #include "../mt_sch.h"
-#include "../mt_shared_queue.h"
 #include "../mt_util.h"
 
 struct mur_queue;
@@ -53,9 +51,7 @@ struct mur_queue {
   int client_idx;        /* incremental idx fort client */
   pthread_mutex_t mutex; /* clients lock */
 
-  struct mt_rx_queue* rxq;
-  struct mt_rsq_entry* rsq;
-  struct mt_rss_entry* rss;
+  struct mt_rxq_entry* rxq;
   uint16_t rxq_id;
   uint16_t dst_port;
   uint16_t rx_burst_pkts;


### PR DESCRIPTION
mt_rxq_get will call the real rx path according to the system config.
cni/ptp/udp/rx: use mt_rxq_get