### PR TITLE
ecosystem/ffmpeg: doc for udp_port increment by 2 (#420)

### DIFF
--- a/ecosystem/ffmpeg_plugin/README.md
+++ b/ecosystem/ffmpeg_plugin/README.md
@@ -16,7 +16,7 @@ Two-sessions input example:
 
 ```bash
 <!-- markdownlint-disable line-length -->
-ffmpeg -framerate 60 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20000 -port 0000:31:00.0 -local_addr "192.168.96.2" -src_addr "239.168.85.20" -total_sessions 2 -ext_frames_mode 1 -f kahawai -i "1" -framerate 60 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20001 -port 0000:31:00.0 -local_addr "192.168.96.3" -src_addr "239.168.85.20" -total_sessions 2 -ext_frames_mode 1 -f kahawai -i "2" -map 0:0 -vframes 5000 -f rawvideo /dev/null -y -map 1:0 -vframes 5000 -f rawvideo /dev/null -y
+ffmpeg -framerate 60 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20000 -port 0000:31:00.0 -local_addr "192.168.96.2" -src_addr "239.168.85.20" -total_sessions 2 -ext_frames_mode 1 -f kahawai -i "1" -framerate 60 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20002 -port 0000:31:00.0 -local_addr "192.168.96.3" -src_addr "239.168.85.20" -total_sessions 2 -ext_frames_mode 1 -f kahawai -i "2" -map 0:0 -vframes 5000 -f rawvideo /dev/null -y -map 1:0 -vframes 5000 -f rawvideo /dev/null -y
 ```
 
 With openh264 encoder example:


### PR DESCRIPTION
The udp_port of the RxTxApp will increment by two when operating in replica mode.

Signed-off-by: Frank Du <frank.du@intel.com>
(cherry picked from commit 701404aff233d3889d477f4515f62327514e93ca)