### PR TITLE
Resolved warnings introduced

### DIFF
--- a/ecosystem/ffmpeg_plugin/kahawai_common.c
+++ b/ecosystem/ffmpeg_plugin/kahawai_common.c
@@ -38,7 +38,7 @@ mtl_handle kahawai_init(char* port, char* local_addr, int enc_session_cnt,
                         int dec_session_cnt, char* dma_dev) {
   param.num_ports = 1;
 
-  strncpy(param.port[MTL_PORT_P], port, MTL_PORT_MAX_LEN);
+  snprintf(param.port[MTL_PORT_P], MTL_PORT_MAX_LEN, "%s", port);
 
   if (NULL == local_addr) {
     av_log(NULL, AV_LOG_ERROR, "Invalid local IP address\n");
@@ -51,11 +51,11 @@ mtl_handle kahawai_init(char* port, char* local_addr, int enc_session_cnt,
   }
 
   if (enc_session_cnt > 0) {
-    param.tx_sessions_cnt_max = enc_session_cnt;
+    param.tx_queues_cnt = enc_session_cnt;
     param.flags |= MTL_FLAG_TX_VIDEO_MIGRATE;
   }
   if (dec_session_cnt > 0) {
-    param.rx_sessions_cnt_max = dec_session_cnt;
+    param.rx_queues_cnt = dec_session_cnt;
     param.flags |= MTL_FLAG_RX_VIDEO_MIGRATE;
     param.flags |= MTL_FLAG_RX_SEPARATE_VIDEO_LCORE;
   }
@@ -68,7 +68,7 @@ mtl_handle kahawai_init(char* port, char* local_addr, int enc_session_cnt,
 
   if (dma_dev) {
     param.num_dma_dev_port = 1;
-    strncpy(param.dma_dev_port[0], dma_dev, MTL_PORT_MAX_LEN);
+    snprintf(param.dma_dev_port[0], MTL_PORT_MAX_LEN, "%s", dma_dev);
     av_log(NULL, AV_LOG_VERBOSE, "DMA enabled on %s\n", dma_dev);
   }
 

--- a/ecosystem/ffmpeg_plugin/kahawai_common.h
+++ b/ecosystem/ffmpeg_plugin/kahawai_common.h
@@ -30,5 +30,5 @@ typedef struct KahawaiFpsDecs {
 enum st_fps kahawai_fps_to_st_fps(AVRational framerate);
 mtl_handle kahawai_init(char* port, char* local_addr, int enc_session_cnt,
                         int dec_session_cnt, char* dma_dev);
-mtl_handle kahawai_get_handle();
+mtl_handle kahawai_get_handle(void);
 void kahawai_set_handle(mtl_handle handle);

--- a/ecosystem/ffmpeg_plugin/kahawai_dec.c
+++ b/ecosystem/ffmpeg_plugin/kahawai_dec.c
@@ -80,7 +80,7 @@ static int kahawai_read_header(AVFormatContext* ctx) {
   AVStream* st = NULL;
   enum AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
   int packet_size = 0;
-  int ret = 0;
+  const AVPixFmtDescriptor* pix_fmt_desc = NULL;
 
   // struct mtl_init_params param;
   struct st20p_rx_ops ops_rx;
@@ -127,7 +127,7 @@ static int kahawai_read_header(AVFormatContext* ctx) {
   ops_rx.height = s->height;
 
   pix_fmt = av_get_pix_fmt(s->pixel_format);
-  const AVPixFmtDescriptor* pix_fmt_desc = av_pix_fmt_desc_get(pix_fmt);
+  pix_fmt_desc = av_pix_fmt_desc_get(pix_fmt);
   switch (pix_fmt) {
     case AV_PIX_FMT_YUV422P10LE:
       ops_rx.transport_fmt = ST20_FMT_YUV_422_10BIT;

--- a/ecosystem/ffmpeg_plugin/kahawai_enc.c
+++ b/ecosystem/ffmpeg_plugin/kahawai_enc.c
@@ -89,6 +89,7 @@ static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
 static int kahawai_write_header(AVFormatContext* ctx) {
   KahawaiMuxerContext* s = ctx->priv_data;
   struct st20p_tx_ops ops_tx;
+  const AVPixFmtDescriptor* pix_fmt_desc = NULL;
 
   av_log(ctx, AV_LOG_VERBOSE, "kahawai_write_header triggered\n");
 
@@ -124,7 +125,7 @@ static int kahawai_write_header(AVFormatContext* ctx) {
   ops_tx.height = s->height = ctx->streams[0]->codecpar->height;
 
   s->pixel_format = ctx->streams[0]->codecpar->format;
-  const AVPixFmtDescriptor* pix_fmt_desc = av_pix_fmt_desc_get(s->pixel_format);
+  av_pix_fmt_desc_get(s->pixel_format);
 
   switch (s->pixel_format) {
     case AV_PIX_FMT_YUV422P10LE:
@@ -205,6 +206,9 @@ static int kahawai_write_header(AVFormatContext* ctx) {
 
 static int kahawai_write_packet(AVFormatContext* ctx, AVPacket* pkt) {
   KahawaiMuxerContext* s = ctx->priv_data;
+  uint8_t* data[4] = {NULL};
+  int linesize[4] = {0};
+  const AVPixFmtDescriptor* pix_fmt_desc = NULL;
 
   av_log(ctx, AV_LOG_VERBOSE, "kahawai_write_packet triggered\n");
   s->frame = st20p_tx_get_frame(s->tx_handle);
@@ -229,9 +233,7 @@ static int kahawai_write_packet(AVFormatContext* ctx, AVPacket* pkt) {
     return AVERROR(EIO);
   }
 
-  uint8_t* data[4];
-  int linesize[4];
-  const AVPixFmtDescriptor* pix_fmt_desc = av_pix_fmt_desc_get(s->pixel_format);
+  pix_fmt_desc = av_pix_fmt_desc_get(s->pixel_format);
 
   switch (s->pixel_format) {
     case AV_PIX_FMT_YUV422P10LE:
@@ -243,8 +245,8 @@ static int kahawai_write_packet(AVFormatContext* ctx, AVPacket* pkt) {
     case AV_PIX_FMT_RGB24:
       av_image_fill_arrays(data, linesize, pkt->data, s->pixel_format, s->width,
                            s->height, 1);
-      av_image_copy(s->frame->addr, s->frame->linesize, data, linesize, s->pixel_format,
-                    s->width, s->height);
+      av_image_copy((uint8_t **)s->frame->addr, (int*)s->frame->linesize,
+                    (const uint8_t**)data, linesize, s->pixel_format, s->width, s->height);
       break;
     default:
       av_log(ctx, AV_LOG_ERROR, "Unsupported pixel format: %s.\n", pix_fmt_desc->name);


### PR DESCRIPTION
1) libavdevice/kahawai_common.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes] mtl_handle kahawai_get_handle();
2) libavdevice/kahawai_common.c:54:5: warning: 'tx_sessions_cnt_max' is deprecated: Use tx_queues_cnt instead [-Wdeprecated-declarations] 
3) libavdevice/kahawai_common.c:58:5: warning: 'rx_sessions_cnt_max' is deprecated: Use rx_queues_cnt instead [-Wdeprecated-declarations] 
4) warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement] 
5) warning: '__builtin_strncpy' specified bound 64 equals destination size [-Wstringop-truncation]