### PR TITLE
rtcp: add active control

### DIFF
--- a/lib/src/mt_rtcp.c
+++ b/lib/src/mt_rtcp.c
@@ -27,6 +27,7 @@ static int rtp_seq_num_cmp(uint16_t seq0, uint16_t seq1) {
 
 int mt_rtcp_tx_buffer_rtp_packets(struct mt_rtcp_tx* tx, struct rte_mbuf** mbufs,
                                   unsigned int bulk) {
+  if (!tx->active) return 0;
   if (mt_u64_fifo_free_count(tx->mbuf_ring) < bulk) {
     struct rte_mbuf* clean_mbufs[bulk];
     if (mt_u64_fifo_get_bulk(tx->mbuf_ring, (uint64_t*)clean_mbufs, bulk) < 0) {
@@ -114,6 +115,7 @@ rt_exit:
 }
 
 int mt_rtcp_tx_parse_rtcp_packet(struct mt_rtcp_tx* tx, struct mt_rtcp_hdr* rtcp) {
+  if (!tx->active) return 0;
   if (rtcp->flags != 0x80) {
     err("%s(%s), wrong rtcp flags %u\n", __func__, tx->name, rtcp->flags);
     return -EIO;
@@ -158,6 +160,7 @@ static int rtcp_rx_update_last_cont(struct mt_rtcp_rx* rx) {
 }
 
 int mt_rtcp_rx_parse_rtp_packet(struct mt_rtcp_rx* rx, struct st_rfc3550_rtp_hdr* rtp) {
+  if (!rx->active) return 0;
   uint16_t seq = ntohs(rtp->seq_number);
 
   if (rx->ssrc == 0) { /* first received */
@@ -200,6 +203,7 @@ int mt_rtcp_rx_parse_rtp_packet(struct mt_rtcp_rx* rx, struct st_rfc3550_rtp_hdr
 }
 
 int mt_rtcp_rx_send_nack_packet(struct mt_rtcp_rx* rx) {
+  if (!rx->active) return 0;
   struct mtl_main_impl* impl = rx->parent;
   enum mtl_port port = rx->port;
   struct rte_mbuf* pkt;
@@ -350,6 +354,7 @@ struct mt_rtcp_tx* mt_rtcp_tx_create(struct mtl_main_impl* impl,
   rte_memcpy(&tx->udp_hdr, ops->udp_hdr, sizeof(tx->udp_hdr));
 
   mt_stat_register(impl, rtcp_tx_stat, tx, tx->name);
+  tx->active = true;
 
   info("%s(%s), suss\n", __func__, tx->name);
 
@@ -358,6 +363,8 @@ struct mt_rtcp_tx* mt_rtcp_tx_create(struct mtl_main_impl* impl,
 
 void mt_rtcp_tx_free(struct mt_rtcp_tx* tx) {
   mt_stat_unregister(tx->parent, rtcp_tx_stat, tx);
+
+  tx->active = false;
 
   if (tx->mbuf_ring) {
     mt_fifo_mbuf_clean(tx->mbuf_ring);
@@ -397,6 +404,7 @@ struct mt_rtcp_rx* mt_rtcp_rx_create(struct mtl_main_impl* impl,
   rx->seq_window_size = ops->seq_bitmap_size * 8;
 
   mt_stat_register(impl, rtcp_rx_stat, rx, rx->name);
+  rx->active = true;
 
   info("%s(%s), suss\n", __func__, rx->name);
 
@@ -405,6 +413,8 @@ struct mt_rtcp_rx* mt_rtcp_rx_create(struct mtl_main_impl* impl,
 
 void mt_rtcp_rx_free(struct mt_rtcp_rx* rx) {
   mt_stat_unregister(rx->parent, rtcp_rx_stat, rx);
+
+  rx->active = false;
 
   if (rx->seq_bitmap) mt_rte_free(rx->seq_bitmap);
 

--- a/lib/src/mt_rtcp.h
+++ b/lib/src/mt_rtcp.h
@@ -50,6 +50,7 @@ struct mt_rtcp_tx {
   struct mt_udp_hdr udp_hdr;
   char name[MT_RTCP_MAX_NAME_LEN];
   uint32_t ssrc;
+  bool active;
 
   uint16_t ipv4_packet_id;
 
@@ -70,6 +71,7 @@ struct mt_rtcp_rx {
   char name[MT_RTCP_MAX_NAME_LEN];
   uint64_t nacks_send_interval;
   uint32_t ssrc;
+  bool active;
 
   uint16_t ipv4_packet_id;
   uint64_t nacks_send_time;


### PR DESCRIPTION
rtcp_tx_free may hang because enqueue not stopped while cleaning the mbuf ring.