### PR TITLE
rtcp/rx: use bitmap and window to detect loss

### DIFF
--- a/app/src/rx_video_app.c
+++ b/app/src/rx_video_app.c
@@ -494,8 +494,6 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
   if (video && video->enable_rtcp) {
     ops.flags |= ST20_RX_FLAG_ENABLE_RTCP;
     ops_rtcp.nack_interval_us = 250;
-    ops_rtcp.nack_expire_us = 500;
-    ops_rtcp.nack_max_retry = 2;
     ops.rtcp = &ops_rtcp;
   }
 

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1191,15 +1191,15 @@ struct st_rx_rtcp_ops {
    */
   uint32_t nack_interval_us;
   /**
-   * RTCP NACK seq bitmap size, window size is bitmap size * 8.
+   * RTCP seq bitmap size, window size is bitmap size * 8.
    * Only used when ST20/22_RX_FLAG_ENABLE_RTCP flag set.
    */
-  uint32_t seq_bitmap_size;
+  uint16_t seq_bitmap_size;
   /**
    * RTCP seq skip window, missing within skip window will be ignored.
-   * Only used when ST20_RX_FLAG_ENABLE_RTCP flag set.
+   * Only used when ST20/22_RX_FLAG_ENABLE_RTCP flag set.
    */
-  uint32_t seq_skip_window;
+  uint16_t seq_skip_window;
 };
 
 /**

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1191,15 +1191,15 @@ struct st_rx_rtcp_ops {
    */
   uint32_t nack_interval_us;
   /**
-   * RTCP NACK expire interval in us.
+   * RTCP NACK seq bitmap size.
    * Only used when ST20/22_RX_FLAG_ENABLE_RTCP flag set.
    */
-  uint32_t nack_expire_us;
+  uint32_t seq_bitmap_size;
   /**
-   * RTCP NACK max retry count.
+   * RTCP seq skip window.
    * Only used when ST20_RX_FLAG_ENABLE_RTCP flag set.
    */
-  uint32_t nack_max_retry;
+  uint32_t seq_skip_window;
 };
 
 /**

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1191,12 +1191,12 @@ struct st_rx_rtcp_ops {
    */
   uint32_t nack_interval_us;
   /**
-   * RTCP NACK seq bitmap size.
+   * RTCP NACK seq bitmap size, window size is bitmap size * 8.
    * Only used when ST20/22_RX_FLAG_ENABLE_RTCP flag set.
    */
   uint32_t seq_bitmap_size;
   /**
-   * RTCP seq skip window.
+   * RTCP seq skip window, missing within skip window will be ignored.
    * Only used when ST20_RX_FLAG_ENABLE_RTCP flag set.
    */
   uint32_t seq_skip_window;

--- a/lib/src/mt_rtcp.c
+++ b/lib/src/mt_rtcp.c
@@ -207,7 +207,7 @@ int mt_rtcp_rx_parse_rtp_packet(struct mt_rtcp_rx* rx, struct st_rfc3550_rtp_hdr
         /* the ideal case where all pkts come in sequence */
         rx->last_cont = seq_id;
       }
-    } else if (seq_id == rx->last_cont + 1) {
+    } else if (seq_id == rx->last_cont + 1) { /* old seq and need update cont */
       rx->last_cont = seq_id;
       rtcp_rx_update_last_cont(rx);
     }
