### PR TITLE
api: remove transport type from mtl_init

### DIFF
--- a/.github/workflows/windows_build_with_gtest.yml
+++ b/.github/workflows/windows_build_with_gtest.yml
@@ -168,4 +168,4 @@ jobs:
 
       - name: Run st2110 test case
         run: |
-          ./tests/build/KahawaiTest --auto_start_stop --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --gtest_filter=-St22_?x.*:*4320p*
+          ./tests/build/KahawaiTest --auto_start_stop --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --gtest_filter=-St22_?x.*:*4320p*:*rtcp*

--- a/app/udp/udp_client_sample.c
+++ b/app/udp/udp_client_sample.c
@@ -142,7 +142,6 @@ int main(int argc, char** argv) {
   ret = sample_parse_args(&ctx, argc, argv, true, false, true);
   if (ret < 0) return ret;
 
-  ctx.param.transport = MTL_TRANSPORT_UDP; /* udp transport */
   ctx.st = mtl_init(&ctx.param);
   if (!ctx.st) {
     err("%s, mtl_init fail\n", __func__);

--- a/app/udp/udp_server_sample.c
+++ b/app/udp/udp_server_sample.c
@@ -190,8 +190,6 @@ int main(int argc, char** argv) {
   ret = sample_parse_args(&ctx, argc, argv, false, true, true);
   if (ret < 0) return ret;
 
-  ctx.param.transport = MTL_TRANSPORT_UDP; /* udp transport */
-
   ctx.st = mtl_init(&ctx.param);
   if (!ctx.st) {
     err("%s, mtl_init fail\n", __func__);

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -443,8 +443,6 @@ struct mtl_af_xdp_params {
  * Include the PCIE port and other required info.
  */
 struct mtl_init_params {
-  /** Mandatory. Transport type, st2110(default) or udp */
-  enum mtl_transport_type transport;
   /**
    * Mandatory. PCIE BDF port, ex: 0000:af:01.0.
    * For MTL_PMD_DPDK_AF_XDP, set kernel interface name here, ex: enp175s0f0.

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -235,11 +235,6 @@ static int mt_user_params_check(struct mtl_init_params* p) {
   uint8_t if_ip[MTL_IP_ADDR_LEN];
   uint8_t if_netmask[MTL_IP_ADDR_LEN];
 
-  /* transport check */
-  if (p->transport >= MTL_TRANSPORT_TYPE_MAX) {
-    err("%s, invalid transport %d\n", __func__, p->transport);
-    return -EINVAL;
-  }
   /* num_ports check */
   if ((num_ports > MTL_PORT_MAX) || (num_ports <= 0)) {
     err("%s, invalid num_ports %d\n", __func__, num_ports);

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1161,13 +1161,6 @@ static inline bool mt_has_srss(struct mtl_main_impl* impl, enum mtl_port port) {
   return mt_get_rss_mode(impl, port) != MTL_RSS_MODE_NONE;
 }
 
-static inline bool mt_udp_transport(struct mtl_main_impl* impl, enum mtl_port port) {
-  if (mt_get_user_params(impl)->transport == MTL_TRANSPORT_UDP)
-    return true;
-  else
-    return false;
-}
-
 static inline bool mt_udp_lcore(struct mtl_main_impl* impl, enum mtl_port port) {
   if (mt_get_user_params(impl)->flags & MTL_FLAG_UDP_LCORE)
     return true;
@@ -1184,13 +1177,6 @@ static inline bool mt_random_src_port(struct mtl_main_impl* impl) {
 
 static inline bool mt_multi_src_port(struct mtl_main_impl* impl) {
   if (mt_get_user_params(impl)->flags & MTL_FLAG_MULTI_SRC_PORT)
-    return true;
-  else
-    return false;
-}
-
-static inline bool mt_st2110_transport(struct mtl_main_impl* impl, enum mtl_port port) {
-  if (mt_get_user_params(impl)->transport == MTL_TRANSPORT_ST2110)
     return true;
   else
     return false;

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -423,9 +423,6 @@ static struct ufd_mt_ctx* ufd_create_mt_ctx(void) {
     }
   }
 
-  /* force udp mode */
-  p->transport = MTL_TRANSPORT_UDP;
-
   /* assign a default if not set by user */
   if (!ctx->init_params.slots_nb_max) ctx->init_params.slots_nb_max = 1024;
   /* ufd is assigned to top of INT, the bottom fd is used by OS */


### PR DESCRIPTION
UDP and ST2110 can co-exist, and actually no code are using this field.