### PR TITLE
log: add log to file support by mtl_openlog_stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changelog for 23.12
 
 * ice: update driver to 1.11.17.1
+* log: add log to file support, see mtl_openlog_stream
 
 ## Changelog for 23.08
 

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -488,6 +488,7 @@ struct st_app_context {
 
   int lcore[ST_APP_MAX_LCORES];
   int rtp_lcore[ST_APP_MAX_LCORES];
+  FILE* mtl_log_stream;
 
   bool runtime_session;
   bool enable_hdr_split;
@@ -583,5 +584,7 @@ int st_app_video_get_lcore(struct st_app_context* ctx, int sch_idx, bool rtp,
 
 uint8_t* st_json_ip(struct st_app_context* ctx, st_json_session_base_t* base,
                     enum mtl_session_port port);
+
+int st_set_mtl_log_file(struct st_app_context* ctx, const char* file);
 
 #endif

--- a/app/src/app_platform.h
+++ b/app/src/app_platform.h
@@ -50,6 +50,10 @@
 typedef unsigned long int nfds_t;
 #endif
 
+#ifdef WINDOWSENV
+#define strdup(p) _strdup(p)
+#endif
+
 enum st_tx_frame_status {
   ST_TX_FRAME_FREE = 0,
   ST_TX_FRAME_READY,

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -69,6 +69,7 @@ enum st_args_cmd {
   ST_ARG_MONO_POOL,
   ST_ARG_RX_POOL_DATA_SIZE,
   ST_ARG_LOG_LEVEL,
+  ST_ARG_LOG_FILE,
   ST_ARG_NB_TX_DESC,
   ST_ARG_NB_RX_DESC,
   ST_ARG_DMA_DEV,
@@ -171,6 +172,7 @@ static struct option st_app_args_options[] = {
     {"r_tx_dst_mac", required_argument, 0, ST_ARG_R_TX_DST_MAC},
     {"promiscuous", no_argument, 0, ST_ARG_NIC_RX_PROMISCUOUS},
     {"log_level", required_argument, 0, ST_ARG_LOG_LEVEL},
+    {"log_file", required_argument, 0, ST_ARG_LOG_FILE},
     {"ptp", no_argument, 0, ST_ARG_LIB_PTP},
     {"phc2sys", no_argument, 0, ST_ARG_LIB_PHC2SYS},
     {"rx_mono_pool", no_argument, 0, ST_ARG_RX_MONO_POOL},
@@ -308,6 +310,7 @@ static int app_args_json(struct st_app_context* ctx, struct mtl_init_params* p,
   if (ctx->json_ctx->shared_rx_queues) p->flags |= MTL_FLAG_SHARED_RX_QUEUE;
   if (ctx->json_ctx->tx_no_chain) p->flags |= MTL_FLAG_TX_NO_CHAIN;
   if (ctx->json_ctx->rss_mode) p->rss_mode = ctx->json_ctx->rss_mode;
+  if (ctx->json_ctx->log_file) st_set_mtl_log_file(ctx, ctx->json_ctx->log_file);
 
   return 0;
 }
@@ -537,6 +540,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         else
           err("%s, unknow log level %s\n", __func__, optarg);
         app_set_log_level(p->log_level);
+        break;
+      case ST_ARG_LOG_FILE:
+        st_set_mtl_log_file(ctx, optarg);
         break;
       case ST_ARG_NB_TX_DESC:
         p->nb_tx_desc = atoi(optarg);

--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -1760,7 +1760,7 @@ void st_app_free_json(st_json_context_t* ctx) {
     ctx->rx_st20r_sessions = NULL;
   }
   if (ctx->log_file) {
-    /* malloc use strndup */
+    /* malloc use strdup */
     free(ctx->log_file);
     ctx->log_file = NULL;
   }
@@ -1838,7 +1838,7 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
   obj = st_json_object_object_get(root_object, "log_file");
   if (obj != NULL) {
     const char* log_file = json_object_get_string(obj);
-    ctx->log_file = strndup(log_file, 128);
+    ctx->log_file = strdup(log_file);
   }
 
   /* parse interfaces for system */

--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -1759,6 +1759,11 @@ void st_app_free_json(st_json_context_t* ctx) {
     st_app_free(ctx->rx_st20r_sessions);
     ctx->rx_st20r_sessions = NULL;
   }
+  if (ctx->log_file) {
+    /* malloc use strndup */
+    free(ctx->log_file);
+    ctx->log_file = NULL;
+  }
 }
 
 int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
@@ -1828,6 +1833,12 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
       err("%s, invalid rss_mode %s\n", __func__, rss);
       return -ST_JSON_NOT_VALID;
     }
+  }
+  /* parse log file */
+  obj = st_json_object_object_get(root_object, "log_file");
+  if (obj != NULL) {
+    const char* log_file = json_object_get_string(obj);
+    ctx->log_file = strndup(log_file, 128);
   }
 
   /* parse interfaces for system */

--- a/app/src/parse_json.h
+++ b/app/src/parse_json.h
@@ -255,6 +255,7 @@ typedef struct st_json_context {
   bool shared_tx_queues;
   bool shared_rx_queues;
   bool tx_no_chain;
+  char* log_file;
 
   st_json_video_session_t* tx_video_sessions;
   int tx_video_session_cnt;

--- a/doc/configuration_guide.md
+++ b/doc/configuration_guide.md
@@ -231,3 +231,5 @@ Items in each element of the "ancillary" array
  **sch_session_quota (int):** The quota unit in 1080p59 yuv422_10bit for one single scheduler(core), (optional). Default it will use the quota define in the lib.
 
  **rss_mode (string):** `"none", "l3_l4", "l3"` (optional). Default it will be detected by lib.
+
+ **log_file (string):** set log file for mtl log. If you're initiating multiple RxTxApp processes simultaneously, please ensure each process has a unique filename path. Default the log is writing to stderr.

--- a/doc/run.md
+++ b/doc/run.md
@@ -268,6 +268,8 @@ This project also provide many loop test(1 port as tx, 1 port as rx) config file
 --rx_separate_lcore                  : If enabled, RX video session will run on dedicated lcores, it means TX video and RX video is not running on the same core.
 --dma_dev <DMA1,DMA2,DMA3...>        : DMA dev list to offload the packet memory copy for RX video frame session.
 --runtime_session                    : start instance before create video/audio/anc sessions, similar to runtime tx/rx create.
+--log_level <level>                  : set log level. e.g. debug, info, notice, warning, error.
+--log_file <file path>               : set log file for mtl log. If you're initiating multiple RxTxApp processes simultaneously, please ensure each process has a unique filename path. Default the log is writing to stderr.
 
 --ebu                                : debug option, enable timing check for video rx streams.
 --pcapng_dump <n>                    : debug option, dump n packets from rx video streams to pcapng files.
@@ -278,7 +280,6 @@ This project also provide many loop test(1 port as tx, 1 port as rx) config file
 --sch_session_quota <count>          : debug option, max sessions count for one lcore, unit: 1080P 60FPS TX.
 --p_tx_dst_mac <mac>                 : debug option, destination MAC address for primary port.
 --r_tx_dst_mac <mac>                 : debug option, destination MAC address for redundant port.
---log_level <level>                  : debug option, set log level. e.g. debug, info, notice, warning, error.
 --nb_tx_desc <count>                 : debug option, number of transmit descriptors for each NIC TX queue, affect the memory usage and the performance.
 --nb_rx_desc <count>                 : debug option, number of receive descriptors for each NIC RX queue, affect the memory usage and the performance.
 --tasklet_time                       : debug option, enable stat info for tasklet running time.

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
@@ -93,7 +94,7 @@ extern "C" {
 #define MTL_DMA_DEV_MAX (8)
 
 /**
- * Max length of a pcap dump file name
+ * Max length of a pcap dump filename
  */
 #define MTL_PCAP_FILE_MAX_LEN (32)
 
@@ -1210,6 +1211,20 @@ enum mtl_pmd_type mtl_pmd_by_port_name(const char* port);
  */
 int mtl_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
                   uint8_t netmask[MTL_IP_ADDR_LEN]);
+
+/**
+ * Change the stream that will be used by the logging system.
+ *
+ * The FILE* f argument represents the stream to be used for logging.
+ * If f is NULL, the default output is used. This can be done at any time.
+ *
+ * @param f
+ *   Pointer to the FILE stream.
+ * @return
+ *   - 0: Success.
+ *   - <0: Error code.
+ */
+int mtl_openlog_stream(FILE* f);
 
 /**
  * Helper function which align a size with pages

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -1110,3 +1110,5 @@ const char* mtl_get_simd_level_name(enum mtl_simd_level level) {
 
   return mt_simd_level_names[level];
 }
+
+int mtl_openlog_stream(FILE* f) { return rte_openlog_stream(f); }

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1590,7 +1590,7 @@ static int rv_stop_pcapng(struct st_rx_video_session_impl* s) {
     rte_pcapng_close(s->pcapng);
     s->pcapng = NULL;
 #ifdef WINDOWSENV
-    /* add suffix to saved file name */
+    /* add suffix to saved filename */
     int temp_len = strlen(s->pcapng_file_name);
     s->pcapng_file_name[temp_len] = '.';
     char old_name[temp_len + 1];


### PR DESCRIPTION
Ex, use "--log_file test.log" argument to output the log instead of console.