### PR TITLE
ptp: add no timesync support

### DIFF
--- a/doc/run.md
+++ b/doc/run.md
@@ -324,7 +324,9 @@ sudo phc2sys -s ens801f2 -m -w
 
 #### 7.1.2 Built-in PTP
 
-This project includes built-in support for the Precision Time Protocol (PTP) protocol, which is also based on the hardware Network Interface Card (NIC) timesync feature. This combination allows for achieving a PTP time clock source with an accuracy of approximately 30ns. To enable this feature in the RxTxApp sample application, use the "--ptp" argument. The control for the built-in PTP feature is the "MTL_FLAG_PTP_ENABLE" flag in the "mtl_init_params" structure.
+This project includes built-in support for the Precision Time Protocol (PTP) protocol, which is also based on the hardware Network Interface Card (NIC) timesync feature. This combination allows for achieving a PTP time clock source with an accuracy of approximately 30ns.
+
+To enable this feature in the RxTxApp sample application, use the "--ptp" argument. The control for the built-in PTP feature is the "MTL_FLAG_PTP_ENABLE" flag in the "mtl_init_params" structure.
 
 Note: Currently, the VF (Virtual Function) does not support the hardware timesync feature. Therefore, for VF deployment, the timestamp of the transmitted (TX) and received (RX) packets is read from the CPU TSC (TimeStamp Counter) instead. In this case, it is not possible to obtain a stable delta in the PTP adjustment, and the maximum accuracy achieved will be up to 1us.
 

--- a/doc/run.md
+++ b/doc/run.md
@@ -326,7 +326,7 @@ sudo phc2sys -s ens801f2 -m -w
 
 This project includes built-in support for the Precision Time Protocol (PTP) protocol, which is also based on the hardware Network Interface Card (NIC) timesync feature. This combination allows for achieving a PTP time clock source with an accuracy of approximately 30ns. To enable this feature in the RxTxApp sample application, use the "--ptp" argument. The control for the built-in PTP feature is the "MTL_FLAG_PTP_ENABLE" flag in the "mtl_init_params" structure.
 
-Note: Currently, the VF (Virtual Function) does not support the hardware timesync feature. Therefore, for VF deployment, the timestamp of the transmitted (TX) and received (RX) packets is read from the CPU TSC (Time Stamp Counter) instead. In this case, it is not possible to obtain a stable delta in the PTP adjustment, and the maximum accuracy achieved will be up to 1us.
+Note: Currently, the VF (Virtual Function) does not support the hardware timesync feature. Therefore, for VF deployment, the timestamp of the transmitted (TX) and received (RX) packets is read from the CPU TSC (TimeStamp Counter) instead. In this case, it is not possible to obtain a stable delta in the PTP adjustment, and the maximum accuracy achieved will be up to 1us.
 
 ## 8. FAQs
 

--- a/doc/run.md
+++ b/doc/run.md
@@ -304,11 +304,11 @@ This section includes some optional guides. If you are not familiar with the det
 
 ### 7.1 PTP setup
 
-The Precision Time Protocol (PTP) enables global microsecond accuracy timing of all essences and is typically deployed with a PTP grandmaster within the network, while clients use tools such as ptp4l to synchronize with it. This library also includes a built-in PTP implementation, and a sample application provides an option to enable it. See section 3.6 for instructions on how to enable it.
+The Precision Time Protocol (PTP) facilitates global timing accuracy in the microsecond range for all essences. Typically, a PTP grandmaster is deployed within the network, and clients synchronize with it using tools like ptp4l. This library includes its own PTP implementation, and a sample application offers the option to enable it. Please refer to section 7.1.2 for instructions on how to enable it.
 
-By default, the built-in PTP is disabled, and the user application's system time source (clock_gettime) is used as the PTP clock. However, if the built-in PTP is enabled, the internal NIC time will be selected as the PTP source.
+By default, the built-in PTP feature is disabled, and the PTP clock relies on the system time source of the user application (clock_gettime). However, if the built-in PTP is enabled, the internal NIC time will be selected as the PTP source.
 
-#### 7.1.1 ptp4l setup sample
+#### 7.1.1 Linux ptp4l setup to sync system time with grandmaster
 
 Firstly run ptp4l to sync the PHC time with grandmaster, customize the interface as your setup.
 
@@ -321,6 +321,12 @@ Then run phc2sys to sync the PHC time to system time, please make sure NTP servi
 ```shell
 sudo phc2sys -s ens801f2 -m -w
 ```
