### PR TITLE
tx/video: add rtp timestamp delta support.

### DIFF
--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -511,6 +511,8 @@ struct st_app_context {
   uint16_t tx_start_vrx;
   uint16_t tx_pad_interval;
   bool tx_no_static_pad;
+  bool tx_ts_first_pkt;
+  int32_t tx_ts_delta_us;
   enum st21_pacing tx_pacing_type;
 
   struct st_app_tx_audio_session* tx_audio_sessions;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -50,6 +50,8 @@ enum st_args_cmd {
   ST_ARG_PAD_INTERVAL,
   ST_ARG_NO_PAD_STATIC,
   ST_ARG_SHAPING,
+  ST_ARG_TIMESTAMP_FIRST_PKT,
+  ST_ARG_TIMESTAMP_DELTA_US,
 
   ST_ARG_CONFIG_FILE = 0x300,
   ST_ARG_TEST_TIME,
@@ -159,6 +161,8 @@ static struct option st_app_args_options[] = {
     {"pad_interval", required_argument, 0, ST_ARG_PAD_INTERVAL},
     {"no_static_pad", no_argument, 0, ST_ARG_NO_PAD_STATIC},
     {"shaping", required_argument, 0, ST_ARG_SHAPING},
+    {"ts_first_pkt", no_argument, 0, ST_ARG_TIMESTAMP_FIRST_PKT},
+    {"ts_delta_us", required_argument, 0, ST_ARG_TIMESTAMP_DELTA_US},
 
     {"config_file", required_argument, 0, ST_ARG_CONFIG_FILE},
     {"test_time", required_argument, 0, ST_ARG_TEST_TIME},
@@ -450,6 +454,12 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_NO_PAD_STATIC:
         ctx->tx_no_static_pad = true;
+        break;
+      case ST_ARG_TIMESTAMP_FIRST_PKT:
+        ctx->tx_ts_first_pkt = true;
+        break;
+      case ST_ARG_TIMESTAMP_DELTA_US:
+        ctx->tx_ts_delta_us = atoi(optarg);
         break;
       case ST_ARG_SHAPING:
         if (!strcmp(optarg, "narrow"))

--- a/app/src/tx_st20p_app.c
+++ b/app/src/tx_st20p_app.c
@@ -278,9 +278,11 @@ static int app_tx_st20p_init(struct st_app_context* ctx, st_json_st20p_session_t
   ops.notify_frame_available = app_tx_st20p_frame_available;
   ops.start_vrx = ctx->tx_start_vrx;
   ops.pad_interval = ctx->tx_pad_interval;
+  ops.rtp_timestamp_delta_us = ctx->tx_ts_delta_us;
   ops.notify_event = app_tx_st20p_notify_event;
   if (ctx->tx_no_static_pad) ops.flags |= ST20P_TX_FLAG_DISABLE_STATIC_PAD_P;
   if (st20p && st20p->enable_rtcp) ops.flags |= ST20P_TX_FLAG_ENABLE_RTCP;
+  if (ctx->tx_ts_first_pkt) ops.flags |= ST20P_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT;
 
   s->width = ops.width;
   s->height = ops.height;

--- a/app/src/tx_video_app.c
+++ b/app/src/tx_video_app.c
@@ -754,8 +754,11 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.payload_type = video ? video->base.payload_type : ST_APP_PAYLOAD_TYPE_VIDEO;
   ops.start_vrx = ctx->tx_start_vrx;
   ops.pad_interval = ctx->tx_pad_interval;
+  ops.rtp_timestamp_delta_us = ctx->tx_ts_delta_us;
   if (s->enable_vsync) ops.flags |= ST20_TX_FLAG_ENABLE_VSYNC;
   if (ctx->tx_no_static_pad) ops.flags |= ST20_TX_FLAG_DISABLE_STATIC_PAD_P;
+  if (ctx->tx_ts_first_pkt) ops.flags |= ST20_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT;
+
   struct st_tx_rtcp_ops ops_rtcp;
   memset(&ops_rtcp, 0, sizeof(ops_rtcp));
   if (video && video->enable_rtcp) {

--- a/doc/run.md
+++ b/doc/run.md
@@ -294,6 +294,9 @@ If it failed to run the sample, please help to collect the system setup status b
 --pacing_way <way>                   : debug option, set pacing way, available value: "auto", "rl", "tsc", "tsc_narrow", "ptp", "tsn".
 --shaping <shaping>                  : debug option, set st21 shaping type, available value: "narrow", "wide".
 --vrx <n>                            : debug option, set st21 vrx value, refer to st21 spec for possible vrx value.
+--ts_first_pkt                       : debug option, to set the st20 RTP timestamp at the time the first
+packet egresses from the sender.
+--ts_delta_us <n>                    : debug option, to set the st20 rtp timestamp delta(us) to the start time of frame.
 --mono_pool                          : debug option, use mono pool for all tx and rx queues(sessions).
 --tasklet_thread                     : debug option, run the tasklet under thread instead of a pinned lcore.
 --tasklet_sleep                      : debug option, enable sleep if all tasklet report done status.

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -70,6 +70,12 @@ extern "C" {
  * If enable the rtcp.
  */
 #define ST20_TX_FLAG_ENABLE_RTCP (MTL_BIT32(7))
+/**
+ * Flag bit in flags of struct st20_tx_ops.
+ * Set this flag to set rtp timestamp at the time of the first packet egresses from the
+ * sender.
+ */
+#define ST20_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT (MTL_BIT32(8))
 
 /**
  * Flag bit in flags of struct st22_tx_ops.
@@ -973,6 +979,11 @@ struct st20_tx_ops {
    * Leave to zero if not know detail, lib will train the interval in the initial routine.
    */
   uint16_t pad_interval;
+  /**
+   * The rtp timestamp delta(us) to the start time of frame.
+   * Zero means the rtp timestamp at the start of the frame.
+   */
+  int32_t rtp_timestamp_delta_us;
 
   /**
    * the time for lib to detect the hang on the tx queue and try to recovery

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -406,6 +406,12 @@ enum st22_quality_mode {
  * If enable the rtcp.
  */
 #define ST20P_TX_FLAG_ENABLE_RTCP (MTL_BIT32(7))
+/**
+ * Flag bit in flags of struct st20p_tx_ops.
+ * Set this flag to set rtp timestamp at the time of the first packet egresses from the
+ * sender.
+ */
+#define ST20P_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT (MTL_BIT32(8))
 
 /**
  * Flag bit in flags of struct st22p_rx_ops, for non MTL_PMD_DPDK_USER.
@@ -686,6 +692,7 @@ struct st20p_tx_ops {
    * Valid if ST20P_TX_FLAG_USER_P(R)_MAC is enabled
    */
   uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
+
   /**
    * The start vrx buffer.
    * Leave to zero if not know detail, lib will assign a start value of vrx(narrow) based
@@ -698,6 +705,18 @@ struct st20p_tx_ops {
    * Leave to zero if not know detail, lib will train the interval in the initial routine.
    */
   uint16_t pad_interval;
+  /**
+   * The rtp timestamp delta(us) to the start time of frame.
+   * Zero means the rtp timestamp at the start of the frame.
+   */
+  int32_t rtp_timestamp_delta_us;
+
+  /**
+   * the time for lib to detect the hang on the tx queue and try to recovery
+   * Leave to zero system will use the default value(1s).
+   */
+  uint32_t tx_hang_detect_ms;
+
   /** Session resolution width */
   uint32_t width;
   /** Session resolution height */

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -252,6 +252,8 @@ static int tx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_tx
   ops_tx.pacing = ST21_PACING_NARROW;
   ops_tx.start_vrx = ops->start_vrx;
   ops_tx.pad_interval = ops->pad_interval;
+  ops_tx.rtp_timestamp_delta_us = ops->rtp_timestamp_delta_us;
+  ops_tx.tx_hang_detect_ms = ops->tx_hang_detect_ms;
   ops_tx.width = ops->width;
   ops_tx.height = ops->height;
   ops_tx.fps = ops->fps;
@@ -272,6 +274,9 @@ static int tx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_tx
   if (ops->flags & ST20P_TX_FLAG_ENABLE_VSYNC) ops_tx.flags |= ST20_TX_FLAG_ENABLE_VSYNC;
   if (ops->flags & ST20P_TX_FLAG_DISABLE_STATIC_PAD_P)
     ops_tx.flags |= ST20_TX_FLAG_DISABLE_STATIC_PAD_P;
+  if (ops->flags & ST20P_TX_FLAG_ENABLE_RTCP) ops_tx.flags |= ST20_TX_FLAG_ENABLE_RTCP;
+  if (ops->flags & ST20P_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT)
+    ops_tx.flags |= ST20_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT;
 
   transport = st20_tx_create(impl, &ops_tx);
   if (!transport) {

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -454,7 +454,7 @@ struct st_rx_video_ebu_info {
   uint32_t c_max_wide_pass;
   uint32_t vrx_full_narrow_pass;
   uint32_t vrx_full_wide_pass;
-  uint32_t rtp_offset_max_pass;
+  int32_t rtp_offset_max_pass;
 
   bool init;
 };


### PR DESCRIPTION
A synthetic source can timestamp at the start of the frame or at the
time the first packet egresses from the sender. App can customize
this by rtp_timestamp_delta_us.