### PR TITLE
queue/tx: double burst pkts for tx queue flush (#398)

### DIFF
--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -1939,7 +1939,8 @@ int mt_dev_flush_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue,
   enum mtl_port port = queue->port;
   uint16_t queue_id = queue->queue_id;
 
-  int burst_pkts = mt_if_nb_tx_burst(impl, port);
+  /* use double to make sure all the fifo are burst out to clean all mbufs in the pool */
+  int burst_pkts = mt_if_nb_tx_burst(impl, port) * 2;
   struct rte_mbuf* pads[1];
   pads[0] = pad;
 

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -566,7 +566,8 @@ int mt_tsq_flush(struct mtl_main_impl* impl, struct mt_tsq_entry* entry,
   enum mtl_port port = tsqm->port;
   uint16_t queue_id = entry->queue_id;
 
-  int burst_pkts = mt_if_nb_tx_burst(impl, port);
+  /* use double to make sure all the fifo are burst out to clean all mbufs in the pool */
+  int burst_pkts = mt_if_nb_tx_burst(impl, port) * 2;
   struct rte_mbuf* pads[1];
   pads[0] = pad;
 

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -2552,6 +2552,19 @@ TEST(St20_rx, digest_hdr_split) {
   }
 }
 
+TEST(St20_rx, digest_rtcp_s1) {
+  enum st20_type type[1] = {ST20_TYPE_FRAME_LEVEL};
+  enum st20_packing packing[1] = {ST20_PACKING_BPM};
+  enum st_fps fps[1] = {ST_FPS_P50};
+  int width[1] = {1920};
+  int height[1] = {1080};
+  bool interlaced[1] = {false};
+  enum st20_fmt fmt[1] = {ST20_FMT_YUV_422_10BIT};
+  /* check fps */
+  st20_rx_digest_test(type, type, packing, fps, width, height, interlaced, fmt, true,
+                      ST_TEST_LEVEL_MANDATORY, 1, false, false, true);
+}
+
 TEST(St20_rx, digest_rtcp_s3) {
   enum st20_type type[3] = {ST20_TYPE_FRAME_LEVEL, ST20_TYPE_FRAME_LEVEL,
                             ST20_TYPE_FRAME_LEVEL};
@@ -2563,7 +2576,8 @@ TEST(St20_rx, digest_rtcp_s3) {
   bool interlaced[3] = {true, false, false};
   enum st20_fmt fmt[3] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT,
                           ST20_FMT_YUV_422_10BIT};
-  st20_rx_digest_test(type, type, packing, fps, width, height, interlaced, fmt, true,
+  /* no fps check */
+  st20_rx_digest_test(type, type, packing, fps, width, height, interlaced, fmt, false,
                       ST_TEST_LEVEL_MANDATORY, 3, false, false, true);
 }
 


### PR DESCRIPTION
use double to make sure all the fifo are burst out to clean all mbufs in the pool

Signed-off-by: Frank Du <frank.du@intel.com>
(cherry picked from commit c7305d962c0321e3a4cd97049aaa71c47532a937)