### PR TITLE
Fix dangling pointer in mt_platform.h

### DIFF
--- a/lib/src/mt_platform.h
+++ b/lib/src/mt_platform.h
@@ -78,10 +78,10 @@ typedef unsigned long int nfds_t;
 static inline int mt_pthread_mutex_init(pthread_mutex_t* mutex,
                                         pthread_mutexattr_t* p_attr) {
 #ifdef MT_ENABLE_P_SHARED
+  pthread_mutexattr_t attr;
   if (p_attr) {
     pthread_mutexattr_setpshared(p_attr, PTHREAD_PROCESS_SHARED);
   } else {
-    pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
     p_attr = &attr;


### PR DESCRIPTION
Keep attr in scope to prevent usage of dangling pointer