### PR TITLE
queue: add cni base queue support

### DIFF
--- a/app/src/args.c
+++ b/app/src/args.c
@@ -105,6 +105,7 @@ enum st_args_cmd {
   ST_ARG_IOVA_MODE,
   ST_ARG_SHARED_TX_QUEUES,
   ST_ARG_SHARED_RX_QUEUES,
+  ST_ARG_RX_USE_CNI,
   ST_ARG_MAX,
 };
 
@@ -211,6 +212,7 @@ static struct option st_app_args_options[] = {
     {"iova_mode", required_argument, 0, ST_ARG_IOVA_MODE},
     {"shared_tx_queues", no_argument, 0, ST_ARG_SHARED_TX_QUEUES},
     {"shared_rx_queues", no_argument, 0, ST_ARG_SHARED_RX_QUEUES},
+    {"rx_use_cni", no_argument, 0, ST_ARG_RX_USE_CNI},
 
     {0, 0, 0, 0}};
 
@@ -646,6 +648,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_SHARED_RX_QUEUES:
         p->flags |= MTL_FLAG_SHARED_RX_QUEUE;
+        break;
+      case ST_ARG_RX_USE_CNI:
+        p->flags |= MTL_FLAG_RX_USE_CNI;
         break;
       case '?':
         break;

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -349,69 +349,74 @@ enum st21_tx_pacing_way {
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * dedicate thread for cni message
  */
-#define MTL_FLAG_CNI_THREAD (MTL_BIT64(16))
+#define MTL_FLAG_CNI_THREAD (MTL_BIT64(32))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Enable video rx ebu check
  */
-#define MTL_FLAG_RX_VIDEO_EBU (MTL_BIT64(17))
+#define MTL_FLAG_RX_VIDEO_EBU (MTL_BIT64(33))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Enable NIC promiscuous mode for RX
  */
-#define MTL_FLAG_NIC_RX_PROMISCUOUS (MTL_BIT64(20))
+#define MTL_FLAG_NIC_RX_PROMISCUOUS (MTL_BIT64(34))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * use unicast address for ptp PTP_DELAY_REQ message
  */
-#define MTL_FLAG_PTP_UNICAST_ADDR (MTL_BIT64(21))
+#define MTL_FLAG_PTP_UNICAST_ADDR (MTL_BIT64(35))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Mono memory pool for all rx queue(sessions)
  */
-#define MTL_FLAG_RX_MONO_POOL (MTL_BIT64(22))
+#define MTL_FLAG_RX_MONO_POOL (MTL_BIT64(36))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Do mtl_start in mtl_init, mtl_stop in mtl_uninit, and skip the mtl_start/mtl_stop
  */
-#define MTL_FLAG_DEV_AUTO_START_STOP (MTL_BIT64(24))
+#define MTL_FLAG_DEV_AUTO_START_STOP (MTL_BIT64(37))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Enable tasklet time measurement, report status if tasklet run time longer than
  * tasklet_time_thresh_us in mtl_init_params.
  */
-#define MTL_FLAG_TASKLET_TIME_MEASURE (MTL_BIT64(25))
+#define MTL_FLAG_TASKLET_TIME_MEASURE (MTL_BIT64(38))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Disable the zero copy for af_xdp tx video session
  */
-#define MTL_FLAG_AF_XDP_ZC_DISABLE (MTL_BIT64(26))
+#define MTL_FLAG_AF_XDP_ZC_DISABLE (MTL_BIT64(39))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Mono memory pool for all tx queue(session)
  */
-#define MTL_FLAG_TX_MONO_POOL (MTL_BIT64(27))
+#define MTL_FLAG_TX_MONO_POOL (MTL_BIT64(40))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Disable system rx queues, pls use mcast or manual TX mac.
  */
-#define MTL_FLAG_DISABLE_SYSTEM_RX_QUEUES (MTL_BIT64(28))
+#define MTL_FLAG_DISABLE_SYSTEM_RX_QUEUES (MTL_BIT64(41))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Force to get ptp time from tsc source.
  */
-#define MTL_FLAG_PTP_SOURCE_TSC (MTL_BIT64(29))
+#define MTL_FLAG_PTP_SOURCE_TSC (MTL_BIT64(42))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Disable TX chain mbuf, use same mbuf for header and payload.
  * Will do memcpy from framebuffer to packet payload.
  */
-#define MTL_FLAG_TX_NO_CHAIN (MTL_BIT64(30))
+#define MTL_FLAG_TX_NO_CHAIN (MTL_BIT64(43))
 /**
  * Flag bit in flags of struct mtl_init_params, debug usage only.
  * Disable the pkt check for TX burst API.
  */
-#define MTL_FLAG_TX_NO_BURST_CHK (MTL_BIT64(31))
+#define MTL_FLAG_TX_NO_BURST_CHK (MTL_BIT64(44))
+/**
+ * Flag bit in flags of struct mtl_init_params, debug usage only.
+ * Use CNI based queue for RX.
+ */
+#define MTL_FLAG_RX_USE_CNI (MTL_BIT64(45))
 
 /**
  * The structure describing how to init af_xdp interface.

--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -17,23 +17,51 @@
 #include "mt_tap.h"
 #include "mt_util.h"
 
-static void cni_udp_dump(struct mt_cni_udp_entry* entry, enum mtl_port port) {
+#define MT_CSQ_RING_PREFIX "CSQ_"
+
+static inline struct mt_cni_entry* cni_get_entry(struct mtl_main_impl* impl,
+                                                 enum mtl_port port) {
+  return &mt_get_cni(impl)->entries[port];
+}
+
+/* return true if try lock succ */
+static inline bool csq_try_lock(struct mt_cni_entry* cni) {
+  int ret = mt_pthread_mutex_try_lock(&cni->csq_mutex);
+  return ret == 0 ? true : false;
+}
+
+static inline void csq_unlock(struct mt_cni_entry* cni) {
+  mt_pthread_mutex_unlock(&cni->csq_mutex);
+}
+
+static int csq_entry_free(struct mt_csq_entry* entry) {
+  if (entry->ring) {
+    mt_ring_dequeue_clean(entry->ring);
+    rte_ring_free(entry->ring);
+  }
+  info("%s(%d), succ on idx %d\n", __func__, entry->parent->port, entry->idx);
+  mt_rte_free(entry);
+  return 0;
+}
+
+static void cni_udp_detect_dump(struct mt_cni_entry* cni,
+                                struct mt_cni_udp_detect_entry* entry) {
   uint8_t* sip = (uint8_t*)&entry->tuple[0];
   uint8_t* dip = (uint8_t*)&entry->tuple[1];
   uint32_t udp_port = entry->tuple[2];
   uint16_t src_port = ntohs((uint16_t)udp_port);
   uint16_t dst_port = ntohs((uint16_t)(udp_port >> 16));
   info("%s(%d), sip: %d.%d.%d.%d, dip: %d.%d.%d.%d, src_port %u dst_port %d, pkt %d\n",
-       __func__, port, sip[0], sip[1], sip[2], sip[3], dip[0], dip[1], dip[2], dip[3],
-       src_port, dst_port, entry->pkt_cnt);
+       __func__, cni->port, sip[0], sip[1], sip[2], sip[3], dip[0], dip[1], dip[2],
+       dip[3], src_port, dst_port, entry->pkt_cnt);
 }
 
