### PR TITLE
rtcp/tx: use mt_u64_fifo to buffer packets

### DIFF
--- a/lib/src/mt_rtcp.h
+++ b/lib/src/mt_rtcp.h
@@ -46,7 +46,7 @@ struct mt_rtcp_rx_ops {
 struct mt_rtcp_tx {
   struct mtl_main_impl* parent;
   enum mtl_port port;
-  struct rte_ring* mbuf_ring;
+  struct mt_u64_fifo* mbuf_ring;
   struct mt_udp_hdr udp_hdr;
   char name[MT_RTCP_MAX_NAME_LEN];
   uint32_t ssrc;
@@ -58,7 +58,7 @@ struct mt_rtcp_tx {
   uint32_t stat_rtp_retransmit_succ;
   uint32_t stat_rtp_retransmit_fail;
   uint32_t stat_rtp_retransmit_fail_nobuf;
-  uint32_t stat_rtp_retransmit_fail_dequeue;
+  uint32_t stat_rtp_retransmit_fail_read;
   uint32_t stat_rtp_retransmit_fail_obsolete;
   uint32_t stat_nack_received;
 };

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -137,14 +137,25 @@ struct mt_u64_fifo {
 
 struct mt_u64_fifo* mt_u64_fifo_init(int size, int soc_id);
 int mt_u64_fifo_uinit(struct mt_u64_fifo* fifo);
-int mt_u64_fifo_put(struct mt_u64_fifo* fifo, uint64_t item);
+int mt_u64_fifo_put(struct mt_u64_fifo* fifo, const uint64_t item);
 int mt_u64_fifo_get(struct mt_u64_fifo* fifo, uint64_t* item);
+int mt_u64_fifo_put_bulk(struct mt_u64_fifo* fifo, const uint64_t* items, uint32_t n);
+int mt_u64_fifo_get_bulk(struct mt_u64_fifo* fifo, uint64_t* items, uint32_t n);
+int mt_u64_fifo_read_back(struct mt_u64_fifo* fifo, uint64_t* item);
+int mt_u64_fifo_read_front(struct mt_u64_fifo* fifo, uint64_t* item);
+int mt_u64_fifo_read_any(struct mt_u64_fifo* fifo, uint64_t* item, int skip);
+int mt_u64_fifo_read_any_bulk(struct mt_u64_fifo* fifo, uint64_t* items, uint32_t n,
+                              int skip);
 
 static inline int mt_u64_fifo_full(struct mt_u64_fifo* fifo) {
   return fifo->used == fifo->size;
 }
 
 static inline int mt_u64_fifo_count(struct mt_u64_fifo* fifo) { return fifo->used; }
+
+static inline int mt_u64_fifo_free_count(struct mt_u64_fifo* fifo) {
+  return fifo->size - fifo->used;
+}
 
 struct mt_cvt_dma_ctx {
   struct mt_u64_fifo* fifo;


### PR DESCRIPTION
1. change rte_ring to mt_u64_fifo
2. add read and bulk functions for fifo
3. do not dequeue when retransmit