### PR TITLE
Added support for mellanox ConnectX cards. Nvidia PMD uses bifurcated driver don't bind vfio-pci to VFs

### DIFF
--- a/lib/src/mt_dev.c
+++ b/lib/src/mt_dev.c
@@ -64,6 +64,12 @@ static const struct mt_dev_driver_info dev_drvs[] = {
         .flow_type = MT_FLOW_NONE,
         .no_dev_stats_reset = true,
     },
+    {
+        .name = "mlx5_pci",
+        .port_type = MT_PORT_PF,
+        .drv_type = MT_DRV_MLX5,
+        .flow_type = MT_FLOW_ALL,
+    },
 };
 
 static int parse_driver_info(const char* driver, struct mt_dev_driver_info* drv_info) {

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -128,6 +128,7 @@ enum mt_driver_type {
   MT_DRV_E1000_IGB, /* e1000 igb, net_e1000_igb */
   MT_DRV_IGC,       /* igc, net_igc */
   MT_DRV_ENA,       /* aws ena, net_ena */
+  MT_DRV_MLX5,      /* mlx, mlx5_pci */
 };
 
 enum mt_flow_type {


### PR DESCRIPTION
The pull request makes changes in the nicctl.sh script to identify if the mlx driver is loaded.
If so then the NVIDIA PMD which uses bifurcated driver is in play.
As a result do not bind the vfio-pci to the created VFs.
Also added a new support for mlx5_pci driver in the library.