### PR TITLE
tsq: use spin lock to protect the tx burst

### DIFF
--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -796,7 +796,7 @@ struct mt_tsq_queue {
   /* List of rsq entry */
   struct mt_tsq_entrys_list head;
   pthread_mutex_t mutex;
-  pthread_mutex_t tx_mutex;
+  rte_spinlock_t tx_mutex;
   rte_atomic32_t entry_cnt;
   /* stat */
   int stat_pkts_send;

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -145,7 +145,7 @@ static int sch_tasklet_func(void* args) {
       if (time_measure) tsc_s = mt_get_tsc(impl);
       pending += ops->handler(ops->priv);
       if (time_measure) {
-        uint32_t delta_us = (mt_get_tsc(impl) - tsc_s) / 1000;
+        uint32_t delta_us = (mt_get_tsc(impl) - tsc_s) / NS_PER_US;
         tasklet->stat_max_time_us = RTE_MAX(tasklet->stat_max_time_us, delta_us);
         tasklet->stat_min_time_us = RTE_MIN(tasklet->stat_min_time_us, delta_us);
         tasklet->stat_sum_time_us += delta_us;

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -116,8 +116,15 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     s->tmstamp = rtp->tmstamp;
   }
   s->st40_stat_pkts_received++;
+
   /* get a valid packet */
-  if (ops->priv) ops->notify_rtp_ready(ops->priv);
+  uint64_t tsc_start = 0;
+  if (s->time_measure) tsc_start = mt_get_tsc(impl);
+  ops->notify_rtp_ready(ops->priv);
+  if (s->time_measure) {
+    uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+    s->stat_max_notify_rtp_us = RTE_MAX(s->stat_max_notify_rtp_us, delta_us);
+  }
 
   return 0;
 }
@@ -313,6 +320,7 @@ static int rx_ancillary_session_attach(struct mtl_main_impl* impl,
   ret = mt_build_port_map(impl, ports, s->port_maps, num_port);
   if (ret < 0) return ret;
 
+  s->time_measure = mt_has_tasklet_time_measure(impl);
   strncpy(s->ops_name, ops->name, ST_MAX_NAME_LEN - 1);
   s->ops = *ops;
   for (int i = 0; i < num_port; i++) {
@@ -371,9 +379,13 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
     s->st40_stat_pkts_dropped = 0;
   }
   if (s->st40_stat_pkts_wrong_hdr_dropped) {
-    notice("RX_AUDIO_SESSION(%d): wrong hdr dropped pkts %d\n", idx,
+    notice("RX_ANC_SESSION(%d): wrong hdr dropped pkts %d\n", idx,
            s->st40_stat_pkts_wrong_hdr_dropped);
     s->st40_stat_pkts_wrong_hdr_dropped = 0;
+  }
+  if (s->time_measure) {
+    notice("RX_ANC_SESSION(%d): notify rtp max %uus\n", idx, s->stat_max_notify_rtp_us);
+    s->stat_max_notify_rtp_us = 0;
   }
 }
 

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -437,6 +437,8 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   // notify frame done
   if (s->frame_recv_size >= s->st30_frame_size) {
     struct st30_rx_frame_meta* meta = &s->meta;
+    uint64_t tsc_start = 0;
+
     meta->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
     meta->timestamp = tmstamp;
     meta->fmt = ops->fmt;
@@ -444,9 +446,12 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     meta->channel = ops->channel;
 
     /* get a full frame */
-    int ret = -EIO;
-    if (ops->notify_frame_ready)
-      ret = ops->notify_frame_ready(ops->priv, s->st30_cur_frame, meta);
+    if (s->time_measure) tsc_start = mt_get_tsc(impl);
+    int ret = ops->notify_frame_ready(ops->priv, s->st30_cur_frame, meta);
+    if (s->time_measure) {
+      uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+      s->stat_max_notify_frame_us = RTE_MAX(s->stat_max_notify_frame_us, delta_us);
+    }
     if (ret < 0) {
       err("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
       rx_audio_session_put_frame(s, s->st30_cur_frame);
@@ -702,6 +707,7 @@ static int rx_audio_session_attach(struct mtl_main_impl* impl,
   ret = mt_build_port_map(impl, ports, s->port_maps, num_port);
   if (ret < 0) return ret;
 
+  s->time_measure = mt_has_tasklet_time_measure(impl);
   strncpy(s->ops_name, ops->name, ST_MAX_NAME_LEN - 1);
   s->ops = *ops;
   for (int i = 0; i < num_port; i++) {
@@ -805,6 +811,11 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
     notice("RX_AUDIO_SESSION(%d,%d): pkt len mismatch dropped pkts %d\n", m_idx, idx,
            s->st30_stat_pkts_len_mismatch_dropped);
     s->st30_stat_pkts_len_mismatch_dropped = 0;
+  }
+  if (s->time_measure) {
+    notice("RX_AUDIO_SESSION(%d,%d): notify frame max %uus\n", m_idx, idx,
+           s->stat_max_notify_frame_us);
+    s->stat_max_notify_frame_us = 0;
   }
 }
 

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -576,6 +576,7 @@ static int tx_audio_session_tasklet_frame(struct mtl_main_impl* impl,
     if (ST30_TX_STAT_WAIT_FRAME == s->st30_frame_stat) {
       uint16_t next_frame_idx;
       struct st30_tx_frame_meta meta;
+      uint64_t tsc_start = 0;
 
       if (s->check_frame_done_time) {
         uint64_t frame_end_time = mt_get_tsc(impl);
@@ -589,7 +590,12 @@ static int tx_audio_session_tasklet_frame(struct mtl_main_impl* impl,
 
       tx_audio_session_init_next_meta(s, &meta);
       /* Query next frame buffer idx */
+      if (s->time_measure) tsc_start = mt_get_tsc(impl);
       ret = ops->get_next_frame(ops->priv, &next_frame_idx, &meta);
+      if (s->time_measure) {
+        uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+        s->stat_max_next_frame_us = RTE_MAX(s->stat_max_next_frame_us, delta_us);
+      }
       if (ret < 0) { /* no frame ready from app */
         dbg("%s(%d), get_next_frame fail %d\n", __func__, idx, ret);
         s->stat_build_ret_code = -STI_FRAME_APP_GET_FRAME_BUSY;
@@ -720,9 +726,16 @@ static int tx_audio_session_tasklet_frame(struct mtl_main_impl* impl,
   if (s->st30_pkt_idx >= s->st30_total_pkts) {
     dbg("%s(%d), frame %d done\n", __func__, idx, s->st30_frame_idx);
     struct st_frame_trans* frame = &s->st30_frames[s->st30_frame_idx];
+    uint64_t tsc_start = 0;
+    if (s->time_measure) tsc_start = mt_get_tsc(impl);
     /* end of current frame */
     if (s->ops.notify_frame_done)
       ops->notify_frame_done(ops->priv, s->st30_frame_idx, &frame->ta_meta);
+    if (s->time_measure) {
+      uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+      s->stat_max_notify_frame_us = RTE_MAX(s->stat_max_notify_frame_us, delta_us);
+    }
+
     rte_atomic32_dec(&frame->refcnt);
     s->st30_frame_stat = ST30_TX_STAT_WAIT_FRAME;
     s->check_frame_done_time = true;
@@ -919,7 +932,7 @@ static int tx_audio_session_tasklet_transmit(struct mtl_main_impl* impl,
   return 0;
 }
 
-static int tx_audio_sessions_tasklet_handler(void* priv) {
+static int tx_audio_sessions_tasklet_build(void* priv) {
   struct st_tx_audio_sessions_mgr* mgr = priv;
   struct mtl_main_impl* impl = mgr->parent;
   struct st_tx_audio_session_impl* s;
@@ -934,6 +947,21 @@ static int tx_audio_sessions_tasklet_handler(void* priv) {
       pending += tx_audio_session_tasklet_frame(impl, s);
     else
       pending += tx_audio_session_tasklet_rtp(impl, s);
+    tx_audio_session_put(mgr, sidx);
+  }
+
+  return pending;
+}
+
+static int tx_audio_sessions_tasklet_trans(void* priv) {
+  struct st_tx_audio_sessions_mgr* mgr = priv;
+  struct mtl_main_impl* impl = mgr->parent;
+  struct st_tx_audio_session_impl* s;
+  int pending = MT_TASKLET_ALL_DONE;
+
+  for (int sidx = 0; sidx < mgr->max_idx; sidx++) {
+    s = tx_audio_session_try_get(mgr, sidx);
+    if (!s) continue;
     for (int port = 0; port < s->ops.num_port; port++) {
       pending += tx_audio_session_tasklet_transmit(impl, mgr, s, port);
     }
@@ -1299,6 +1327,7 @@ static int tx_audio_session_attach(struct mtl_main_impl* impl,
   ret = mt_build_port_map(impl, ports, s->port_maps, num_port);
   if (ret < 0) return ret;
 
+  s->time_measure = mt_has_tasklet_time_measure(impl);
   strncpy(s->ops_name, ops->name, ST_MAX_NAME_LEN - 1);
   s->ops = *ops;
   for (int i = 0; i < num_port; i++) {
@@ -1487,6 +1516,12 @@ static void tx_audio_session_stat(struct st_tx_audio_sessions_mgr* mgr,
            s->stat_error_user_timestamp);
     s->stat_error_user_timestamp = 0;
   }
+  if (s->time_measure) {
+    notice("TX_AUDIO_SESSION(%d,%d): get next frame max %uus, notify done max %uus\n",
+           m_idx, idx, s->stat_max_next_frame_us, s->stat_max_notify_frame_us);
+    s->stat_max_next_frame_us = 0;
+    s->stat_max_notify_frame_us = 0;
+  }
 }
 
 static int tx_audio_session_detach(struct st_tx_audio_sessions_mgr* mgr,
@@ -1544,15 +1579,27 @@ static int tx_audio_sessions_mgr_init(struct mtl_main_impl* impl, struct mt_sch_
 
   memset(&ops, 0x0, sizeof(ops));
   ops.priv = mgr;
-  ops.name = "tx_audio_sessions_mgr";
+  ops.name = "tx_audio_sessions_build";
   ops.start = tx_audio_sessions_tasklet_start;
   ops.stop = tx_audio_sessions_tasklet_stop;
-  ops.handler = tx_audio_sessions_tasklet_handler;
+  ops.handler = tx_audio_sessions_tasklet_build;
 
-  mgr->tasklet = mt_sch_register_tasklet(sch, &ops);
-  if (!mgr->tasklet) {
+  mgr->tasklet_build = mt_sch_register_tasklet(sch, &ops);
+  if (!mgr->tasklet_build) {
     tx_audio_sessions_mgr_uinit_hw(impl, mgr);
-    err("%s(%d), mt_sch_register_tasklet fail\n", __func__, idx);
+    err("%s(%d), tasklet_build register fail\n", __func__, idx);
+    return -EIO;
+  }
+
+  memset(&ops, 0x0, sizeof(ops));
+  ops.priv = mgr;
+  ops.name = "tx_audio_sessions_trans";
+  ops.handler = tx_audio_sessions_tasklet_trans;
+
+  mgr->tasklet_trans = mt_sch_register_tasklet(sch, &ops);
+  if (!mgr->tasklet_trans) {
+    tx_audio_sessions_mgr_uinit_hw(impl, mgr);
+    err("%s(%d), tasklet_trans register fail\n", __func__, idx);
     return -EIO;
   }
 
@@ -1641,9 +1688,13 @@ static int tx_audio_sessions_mgr_uinit(struct st_tx_audio_sessions_mgr* mgr) {
 
   mt_stat_unregister(mgr->parent, st_tx_audio_sessions_stat, mgr);
 
-  if (mgr->tasklet) {
-    mt_sch_unregister_tasklet(mgr->tasklet);
-    mgr->tasklet = NULL;
+  if (mgr->tasklet_build) {
+    mt_sch_unregister_tasklet(mgr->tasklet_build);
+    mgr->tasklet_build = NULL;
+  }
+  if (mgr->tasklet_trans) {
+    mt_sch_unregister_tasklet(mgr->tasklet_trans);
+    mgr->tasklet_trans = NULL;
   }
 
   for (int i = 0; i < ST_SCH_MAX_TX_AUDIO_SESSIONS; i++) {

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -63,6 +63,8 @@ static inline uint64_t tv_rl_bps(struct st_tx_video_session_impl* s) {
 }
 
 static void tv_notify_frame_done(struct st_tx_video_session_impl* s, uint16_t frame_idx) {
+  uint64_t tsc_start = 0;
+  if (s->time_measure) tsc_start = mt_get_tsc(s->impl);
   if (s->st22_info) {
     if (s->st22_info->notify_frame_done)
       s->st22_info->notify_frame_done(s->ops.priv, frame_idx,
@@ -71,6 +73,10 @@ static void tv_notify_frame_done(struct st_tx_video_session_impl* s, uint16_t fr
     if (s->ops.notify_frame_done)
       s->ops.notify_frame_done(s->ops.priv, frame_idx,
                                &s->st20_frames[frame_idx].tv_meta);
+  }
+  if (s->time_measure) {
+    uint32_t delta_us = (mt_get_tsc(s->impl) - tsc_start) / NS_PER_US;
+    s->stat_max_notify_frame_us = RTE_MAX(s->stat_max_notify_frame_us, delta_us);
   }
 }
 
@@ -1555,10 +1561,16 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
     if (ST21_TX_STAT_WAIT_FRAME == s->st20_frame_stat) {
       uint16_t next_frame_idx = 0;
       struct st20_tx_frame_meta meta;
+      uint64_t tsc_start = 0;
 
       tv_init_next_meta(s, &meta);
       /* Query next frame buffer idx */
+      if (s->time_measure) tsc_start = mt_get_tsc(impl);
       ret = ops->get_next_frame(ops->priv, &next_frame_idx, &meta);
+      if (s->time_measure) {
+        uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+        s->stat_max_next_frame_us = RTE_MAX(s->stat_max_next_frame_us, delta_us);
+      }
       if (ret < 0) { /* no frame ready from app */
         if (s->stat_user_busy_first) {
           s->stat_user_busy++;
@@ -1591,8 +1603,8 @@ static int tv_tasklet_frame(struct mtl_main_impl* impl,
       struct st_frame_trans* frame = &s->st20_frames[next_frame_idx];
       int refcnt = rte_atomic32_read(&frame->refcnt);
       if (refcnt) {
-        info("%s(%d), frame %u refcnt not zero %d\n", __func__, idx, next_frame_idx,
-             refcnt);
+        err("%s(%d), frame %u refcnt not zero %d\n", __func__, idx, next_frame_idx,
+            refcnt);
         s->stat_build_ret_code = -STI_FRAME_APP_ERR_TX_FRAME;
         return MT_TASKLET_ALL_DONE;
       }
@@ -2008,10 +2020,16 @@ static int tv_tasklet_st22(struct mtl_main_impl* impl,
     if (ST21_TX_STAT_WAIT_FRAME == s->st20_frame_stat) {
       uint16_t next_frame_idx;
       struct st22_tx_frame_meta meta;
+      uint64_t tsc_start = 0;
 
       tv_init_st22_next_meta(s, &meta);
       /* Query next frame buffer idx */
+      if (s->time_measure) tsc_start = mt_get_tsc(impl);
       ret = st22_info->get_next_frame(ops->priv, &next_frame_idx, &meta);
+      if (s->time_measure) {
+        uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+        s->stat_max_next_frame_us = RTE_MAX(s->stat_max_next_frame_us, delta_us);
+      }
       if (ret < 0) { /* no frame ready from app */
         if (s->stat_user_busy_first) {
           s->stat_user_busy++;
@@ -2759,6 +2777,8 @@ static int tv_attach(struct mtl_main_impl* impl, struct st_tx_video_sessions_mgr
     return ret;
   }
 
+  s->impl = impl;
+
   s->st20_linesize = ops->width * s->st20_pg.size / s->st20_pg.coverage;
   if (ops->linesize > s->st20_linesize)
     s->st20_linesize = ops->linesize;
@@ -2781,6 +2801,7 @@ static int tv_attach(struct mtl_main_impl* impl, struct st_tx_video_sessions_mgr
     s->st20_fb_size = s->st20_linesize * height;
   }
   s->st20_frames_cnt = ops->framebuff_cnt;
+  s->time_measure = mt_has_tasklet_time_measure(impl);
 
   ret = tv_init_pkt(impl, s, ops, s_type, st22_frame_ops);
   if (ret < 0) {
@@ -3034,6 +3055,12 @@ static void tv_stat(struct st_tx_video_sessions_mgr* mgr,
            s->stat_user_meta_cnt, s->stat_user_meta_pkt_cnt);
     s->stat_user_meta_cnt = 0;
     s->stat_user_meta_pkt_cnt = 0;
+  }
+  if (s->time_measure) {
+    notice("TX_VIDEO_SESSION(%d,%d): get next frame max %uus, notify done max %uus\n",
+           m_idx, idx, s->stat_max_next_frame_us, s->stat_max_notify_frame_us);
+    s->stat_max_next_frame_us = 0;
+    s->stat_max_notify_frame_us = 0;
   }
 
   /* check frame busy stat */


### PR DESCRIPTION
audio_transmitter avg time reduce to 30us from 96us for tx_shared_queue_750v.json
stat: add time info for frame get/notify call back