-static int cni_udp_analyses(struct mtl_main_impl* impl, struct mt_cni_impl* cni,
-                            struct mt_ipv4_udp* hdr, enum mtl_port port) {
+static int cni_udp_detect_analyses(struct mt_cni_entry* cni, struct mt_udp_hdr* hdr) {
+  enum mtl_port port = cni->port;
   uint32_t tuple[3];
-  struct mt_cni_udp_entry* entry;
-  struct mt_cni_udp_list* list = &cni->udps[port];
-  rte_memcpy(tuple, &hdr->ip.src_addr, sizeof(tuple));
+  struct mt_cni_udp_detect_entry* entry;
+  struct mt_cni_udp_detect_list* list = &cni->udp_detect;
+  rte_memcpy(tuple, &hdr->ipv4.src_addr, sizeof(tuple));
 
   /* search if it's a known udp stream */
   MT_TAILQ_FOREACH(entry, list, next) {
@@ -43,7 +71,7 @@ static int cni_udp_analyses(struct mtl_main_impl* impl, struct mt_cni_impl* cni,
     }
   }
 
-  entry = mt_rte_zmalloc_socket(sizeof(*entry), mt_socket_id(impl, port));
+  entry = mt_rte_zmalloc_socket(sizeof(*entry), mt_socket_id(cni->impl, port));
   if (!entry) {
     err("%s(%d), entry malloc fail\n", __func__, port);
     return -ENOMEM;
@@ -52,14 +80,92 @@ static int cni_udp_analyses(struct mtl_main_impl* impl, struct mt_cni_impl* cni,
   /* add to list */
   MT_TAILQ_INSERT_TAIL(list, entry, next);
   info("%s(%d), new udp stream:\n", __func__, port);
-  cni_udp_dump(entry, port);
+  cni_udp_detect_dump(cni, entry);
 
   return 0;
 }
 
-static int cni_rx_handle(struct mtl_main_impl* impl, struct rte_mbuf* m,
-                         enum mtl_port port) {
-  struct mt_cni_impl* cni = mt_get_cni(impl);
+static int csq_stat(struct mt_cni_entry* cni) {
+  enum mtl_port port = cni->port;
+  struct mt_csq_entry* csq = NULL;
+  int idx;
+
+  if (!csq_try_lock(cni)) return 0;
+  MT_TAILQ_FOREACH(csq, &cni->csq_queues, next) {
+    idx = csq->idx;
+    notice("%s(%d,%d), enqueue %u dequeue %u\n", __func__, port, idx,
+           csq->stat_enqueue_cnt, csq->stat_dequeue_cnt);
+    csq->stat_enqueue_cnt = 0;
+    csq->stat_dequeue_cnt = 0;
+    if (csq->stat_enqueue_fail_cnt) {
+      warn("%s(%d,%d), enqueue fail %u\n", __func__, port, idx,
+           csq->stat_enqueue_fail_cnt);
+      csq->stat_enqueue_fail_cnt = 0;
+    }
+  }
+  csq_unlock(cni);
+
+  return 0;
+}
+
+static inline void csq_entry_pkts_enqueue(struct mt_csq_entry* entry,
+                                          struct rte_mbuf** pkts,
+                                          const uint16_t nb_pkts) {
+  /* use bulk version */
+  unsigned int n = rte_ring_sp_enqueue_bulk(entry->ring, (void**)pkts, nb_pkts, NULL);
+  entry->stat_enqueue_cnt += n;
+  if (n == 0) {
+    rte_pktmbuf_free_bulk(pkts, nb_pkts);
+    entry->stat_enqueue_fail_cnt += nb_pkts;
+  }
+}
+
+static int cni_udp_handle(struct mt_cni_entry* cni, struct rte_mbuf* m) {
+  struct mt_udp_hdr* hdr;
+  struct rte_ipv4_hdr* ipv4;
+  struct rte_udp_hdr* udp;
+  struct mt_csq_entry* csq = NULL;
+  int ret;
+
+  hdr = rte_pktmbuf_mtod(m, struct mt_udp_hdr*);
+  ipv4 = &hdr->ipv4;
+  udp = &hdr->udp;
+
+  MT_TAILQ_FOREACH(csq, &cni->csq_queues, next) {
+    bool ip_matched;
+    if (csq->flow.no_ip_flow) {
+      ip_matched = true;
+    } else {
+      ip_matched = mt_is_multicast_ip(csq->flow.dip_addr)
+                       ? (ipv4->dst_addr == *(uint32_t*)csq->flow.dip_addr)
+                       : (ipv4->src_addr == *(uint32_t*)csq->flow.dip_addr);
+    }
+    bool port_matched;
+    if (csq->flow.no_port_flow) {
+      port_matched = true;
+    } else {
+      port_matched = ntohs(udp->dst_port) == csq->flow.dst_port;
+    }
+    if (ip_matched && port_matched) { /* match dst ip:port */
+      ret = rte_ring_sp_enqueue(csq->ring, m);
+      if (ret < 0) {
+        csq->stat_enqueue_fail_cnt++;
+      } else {
+        rte_mbuf_refcnt_update(m, 1);
+        csq->stat_enqueue_cnt++;
+      }
+      return 0;
+    }
+  }
+
+  /* analyses if it's a UDP stream, for debug usage */
+  cni_udp_detect_analyses(cni, hdr);
+  return 0;
+}
+
+static int cni_rx_handle(struct mt_cni_entry* cni, struct rte_mbuf* m) {
+  struct mtl_main_impl* impl = cni->impl;
+  enum mtl_port port = cni->port;
   struct mt_ptp_impl* ptp = mt_get_ptp(impl, port);
   struct mt_dhcp_impl* dhcp = mt_get_dhcp(impl, port);
   struct rte_ether_hdr* eth_hdr = rte_pktmbuf_mtod(m, struct rte_ether_hdr*);
@@ -107,8 +213,7 @@ static int cni_rx_handle(struct mtl_main_impl* impl, struct rte_mbuf* m,
           dhcp_hdr = rte_pktmbuf_mtod_offset(m, struct mt_dhcp_hdr*, hdr_offset);
           mt_dhcp_parse(impl, dhcp_hdr, port);
         } else {
-          /* analyses if it's a UDP stream, for debug usage */
-          cni_udp_analyses(impl, cni, ipv4_hdr, port);
+          cni_udp_handle(cni, m);
         }
       }
       break;
@@ -116,27 +221,29 @@ static int cni_rx_handle(struct mtl_main_impl* impl, struct rte_mbuf* m,
       // dbg("%s(%d), unknown ether_type %d\n", __func__, port, ether_type);
       break;
   }
-  cni->eth_rx_bytes[port] += m->pkt_len;
+  cni->eth_rx_bytes += m->pkt_len;
 
   return 0;
 }
 
 static int cni_traffic(struct mtl_main_impl* impl) {
-  struct mt_cni_impl* cni = mt_get_cni(impl);
+  struct mt_cni_entry* cni;
   int num_ports = mt_num_ports(impl);
   struct rte_mbuf* pkts_rx[ST_CNI_RX_BURST_SIZE];
   uint16_t rx;
   bool done = true;
 
   for (int i = 0; i < num_ports; i++) {
+    cni = cni_get_entry(impl, i);
+
     mt_tap_handle(impl, i);
 
     /* rx from cni rx queue */
-    if (cni->rxq[i]) {
-      rx = mt_rxq_burst(cni->rxq[i], pkts_rx, ST_CNI_RX_BURST_SIZE);
+    if (cni->rxq) {
+      rx = mt_rxq_burst(cni->rxq, pkts_rx, ST_CNI_RX_BURST_SIZE);
       if (rx > 0) {
-        cni->eth_rx_cnt[i] += rx;
-        for (uint16_t ri = 0; ri < rx; ri++) cni_rx_handle(impl, pkts_rx[ri], i);
+        cni->eth_rx_cnt += rx;
+        for (uint16_t ri = 0; ri < rx; ri++) cni_rx_handle(cni, pkts_rx[ri]);
         mt_kni_handle(impl, i, pkts_rx, rx);
         mt_free_mbufs(&pkts_rx[0], rx);
         done = false;
@@ -216,20 +323,23 @@ static int cni_tasklet_handler(void* priv) {
 
 static int cni_queues_uinit(struct mtl_main_impl* impl) {
   int num_ports = mt_num_ports(impl);
-  struct mt_cni_impl* cni = mt_get_cni(impl);
+  struct mt_cni_entry* cni;
 
   for (int i = 0; i < num_ports; i++) {
-    if (cni->rxq[i]) {
-      mt_rxq_put(cni->rxq[i]);
-      cni->rxq[i] = NULL;
+    cni = cni_get_entry(impl, i);
+
+    if (cni->rxq) {
+      mt_rxq_put(cni->rxq);
+      cni->rxq = NULL;
     }
   }
 
   return 0;
 }
 
-static int cni_queues_init(struct mtl_main_impl* impl, struct mt_cni_impl* cni) {
+static int cni_queues_init(struct mtl_main_impl* impl) {
   int num_ports = mt_num_ports(impl);
+  struct mt_cni_entry* cni;
 
   if (mt_no_system_rxq(impl)) {
     warn("%s, disabled as no system rx queues\n", __func__);
@@ -237,22 +347,21 @@ static int cni_queues_init(struct mtl_main_impl* impl, struct mt_cni_impl* cni) 
   }
 
   for (int i = 0; i < num_ports; i++) {
+    cni = cni_get_entry(impl, i);
+
     /* no cni for kernel based pmd */
     if (mt_pmd_is_kernel(impl, i)) continue;
-
-    cni->cni_priv[i].impl = impl;
-    cni->cni_priv[i].port = i;
 
     struct mt_rxq_flow flow;
     memset(&flow, 0, sizeof(flow));
     flow.sys_queue = true;
-    cni->rxq[i] = mt_rxq_get(impl, i, &flow);
-    info("%s(%d), rxq %d\n", __func__, i, mt_rxq_queue_id(cni->rxq[i]));
-    if (!cni->rxq[i]) {
+    cni->rxq = mt_rxq_get(impl, i, &flow);
+    if (!cni->rxq) {
       err("%s(%d), rx queue get fail\n", __func__, i);
       cni_queues_uinit(impl);
       return -EIO;
     }
+    info("%s(%d), rxq %d\n", __func__, i, mt_rxq_queue_id(cni->rxq));
   }
 
   return 0;
@@ -269,17 +378,22 @@ static bool cni_if_need(struct mtl_main_impl* impl) {
 }
 
 static int cni_stat(void* priv) {
-  struct mt_cni_impl* cni = priv;
-  int num_ports = cni->num_ports;
+  struct mt_cni_impl* cni_impl = priv;
+  struct mt_cni_entry* cni;
+  int num_ports = cni_impl->num_ports;
 
-  if (!cni->used) return 0;
+  if (!cni_impl->used) return 0;
 
   for (int i = 0; i < num_ports; i++) {
+    cni = &cni_impl->entries[i];
+
     notice("CNI(%d): eth_rx_rate %" PRIu64 " Mb/s, eth_rx_cnt %u\n", i,
-           cni->eth_rx_bytes[i] * 8 / MT_DEV_STAT_INTERVAL_S / MT_DEV_STAT_M_UNIT,
-           cni->eth_rx_cnt[i]);
-    cni->eth_rx_cnt[i] = 0;
-    cni->eth_rx_bytes[i] = 0;
+           cni->eth_rx_bytes * 8 / MT_DEV_STAT_INTERVAL_S / MT_DEV_STAT_M_UNIT,
+           cni->eth_rx_cnt);
+    cni->eth_rx_cnt = 0;
+    cni->eth_rx_bytes = 0;
+
+    csq_stat(cni);
   }
 
   return 0;
@@ -287,23 +401,29 @@ static int cni_stat(void* priv) {
 
 int mt_cni_init(struct mtl_main_impl* impl) {
   int ret;
-  struct mt_cni_impl* cni = mt_get_cni(impl);
+  struct mt_cni_impl* cni_impl = mt_get_cni(impl);
   struct mtl_init_params* p = mt_get_user_params(impl);
 
-  cni->num_ports = mt_num_ports(impl);
-  cni->lcore_tasklet = (p->flags & MTL_FLAG_CNI_THREAD) ? false : true;
-  rte_atomic32_set(&cni->stop_thread, 0);
-  for (int i = 0; i < cni->num_ports; i++) {
-    MT_TAILQ_INIT(&cni->udps[i]);
+  cni_impl->num_ports = mt_num_ports(impl);
+  cni_impl->lcore_tasklet = (p->flags & MTL_FLAG_CNI_THREAD) ? false : true;
+  rte_atomic32_set(&cni_impl->stop_thread, 0);
+
+  for (int i = 0; i < cni_impl->num_ports; i++) {
+    struct mt_cni_entry* cni = cni_get_entry(impl, i);
+    cni->port = i;
+    cni->impl = impl;
+    MT_TAILQ_INIT(&cni->csq_queues);
+    mt_pthread_mutex_init(&cni->csq_mutex, NULL);
+    MT_TAILQ_INIT(&cni->udp_detect);
   }
 
-  cni->used = cni_if_need(impl);
-  if (!cni->used) return 0;
+  cni_impl->used = cni_if_need(impl);
+  if (!cni_impl->used) return 0;
 
   ret = mt_kni_init(impl);
   if (ret < 0) return ret;
 
-  ret = cni_queues_init(impl, cni);
+  ret = cni_queues_init(impl);
   if (ret < 0) {
     mt_cni_uinit(impl);
     return ret;
@@ -312,7 +432,7 @@ int mt_cni_init(struct mtl_main_impl* impl) {
   ret = mt_tap_init(impl);
   if (ret < 0) return ret;
 
-  if (cni->lcore_tasklet) {
+  if (cni_impl->lcore_tasklet) {
     struct mt_sch_tasklet_ops ops;
 
     memset(&ops, 0x0, sizeof(ops));
@@ -322,8 +442,8 @@ int mt_cni_init(struct mtl_main_impl* impl) {
     ops.stop = cni_tasklet_stop;
     ops.handler = cni_tasklet_handler;
 
-    cni->tasklet = mt_sch_register_tasklet(impl->main_sch, &ops);
-    if (!cni->tasklet) {
+    cni_impl->tasklet = mt_sch_register_tasklet(impl->main_sch, &ops);
+    if (!cni_impl->tasklet) {
       err("%s, mt_sch_register_tasklet fail\n", __func__);
       mt_cni_uinit(impl);
       return -EIO;
@@ -337,29 +457,38 @@ int mt_cni_init(struct mtl_main_impl* impl) {
     return ret;
   }
 
-  mt_stat_register(impl, cni_stat, cni, "cni");
+  mt_stat_register(impl, cni_stat, cni_impl, "cni");
   return 0;
 }
 
 int mt_cni_uinit(struct mtl_main_impl* impl) {
-  struct mt_cni_impl* cni = mt_get_cni(impl);
-  struct mt_cni_udp_entry* udp;
+  struct mt_cni_impl* cni_impl = mt_get_cni(impl);
+  struct mt_cni_udp_detect_entry* udp_detect;
+  struct mt_csq_entry* csq;
 
-  for (int i = 0; i < cni->num_ports; i++) {
+  for (int i = 0; i < cni_impl->num_ports; i++) {
+    struct mt_cni_entry* cni = cni_get_entry(impl, i);
+
+    /* free all udp queue entry */
+    while ((csq = MT_TAILQ_FIRST(&cni->csq_queues))) {
+      MT_TAILQ_REMOVE(&cni->csq_queues, csq, next);
+      warn("%s(%d,%d), entry %p not free\n", __func__, i, csq->idx, csq);
+      mt_rte_free(csq);
+    }
     /* free all udp detected entry */
-    while ((udp = MT_TAILQ_FIRST(&cni->udps[i]))) {
-      MT_TAILQ_REMOVE(&cni->udps[i], udp, next);
-      cni_udp_dump(udp, i);
-      mt_rte_free(udp);
+    while ((udp_detect = MT_TAILQ_FIRST(&cni->udp_detect))) {
+      MT_TAILQ_REMOVE(&cni->udp_detect, udp_detect, next);
+      cni_udp_detect_dump(cni, udp_detect);
+      mt_rte_free(udp_detect);
     }
   }
 
-  if (cni->tasklet) {
-    mt_sch_unregister_tasklet(cni->tasklet);
-    cni->tasklet = NULL;
+  if (cni_impl->tasklet) {
+    mt_sch_unregister_tasklet(cni_impl->tasklet);
+    cni_impl->tasklet = NULL;
   }
 
-  mt_stat_unregister(impl, cni_stat, cni);
+  mt_stat_unregister(impl, cni_stat, cni_impl);
 
   mt_cni_stop(impl);
 
@@ -393,4 +522,73 @@ int mt_cni_stop(struct mtl_main_impl* impl) {
   cni_traffic_thread_stop(cni);
 
   return 0;
+}
+
+static inline void csq_lock(struct mt_cni_entry* cni) {
+  mt_pthread_mutex_lock(&cni->csq_mutex);
+}
+
+struct mt_csq_entry* mt_csq_get(struct mtl_main_impl* impl, enum mtl_port port,
+                                struct mt_rxq_flow* flow) {
+  struct mt_cni_entry* cni = cni_get_entry(impl, port);
+  int idx = cni->csq_idx;
+
+  if (flow->sys_queue) {
+    err("%s(%d,%d), not support sys queue\n", __func__, port, idx);
+    return NULL;
+  }
+
+  struct mt_csq_entry* entry =
+      mt_rte_zmalloc_socket(sizeof(*entry), mt_socket_id(impl, port));
+  if (!entry) {
+    err("%s(%d,%d), entry malloc fail\n", __func__, port, idx);
+    return NULL;
+  }
+  entry->idx = idx;
+  entry->parent = cni;
+  rte_memcpy(&entry->flow, flow, sizeof(entry->flow));
+
+  /* ring create */
+  char ring_name[32];
+  snprintf(ring_name, 32, "%sP%d_%d", MT_CSQ_RING_PREFIX, port, idx);
+  entry->ring = rte_ring_create(ring_name, 512, mt_socket_id(impl, MTL_PORT_P),
+                                RING_F_SP_ENQ | RING_F_SC_DEQ);
+  if (!entry->ring) {
+    err("%s(%d,%d), ring %s create fail\n", __func__, port, idx, ring_name);
+    mt_rte_free(entry);
+    return NULL;
+  }
+
+  csq_lock(cni);
+  MT_TAILQ_INSERT_HEAD(&cni->csq_queues, entry, next);
+  cni->csq_idx++;
+  csq_unlock(cni);
+
+  uint8_t* ip = flow->dip_addr;
+  info("%s(%d), ip %u.%u.%u.%u port %u on %d\n", __func__, port, ip[0], ip[1], ip[2],
+       ip[3], flow->dst_port, idx);
+  return entry;
+}
+
+int mt_csq_put(struct mt_csq_entry* entry) {
+  struct mt_cni_entry* cni = entry->parent;
+
+  csq_lock(cni);
+  MT_TAILQ_REMOVE(&cni->csq_queues, entry, next);
+  csq_unlock(cni);
+
+  csq_entry_free(entry);
+  return 0;
+}
+
+uint16_t mt_csq_burst(struct mt_csq_entry* entry, struct rte_mbuf** rx_pkts,
+                      uint16_t nb_pkts) {
+  struct mt_cni_entry* cni = entry->parent;
+
+  if (!csq_try_lock(cni)) return 0;
+  uint16_t n = rte_ring_sc_dequeue_burst(entry->ring, (void**)rx_pkts, nb_pkts, NULL);
+  entry->stat_dequeue_cnt += n;
+  csq_unlock(cni);
+
+  return n;
 }

--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -108,18 +108,6 @@ static int csq_stat(struct mt_cni_entry* cni) {
   return 0;
 }
 
-static inline void csq_entry_pkts_enqueue(struct mt_csq_entry* entry,
-                                          struct rte_mbuf** pkts,
-                                          const uint16_t nb_pkts) {
-  /* use bulk version */
-  unsigned int n = rte_ring_sp_enqueue_bulk(entry->ring, (void**)pkts, nb_pkts, NULL);
-  entry->stat_enqueue_cnt += n;
-  if (n == 0) {
-    rte_pktmbuf_free_bulk(pkts, nb_pkts);
-    entry->stat_enqueue_fail_cnt += nb_pkts;
-  }
-}
-
 static int cni_udp_handle(struct mt_cni_entry* cni, struct rte_mbuf* m) {
   struct mt_udp_hdr* hdr;
   struct rte_ipv4_hdr* ipv4;

--- a/lib/src/mt_cni.h
+++ b/lib/src/mt_cni.h
@@ -18,4 +18,11 @@ static inline struct mt_cni_impl* mt_get_cni(struct mtl_main_impl* impl) {
   return &impl->cni;
 }
 
+struct mt_csq_entry* mt_csq_get(struct mtl_main_impl* impl, enum mtl_port port,
+                                struct mt_rxq_flow* flow);
+static inline uint16_t mt_csq_queue_id(struct mt_csq_entry* entry) { return entry->idx; }
+uint16_t mt_csq_burst(struct mt_csq_entry* entry, struct rte_mbuf** rx_pkts,
+                      uint16_t nb_pkts);
+int mt_csq_put(struct mt_csq_entry* entry);
+
 #endif

--- a/lib/src/mt_queue.h
+++ b/lib/src/mt_queue.h
@@ -2,6 +2,7 @@
  * Copyright(c) 2023 Intel Corporation
  */
 
+#include "mt_cni.h"
 #include "mt_dev.h"
 #include "mt_shared_queue.h"
 #include "mt_shared_rss.h"
@@ -14,8 +15,8 @@ struct mt_rxq_entry {
   uint16_t queue_id;
   struct mt_rx_queue* rxq;
   struct mt_rsq_entry* rsq;
-  struct mt_rss_entry* rss;
   struct mt_srss_entry* srss;
+  struct mt_csq_entry* csq;
 };
 
 struct mt_rxq_entry* mt_rxq_get(struct mtl_main_impl* impl, enum mtl_port port,

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -174,7 +174,6 @@ struct mt_rsq_entry* mt_rsq_get(struct mtl_main_impl* impl, enum mtl_port port,
   entry->idx = idx;
   entry->parent = rsqm;
   rte_memcpy(&entry->flow, flow, sizeof(entry->flow));
-  entry->dst_port_net = htons(flow->dst_port);
 
   if (!flow->sys_queue) {
     entry->flow_rsp = mt_dev_create_rx_flow(impl, port, q, flow);

--- a/lib/src/mt_tap.c
+++ b/lib/src/mt_tap.c
@@ -869,7 +869,7 @@ int mt_tap_handle(struct mtl_main_impl* impl, enum mtl_port port) {
     rx = mt_rxq_burst(cni->tap_rx_q[port], pkts_rx, ST_CNI_RX_BURST_SIZE);
 
     if (rx > 0) {
-      cni->eth_rx_cnt[port] += rx;
+      cni->entries[port].eth_rx_cnt += rx;
       for (int i = 0; i < rx; i++) {
         tap_put_mbuf(tap_tx_ring, pkts_rx[i]);
       }

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -211,6 +211,7 @@ static int rx_ancillary_session_init_hw(struct mtl_main_impl* impl,
     rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
     rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
     flow.dst_port = s->st40_dst_port[i];
+    if (mt_has_cni_rx(impl)) flow.use_cni_queue = true;
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST40_RX_FLAG_DATA_PATH_ONLY))

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -607,6 +607,7 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
     rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
     rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
     flow.dst_port = s->st30_dst_port[i];
+    if (mt_has_cni_rx(impl)) flow.use_cni_queue = true;
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (s->ops.flags & ST30_RX_FLAG_DATA_PATH_ONLY))

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2816,6 +2816,7 @@ static int rv_init_hw(struct mtl_main_impl* impl, struct st_rx_video_session_imp
     } else {
       flow.hdr_split = false;
     }
+    if (mt_has_cni_rx(impl)) flow.use_cni_queue = true;
 
     /* no flow for data path only */
     if (mt_pmd_is_kernel(impl, port) && (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY))


### PR DESCRIPTION
set use_cni_queue to true in mt_rxq_flow to enable it.
For app, use "--rx_use_cni" to enable this debug option.