### PR TITLE
audio: deprecate sample_size and sample_num

### DIFF
--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -49,6 +49,14 @@
 #define NS_PER_S (1000000000)
 #endif
 
+#ifndef NS_PER_US
+#define NS_PER_US (1000)
+#endif
+
+#ifndef NS_PER_MS
+#define NS_PER_MS (1000 * 1000)
+#endif
+
 #define UTC_OFFSET (37) /* 2022/07 */
 
 #define ST_MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -280,14 +280,12 @@ struct st30_tx_ops {
    * size for each sample group,
    * use st30_get_sample_size to get the size for different format.
    */
-  uint16_t sample_size
-      __mtl_deprecated_msg("Not use anymore, plan to remove in next version");
+  uint16_t sample_size __mtl_deprecated_msg("Not use anymore, plan to remove");
   /**
    * number of samples for single channel in packet,
    * use st30_get_sample_num to get the number from different ptime and sampling rate.
    */
-  uint16_t sample_num
-      __mtl_deprecated_msg("Not use anymore, plan to remove in next version");
+  uint16_t sample_num __mtl_deprecated_msg("Not use anymore, plan to remove");
   /*
    * The size of fifo ring which used between the packet builder and pacing.
    * Leave to zero to use default value: the packet number within
@@ -308,7 +306,7 @@ struct st30_tx_ops {
    */
   uint16_t framebuff_cnt;
   /**
-   * size for each frame buffer, should be multiple of packet size(st30_get_packet_size),,
+   * size for each frame buffer, should be multiple of packet size(st30_get_packet_size),
    * only for ST30_TYPE_FRAME_LEVEL.
    */
   uint32_t framebuff_size;
