### PR TITLE
lib: use concise name for ring/mempool

### DIFF
--- a/doc/aws.md
+++ b/doc/aws.md
@@ -6,7 +6,7 @@ Instance type tested: **m6i.nxlarge**, **m6i.metal**
 
 (check the bandwidth limitation here: [network-performance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose-instances.html#general-purpose-network-performance))
 
-Image tested: **Amazon Linux 2 AMI**
+Image tested: **Amazon Linux 2, Amazon Linux 2023**
 
 Created 2 instances (TX and RX) with required storage.
 
@@ -37,9 +37,8 @@ If you use bare metal, you can turn on IOMMU refer to [run.md](./run.md).
 If you use VM, set NO-IOMMU mode for vfio after each boot.
 
 ```shell
-# under root user
-modprobe vfio-pci
-echo 1 > /sys/module/vfio/parameters/enable_unsafe_noiommu_mode
+sudo modprobe vfio-pci
+sudo bash -c 'echo 1 > /sys/module/vfio/parameters/enable_unsafe_noiommu_mode'
 ```
 
 ## 4. Attach interfaces for DPDK
@@ -63,9 +62,8 @@ After attaching the interface, remember the Private IPv4 address allocated by AW
 Unbind the interface from kernel driver and bind to PMD.
 
 ```shell
-# under root user
-ifconfig eth1 down
-dpdk-devbind.py -b vfio-pci 0000:00:06.0
+sudo ifconfig eth1 down
+sudo dpdk-devbind.py -b vfio-pci 0000:00:06.0
 # check the interfaces
 dpdk-devbind.py -s
 ```

--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -1537,7 +1537,8 @@ static int dev_if_init_rx_queues(struct mtl_main_impl* impl, struct mt_interface
       /* Create mempool to hold the rx queue mbufs. */
       unsigned int mbuf_elements = inf->nb_rx_desc + 1024;
       char pool_name[ST_MAX_NAME_LEN];
-      snprintf(pool_name, ST_MAX_NAME_LEN, "ST%d_RX%d_MBUF_POOL", inf->port, q);
+      snprintf(pool_name, ST_MAX_NAME_LEN, "%sP%dQ%d_MBUF", MT_RX_MEMPOOL_PREFIX,
+               inf->port, q);
       struct rte_mempool* mbuf_pool = NULL;
 
       if (mt_pmd_is_kernel(impl, inf->port)) {
@@ -1572,7 +1573,8 @@ static int dev_if_init_rx_queues(struct mtl_main_impl* impl, struct mt_interface
           dev_if_uinit_rx_queues(inf);
           return -EIO;
         }
-        snprintf(pool_name, ST_MAX_NAME_LEN, "ST%d_RX%d_PAYLOAD_POOL", inf->port, q);
+        snprintf(pool_name, ST_MAX_NAME_LEN, "%sP%dQ%d_PAYLOAD", MT_RX_MEMPOOL_PREFIX,
+                 inf->port, q);
         mbuf_pool = mt_mempool_create(impl, inf->port, pool_name, mbuf_elements,
                                       MT_MBUF_CACHE_SIZE, sizeof(struct mt_muf_priv_data),
                                       ST_PKT_MAX_ETHER_BYTES);
@@ -2502,7 +2504,7 @@ int mt_dev_if_init(struct mtl_main_impl* impl) {
       mbuf_elements = 1024;
       /* append as rx queues */
       mbuf_elements += inf->max_rx_queues * inf->nb_rx_desc;
-      snprintf(pool_name, ST_MAX_NAME_LEN, "ST%d_RX_SYS_MBUF_POOL", i);
+      snprintf(pool_name, ST_MAX_NAME_LEN, "%sP%d_SYS", MT_RX_MEMPOOL_PREFIX, i);
       mbuf_pool = mt_mempool_create_common(impl, i, pool_name, mbuf_elements);
       if (!mbuf_pool) {
         mt_dev_if_uinit(impl);
@@ -2517,7 +2519,7 @@ int mt_dev_if_init(struct mtl_main_impl* impl) {
       /* append as tx queues, double as tx ring */
       mbuf_elements += inf->max_tx_queues * inf->nb_tx_desc * 2;
     }
-    snprintf(pool_name, ST_MAX_NAME_LEN, "ST%d_TX_SYS_MBUF_POOL", i);
+    snprintf(pool_name, ST_MAX_NAME_LEN, "%sP%d_SYS", MT_TX_MEMPOOL_PREFIX, i);
     mbuf_pool = mt_mempool_create_common(impl, i, pool_name, mbuf_elements);
     if (!mbuf_pool) {
       mt_dev_if_uinit(impl);

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -20,6 +20,9 @@
 
 #define MT_EAL_MAX_ARGS (32)
 
+#define MT_TX_MEMPOOL_PREFIX "T_"
+#define MT_RX_MEMPOOL_PREFIX "R_"
+
 int mt_dev_get_socket(const char* port);
 
 int mt_dev_init(struct mtl_init_params* p, struct mt_kport_info* kport_info);

--- a/lib/src/mt_dma.c
+++ b/lib/src/mt_dma.c
@@ -294,7 +294,7 @@ static int dma_sw_init(struct mtl_main_impl* impl, struct mt_dma_dev* dev) {
   struct rte_ring* ring;
   unsigned int flags, count;
 
-  snprintf(ring_name, 32, "RX-DMA-BORROW-RING-D%d", idx);
+  snprintf(ring_name, 32, "%sD%d", MT_DMA_BORROW_RING_PREFIX, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ;
   count = dev->nb_desc;
   ring = rte_ring_create(ring_name, count, mt_socket_id(impl, MTL_PORT_P), flags);

--- a/lib/src/mt_dma.h
+++ b/lib/src/mt_dma.h
@@ -7,6 +7,8 @@
 
 #include "mt_main.h"
 
+#define MT_DMA_BORROW_RING_PREFIX "DB_"
+
 int mt_dma_init(struct mtl_main_impl* impl);
 int mt_dma_uinit(struct mtl_main_impl* impl);
 

--- a/lib/src/mt_kni.c
+++ b/lib/src/mt_kni.c
@@ -48,7 +48,7 @@ static int kni_init_conf(uint16_t port_id, struct rte_kni_conf* conf) {
     return ret;
   }
 
-  snprintf(conf->name, RTE_KNI_NAMESIZE, "vStKni%u_%s", port_id, dev_info.driver_name);
+  snprintf(conf->name, RTE_KNI_NAMESIZE, "K_P%u_%s", port_id, dev_info.driver_name);
   conf->group_id = port_id;
   conf->mbuf_size = 2048;
   conf->min_mtu = dev_info.min_mtu;

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -378,7 +378,7 @@ struct mt_tsq_entry* mt_tsq_get(struct mtl_main_impl* impl, enum mtl_port port,
   mt_pthread_mutex_lock(&tsq_queue->mutex);
   if (!tsq_queue->tx_pool) {
     char pool_name[32];
-    snprintf(pool_name, 32, "TSQ-P%d-Q%u", port, q);
+    snprintf(pool_name, 32, "TSQ_P%dQ%u", port, q);
     struct rte_mempool* pool =
         mt_mempool_create(impl, port, pool_name, mt_if_nb_tx_desc(impl, port) + 512,
                           MT_MBUF_CACHE_SIZE, 0, MTL_MTU_MAX_BYTES);

--- a/lib/src/mt_tap.c
+++ b/lib/src/mt_tap.c
@@ -576,7 +576,7 @@ static int configure_tap() {
   }
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ;
   count = ST_TX_VIDEO_SESSIONS_RING_SIZE;
-  snprintf(ring_name, 32, "TX-TAP-PACKET-RING%d", 0);
+  snprintf(ring_name, 32, "TX-TAP-PACKET-%d", 0);
   tap_tx_ring = rte_ring_create(ring_name, count, mt_socket_id(impl, 0), flags);
   if (!tap_tx_ring) {
     err("%s, tx rte_ring_create fail\n", __func__);

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -275,7 +275,7 @@ static int rx_ancillary_session_init_sw(struct mtl_main_impl* impl,
   int mgr_idx = mgr->idx, idx = s->idx;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
-  snprintf(ring_name, 32, "RX-ANC-PACKET-RING-M%d-R%d", mgr_idx, idx);
+  snprintf(ring_name, 32, "%sM%dS%d_PKT", ST_RX_ANCILLARY_PREFIX, mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   count = s->ops.rtp_ring_size;
   ring = rte_ring_create(ring_name, count, mt_socket_id(impl, port), flags);

--- a/lib/src/st2110/st_rx_ancillary_session.h
+++ b/lib/src/st2110/st_rx_ancillary_session.h
@@ -9,6 +9,8 @@
 
 #define ST_RX_ANCILLARY_BURST_SIZE (128)
 
+#define ST_RX_ANCILLARY_PREFIX "RC_"
+
 int st_rx_ancillary_sessions_mgr_uinit(struct st_rx_ancillary_sessions_mgr* mgr);
 
 #endif

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -335,7 +335,7 @@ static int rx_audio_session_alloc_rtps(struct mtl_main_impl* impl,
   int mgr_idx = mgr->idx, idx = s->idx;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
-  snprintf(ring_name, 32, "RX-AUDIO-RTP-RING-M%d-R%d", mgr_idx, idx);
+  snprintf(ring_name, 32, "%sM%dS%d_RTP", ST_RX_AUDIO_PREFIX, mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   count = s->ops.rtp_ring_size;
   if (count <= 0) {

--- a/lib/src/st2110/st_rx_audio_session.h
+++ b/lib/src/st2110/st_rx_audio_session.h
@@ -9,6 +9,8 @@
 
 #define ST_RX_AUDIO_BURST_SIZE (128)
 
+#define ST_RX_AUDIO_PREFIX "RA_"
+
 int st_rx_audio_sessions_mgr_uinit(struct st_rx_audio_sessions_mgr* mgr);
 
 #endif

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -876,7 +876,7 @@ static int rv_alloc_rtps(struct mtl_main_impl* impl, struct st_rx_video_sessions
   int mgr_idx = mgr->idx, idx = s->idx;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
-  snprintf(ring_name, 32, "RX-VIDEO-RTP-RING-M%d-R%d", mgr_idx, idx);
+  snprintf(ring_name, 32, "%sM%dS%d_RTP", ST_RX_VIDEO_PREFIX, mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   count = s->ops.rtp_ring_size;
   if (count <= 0) {
@@ -1487,7 +1487,7 @@ static int rv_start_pcapng(struct mtl_main_impl* impl, struct st_rx_video_sessio
 #endif
 
   char pool_name[ST_MAX_NAME_LEN];
-  snprintf(pool_name, ST_MAX_NAME_LEN, "pcapng_pool_p%d_s%d", port, idx);
+  snprintf(pool_name, ST_MAX_NAME_LEN, "%sP%dS%d_PCAPNG", ST_RX_VIDEO_PREFIX, port, idx);
   struct rte_mempool* mp =
       mt_mempool_create_by_ops(impl, port, pool_name, 256, MT_MBUF_CACHE_SIZE, 0,
                                rte_pcapng_mbuf_size(pkt_len), "ring_mp_sc");
@@ -2346,7 +2346,7 @@ static int rv_init_pkt_lcore(struct mtl_main_impl* impl,
   int mgr_idx = mgr->idx, idx = s->idx, ret;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
-  snprintf(ring_name, 32, "RX-VIDEO-PKT-RING-M%d-R%d", mgr_idx, idx);
+  snprintf(ring_name, 32, "%sM%dS%d_PKT", ST_RX_VIDEO_PREFIX, mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   count = ST_RX_VIDEO_BURST_SIZE * 4;
   ring = rte_ring_create(ring_name, count, mt_socket_id(impl, port), flags);

--- a/lib/src/st2110/st_rx_video_session.h
+++ b/lib/src/st2110/st_rx_video_session.h
@@ -14,6 +14,8 @@
 #define ST_RV_EBU_TSC_SYNC_MS (100) /* sync tsc with ptp period(ms) */
 #define ST_RV_EBU_TSC_SYNC_NS (ST_RV_EBU_TSC_SYNC_MS * 1000 * 1000)
 
+#define ST_RX_VIDEO_PREFIX "RV_"
+
 int st_rx_video_sessions_sch_init(struct mtl_main_impl* impl, struct mt_sch_impl* sch);
 
 int st_rx_video_sessions_sch_uinit(struct mtl_main_impl* impl, struct mt_sch_impl* sch);

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -998,7 +998,7 @@ static int tx_ancillary_sessions_mgr_init_hw(struct mtl_main_impl* impl,
       return -EIO;
     }
 
-    snprintf(ring_name, 32, "TX-ANC-RING-M%d-P%d", mgr_idx, i);
+    snprintf(ring_name, 32, "%sM%dP%d", ST_TX_ANCILLARY_PREFIX, mgr_idx, i);
     flags = RING_F_MP_HTS_ENQ | RING_F_SC_DEQ; /* multi-producer and single-consumer */
     count = ST_TX_ANC_SESSIONS_RING_SIZE;
     ring = rte_ring_create(ring_name, count, mt_socket_id(impl, i), flags);
@@ -1124,7 +1124,8 @@ static int tx_ancillary_session_mempool_init(struct mtl_main_impl* impl,
       warn("%s(%d), use previous hdr mempool for port %d\n", __func__, idx, i);
     } else {
       char pool_name[32];
-      snprintf(pool_name, 32, "TXANCHDR-M%d-R%d-P%d", mgr->idx, idx, i);
+      snprintf(pool_name, 32, "%sM%dS%dP%d_HDR", ST_TX_ANCILLARY_PREFIX, mgr->idx, idx,
+               i);
       struct rte_mempool* mbuf_pool =
           mt_mempool_create(impl, port, pool_name, n, MT_MBUF_CACHE_SIZE,
                             sizeof(struct mt_muf_priv_data), hdr_room_size);
@@ -1147,7 +1148,7 @@ static int tx_ancillary_session_mempool_init(struct mtl_main_impl* impl,
     warn("%s(%d), use previous chain mempool\n", __func__, idx);
   } else {
     char pool_name[32];
-    snprintf(pool_name, 32, "TXANCCHAIN-M%d-R%d", mgr->idx, idx);
+    snprintf(pool_name, 32, "%sM%dS%d_CHAIN", ST_TX_ANCILLARY_PREFIX, mgr->idx, idx);
     struct rte_mempool* mbuf_pool =
         mt_mempool_create(impl, port, pool_name, n, MT_MBUF_CACHE_SIZE,
                           sizeof(struct mt_muf_priv_data), chain_room_size);
@@ -1170,7 +1171,7 @@ static int tx_ancillary_session_init_rtp(struct mtl_main_impl* impl,
   int mgr_idx = mgr->idx, idx = s->idx;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
-  snprintf(ring_name, 32, "TX-ANC-PACKET-RING-M%d-R%d", mgr_idx, idx);
+  snprintf(ring_name, 32, "%sM%dS%d_PKT", ST_TX_ANCILLARY_PREFIX, mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   ring = rte_ring_create(ring_name, count, mt_socket_id(impl, port), flags);
   if (!ring) {

--- a/lib/src/st2110/st_tx_ancillary_session.h
+++ b/lib/src/st2110/st_tx_ancillary_session.h
@@ -7,6 +7,8 @@
 
 #include "st_main.h"
 
+#define ST_TX_ANCILLARY_PREFIX "TC_"
+
 int st_tx_ancillary_sessions_mgr_uinit(struct st_tx_ancillary_sessions_mgr* mgr);
 
 #endif

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -977,7 +977,7 @@ static int tx_audio_sessions_mgr_init_hw(struct mtl_main_impl* impl,
       return -EIO;
     }
 
-    snprintf(ring_name, 32, "TX-AUDIO-RING-M%d-P%d", mgr_idx, i);
+    snprintf(ring_name, 32, "%sM%dP%d", ST_TX_AUDIO_PREFIX, mgr_idx, i);
     flags = RING_F_MP_HTS_ENQ | RING_F_SC_DEQ; /* multi-producer and single-consumer */
     count = ST_TX_AUDIO_SESSIONS_RING_SIZE;
     ring = rte_ring_create(ring_name, count, mt_socket_id(impl, i), flags);
@@ -1104,7 +1104,7 @@ static int tx_audio_session_mempool_init(struct mtl_main_impl* impl,
       warn("%s(%d), use previous hdr mempool for port %d\n", __func__, idx, i);
     } else {
       char pool_name[32];
-      snprintf(pool_name, 32, "TXAUDIOHDR-M%d-R%d-P%d", mgr->idx, idx, i);
+      snprintf(pool_name, 32, "%sM%dS%dP%d_HDR", ST_TX_AUDIO_PREFIX, mgr->idx, idx, i);
       struct rte_mempool* mbuf_pool =
           mt_mempool_create(impl, port, pool_name, n, MT_MBUF_CACHE_SIZE,
                             sizeof(struct mt_muf_priv_data), hdr_room_size);
@@ -1130,7 +1130,7 @@ static int tx_audio_session_mempool_init(struct mtl_main_impl* impl,
       warn("%s(%d), use previous chain mempool\n", __func__, idx);
     } else {
       char pool_name[32];
-      snprintf(pool_name, 32, "TXAUDIOCHAIN-M%d-R%d", mgr->idx, idx);
+      snprintf(pool_name, 32, "%sM%dS%d_CHAIN", ST_TX_AUDIO_PREFIX, mgr->idx, idx);
       struct rte_mempool* mbuf_pool = mt_mempool_create(
           impl, port, pool_name, n, MT_MBUF_CACHE_SIZE, 0, chain_room_size);
       if (!mbuf_pool) {
@@ -1153,7 +1153,7 @@ static int tx_audio_session_init_rtp(struct mtl_main_impl* impl,
   int mgr_idx = mgr->idx, idx = s->idx;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
-  snprintf(ring_name, 32, "TX-AUDIO-PACKET-RING-M%d-R%d", mgr_idx, idx);
+  snprintf(ring_name, 32, "%sM%dS%d_PKT", ST_TX_AUDIO_PREFIX, mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   ring = rte_ring_create(ring_name, count, mt_socket_id(impl, port), flags);
   if (!ring) {
@@ -1194,7 +1194,7 @@ static int tx_audio_session_init_trans_ring(struct mtl_main_impl* impl,
   }
 
   for (int port = 0; port < num_port; port++) {
-    snprintf(ring_name, 32, "TX-AUDIO-MBUF-RING-M%d-S%d-P%d", mgr_idx, idx, port);
+    snprintf(ring_name, 32, "%sM%dS%dP%d_TRAN", ST_TX_AUDIO_PREFIX, mgr_idx, idx, port);
     flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
     ring = rte_ring_create(ring_name, count, mt_socket_id(impl, port), flags);
     if (!ring) {

--- a/lib/src/st2110/st_tx_audio_session.h
+++ b/lib/src/st2110/st_tx_audio_session.h
@@ -7,6 +7,8 @@
 
 #include "st_main.h"
 
+#define ST_TX_AUDIO_PREFIX "TA_"
+
 int st_tx_audio_sessions_mgr_uinit(struct st_tx_audio_sessions_mgr* mgr);
 
 #endif

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -2142,7 +2142,7 @@ static int tv_init_hw(struct mtl_main_impl* impl, struct st_tx_video_sessions_mg
     }
     queue_id = mt_txq_queue_id(s->queue[i]);
 
-    snprintf(ring_name, 32, "TX-VIDEO-RING-M%d-R%d-P%d", mgr_idx, idx, i);
+    snprintf(ring_name, 32, "%sM%dS%dP%d", ST_TX_VIDEO_PREFIX, mgr_idx, idx, i);
     flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
     count = s->ring_count;
     ring = rte_ring_create(ring_name, count, mt_socket_id(impl, i), flags);
@@ -2275,7 +2275,7 @@ static int tv_mempool_init(struct mtl_main_impl* impl,
         warn("%s(%d), use previous hdr mempool for port %d\n", __func__, idx, i);
       } else {
         char pool_name[32];
-        snprintf(pool_name, 32, "TXVIDEOHDR-M%d-R%d-P%d", mgr->idx, idx, i);
+        snprintf(pool_name, 32, "%sM%dS%dP%d_HDR", ST_TX_VIDEO_PREFIX, mgr->idx, idx, i);
         struct rte_mempool* mbuf_pool =
             mt_mempool_create(impl, port, pool_name, n, MT_MBUF_CACHE_SIZE,
                               sizeof(struct mt_muf_priv_data), hdr_room_size);
@@ -2300,7 +2300,7 @@ static int tv_mempool_init(struct mtl_main_impl* impl,
            s->mbuf_mempool_chain);
     } else {
       char pool_name[32];
-      snprintf(pool_name, 32, "TXVIDEOCHAIN-M%d-R%d", mgr->idx, idx);
+      snprintf(pool_name, 32, "%sM%dS%d_CHAIN", ST_TX_VIDEO_PREFIX, mgr->idx, idx);
       struct rte_mempool* mbuf_pool = mt_mempool_create(
           impl, port, pool_name, n, MT_MBUF_CACHE_SIZE, 0, chain_room_size);
       if (!mbuf_pool) {
@@ -2315,7 +2315,7 @@ static int tv_mempool_init(struct mtl_main_impl* impl,
         chain_room_size = s->st20_pkt_len;
         n /= s->st20_total_pkts / s->st20_pkt_info[ST20_PKT_TYPE_EXTRA].number;
         char pool_name[32];
-        snprintf(pool_name, 32, "TXVIDEOCOPYCHAIN-M%d-R%d", mgr->idx, idx);
+        snprintf(pool_name, 32, "%sM%dS%d_COPY", ST_TX_VIDEO_PREFIX, mgr->idx, idx);
         struct rte_mempool* mbuf_pool = mt_mempool_create(
             impl, port, pool_name, n, MT_MBUF_CACHE_SIZE, 0, chain_room_size);
         if (!mbuf_pool) {
@@ -2339,7 +2339,7 @@ static int tv_init_packet_ring(struct mtl_main_impl* impl,
   int mgr_idx = mgr->idx, idx = s->idx;
   enum mtl_port port = mt_port_logic2phy(s->port_maps, MTL_SESSION_PORT_P);
 
-  snprintf(ring_name, 32, "TX-VIDEO-PACKET-RING-M%d-R%d", mgr_idx, idx);
+  snprintf(ring_name, 32, "%sM%dS%d_PKT", ST_TX_VIDEO_PREFIX, mgr_idx, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   ring = rte_ring_create(ring_name, count, mt_socket_id(impl, port), flags);
   if (!ring) {

--- a/lib/src/st2110/st_tx_video_session.h
+++ b/lib/src/st2110/st_tx_video_session.h
@@ -7,6 +7,8 @@
 
 #include "st_main.h"
 
+#define ST_TX_VIDEO_PREFIX "TV_"
+
 int st_tx_video_sessions_sch_init(struct mtl_main_impl* impl, struct mt_sch_impl* sch);
 
 int st_tx_video_sessions_sch_uinit(struct mtl_main_impl* impl, struct mt_sch_impl* sch);

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -460,7 +460,7 @@ static int udp_init_txq(struct mtl_main_impl* impl, struct mudp_impl* s,
   s->tx_pool = mt_txq_mempool(s->txq);
   if (!s->tx_pool) {
     char pool_name[32];
-    snprintf(pool_name, 32, "MUDP-TX-P%d-Q%u-%d", port, queue_id, idx);
+    snprintf(pool_name, 32, "%sP%dQ%uS%d_TX", MUDP_PREFIX, port, queue_id, idx);
     struct rte_mempool* pool = mt_mempool_create(impl, port, pool_name, s->element_nb,
                                                  MT_MBUF_CACHE_SIZE, 0, s->element_size);
     if (!pool) {

--- a/lib/src/udp/udp_main.h
+++ b/lib/src/udp/udp_main.h
@@ -36,6 +36,8 @@
 /* 1g */
 #define MUDP_DEFAULT_RL_BPS (1ul * 1024 * 1024 * 1024)
 
+#define MUDP_PREFIX "MU_"
+
 struct mudp_impl {
   struct mtl_main_impl* parent;
   enum mt_handle_type type;

--- a/lib/src/udp/udp_rxq.c
+++ b/lib/src/udp/udp_rxq.c
@@ -338,7 +338,8 @@ static int urc_init_tasklet(struct mtl_main_impl* impl, struct mur_client* c) {
 
   struct mt_sch_tasklet_ops ops;
   char name[32];
-  snprintf(name, 32, "MUDP%d-RX-P%d-Q%u-%d", c->port, c->dst_port, c->q->rxq_id, c->idx);
+  snprintf(name, 32, "%sP%dDP%dQ%uC%d", MT_UDP_RXQ_PREFIX, c->port, c->dst_port,
+           c->q->rxq_id, c->idx);
 
   memset(&ops, 0x0, sizeof(ops));
   ops.priv = c;
@@ -399,8 +400,8 @@ struct mur_client* mur_client_get(struct mur_client_create* create) {
   char ring_name[64];
   struct rte_ring* ring;
   unsigned int flags, count;
-  snprintf(ring_name, sizeof(ring_name), "MUDP%d-RX-P%d-Q%u-%d", port, dst_port,
-           q->rxq_id, idx);
+  snprintf(ring_name, sizeof(ring_name), "%sP%dDP%dQ%uC%d", MT_UDP_RXQ_PREFIX, port,
+           dst_port, q->rxq_id, idx);
   flags = RING_F_SP_ENQ | RING_F_SC_DEQ; /* single-producer and single-consumer */
   count = create->ring_count;
   ring = rte_ring_create(ring_name, count, mt_socket_id(impl, port), flags);

--- a/lib/src/udp/udp_rxq.h
+++ b/lib/src/udp/udp_rxq.h
@@ -10,6 +10,8 @@
 #include "../mt_sch.h"
 #include "../mt_util.h"
 
+#define MT_UDP_RXQ_PREFIX "UR_"
+
 struct mur_queue;
 
 struct mur_client {


### PR DESCRIPTION
Resolved issue where audio session initialization failed when creating 100 or more sessions. To avoid this problem, the ring and mempool names should be kept concise since the maximum name size is 32.