### PR TITLE
rx/video: use 2 frame slots when rtcp enabled

### DIFF
--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1056,7 +1056,10 @@ static int rv_init_slot(struct mtl_main_impl* impl, struct st_rx_video_session_i
     }
   }
   s->slot_idx = -1;
-  s->slot_max = 1; /* default only one slot */
+  if (s->ops.flags & ST20_RX_FLAG_ENABLE_RTCP)
+    s->slot_max = 2; /* use 2 slots for rtcp */
+  else
+    s->slot_max = 1; /* default only one slot */
 
   dbg("%s(%d), succ\n", __func__, idx);
   return 0;


### PR DESCRIPTION
In some case when the marker packet lost, the retransmission happens after next frame packet arrives, so there should be at least 2 frame slots.
If the marker packet is missed and not recovered, frame notify latency can be at lease 1 frame time.