@@ -383,12 +381,12 @@ struct st30_rx_ops {
    * size for each sample group,
    * use st30_get_sample_size to get the size for different format.
    */
-  uint16_t sample_size;
+  // uint16_t sample_size __mtl_deprecated_msg("Not use anymore, plan to remove");
   /**
    * number of samples for single channel in packet,
    * use st30_get_sample_num to get the number from different ptime and sampling rate.
    */
-  uint16_t sample_num;
+  // uint16_t sample_num __mtl_deprecated_msg("Not use anymore, plan to remove");
 
   /**
    * the frame buffer count requested for one st30 rx session,
@@ -396,7 +394,7 @@ struct st30_rx_ops {
    */
   uint16_t framebuff_cnt;
   /**
-   * size for each frame buffer, should be multiple of sample_size,
+   * size for each frame buffer, should be multiple of packet size(st30_get_packet_size),
    * only for ST30_TX_TYPE_FRAME_LEVEL.
    */
   uint32_t framebuff_size;

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -381,12 +381,12 @@ struct st30_rx_ops {
    * size for each sample group,
    * use st30_get_sample_size to get the size for different format.
    */
-  // uint16_t sample_size __mtl_deprecated_msg("Not use anymore, plan to remove");
+  uint16_t sample_size __mtl_deprecated_msg("Not use anymore, plan to remove");
   /**
    * number of samples for single channel in packet,
    * use st30_get_sample_num to get the number from different ptime and sampling rate.
    */
-  // uint16_t sample_num __mtl_deprecated_msg("Not use anymore, plan to remove");
+  uint16_t sample_num __mtl_deprecated_msg("Not use anymore, plan to remove");
 
   /**
    * the frame buffer count requested for one st30 rx session,

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -280,12 +280,14 @@ struct st30_tx_ops {
    * size for each sample group,
    * use st30_get_sample_size to get the size for different format.
    */
-  uint16_t sample_size;
+  uint16_t sample_size
+      __mtl_deprecated_msg("Not use anymore, plan to remove in next version");
   /**
    * number of samples for single channel in packet,
    * use st30_get_sample_num to get the number from different ptime and sampling rate.
    */
-  uint16_t sample_num;
+  uint16_t sample_num
+      __mtl_deprecated_msg("Not use anymore, plan to remove in next version");
   /*
    * The size of fifo ring which used between the packet builder and pacing.
    * Leave to zero to use default value: the packet number within
@@ -306,7 +308,7 @@ struct st30_tx_ops {
    */
   uint16_t framebuff_cnt;
   /**
-   * size for each frame buffer, should be multiple of sample_size,
+   * size for each frame buffer, should be multiple of packet size(st30_get_packet_size),,
    * only for ST30_TYPE_FRAME_LEVEL.
    */
   uint32_t framebuff_size;
@@ -554,6 +556,24 @@ int st30_get_sample_num(enum st30_ptime ptime, enum st30_sampling sampling);
  *   - <0: Error code if fail.
  */
 int st30_get_sample_rate(enum st30_sampling sampling);
+
+/**
+ * Retrieve the size for each pkt.
+ *
+ * @param fmt
+ *   The st2110-30(audio) format.
+ * @param ptime
+ *   The st2110-30(audio) packet time.
+ * @param sampling
+ *   The st2110-30(audio) sampling rate.
+ * @param channel
+ *   The st2110-30(audio) channel.
+ * @return
+ *   - >0 the clock rate.
+ *   - <0: Error code if fail.
+ */
+int st30_get_packet_size(enum st30_fmt fmt, enum st30_ptime ptime,
+                         enum st30_sampling sampling, uint16_t channel);
 
 /**
  * Create one rx st2110-30(audio) session.

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -890,6 +890,15 @@ double st30_get_packet_time(enum st30_ptime ptime) {
     case ST31_PTIME_80US:
       packet_time_ns = (double)1000000000.0 * 1 / 12500;
       break;
+    case ST31_PTIME_1_09MS:
+      packet_time_ns = (double)1000000000.0 * 48 / 44100;
+      break;
+    case ST31_PTIME_0_14MS:
+      packet_time_ns = (double)1000000000.0 * 6 / 44100;
+      break;
+    case ST31_PTIME_0_09MS:
+      packet_time_ns = (double)1000000000.0 * 4 / 44100;
+      break;
     default:
       err("%s, wrong ptime %d\n", __func__, ptime);
       return -EINVAL;

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -943,7 +943,7 @@ int st30_get_sample_num(enum st30_ptime ptime, enum st30_sampling sampling) {
           samples = 4;
           break;
         default:
-          err("%s, wrong ptime %d\n", __func__, ptime);
+          err("%s, wrong ptime %d for 48k\n", __func__, ptime);
           return -EINVAL;
       }
       break;
@@ -968,7 +968,7 @@ int st30_get_sample_num(enum st30_ptime ptime, enum st30_sampling sampling) {
           samples = 8;
           break;
         default:
-          err("%s, wrong ptime %d\n", __func__, ptime);
+          err("%s, wrong ptime %d for 96k\n", __func__, ptime);
           return -EINVAL;
       }
       break;
@@ -984,7 +984,7 @@ int st30_get_sample_num(enum st30_ptime ptime, enum st30_sampling sampling) {
           samples = 4;
           break;
         default:
-          err("%s, wrong ptime %d\n", __func__, ptime);
+          err("%s, wrong ptime %d for 44k\n", __func__, ptime);
           return -EINVAL;
       }
       break;

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -1009,6 +1009,28 @@ int st30_get_sample_rate(enum st30_sampling sampling) {
   }
 }
 
+int st30_get_packet_size(enum st30_fmt fmt, enum st30_ptime ptime,
+                         enum st30_sampling sampling, uint16_t channel) {
+  int ret;
+  int sample_size;
+  int sample_num;
+
+  ret = st30_get_sample_size(fmt);
+  if (ret < 0) return ret;
+  sample_size = ret;
+
+  ret = st30_get_sample_num(ptime, sampling);
+  if (ret < 0) return ret;
+  sample_num = ret;
+
+  if (!channel) {
+    err("%s, invalid channel %u\n", __func__, channel);
+    return -EINVAL;
+  }
+
+  return sample_size * sample_num * channel;
+}
+
 void st_frame_init_plane_single_src(struct st_frame* frame, void* addr, mtl_iova_t iova) {
   uint8_t planes = st_frame_fmt_planes(frame->fmt);
 

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -715,10 +715,9 @@ struct st_rx_video_sessions_mgr {
 };
 
 struct st_tx_audio_session_pacing {
-  double trs;                 /* in ns for of 2 consecutive packets */
-  double frame_time;          /* time of the frame in nanoseconds */
-  double frame_time_sampling; /* time of the frame in sampling(48k) */
-  uint64_t cur_epochs;        /* epoch of current frame */
+  double trs;               /* in ns for of 2 consecutive packets */
+  double pkt_time_sampling; /* time of each pkt in sampling(48k) */
+  uint64_t cur_epochs;      /* epoch of current pkt */
   /* timestamp for rtp header */
   uint32_t rtp_time_stamp;
   /* timestamp for pacing */

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -768,6 +768,8 @@ struct st_tx_audio_session_impl {
   bool calculate_time_cursor;
   bool check_frame_done_time;
 
+  uint16_t sample_size;
+  uint16_t sample_num;
   uint32_t pkt_len;           /* data len(byte) for each pkt */
   uint32_t st30_pkt_size;     /* size for each pkt which include the header */
   int st30_total_pkts;        /* total pkts in one frame */

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -193,6 +193,7 @@ static int tx_audio_session_init_pacing(struct mtl_main_impl* impl,
   struct st_tx_audio_session_pacing* pacing = &s->pacing;
   struct st30_tx_ops* ops = &s->ops;
   double pkt_time = st30_get_packet_time(ops->ptime);
+  if (pkt_time < 0) return -EINVAL;
 
   pacing->pkt_time_sampling = (double)(s->sample_num * 1000) * 1 / 1000;
   pacing->trs = pkt_time;
@@ -1331,7 +1332,7 @@ static int tx_audio_session_attach(struct mtl_main_impl* impl,
 
   /* calculate pkts in line*/
   size_t bytes_in_pkt = ST_PKT_MAX_ETHER_BYTES - sizeof(struct st_rfc3550_audio_hdr);
-  
+
   s->st30_pkt_size = s->pkt_len + sizeof(struct st_rfc3550_audio_hdr);
   if (s->pkt_len > bytes_in_pkt) {
     err("%s(%d), invalid pkt_len %d\n", __func__, idx, s->pkt_len);
@@ -1381,8 +1382,8 @@ static int tx_audio_session_attach(struct mtl_main_impl* impl,
     return ret;
   }
 
-  info("%s(%d), pkt_len %u frame_size %u\n", __func__, idx, s->pkt_len,
-       s->st30_frame_size);
+  info("%s(%d), pkt_len %u frame_size %u fps %f\n", __func__, idx, s->pkt_len,
+       s->st30_frame_size, (double)NS_PER_S / s->pacing.trs / s->st30_total_pkts);
   return 0;
 }
 

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -194,7 +194,7 @@ static int tx_audio_session_init_pacing(struct mtl_main_impl* impl,
   struct st30_tx_ops* ops = &s->ops;
   double pkt_time = st30_get_packet_time(ops->ptime);
 
-  pacing->pkt_time_sampling = (double)(ops->sample_num * 1000) * 1 / 1000;
+  pacing->pkt_time_sampling = (double)(s->sample_num * 1000) * 1 / 1000;
   pacing->trs = pkt_time;
 
   pacing->max_onward_epochs = (double)(NS_PER_S * 1) / pkt_time;     /* 1s */
@@ -1318,9 +1318,20 @@ static int tx_audio_session_attach(struct mtl_main_impl* impl,
 
   s->st30_frames_cnt = ops->framebuff_cnt;
 
+  ret = st30_get_sample_size(ops->fmt);
+  if (ret < 0) return ret;
+  s->sample_size = ret;
+  ret = st30_get_sample_num(ops->ptime, ops->sampling);
+  if (ret < 0) return ret;
+  s->sample_num = ret;
+
+  ret = st30_get_packet_size(ops->fmt, ops->ptime, ops->sampling, ops->channel);
+  if (ret < 0) return ret;
+  s->pkt_len = ret;
+
   /* calculate pkts in line*/
   size_t bytes_in_pkt = ST_PKT_MAX_ETHER_BYTES - sizeof(struct st_rfc3550_audio_hdr);
-  s->pkt_len = ops->sample_size * ops->sample_num * ops->channel;
+  
   s->st30_pkt_size = s->pkt_len + sizeof(struct st_rfc3550_audio_hdr);
   if (s->pkt_len > bytes_in_pkt) {
     err("%s(%d), invalid pkt_len %d\n", __func__, idx, s->pkt_len);
@@ -1686,10 +1697,6 @@ static int tx_audio_ops_check(struct st30_tx_ops* ops) {
   } else if (ops->type == ST30_TYPE_RTP_LEVEL) {
     if (ops->rtp_ring_size <= 0) {
       err("%s, invalid rtp_ring_size %d\n", __func__, ops->rtp_ring_size);
-      return -EINVAL;
-    }
-    if ((ops->sample_size <= 0) || (ops->sample_size > MTL_PKT_MAX_RTP_BYTES)) {
-      err("%s, invalid sample_size %d\n", __func__, ops->sample_size);
       return -EINVAL;
     }
     if (!ops->notify_rtp_done) {

--- a/tests/script/loop_json/unicast_4a.json
+++ b/tests/script/loop_json/unicast_4a.json
@@ -1,0 +1,124 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "192.168.17.102"
+            ],
+            "interface": [
+                0
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                },
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30001,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "0.12",
+                    "audio_url": "./test.wav"
+                },
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30002,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "0.25",
+                    "audio_url": "./test.wav"
+                },
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30003,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "4",
+                    "audio_url": "./test.wav"
+                },
+            ],
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "192.168.17.101",
+            ],
+            "interface": [
+                1
+            ],
+            "audio": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                },
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30001,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "0.12",
+                    "audio_url": "./test.wav"
+                },
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30002,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "0.25",
+                    "audio_url": "./test.wav"
+                },
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "start_port": 30003,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "4",
+                    "audio_url": "./test.wav"
+                },
+            ],
+        }
+    ]
+}

