### PR TITLE
st20: fix half fps issue for interlace rtp mode (#388)

### DIFF
--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -1702,8 +1702,13 @@ static int parse_session_ip(const char* str_ip, struct st_json_session_base* bas
   if (ret == 1) return 0;
 
   /* if it's local interface case for test */
-  ret = strtol(str_ip, NULL, 10);
+  char* endptr;
+  ret = strtol(str_ip, &endptr, 10);
   if (ret < 0) return ret;
+  if (endptr == str_ip) {
+    err("%s, No digits were found in %s\n", __func__, str_ip);
+    return -EIO;
+  }
   base->type[port] = ST_JSON_IP_LOCAL_IF;
   base->local[port] = ret;
   dbg("%s, local if port %d\n", __func__, ret);

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -1203,7 +1203,14 @@ static int tv_build_rtp_chain(struct mtl_main_impl* impl,
     s->st20_pkt_idx = 0;
     rte_atomic32_inc(&s->stat_frame_cnt);
     s->st20_rtp_time = rtp->tmstamp;
-    tv_sync_pacing(impl, s, false, 0, false);
+    bool second_field = false;
+    if (s->ops.interlaced) {
+      struct st20_rfc4175_rtp_hdr* rfc4175 =
+          rte_pktmbuf_mtod(pkt_chain, struct st20_rfc4175_rtp_hdr*);
+      uint16_t line1_number = ntohs(rfc4175->row_number);
+      second_field = (line1_number & ST20_SECOND_FIELD) ? true : false;
+    }
+    tv_sync_pacing(impl, s, false, 0, second_field);
     if (s->ops.flags & ST20_TX_FLAG_USER_TIMESTAMP) {
       s->pacing.rtp_time_stamp = ntohl(rtp->tmstamp);
     }


### PR DESCRIPTION
get second field from rtp buffer

Signed-off-by: Frank Du <frank.du@intel.com>
(cherry picked from commit 94a550df904d95f2a1d8135bb15f73e76b705233)