### PR TITLE
rx/video: record latest rtp timestamp

### DIFF
--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -727,6 +727,7 @@ struct st_rx_video_session_impl {
   uint32_t stat_slot_query_ext_fail;
   uint64_t stat_bytes_received;
   uint32_t stat_max_notify_frame_us;
+  uint32_t stat_latest_tmstamp;
 
   struct st_rx_video_ebu_info ebu_info;
   struct st_rx_video_ebu_stat ebu;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1317,6 +1317,14 @@ static struct st_rx_video_slot_impl* rv_slot_by_tmstamp(
     if (tmstamp == slot->tmstamp) return slot;
   }
 
+  if (tmstamp - s->stat_latest_tmstamp < UINT32_MAX / 2 || s->stat_latest_tmstamp == 0) {
+    s->stat_latest_tmstamp = tmstamp;
+  } else {
+    dbg("%s(%d): tmstamp %u is older than latest %u\n", __func__, s->idx, tmstamp,
+        s->stat_latest_tmstamp);
+    return NULL;
+  }
+
   dbg("%s(%d): new tmstamp %u\n", __func__, s->idx, tmstamp);
   if (s->dma_dev && !mt_dma_empty(s->dma_dev)) {
     /* still in progress of previous frame, drop current pkt */


### PR DESCRIPTION
only open new slot for newer tmstamp