--- a/tests/script/loop_json/unicast_4a.json
+++ b/tests/script/loop_json/unicast_4a.json
@@ -47,8 +47,8 @@
                     "payload_type": 111,
                     "audio_format": "PCM16",
                     "audio_channel": ["ST"],
-                    "audio_sampling": "48kHz",
-                    "audio_ptime": "0.25",
+                    "audio_sampling": "44.1kHz",
+                    "audio_ptime": "0.09",
                     "audio_url": "./test.wav"
                 },
                 {
@@ -103,8 +103,8 @@
                     "payload_type": 111,
                     "audio_format": "PCM16",
                     "audio_channel": ["ST"],
-                    "audio_sampling": "48kHz",
-                    "audio_ptime": "0.25",
+                    "audio_sampling": "44.1kHz",
+                    "audio_ptime": "0.09",
                     "audio_url": "./test.wav"
                 },
                 {

--- a/tests/src/st30_test.cpp
+++ b/tests/src/st30_test.cpp
@@ -202,10 +202,9 @@ static void st30_rx_ops_init(tests_context* st30, struct st30_rx_ops* ops) {
   ops->payload_type = ST30_TEST_PAYLOAD_TYPE;
   ops->sampling = ST30_SAMPLING_48K;
   ops->ptime = ST30_PTIME_1MS;
-  ops->sample_size = st30_get_sample_size(ops->fmt);
-  ops->sample_num = st30_get_sample_num(ops->ptime, ops->sampling);
   ops->framebuff_cnt = st30->fb_cnt;
-  ops->framebuff_size = ops->sample_size * ops->sample_num * ops->channel;
+  ops->framebuff_size =
+      st30_get_packet_size(ops->fmt, ops->ptime, ops->sampling, ops->channel);
   ops->notify_frame_ready = st30_rx_frame_ready;
   ops->notify_rtp_ready = rx_rtp_ready;
   ops->rtp_ring_size = 1024;
@@ -509,9 +508,8 @@ static void st30_rx_fps_test(enum st30_type type[], enum st30_sampling sample[],
     ops_rx.fmt = fmt[i];
     ops_rx.payload_type = ST30_TEST_PAYLOAD_TYPE;
     ops_rx.ptime = ptime[i];
-    ops_rx.sample_size = st30_get_sample_size(ops_rx.fmt);
-    ops_rx.sample_num = st30_get_sample_num(ops_rx.ptime, ops_rx.sampling);
-    ops_rx.framebuff_size = ops_rx.sample_size * ops_rx.sample_num * ops_rx.channel;
+    ops_rx.framebuff_size =
+        st30_get_packet_size(ops_rx.fmt, ops_rx.ptime, ops_rx.sampling, ops_rx.channel);
     ops_rx.framebuff_cnt = test_ctx_rx[i]->fb_cnt;
     ops_rx.notify_frame_ready = st30_rx_frame_ready;
     ops_rx.notify_rtp_ready = rx_rtp_ready;
@@ -888,9 +886,8 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
     ops_rx.fmt = ST30_FMT_PCM24;
     ops_rx.payload_type = ST30_TEST_PAYLOAD_TYPE;
     ops_rx.ptime = ST30_PTIME_1MS;
-    ops_rx.sample_size = st30_get_sample_size(ops_rx.fmt);
-    ops_rx.sample_num = st30_get_sample_num(ops_rx.ptime, ops_rx.sampling);
-    ops_rx.framebuff_size = ops_rx.sample_size * ops_rx.sample_num * ops_rx.channel;
+    ops_rx.framebuff_size =
+        st30_get_packet_size(ops_rx.fmt, ops_rx.ptime, ops_rx.sampling, ops_rx.channel);
     ops_rx.framebuff_cnt = test_ctx_rx[i]->fb_cnt;
     ops_rx.notify_frame_ready = st30_rx_frame_ready;
     ops_rx.notify_rtp_ready = rx_rtp_ready;
@@ -1178,9 +1175,8 @@ static void st30_rx_meta_test(enum st30_fmt fmt[], enum st30_sampling sampling[]
     ops_rx.fmt = fmt[i];
     ops_rx.payload_type = ST30_TEST_PAYLOAD_TYPE;
     ops_rx.ptime = ST30_PTIME_1MS;
-    ops_rx.sample_size = st30_get_sample_size(ops_rx.fmt);
-    ops_rx.sample_num = st30_get_sample_num(ops_rx.ptime, ops_rx.sampling);
-    ops_rx.framebuff_size = ops_rx.sample_size * ops_rx.sample_num * ops_rx.channel;
+    ops_rx.framebuff_size =
+        st30_get_packet_size(ops_rx.fmt, ops_rx.ptime, ops_rx.sampling, ops_rx.channel);
     ops_rx.framebuff_cnt = test_ctx_rx[i]->fb_cnt;
     ops_rx.notify_frame_ready = st30_rx_meta_frame_ready;
     ops_rx.notify_rtp_ready = rx_rtp_ready;
@@ -1357,9 +1353,8 @@ static void st30_create_after_start_test(enum st30_type type[],
       ops_rx.fmt = fmt[i];
       ops_rx.payload_type = ST30_TEST_PAYLOAD_TYPE;
       ops_rx.ptime = ST30_PTIME_1MS;
-      ops_rx.sample_size = st30_get_sample_size(ops_rx.fmt);
-      ops_rx.sample_num = st30_get_sample_num(ops_rx.ptime, ops_rx.sampling);
-      ops_rx.framebuff_size = ops_rx.sample_size * ops_rx.sample_num * ops_rx.channel;
+      ops_rx.framebuff_size =
+          st30_get_packet_size(ops_rx.fmt, ops_rx.ptime, ops_rx.sampling, ops_rx.channel);
       ops_rx.framebuff_cnt = test_ctx_rx[i]->fb_cnt;
       ops_rx.notify_frame_ready = st30_rx_frame_ready;
       ops_rx.notify_rtp_ready = rx_rtp_ready;


### PR DESCRIPTION
It's duplicate to fmt, channel, ptime, sampling