### PR TITLE
tx/video: add recovery from tx burst hang

### DIFF
--- a/app/src/rxtx_app.c
+++ b/app/src/rxtx_app.c
@@ -320,6 +320,7 @@ int main(int argc, char** argv) {
     if (!ctx->para.tx_queues_cnt[i]) {
       ctx->para.tx_queues_cnt[i] = st_tx_sessions_queue_cnt(
           tx_st20_sessions, ctx->tx_audio_session_cnt, ctx->tx_anc_session_cnt);
+      ctx->para.tx_queues_cnt[i] += 4; /* add extra 4 queues for recovery */
     }
     if (!ctx->para.rx_queues_cnt[i]) {
       ctx->para.rx_queues_cnt[i] = st_rx_sessions_queue_cnt(

--- a/app/src/tx_st20p_app.c
+++ b/app/src/tx_st20p_app.c
@@ -37,6 +37,20 @@ static int app_tx_st20p_frame_available(void* priv) {
   return 0;
 }
 
+static int app_tx_st20p_notify_event(void* priv, enum st_event event, void* args) {
+  struct st_app_tx_st20p_session* s = priv;
+  if (event == ST_EVENT_VSYNC) {
+    struct st10_vsync_meta* meta = args;
+    info("%s(%d), epoch %" PRIu64 "\n", __func__, s->idx, meta->epoch);
+  } else if (event == ST_EVENT_FATAL_ERROR) {
+    err("%s(%d), ST_EVENT_FATAL_ERROR\n", __func__, s->idx);
+    /* add a exist routine */
+  } else if (event == ST_EVENT_RECOVERY_ERROR) {
+    info("%s(%d), ST_EVENT_RECOVERY_ERROR\n", __func__, s->idx);
+  }
+  return 0;
+}
+
 static void app_tx_st20p_build_frame(struct st_app_tx_st20p_session* s,
                                      struct st_frame* frame) {
   if (s->st20p_frame_cursor + s->st20p_frame_size > s->st20p_source_end) {
@@ -264,6 +278,7 @@ static int app_tx_st20p_init(struct st_app_context* ctx, st_json_st20p_session_t
   ops.notify_frame_available = app_tx_st20p_frame_available;
   ops.start_vrx = ctx->tx_start_vrx;
   ops.pad_interval = ctx->tx_pad_interval;
+  ops.notify_event = app_tx_st20p_notify_event;
   if (ctx->tx_no_static_pad) ops.flags |= ST20P_TX_FLAG_DISABLE_STATIC_PAD_P;
   if (st20p && st20p->enable_rtcp) ops.flags |= ST20P_TX_FLAG_ENABLE_RTCP;
 

--- a/app/src/tx_video_app.c
+++ b/app/src/tx_video_app.c
@@ -4,11 +4,16 @@
 
 #include "tx_video_app.h"
 
-static int app_tx_notify_event(void* priv, enum st_event event, void* args) {
+static int app_tx_video_notify_event(void* priv, enum st_event event, void* args) {
+  struct st_app_tx_video_session* s = priv;
   if (event == ST_EVENT_VSYNC) {
-    struct st_app_tx_video_session* s = priv;
     struct st10_vsync_meta* meta = args;
     info("%s(%d), epoch %" PRIu64 "\n", __func__, s->idx, meta->epoch);
+  } else if (event == ST_EVENT_FATAL_ERROR) {
+    err("%s(%d), ST_EVENT_FATAL_ERROR\n", __func__, s->idx);
+    /* add a exist routine */
+  } else if (event == ST_EVENT_RECOVERY_ERROR) {
+    info("%s(%d), ST_EVENT_RECOVERY_ERROR\n", __func__, s->idx);
   }
   return 0;
 }
@@ -744,7 +749,7 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.notify_frame_done = app_tx_video_frame_done;
   ops.query_frame_lines_ready = app_tx_video_frame_lines_ready;
   ops.notify_rtp_done = app_tx_video_rtp_done;
-  ops.notify_event = app_tx_notify_event;
+  ops.notify_event = app_tx_video_notify_event;
   ops.framebuff_cnt = 2;
   ops.payload_type = video ? video->base.payload_type : ST_APP_PAYLOAD_TYPE_VIDEO;
   ops.start_vrx = ctx->tx_start_vrx;

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -975,6 +975,12 @@ struct st20_tx_ops {
   uint16_t pad_interval;
 
   /**
+   * the time for lib to detect the hang on the tx queue and try to recovery
+   * Leave to zero system will use the default value(1s).
+   */
+  uint32_t tx_hang_detect_ms;
+
+  /**
    * the frame buffer count requested for one st20 tx session,
    * should be in range [2, ST20_FB_MAX_COUNT],
    * only for ST20_TYPE_FRAME_LEVEL.

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -190,6 +190,10 @@ enum st_event {
    * args point to struct st10_vsync_meta.
    */
   ST_EVENT_VSYNC = 0,
+  /** a error but session recovery successfully */
+  ST_EVENT_RECOVERY_ERROR,
+  /** fatal error which session can't recovery, app should free the session */
+  ST_EVENT_FATAL_ERROR,
   /** max value of this enum */
   ST_EVENT_MAX,
 };

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -190,9 +190,9 @@ enum st_event {
    * args point to struct st10_vsync_meta.
    */
   ST_EVENT_VSYNC = 0,
-  /** a error but session recovery successfully */
+  /** the error occurred and session recovery successfully */
   ST_EVENT_RECOVERY_ERROR,
-  /** fatal error which session can't recovery, app should free the session */
+  /** fatal error and session can't recovery, app should free the session then */
   ST_EVENT_FATAL_ERROR,
   /** max value of this enum */
   ST_EVENT_MAX,

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -22,6 +22,7 @@
 #define MT_TX_MEMPOOL_PREFIX "T_"
 #define MT_RX_MEMPOOL_PREFIX "R_"
 
+/* set to 1 to enable the simulated test */
 #define MT_DEV_SIMULATE_MALICIOUS_PKT (0)
 
 int mt_dev_get_socket(const char* port);

--- a/lib/src/mt_dev.h
+++ b/lib/src/mt_dev.h
@@ -22,6 +22,8 @@
 #define MT_TX_MEMPOOL_PREFIX "T_"
 #define MT_RX_MEMPOOL_PREFIX "R_"
 
+#define MT_DEV_SIMULATE_MALICIOUS_PKT (0)
+
 int mt_dev_get_socket(const char* port);
 
 int mt_dev_init(struct mtl_init_params* p, struct mt_kport_info* kport_info);
@@ -42,6 +44,7 @@ int mt_dev_put_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue);
 static inline uint16_t mt_dev_tx_queue_id(struct mt_tx_queue* queue) {
   return queue->queue_id;
 }
+int mt_dev_tx_queue_fatal_error(struct mtl_main_impl* impl, struct mt_tx_queue* queue);
 int mt_dev_set_tx_bps(struct mtl_main_impl* impl, enum mtl_port port, uint16_t q,
                       uint64_t bytes_per_sec);
 int mt_dev_flush_tx_queue(struct mtl_main_impl* impl, struct mt_tx_queue* queue,

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -552,6 +552,8 @@ struct mt_tx_queue {
   uint16_t port_id;
   uint16_t queue_id;
   bool active;
+  /* VF, caused by malicious detection in the PF */
+  bool fatal_error;
   int rl_shapers_mapping; /* map to tx_rl_shapers */
   uint64_t bps;           /* bytes per sec for rate limit */
 };
@@ -627,6 +629,8 @@ struct mt_interface {
   struct mt_dev_stats* dev_stats_not_reset; /* for nic without reset func */
   struct rte_eth_stats stats_sum;           /* for dev_inf_stat dump */
   struct mtl_port_status user_stats_port;   /* for mtl_get_port_stats */
+
+  uint64_t simulate_malicious_pkt_tsc;
 };
 
 struct mt_lcore_shm {
@@ -821,6 +825,7 @@ struct mt_tsq_queue {
   pthread_mutex_t mutex;
   rte_spinlock_t tx_mutex;
   rte_atomic32_t entry_cnt;
+  bool fatal_error;
   /* stat */
   int stat_pkts_send;
 };

--- a/lib/src/mt_queue.c
+++ b/lib/src/mt_queue.c
@@ -118,6 +118,12 @@ int mt_txq_put(struct mt_txq_entry* entry) {
   return 0;
 }
 
+int mt_txq_fatal_error(struct mt_txq_entry* entry) {
+  if (entry->txq) mt_dev_tx_queue_fatal_error(entry->parent, entry->txq);
+  if (entry->tsq) mt_tsq_fatal_error(entry->tsq);
+  return 0;
+}
+
 int mt_txq_flush(struct mt_txq_entry* entry, struct rte_mbuf* pad) {
   if (entry->tsq)
     return mt_tsq_flush(entry->parent, entry->tsq, pad);

--- a/lib/src/mt_queue.h
+++ b/lib/src/mt_queue.h
@@ -52,5 +52,6 @@ uint16_t mt_txq_burst_busy(struct mt_txq_entry* entry, struct rte_mbuf** tx_pkts
                            uint16_t nb_pkts, int timeout_ms);
 int mt_txq_flush(struct mt_txq_entry* entry, struct rte_mbuf* pad);
 int mt_txq_put(struct mt_txq_entry* entry);
+int mt_txq_fatal_error(struct mt_txq_entry* entry);
 
 #endif

--- a/lib/src/mt_shared_queue.c
+++ b/lib/src/mt_shared_queue.c
@@ -473,15 +473,29 @@ struct mt_tsq_entry* mt_tsq_get(struct mtl_main_impl* impl, enum mtl_port port,
 
   struct mt_tsq_impl* tsqm = tsq_ctx_get(impl, port);
   uint32_t hash = tsq_flow_hash(flow);
-  uint16_t q = (hash % RTE_ETH_RETA_GROUP_SIZE) % tsqm->max_tsq_queues;
+  uint16_t q = 0;
+  if (!flow->sys_queue) { /* queue zero is reserved for system queue */
+    q = (hash % RTE_ETH_RETA_GROUP_SIZE) % (tsqm->max_tsq_queues - 1) + 1;
+  }
   struct mt_tsq_queue* tsq_queue = &tsqm->tsq_queues[q];
+
   if (tsq_queue->fatal_error) {
-    /* point to another queue */
-    uint16_t q_b = rand() % tsqm->max_tsq_queues;
-    if (q == q_b) { /* still same q, point to next  */
-      q_b = q++;
-      if (q_b >= tsqm->max_tsq_queues) q_b = 0;
+    /* try to find one valid queue */
+    uint16_t q_b = rand() % (tsqm->max_tsq_queues - 1) + 1;
+    tsq_queue = &tsqm->tsq_queues[q];
+
+    if (tsq_queue->fatal_error) { /* loop to find a valid queue*/
+      for (q_b = 1; q_b < tsqm->max_tsq_queues; q_b++) {
+        tsq_queue = &tsqm->tsq_queues[q_b];
+        if (!tsq_queue->fatal_error) break;
+      }
     }
+
+    if (tsq_queue->fatal_error) {
+      err("%s(%d), all queues are in fatal error stat\n", __func__, port);
+      return NULL;
+    }
+
     warn("%s(%d), q %u is fatal error, use %u instead\n", __func__, port, q, q_b);
     q = q_b;
     tsq_queue = &tsqm->tsq_queues[q];

--- a/lib/src/mt_shared_queue.h
+++ b/lib/src/mt_shared_queue.h
@@ -37,5 +37,6 @@ uint16_t mt_tsq_burst_busy(struct mtl_main_impl* impl, struct mt_tsq_entry* entr
 int mt_tsq_flush(struct mtl_main_impl* impl, struct mt_tsq_entry* entry,
                  struct rte_mbuf* pad);
 int mt_tsq_put(struct mt_tsq_entry* entry);
+int mt_tsq_fatal_error(struct mt_tsq_entry* entry);
 
 #endif

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -400,8 +400,9 @@ struct rte_mempool* mt_mempool_create_by_ops(struct mtl_main_impl* impl,
 int mt_mempool_free(struct rte_mempool* mp) {
   unsigned int in_use_count = rte_mempool_in_use_count(mp);
   if (in_use_count) {
-    /* caused by the mbuf is still in nix tx queues? */
+    /* failed to free the mempool, caused by the mbuf is still in nix tx queues? */
     err("%s, still has %d mbuf in mempool %s\n", __func__, in_use_count, mp->name);
+    return 0;
   }
 
   /* no any in-use mbuf */

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -247,6 +247,7 @@ struct st_vsync_info {
 
 struct st_tx_video_session_impl {
   struct mtl_main_impl* impl;
+  struct st_tx_video_sessions_mgr* mgr;
   bool time_measure;
   enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
   struct rte_mempool* mbuf_mempool_hdr[MTL_SESSION_PORT_MAX];
@@ -269,6 +270,7 @@ struct st_tx_video_session_impl {
   uint64_t advice_sleep_us;
   uint16_t queue_burst_pkts[MTL_SESSION_PORT_MAX];
   uint16_t tx_done_cleanup[MTL_SESSION_PORT_MAX];
+  int recovery_idx;
 
   struct st_tx_video_session_handle_impl* st20_handle;
   struct st22_tx_video_session_handle_impl* st22_handle;
@@ -307,6 +309,10 @@ struct st_tx_video_session_impl {
   unsigned int trs_inflight_num2[MTL_SESSION_PORT_MAX];
   unsigned int trs_inflight_idx2[MTL_SESSION_PORT_MAX];
   int trs_inflight_cnt2[MTL_SESSION_PORT_MAX]; /* for stats */
+
+  /* the last burst succ time(tsc) */
+  uint64_t last_burst_succ_time_tsc[MTL_SESSION_PORT_MAX];
+  uint64_t tx_hang_detect_time_thresh;
 
   /* frame info */
   size_t st20_frame_size;   /* size per frame */
@@ -380,6 +386,8 @@ struct st_tx_video_session_impl {
   uint32_t stat_user_meta_pkt_cnt;
   uint32_t stat_max_next_frame_us;
   uint32_t stat_max_notify_frame_us;
+  uint32_t stat_unrecoverable_error;
+  uint32_t stat_recoverable_error;
 };
 
 struct st_tx_video_sessions_mgr {

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -3516,7 +3516,7 @@ static int tv_st22_ops_check(struct st22_tx_ops* ops) {
 int st20_tx_queue_fatal_error(struct mtl_main_impl* impl,
                               struct st_tx_video_session_impl* s,
                               enum mtl_session_port s_port) {
-  enum mtl_port port = mt_port_id(impl, s_port);
+  enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
   int idx = s->idx;
   int ret;
 

--- a/lib/src/st2110/st_video_transmitter.h
+++ b/lib/src/st2110/st_video_transmitter.h
@@ -18,4 +18,8 @@ int st_video_resolve_pacing_tasklet(struct st_tx_video_session_impl* s,
 int st20_frame_tx_start(struct mtl_main_impl* impl, struct st_tx_video_session_impl* s,
                         enum mtl_session_port s_port, struct st_frame_trans* frame);
 
+int st20_tx_queue_fatal_error(struct mtl_main_impl* impl,
+                              struct st_tx_video_session_impl* s,
+                              enum mtl_session_port s_port);
+
 #endif

--- a/tests/script/loop_json/st20p_redundant_1v_1080p59.json
+++ b/tests/script/loop_json/st20p_redundant_1v_1080p59.json
@@ -1,0 +1,65 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "192.168.17.102",
+                "192.168.17.101",
+            ],
+            "interface": [
+                0,
+                1,
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "input_format": "YUV422RFC4175PG2BE10",
+                    "transport_format": "YUV_422_10bit",
+                    "st20p_url": "./test.yuv"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "192.168.17.101",
+                "192.168.17.102",
+            ],
+            "interface": [
+                1,
+                0,
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "output_format": "YUV422RFC4175PG2BE10",
+                    "transport_format": "YUV_422_10bit",
+                    "display": false,
+                    "measure_latency": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/loop_json/st20p_redundant_1v_v210.json
+++ b/tests/script/loop_json/st20p_redundant_1v_v210.json
@@ -1,0 +1,65 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "192.168.17.102",
+                "192.168.17.101",
+            ],
+            "interface": [
+                0,
+                1,
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "input_format": "V210",
+                    "transport_format": "YUV_422_10bit",
+                    "st20p_url": "./test.yuv"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "192.168.17.101",
+                "192.168.17.102",
+            ],
+            "interface": [
+                1,
+                0,
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "output_format": "V210",
+                    "transport_format": "YUV_422_10bit",
+                    "display": false,
+                    "measure_latency": true
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
tx burst may hang on one queue due to malicious event on VF, we add hang check by poll the tx burst status, and use another queue to continue the frame sending.

And application should malloc more queues to allow lib can alloc a new queue in failed case.

For simulated test, please set MT_DEV_SIMULATE_MALICIOUS_PKT to 1.