### PR TITLE
rxq: remove unused src port

### DIFF
--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1136,8 +1136,6 @@ struct st20_rx_ops {
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
   char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
-  /** UDP source port number, leave as 0 to use same port as dst */
-  uint16_t udp_src_port[MTL_SESSION_PORT_MAX];
   /** UDP destination port number */
   uint16_t udp_port[MTL_SESSION_PORT_MAX];
 
@@ -1278,8 +1276,6 @@ struct st22_rx_ops {
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
   char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
-  /** UDP source port number, leave as 0 to use same port as dst */
-  uint16_t udp_src_port[MTL_SESSION_PORT_MAX];
   /** UDP destination port number */
   uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** flags, value in ST22_RX_FLAG_* */

--- a/include/st20_redundant_api.h
+++ b/include/st20_redundant_api.h
@@ -69,8 +69,6 @@ struct st20r_rx_ops {
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
   char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
-  /** UDP source port number, leave as 0 to use same port as dst */
-  uint16_t udp_src_port[MTL_SESSION_PORT_MAX];
   /** UDP destination port number */
   uint16_t udp_port[MTL_SESSION_PORT_MAX];
 

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -350,8 +350,6 @@ struct st30_rx_ops {
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
   char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
-  /** UDP source port number, leave as 0 to use same port as dst */
-  uint16_t udp_src_port[MTL_SESSION_PORT_MAX];
   /** UDP destination port number */
   uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** flags, value in ST30_RX_FLAG_* */

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -299,8 +299,6 @@ struct st40_rx_ops {
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
   char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
-  /** UDP source port number, leave as 0 to use same port as dst */
-  uint16_t udp_src_port[MTL_SESSION_PORT_MAX];
   /** UDP destination port number */
   uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** flags, value in ST40_RX_FLAG_* */

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -637,8 +637,6 @@ struct st_rx_port {
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
   char port[MTL_SESSION_PORT_MAX][MTL_PORT_MAX_LEN];
-  /** UDP source port number, leave as 0 to use same port as dst */
-  uint16_t udp_src_port[MTL_SESSION_PORT_MAX];
   /** UDP destination port number */
   uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** 7 bits payload type define in RFC3550 */

--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -126,23 +126,11 @@ static int cni_traffic(struct mtl_main_impl* impl) {
   int num_ports = mt_num_ports(impl);
   struct rte_mbuf* pkts_rx[ST_CNI_RX_BURST_SIZE];
   uint16_t rx;
-  struct mt_ptp_impl* ptp;
   bool done = true;
 
   for (int i = 0; i < num_ports; i++) {
-    ptp = mt_get_ptp(impl, i);
-
-    /* rx from ptp rx queue */
-    if (ptp && ptp->rxq) {
-      rx = mt_rxq_burst(ptp->rxq, pkts_rx, ST_CNI_RX_BURST_SIZE);
-      if (rx > 0) {
-        cni->eth_rx_cnt[i] += rx;
-        for (uint16_t ri = 0; ri < rx; ri++) cni_rx_handle(impl, pkts_rx[ri], i);
-        mt_free_mbufs(&pkts_rx[0], rx);
-        done = false;
-      }
-    }
     mt_tap_handle(impl, i);
+
     /* rx from cni rx queue */
     if (cni->rxq[i]) {
       rx = mt_rxq_burst(cni->rxq[i], pkts_rx, ST_CNI_RX_BURST_SIZE);

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -150,7 +150,6 @@ struct mt_ptp_impl {
   enum mtl_port port;
   uint16_t port_id;
 
-  struct mt_rxq_entry* rxq;
   struct rte_mempool* mbuf_pool;
 
   uint8_t mcast_group_addr[MTL_IP_ADDR_LEN]; /* 224.0.1.129 */
@@ -457,10 +456,10 @@ struct mt_rxq_flow {
   bool no_ip_flow; /* no ip flow, only use port flow, for udp transport */
   /* mandatory if not no_ip_flow */
   uint8_t dip_addr[MTL_IP_ADDR_LEN]; /* rx destination IP */
+  /* source ip is ignored if destination is a multicast address */
   uint8_t sip_addr[MTL_IP_ADDR_LEN]; /* source IP */
-  bool no_port_flow;                 /* if apply port flow or not */
+  bool no_port_flow;                 /* if apply destination port flow or not */
   uint16_t dst_port;                 /* udp destination port */
-  uint16_t src_port;                 /* udp source port */
 
   /* optional */
   bool hdr_split; /* if request hdr split */

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -710,19 +710,7 @@ static int ptp_init(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp,
 
   inet_pton(AF_INET, "224.0.1.129", ptp->mcast_group_addr);
 
-  /* create rx queue */
-  struct mt_rxq_flow flow;
-  memset(&flow, 0, sizeof(flow));
-  rte_memcpy(flow.dip_addr, ptp->mcast_group_addr, MTL_IP_ADDR_LEN);
-  rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
-  flow.no_port_flow = true;
-  flow.dst_port = MT_PTP_UDP_GEN_PORT;
-  ptp->rxq = mt_rxq_get(impl, port, &flow);
-  if (ptp->rxq) {
-    info("%s(%d), rx queue %d\n", __func__, port, mt_rxq_queue_id(ptp->rxq));
-  } else {
-    warn("%s(%d), fall back to cni path\n", __func__, port);
-  }
+  /* no need to create rx queue, always use CNI path */
 
   /* join mcast */
   ret = mt_mcast_join(impl, mt_ip_to_u32(ptp->mcast_group_addr), port);
@@ -750,11 +738,6 @@ static int ptp_uinit(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp) {
 
   mt_mcast_l2_leave(impl, &ptp_l2_multicast_eaddr, port);
   mt_mcast_leave(impl, mt_ip_to_u32(ptp->mcast_group_addr), port);
-
-  if (ptp->rxq) {
-    mt_rxq_put(ptp->rxq);
-    ptp->rxq = NULL;
-  }
 
   info("%s(%d), succ\n", __func__, port);
   return 0;

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -147,8 +147,8 @@ static uint32_t rsq_flow_hash(struct mt_rxq_flow* flow) {
                             flow->dip_addr[3]);
   tuple.dst_addr = RTE_IPV4(flow->sip_addr[0], flow->sip_addr[1], flow->sip_addr[2],
                             flow->sip_addr[3]);
-  tuple.sport = flow->src_port;
   tuple.dport = flow->dst_port;
+  tuple.sport = tuple.dport;
   return mt_dev_softrss((uint32_t*)&tuple, len);
 }
 

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -322,7 +322,6 @@ static int rx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_rx
   for (int i = 0; i < ops_rx.num_port; i++) {
     memcpy(ops_rx.sip_addr[i], ops->port.sip_addr[i], MTL_IP_ADDR_LEN);
     strncpy(ops_rx.port[i], ops->port.port[i], MTL_PORT_MAX_LEN);
-    ops_rx.udp_src_port[i] = ops->port.udp_src_port[i];
     ops_rx.udp_port[i] = ops->port.udp_port[i];
   }
   if (ops->flags & ST20P_RX_FLAG_DATA_PATH_ONLY)

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -196,7 +196,6 @@ static int rx_st22p_create_transport(struct mtl_main_impl* impl, struct st22p_rx
   for (int i = 0; i < ops_rx.num_port; i++) {
     memcpy(ops_rx.sip_addr[i], ops->port.sip_addr[i], MTL_IP_ADDR_LEN);
     strncpy(ops_rx.port[i], ops->port.port[i], MTL_PORT_MAX_LEN);
-    ops_rx.udp_src_port[i] = ops->port.udp_src_port[i];
     ops_rx.udp_port[i] = ops->port.udp_port[i];
   }
   if (ops->flags & ST22P_RX_FLAG_DATA_PATH_ONLY)

--- a/lib/src/st2110/redundant/st20_redundant_rx.c
+++ b/lib/src/st2110/redundant/st20_redundant_rx.c
@@ -147,7 +147,6 @@ static int rx_st20r_create_transport(struct st20r_rx_ctx* ctx, struct st20r_rx_o
   ops_rx.num_port = 1;
   memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ops->sip_addr[port], MTL_IP_ADDR_LEN);
   strncpy(ops_rx.port[MTL_SESSION_PORT_P], ops->port[port], MTL_PORT_MAX_LEN - 1);
-  ops_rx.udp_src_port[MTL_SESSION_PORT_P] = ops->udp_src_port[port];
   ops_rx.udp_port[MTL_SESSION_PORT_P] = ops->udp_port[port];
 
   if (ops->flags & ST20R_RX_FLAG_DATA_PATH_ONLY)

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -578,7 +578,6 @@ struct st_rx_video_session_impl {
   enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
   struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
   uint16_t port_id[MTL_SESSION_PORT_MAX];
-  uint16_t st20_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
   uint16_t st20_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
 
   struct st_rx_video_session_handle_impl* st20_handle;
@@ -872,7 +871,6 @@ struct st_rx_audio_session_impl {
   struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
   uint16_t port_id[MTL_SESSION_PORT_MAX];
 
-  uint16_t st30_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
   uint16_t st30_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
 
   struct st_frame_trans* st30_frames;
@@ -1025,7 +1023,6 @@ struct st_rx_ancillary_session_impl {
   uint16_t port_id[MTL_SESSION_PORT_MAX];
   struct rte_ring* packet_ring;
 
-  uint16_t st40_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
   uint16_t st40_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
 
   int st40_seq_id; /* seq id for each pkt */

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -211,7 +211,6 @@ static int rx_ancillary_session_init_hw(struct mtl_main_impl* impl,
     rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
     rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
     flow.dst_port = s->st40_dst_port[i];
-    flow.src_port = s->st40_src_port[i];
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST40_RX_FLAG_DATA_PATH_ONLY))
@@ -317,8 +316,6 @@ static int rx_ancillary_session_attach(struct mtl_main_impl* impl,
   s->ops = *ops;
   for (int i = 0; i < num_port; i++) {
     s->st40_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (30000 + idx);
-    s->st40_src_port[i] =
-        (ops->udp_src_port[i]) ? (ops->udp_src_port[i]) : s->st40_dst_port[i];
   }
 
   s->st40_seq_id = -1;
@@ -404,8 +401,6 @@ static int rx_ancillary_session_update_src(struct mtl_main_impl* impl,
     memcpy(ops->sip_addr[i], src->sip_addr[i], MTL_IP_ADDR_LEN);
     ops->udp_port[i] = src->udp_port[i];
     s->st40_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (30000 + idx);
-    s->st40_src_port[i] =
-        (ops->udp_src_port[i]) ? (ops->udp_src_port[i]) : s->st40_dst_port[i];
   }
   /* reset seq id */
   s->st40_seq_id = -1;

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -607,7 +607,6 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
     rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
     rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
     flow.dst_port = s->st30_dst_port[i];
-    flow.src_port = s->st30_src_port[i];
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST30_RX_FLAG_DATA_PATH_ONLY))
@@ -706,8 +705,6 @@ static int rx_audio_session_attach(struct mtl_main_impl* impl,
   s->ops = *ops;
   for (int i = 0; i < num_port; i++) {
     s->st30_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (20000 + idx);
-    s->st30_src_port[i] =
-        (ops->udp_src_port[i]) ? (ops->udp_src_port[i]) : s->st30_dst_port[i];
   }
 
   size_t bytes_in_pkt = ST_PKT_MAX_ETHER_BYTES - sizeof(struct st_rfc3550_audio_hdr);
@@ -834,8 +831,6 @@ static int rx_audio_session_update_src(struct mtl_main_impl* impl,
     memcpy(ops->sip_addr[i], src->sip_addr[i], MTL_IP_ADDR_LEN);
     ops->udp_port[i] = src->udp_port[i];
     s->st30_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (20000 + idx);
-    s->st30_src_port[i] =
-        (ops->udp_src_port[i]) ? (ops->udp_src_port[i]) : s->st30_dst_port[i];
   }
   /* reset seq id */
   s->st30_seq_id = -1;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2803,7 +2803,6 @@ static int rv_init_hw(struct mtl_main_impl* impl, struct st_rx_video_session_imp
     rte_memcpy(flow.dip_addr, ops->sip_addr[i], MTL_IP_ADDR_LEN);
     rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
     flow.dst_port = s->st20_dst_port[i];
-    flow.src_port = s->st20_src_port[i];
     if (rv_is_hdr_split(s)) {
       flow.hdr_split = true;
 #ifdef ST_HAS_DPDK_HDR_SPLIT
@@ -2952,8 +2951,6 @@ static int rv_attach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
   s->ops = *ops;
   for (int i = 0; i < num_port; i++) {
     s->st20_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (10000 + idx);
-    s->st20_src_port[i] =
-        (ops->udp_src_port[i]) ? (ops->udp_src_port[i]) : s->st20_dst_port[i];
   }
 
   s->stat_pkts_idx_dropped = 0;
@@ -3301,8 +3298,6 @@ static int rv_update_src(struct mtl_main_impl* impl, struct st_rx_video_session_
     memcpy(ops->sip_addr[i], src->sip_addr[i], MTL_IP_ADDR_LEN);
     ops->udp_port[i] = src->udp_port[i];
     s->st20_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (10000 + idx);
-    s->st20_src_port[i] =
-        (ops->udp_src_port[i]) ? (ops->udp_src_port[i]) : s->st20_dst_port[i];
   }
 
   ret = rv_init_hw(impl, s);
@@ -4110,7 +4105,6 @@ st22_rx_handle st22_rx_create(mtl_handle mt, struct st22_rx_ops* ops) {
   for (int i = 0; i < ops->num_port; i++) {
     memcpy(st20_ops.sip_addr[i], ops->sip_addr[i], MTL_IP_ADDR_LEN);
     strncpy(st20_ops.port[i], ops->port[i], MTL_PORT_MAX_LEN);
-    st20_ops.udp_src_port[i] = ops->udp_src_port[i];
     st20_ops.udp_port[i] = ops->udp_port[i];
   }
   if (ops->flags & ST22_RX_FLAG_DATA_PATH_ONLY)

--- a/tests/src/ufd_test.cpp
+++ b/tests/src/ufd_test.cpp
@@ -135,7 +135,7 @@ static void utest_ctx_init(struct utest_ctx* ctx) {
   p->rx_queues_cnt[MTL_PORT_P] = 16;
   p->rx_queues_cnt[MTL_PORT_R] = 16;
 
-  ctx->init_params.slots_nb_max = 256;
+  ctx->init_params.slots_nb_max = p->tx_queues_cnt[MTL_PORT_P] * 4;
   p->tasklets_nb_per_sch = ctx->init_params.slots_nb_max + 8;
 }
 


### PR DESCRIPTION
For one stream, the src port usually is random and no way to get the source port.