+
+#### 7.1.2 Built-in PTP
+
+This project includes built-in support for the Precision Time Protocol (PTP) protocol, which is also based on the hardware Network Interface Card (NIC) timesync feature. This combination allows for achieving a PTP time clock source with an accuracy of approximately 30ns. To enable this feature in the RxTxApp sample application, use the "--ptp" argument. The control for the built-in PTP feature is the "MTL_FLAG_PTP_ENABLE" flag in the "mtl_init_params" structure.
+
+Note: Currently, the VF (Virtual Function) does not support the hardware timesync feature. Therefore, for VF deployment, the timestamp of the transmitted (TX) and received (RX) packets is read from the CPU TSC (Time Stamp Counter) instead. In this case, it is not possible to obtain a stable delta in the PTP adjustment, and the maximum accuracy achieved will be up to 1us.
 
 ## 8. FAQs
 

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -152,6 +152,8 @@ struct mt_ptp_impl {
   enum mtl_port port;
   uint16_t port_id;
   bool active; /* if the ptp stack is running */
+  bool no_timesync;
+  int64_t no_timesync_delta;
 
   struct rte_mempool* mbuf_pool;
 
@@ -1198,13 +1200,6 @@ static inline bool mt_if_has_hdr_split(struct mtl_main_impl* impl, enum mtl_port
 static inline struct rte_mempool* mt_if_hdr_split_pool(struct mt_interface* inf,
                                                        uint16_t q) {
   return inf->rx_queues[q].mbuf_payload_pool;
-}
-
-static inline bool mt_if_has_ptp(struct mtl_main_impl* impl, enum mtl_port port) {
-  if (mt_has_ptp_service(impl) && mt_if_has_timesync(impl, port))
-    return true;
-  else
-    return false;
 }
 
 static inline uint16_t mt_if_nb_tx_desc(struct mtl_main_impl* impl, enum mtl_port port) {

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -185,6 +185,8 @@ struct mt_ptp_impl {
   int32_t expect_result_cnt;
   int32_t expect_result_sum;
   int32_t expect_result_avg;
+  int32_t expect_correct_result_sum;
+  int32_t expect_correct_result_avg;
   uint64_t expect_result_start_ns;
   uint64_t expect_result_period_ns;
 

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -262,7 +262,6 @@ static void ptp_result_reset(struct mt_ptp_impl* ptp) {
 }
 
 static int ptp_sync_expect_result(struct mt_ptp_impl* ptp) {
-  if (ptp->expect_result_avg) ptp_adjust_delta(ptp, ptp->expect_result_avg);
   if (ptp->expect_correct_result_avg) {
     if (ptp->use_pi) {
       /* fine tune coefficient */
@@ -274,6 +273,7 @@ static int ptp_sync_expect_result(struct mt_ptp_impl* ptp) {
       ptp_calculate_coefficient(ptp, ptp->expect_result_avg);
     }
   }
+  if (ptp->expect_result_avg) ptp_adjust_delta(ptp, ptp->expect_result_avg);
   return 0;
 }
 

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -2051,7 +2051,7 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
     EXPECT_GT(test_ctx_rx[i]->fb_rec, 0);
     EXPECT_GT(test_ctx_rx[i]->check_sha_frame_cnt, 0);
     if (rx_type[i] == ST20_TYPE_SLICE_LEVEL)
-      EXPECT_LT(test_ctx_rx[i]->incomplete_frame_cnt, 2 * 5);
+      EXPECT_LT(test_ctx_rx[i]->incomplete_frame_cnt, 2 * 8);
     else
       EXPECT_LT(test_ctx_rx[i]->incomplete_frame_cnt, 4);
     if (!disable_meta_timing) {


### PR DESCRIPTION
use tsc time as timesync source if no timesync support.

The accuracy is not stable(max to 10us for VF) since it can't read exactly the t2 and t3 time.

MT: PTP(0): time 1689580576680416367, 2023-07-17 15:55:39
MT: PTP(0): delta avg 3978, min -2313, max 9985, cnt 40
MT: PTP(0): correct_delta avg 442, min -6134, max 6152, cnt 39
MT: PTP(0): path_delay avg 2664, min 2306, max 8591, cnt 39
MT: PTP(0): mode l4, sync cnt 40, expect avg 4483:667@0.251065s
MT: PTP(0): rx time error 0, tx time error 0, delta result error 1

MT: PTP(0): time 1689580596680572512, 2023-07-17 15:55:59
MT: PTP(0): delta avg 3853, min 3568, max 4130, cnt 40
MT: PTP(0): correct_delta avg 116, min -269, max 368, cnt 40
MT: PTP(0): path_delay avg 2497, min 2341, max 2756, cnt 40
MT: PTP(0): mode l4, sync cnt 40, expect avg 3844:47@0.250758s