@@ -237,7 +237,7 @@ int mt_rtcp_rx_send_nack_packet(struct mt_rtcp_rx* rx) {
   uint16_t seq = rx->last_cont + 1;
   uint16_t start = seq;
   uint16_t miss = 0;
-  while (rtp_seq_num_cmp(seq, rx->last_seq - rx->seq_skip_window) < 0) {
+  while (rtp_seq_num_cmp(seq, rx->last_seq - rx->seq_skip_window) <= 0) {
     if (!mt_bitmap_test(rx->seq_bitmap, seq % rx->seq_window_size)) {
       miss++;
     } else if (miss != 0) {

--- a/lib/src/mt_rtcp.c
+++ b/lib/src/mt_rtcp.c
@@ -9,12 +9,14 @@
 #include "mt_stat.h"
 #include "mt_util.h"
 
+#define UINT16_MAX_HALF (1 << 15)
+
 static int rtp_seq_num_cmp(uint16_t seq0, uint16_t seq1) {
   if (seq0 == seq1) {
     /* equal */
     return 0;
-  } else if ((seq0 < seq1 && seq1 - seq0 < 32768) ||
-             (seq0 > seq1 && seq0 - seq1 > 32768)) {
+  } else if ((seq0 < seq1 && seq1 - seq0 < UINT16_MAX_HALF) ||
+             (seq0 > seq1 && seq0 - seq1 > UINT16_MAX_HALF)) {
     /* seq1 newer than seq0 */
     return -1;
   } else {
@@ -163,90 +165,55 @@ int mt_rtcp_tx_parse_nack_packet(struct mt_rtcp_tx* tx, struct mt_rtcp_hdr* rtcp
   return 0;
 }
 
-int mt_rtcp_rx_parse_rtp_packet(struct mt_rtcp_rx* rx, struct st_rfc3550_rtp_hdr* rtp) {
-  struct mtl_main_impl* impl = rx->parent;
-  enum mtl_port port = rx->port;
+static int rtcp_rx_update_last_cont(struct mt_rtcp_rx* rx) {
+  uint16_t last_cont = rx->last_cont;
+  uint16_t last_seq = rx->last_seq;
+  /* find the last continuous seq */
+  for (uint16_t i = last_cont + 1; i <= last_seq; i++) {
+    if (!mt_bitmap_test(rx->seq_bitmap, i % rx->seq_window_size)) break;
+    rx->last_cont = i;
+  }
 
+  return 0;
+}
+
+int mt_rtcp_rx_parse_rtp_packet(struct mt_rtcp_rx* rx, struct st_rfc3550_rtp_hdr* rtp) {
   uint16_t seq_id = ntohs(rtp->seq_number);
 
   if (rx->ssrc == 0) { /* first received */
     rx->ssrc = ntohl(rtp->ssrc);
-    rx->last_seq_id = seq_id;
+    rx->last_cont = seq_id;
+    rx->last_seq = seq_id;
+    mt_bitmap_test_and_set(rx->seq_bitmap, seq_id % rx->seq_window_size);
     rx->stat_rtp_received++;
     return 0;
   }
 
-  int cmp_result = rtp_seq_num_cmp(seq_id, rx->last_seq_id + 1);
-  if (cmp_result == 0) { /* pkt received in sequence */
-    rx->last_seq_id = seq_id;
-  } else if (cmp_result > 0) { /* pkt(s) lost */
-    uint16_t lost_packets = seq_id - rx->last_seq_id - 1;
-    if (lost_packets > 128) {
-      dbg("%s(%s), pkt seq out of range\n", __func__, rx->name);
-      rx->last_seq_id = seq_id;
-      rx->stat_nack_drop_oor++;
-      return -EIO;
-    }
-    rx->stat_rtp_lost_detected += lost_packets;
-    /* insert nack */
-    struct mt_rtcp_nack_item* nack =
-        mt_rte_zmalloc_socket(sizeof(*nack), mt_socket_id(impl, port));
-    if (!nack) {
-      err("%s(%s), failed to alloc nack item\n", __func__, rx->name);
-      return -ENOMEM;
-    }
-    nack->expire_time = mt_get_tsc(impl) + rx->nack_expire_interval;
-    nack->seq_id = rx->last_seq_id + 1;
-    nack->bulk = lost_packets - 1;
-    nack->retry_count = rx->max_retry;
-    MT_TAILQ_INSERT_TAIL(&rx->nack_list, nack, next);
-    dbg("%s(%s), pkt lost, ts %u seq %u last_seq %u, insert nack %u,%u\n", __func__,
-        rx->name, ntohl(rtp->tmstamp), seq_id, rx->last_seq_id, nack->seq_id, nack->bulk);
-    rx->last_seq_id = seq_id;
-  } else {
-    /* remove old/recovered/redundant pkt from nack list, split nack to left and right */
-    dbg("%s(%s), pkt recovered, ts %u seq %u last_seq %u\n", __func__, rx->name, ts,
-        seq_id, rx->last_seq_id);
-    struct mt_rtcp_nack_item *nack, *tmp_nack;
-    for (nack = MT_TAILQ_FIRST(&rx->nack_list); nack != NULL; nack = tmp_nack) {
-      tmp_nack = MT_TAILQ_NEXT(nack, next);
-      if (seq_id - nack->seq_id >= 0 && seq_id - nack->seq_id <= nack->bulk) {
-        if (nack->seq_id + nack->bulk - seq_id > 0) {
-          /* insert right nack */
-          struct mt_rtcp_nack_item* right_nack =
-              mt_rte_zmalloc_socket(sizeof(*right_nack), mt_socket_id(impl, port));
-          if (!right_nack) {
-            err("%s(%s), failed to alloc right nack item\n", __func__, rx->name);
-            return -ENOMEM;
-          }
-          right_nack->seq_id = seq_id + 1;
-          right_nack->bulk = nack->seq_id + nack->bulk - seq_id - 1;
-          right_nack->retry_count = nack->retry_count;
-          right_nack->expire_time = nack->expire_time;
-          MT_TAILQ_INSERT_HEAD(&rx->nack_list, right_nack, next);
-        }
-        if (seq_id - nack->seq_id > 0) {
-          /* insert left nack */
-          struct mt_rtcp_nack_item* left_nack =
-              mt_rte_zmalloc_socket(sizeof(*left_nack), mt_socket_id(impl, port));
-          if (!left_nack) {
-            err("%s(%s), failed to alloc left nack item\n", __func__, rx->name);
-            return -ENOMEM;
-          }
-          left_nack->seq_id = nack->seq_id;
-          left_nack->bulk = seq_id - nack->seq_id - 1;
-          left_nack->retry_count = nack->retry_count;
-          left_nack->expire_time = nack->expire_time;
-          MT_TAILQ_INSERT_HEAD(&rx->nack_list, left_nack, next);
-        }
-        MT_TAILQ_REMOVE(&rx->nack_list, nack, next);
-        mt_rte_free(nack);
-        rx->stat_rtp_retransmit_succ++;
-        break;
+  uint16_t diff = seq_id - rx->last_seq;
+  if (diff != 0) {
+    if (diff < UINT16_MAX_HALF) { /* new seq */
+      /* clean the bitmap for missing packets */
+      for (uint16_t i = rx->last_seq + 1; i < seq_id; i++) {
+        mt_bitmap_test_and_unset(rx->seq_bitmap, i % rx->seq_window_size);
       }
-    }
-  }
+      rx->last_seq = seq_id;
 
+      uint16_t last_cont_diff = seq_id - rx->last_cont;
+      if (last_cont_diff > rx->seq_bitmap_size * 8) {
+        /* last cont is out of bitmap window, re-calculate from bitmap begin */
+        rx->last_cont = seq_id - rx->seq_bitmap_size * 8;
+        rtcp_rx_update_last_cont(rx);
+      } else if (last_cont_diff == 1) {
+        /* the ideal case where all pkts come in sequence */
+        rx->last_cont = seq_id;
+      }
+    } else if (seq_id == rx->last_cont + 1) {
+      rx->last_cont = seq_id;
+      rtcp_rx_update_last_cont(rx);
+    }
+  } /* else diff == 0, duplicate pkt */
+
+  mt_bitmap_test_and_set(rx->seq_bitmap, seq_id % rx->seq_window_size);
   rx->stat_rtp_received++;
 
   return 0;
@@ -262,8 +229,6 @@ int mt_rtcp_rx_send_nack_packet(struct mt_rtcp_rx* rx) {
   uint64_t now = mt_get_tsc(impl);
   if (now < rx->nacks_send_time) return 0;
   rx->nacks_send_time = now + rx->nacks_send_interval;
-
-  if (MT_TAILQ_FIRST(&rx->nack_list) == NULL) return 0;
 
   pkt = rte_pktmbuf_alloc(mt_get_tx_mempool(impl, port));
   if (!pkt) {
@@ -289,25 +254,35 @@ int mt_rtcp_rx_send_nack_packet(struct mt_rtcp_rx* rx) {
   rte_memcpy(rtcp->name, "IMTL", 4);
   uint16_t num_fci = 0;
 
-  struct mt_rtcp_nack_item *nack, *tmp_nack;
   struct mt_rtcp_fci* fci = rtcp->fci;
-  for (nack = MT_TAILQ_FIRST(&rx->nack_list); nack != NULL; nack = tmp_nack) {
-    tmp_nack = MT_TAILQ_NEXT(nack, next);
-    if (now > nack->expire_time) {
-      MT_TAILQ_REMOVE(&rx->nack_list, nack, next);
-      mt_rte_free(nack);
-      rx->stat_nack_drop_expire++;
-      continue;
+
+  /* check missing pkts with bitmap, fill fci fields */
+  uint16_t seq = rx->last_cont + 1;
+  uint16_t start = seq;
+  uint16_t miss = 0;
+  while (rtp_seq_num_cmp(seq, rx->last_seq - rx->seq_skip_window) < 0) {
+    if (!mt_bitmap_test(rx->seq_bitmap, seq % rx->seq_window_size)) {
+      miss++;
+    } else if (miss != 0) {
+      fci->start = htons(start);
+      fci->follow = htons(miss - 1);
+      fci++;
+      num_fci++;
+      rx->stat_rtp_lost_detected += miss;
+      start = seq + 1;
+      miss = 0;
     }
-    if (nack->retry_count == 0) continue;
-    fci->start = htons(nack->seq_id);
-    fci->follow = htons(nack->bulk);
-    num_fci++;
-    fci++;
-    nack->retry_count--;
+    seq++;
   }
-  if (num_fci > 32) {
-    dbg("%s(%s), too many nack items\n", __func__, rx->name);
+  if (miss != 0) {
+    fci->start = htons(start);
+    fci->follow = htons(miss - 1);
+    num_fci++;
+    rx->stat_rtp_lost_detected += miss;
+  }
+
+  if (num_fci == 0 || num_fci > 32) {
+    dbg("%s(%s), no / too many nack items %u\n", __func__, rx->name, num_fci);
     rte_pktmbuf_free(pkt);
     rx->stat_nack_drop_exceed += num_fci;
     return -EINVAL;
@@ -362,16 +337,9 @@ static int rtcp_rx_stat(void* priv) {
   rx->stat_rtp_received = 0;
   rx->stat_rtp_lost_detected = 0;
   rx->stat_nack_sent = 0;
-  if (rx->stat_rtp_retransmit_succ) {
-    notice("%s(%s), rtp recovered %u\n", __func__, rx->name,
-           rx->stat_rtp_retransmit_succ);
-    rx->stat_rtp_retransmit_succ = 0;
-  }
-  if (rx->stat_nack_drop_expire || rx->stat_nack_drop_oor || rx->stat_nack_drop_exceed) {
-    notice("%s(%s), nack drop, expire %u exceed %u oor %u\n", __func__, rx->name,
-           rx->stat_nack_drop_expire, rx->stat_nack_drop_oor, rx->stat_nack_drop_exceed);
-    rx->stat_nack_drop_expire = 0;
-    rx->stat_nack_drop_oor = 0;
+  if (rx->stat_nack_drop_exceed) {
+    notice("%s(%s), nack drop exceed %u\n", __func__, rx->name,
+           rx->stat_nack_drop_exceed);
     rx->stat_nack_drop_exceed = 0;
   }
 
@@ -434,16 +402,23 @@ struct mt_rtcp_rx* mt_rtcp_rx_create(struct mtl_main_impl* impl,
 
   rx->parent = impl;
   rx->port = ops->port;
-  rx->max_retry = ops->max_retry;
   rx->ipv4_packet_id = 0;
   rx->ssrc = 0;
-  rx->nack_expire_interval = ops->nack_expire_interval;
   rx->nacks_send_interval = ops->nacks_send_interval;
   rx->nacks_send_time = mt_get_tsc(impl);
+  rx->seq_bitmap_size = ops->seq_bitmap_size;
   strncpy(rx->name, ops->name, sizeof(rx->name) - 1);
   rte_memcpy(&rx->udp_hdr, ops->udp_hdr, sizeof(rx->udp_hdr));
 
-  MT_TAILQ_INIT(&rx->nack_list);
+  uint8_t* seq_bitmap = mt_rte_zmalloc_socket(sizeof(uint8_t) * rx->seq_bitmap_size,
+                                              mt_socket_id(impl, rx->port));
+  if (!seq_bitmap) {
+    err("%s(%s), failed to allocate memory for seq_bitmap\n", __func__, rx->name);
+    mt_rtcp_rx_free(rx);
+    return NULL;
+  }
+  rx->seq_bitmap = seq_bitmap;
+  rx->seq_window_size = rx->seq_bitmap_size * 8;
 
   mt_stat_register(impl, rtcp_rx_stat, rx, rx->name);
 
@@ -455,12 +430,7 @@ struct mt_rtcp_rx* mt_rtcp_rx_create(struct mtl_main_impl* impl,
 void mt_rtcp_rx_free(struct mt_rtcp_rx* rx) {
   mt_stat_unregister(rx->parent, rtcp_rx_stat, rx);
 
-  /* free all nack items */
-  struct mt_rtcp_nack_item* nack;
-  while ((nack = MT_TAILQ_FIRST(&rx->nack_list))) {
-    MT_TAILQ_REMOVE(&rx->nack_list, nack, next);
-    mt_rte_free(nack);
-  }
+  if (rx->seq_bitmap) mt_rte_free(rx->seq_bitmap);
 
   mt_rte_free(rx);
 }

--- a/lib/src/mt_rtcp.h
+++ b/lib/src/mt_rtcp.h
@@ -76,7 +76,6 @@ struct mt_rtcp_rx {
 
   uint16_t last_seq;
   uint16_t last_cont;
-  uint16_t seq_bitmap_size;
   uint8_t* seq_bitmap;
   uint16_t seq_window_size;
   uint16_t seq_skip_window;

--- a/lib/src/mt_rtcp.h
+++ b/lib/src/mt_rtcp.h
@@ -26,15 +26,6 @@ MTL_PACK(struct mt_rtcp_hdr {
   struct mt_rtcp_fci fci[0];
 });
 
-struct mt_rtcp_nack_item {
-  uint16_t seq_id;
-  uint16_t bulk;
-  uint16_t retry_count;
-  uint64_t expire_time;
-  MT_TAILQ_ENTRY(mt_rtcp_nack_item) next;
-};
-MT_TAILQ_HEAD(mt_rtcp_nack_list, mt_rtcp_nack_item);
-
 struct mt_rtcp_tx_ops {
   const char* name;           /* short and unique name for each session */
   struct mt_udp_hdr* udp_hdr; /* headers including eth, ipv4 and udp */
@@ -44,12 +35,12 @@ struct mt_rtcp_tx_ops {
 };
 
 struct mt_rtcp_rx_ops {
-  const char* name;              /* short and unique name for each session */
-  struct mt_udp_hdr* udp_hdr;    /* headers including eth, ipv4 and udp */
-  uint16_t max_retry;            /* max retry count for each nack item */
-  uint64_t nacks_send_interval;  /* nack sending interval */
-  uint64_t nack_expire_interval; /* nack expire time interval */
-  enum mtl_port port;            /* port of rtp session */
+  const char* name;             /* short and unique name for each session */
+  struct mt_udp_hdr* udp_hdr;   /* headers including eth, ipv4 and udp */
+  uint64_t nacks_send_interval; /* nack sending interval */
+  enum mtl_port port;           /* port of rtp session */
+  uint16_t seq_bitmap_size;     /* bitmap size of detecting window, can hold n * 8 seq */
+  uint16_t seq_skip_window;     /* skip some seq to handle out of order while detecting */
 };
 
 struct mt_rtcp_tx {
@@ -75,25 +66,25 @@ struct mt_rtcp_tx {
 struct mt_rtcp_rx {
   struct mtl_main_impl* parent;
   enum mtl_port port;
-  struct mt_rtcp_nack_list nack_list;
-  uint16_t max_retry;
-  uint16_t last_seq_id;
   struct mt_udp_hdr udp_hdr;
   char name[MT_RTCP_MAX_NAME_LEN];
+  uint64_t nacks_send_interval;
   uint32_t ssrc;
 
   uint16_t ipv4_packet_id;
   uint64_t nacks_send_time;
-  uint64_t nacks_send_interval;
-  uint64_t nack_expire_interval;
+
+  uint16_t last_seq;
+  uint16_t last_cont;
+  uint16_t seq_bitmap_size;
+  uint8_t* seq_bitmap;
+  uint16_t seq_window_size;
+  uint16_t seq_skip_window;
 
   /* stat */
   uint32_t stat_rtp_received;
   uint32_t stat_rtp_lost_detected;
-  uint32_t stat_rtp_retransmit_succ;
   uint32_t stat_nack_sent;
-  uint32_t stat_nack_drop_expire;
-  uint32_t stat_nack_drop_oor;
   uint32_t stat_nack_drop_exceed;
 };
 

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -147,6 +147,19 @@ bool mt_bitmap_test_and_set(uint8_t* bitmap, int idx) {
   return false;
 }
 
+bool mt_bitmap_test_and_unset(uint8_t* bitmap, int idx) {
+  int pos = idx / 8;
+  int off = idx % 8;
+  uint8_t bits = bitmap[pos];
+
+  /* already unset */
+  if (!(bits & (0x1 << off))) return true;
+
+  /* unset the bit */
+  bitmap[pos] = bits & (UINT8_MAX ^ (0x1 << off));
+  return false;
+}
+
 int mt_ring_dequeue_clean(struct rte_ring* ring) {
   int ret;
   struct rte_mbuf* pkt;

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -49,6 +49,7 @@ static inline void mt_u32_to_ip(uint32_t group, uint8_t ip[MTL_IP_ADDR_LEN]) {
 
 bool mt_bitmap_test_and_set(uint8_t* bitmap, int idx);
 bool mt_bitmap_test(uint8_t* bitmap, int idx);
+bool mt_bitmap_test_and_unset(uint8_t* bitmap, int idx);
 
 /* only for mbuf ring with RING_F_SP_ENQ | RING_F_SC_DEQ */
 int mt_ring_dequeue_clean(struct rte_ring* ring);

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3008,16 +3008,15 @@ static int rv_init_rtcp(struct mtl_main_impl* impl, struct st_rx_video_sessions_
     snprintf(name, sizeof(name), ST_RX_VIDEO_PREFIX "M%dS%dP%d", mgr_idx, idx, i);
     struct mt_rtcp_rx_ops rtcp_ops = {
         .port = port,
-        .max_retry =
-            (ops->rtcp && ops->rtcp->nack_max_retry) ? ops->rtcp->nack_max_retry : 2,
         .name = name,
         .udp_hdr = &uhdr,
         .nacks_send_interval = (ops->rtcp && ops->rtcp->nack_interval_us)
                                    ? ops->rtcp->nack_interval_us * NS_PER_US
                                    : 250 * NS_PER_US,
-        .nack_expire_interval = (ops->rtcp && ops->rtcp->nack_expire_us)
-                                    ? ops->rtcp->nack_expire_us * NS_PER_US
-                                    : 500 * NS_PER_US,
+        .seq_bitmap_size =
+            (ops->rtcp && ops->rtcp->seq_bitmap_size) ? ops->rtcp->seq_bitmap_size : 16,
+        .seq_skip_window =
+            (ops->rtcp && ops->rtcp->seq_skip_window) ? ops->rtcp->seq_skip_window : 10,
     };
     s->rtcp_rx[i] = mt_rtcp_rx_create(impl, &rtcp_ops);
     if (!s->rtcp_rx[i]) {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3015,8 +3015,7 @@ static int rv_init_rtcp(struct mtl_main_impl* impl, struct st_rx_video_sessions_
                                    : 250 * NS_PER_US,
         .seq_bitmap_size =
             (ops->rtcp && ops->rtcp->seq_bitmap_size) ? ops->rtcp->seq_bitmap_size : 16,
-        .seq_skip_window =
-            (ops->rtcp && ops->rtcp->seq_skip_window) ? ops->rtcp->seq_skip_window : 10,
+        .seq_skip_window = (ops->rtcp) ? ops->rtcp->seq_skip_window : 10,
     };
     s->rtcp_rx[i] = mt_rtcp_rx_create(impl, &rtcp_ops);
     if (!s->rtcp_rx[i]) {

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -1970,6 +1970,8 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
     if (enable_rtcp) {
       ops_rx.flags |= ST20_RX_FLAG_ENABLE_RTCP | ST20_RX_FLAG_SIMULATE_PKT_LOSS;
       ops_rx_rtcp.nack_interval_us = 250;
+      ops_rx_rtcp.seq_bitmap_size = 32;
+      ops_rx_rtcp.seq_skip_window = 10;
       ops_rx.rtcp = &ops_rx_rtcp;
       ops_rx.burst_loss_max = 32;
       ops_rx.sim_loss_rate = 0.0001;

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -1970,8 +1970,6 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
     if (enable_rtcp) {
       ops_rx.flags |= ST20_RX_FLAG_ENABLE_RTCP | ST20_RX_FLAG_SIMULATE_PKT_LOSS;
       ops_rx_rtcp.nack_interval_us = 250;
-      ops_rx_rtcp.nack_expire_us = 500;
-      ops_rx_rtcp.nack_max_retry = 2;
       ops_rx.rtcp = &ops_rx_rtcp;
       ops_rx.burst_loss_max = 32;
       ops_rx.sim_loss_rate = 0.0001;

--- a/tests/src/st22_test.cpp
+++ b/tests/src/st22_test.cpp
@@ -1290,6 +1290,7 @@ static void st22_rx_digest_test(enum st_fps fps[], int width[], int height[],
     if (enable_rtcp) {
       ops_rx.flags |= ST22_RX_FLAG_ENABLE_RTCP | ST22_RX_FLAG_SIMULATE_PKT_LOSS;
       ops_rx_rtcp.nack_interval_us = 100;
+      ops_rx_rtcp.seq_skip_window = 0;
       ops_rx.rtcp = &ops_rx_rtcp;
       ops_rx.burst_loss_max = 4;
       ops_rx.sim_loss_rate = 0.002;

--- a/tests/src/st22_test.cpp
+++ b/tests/src/st22_test.cpp
@@ -1290,8 +1290,6 @@ static void st22_rx_digest_test(enum st_fps fps[], int width[], int height[],
     if (enable_rtcp) {
       ops_rx.flags |= ST22_RX_FLAG_ENABLE_RTCP | ST22_RX_FLAG_SIMULATE_PKT_LOSS;
       ops_rx_rtcp.nack_interval_us = 100;
-      ops_rx_rtcp.nack_expire_us = 200;
-      ops_rx_rtcp.nack_max_retry = 2;
       ops_rx.rtcp = &ops_rx_rtcp;
       ops_rx.burst_loss_max = 4;
       ops_rx.sim_loss_rate = 0.002;


### PR DESCRIPTION
1. use bitmap for loss detection, default window size is 16*8
2. add skip window to handle some out of order cases
3. calculate num_fci before alloc mbuf
4. remove the nack item and its expire timer