### PR TITLE
test: ignore timing check when rtcp enabled

### DIFF
--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -963,6 +963,7 @@ struct mtl_main_impl {
   uint16_t pkt_udp_suggest_max_size;
   uint16_t rx_pool_data_size;
   uint32_t sch_schedule_ns;
+  int mempool_idx;
 };
 
 static inline struct mtl_init_params* mt_get_user_params(struct mtl_main_impl* impl) {

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -380,9 +380,12 @@ struct rte_mempool* mt_mempool_create_by_ops(struct mtl_main_impl* impl,
   if (cache_size && (element_size % cache_size)) { /* align to cache size */
     element_size = (element_size / cache_size + 1) * cache_size;
   }
+  char name_with_idx[32];
+  snprintf(name_with_idx, sizeof(name_with_idx), "%s_%d", name, impl->mempool_idx++);
   uint16_t data_room_size = element_size + MT_MBUF_HEADROOM_SIZE; /* include head room */
-  struct rte_mempool* mbuf_pool = rte_pktmbuf_pool_create_by_ops(
-      name, n, cache_size, priv_size, data_room_size, mt_socket_id(impl, port), ops_name);
+  struct rte_mempool* mbuf_pool =
+      rte_pktmbuf_pool_create_by_ops(name_with_idx, n, cache_size, priv_size,
+                                     data_room_size, mt_socket_id(impl, port), ops_name);
   if (!mbuf_pool) {
     err("%s(%d), fail(%s) for %s, n %u\n", __func__, port, rte_strerror(rte_errno), name,
         n);

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -380,7 +380,8 @@ struct rte_mempool* mt_mempool_create_by_ops(struct mtl_main_impl* impl,
   if (cache_size && (element_size % cache_size)) { /* align to cache size */
     element_size = (element_size / cache_size + 1) * cache_size;
   }
-  char name_with_idx[32];
+  char name_with_idx[32]; /* 32 is the max length allowed by mempool api, in our lib we
+                             use concise names so it won't exceed this length */
   snprintf(name_with_idx, sizeof(name_with_idx), "%s_%d", name, impl->mempool_idx++);
   uint16_t data_room_size = element_size + MT_MBUF_HEADROOM_SIZE; /* include head room */
   struct rte_mempool* mbuf_pool =

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -2072,7 +2072,7 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
       EXPECT_LT(test_ctx_rx[i]->incomplete_frame_cnt, 2 * 8);
     else
       EXPECT_LT(test_ctx_rx[i]->incomplete_frame_cnt, 4);
-    if (check_fps) {
+    if (check_fps && !enable_rtcp) {
       EXPECT_LT(test_ctx_rx[i]->meta_timing_fail_cnt, 4);
       EXPECT_LT(test_ctx_tx[i]->tx_tmstamp_delta_fail_cnt, 4);
     }

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -1842,7 +1842,7 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
 
     test_ctx_tx[i]->idx = i;
     test_ctx_tx[i]->ctx = ctx;
-    test_ctx_tx[i]->fb_cnt = enable_rtcp ? TEST_MAX_SHA_HIST_NUM : TEST_SHA_HIST_NUM;
+    test_ctx_tx[i]->fb_cnt = TEST_SHA_HIST_NUM;
     test_ctx_tx[i]->fb_idx = 0;
     test_ctx_tx[i]->check_sha = true;
     memset(&ops_tx, 0, sizeof(ops_tx));

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -1842,7 +1842,7 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
 
     test_ctx_tx[i]->idx = i;
     test_ctx_tx[i]->ctx = ctx;
-    test_ctx_tx[i]->fb_cnt = TEST_SHA_HIST_NUM;
+    test_ctx_tx[i]->fb_cnt = enable_rtcp ? TEST_MAX_SHA_HIST_NUM : TEST_SHA_HIST_NUM;
     test_ctx_tx[i]->fb_idx = 0;
     test_ctx_tx[i]->check_sha = true;
     memset(&ops_tx, 0, sizeof(ops_tx));

--- a/tests/src/test_util.cpp
+++ b/tests/src/test_util.cpp
@@ -10,9 +10,9 @@
 
 void test_sha_dump(const char* tag, unsigned char* sha) {
   for (size_t i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    dbg("0x%02x ", sha[i]);
+    err("0x%02x ", sha[i]);
   }
-  dbg(", %s done\n", tag);
+  err(", %s done\n", tag);
 }
 
 int st_test_check_patter(uint8_t* p, size_t sz, uint8_t base) {

--- a/tests/src/test_util.cpp
+++ b/tests/src/test_util.cpp
@@ -10,9 +10,9 @@
 
 void test_sha_dump(const char* tag, unsigned char* sha) {
   for (size_t i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    err("0x%02x ", sha[i]);
+    dbg("0x%02x ", sha[i]);
   }
-  err(", %s done\n", tag);
+  dbg(", %s done\n", tag);
 }
 
 int st_test_check_patter(uint8_t* p, size_t sz, uint8_t base) {


### PR DESCRIPTION
When packets at the end of frame lost, the time to receive the whole frame will be longer.