### PR TITLE
afxdp: port name use prefix "afxdp:"

### DIFF
--- a/app/src/args.c
+++ b/app/src/args.c
@@ -318,6 +318,7 @@ static int app_args_json(struct st_app_context* ctx, struct mtl_init_params* p,
   if (ctx->json_ctx->rss_mode) p->rss_mode = ctx->json_ctx->rss_mode;
   if (ctx->json_ctx->log_file) st_set_mtl_log_file(ctx, ctx->json_ctx->log_file);
 
+  info("%s, json_file %s succ\n", __func__, json_file);
   return 0;
 }
 

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -450,8 +450,8 @@ struct mtl_af_xdp_params {
 struct mtl_init_params {
   /**
    * Mandatory. PCIE BDF port, ex: 0000:af:01.0.
-   * For MTL_PMD_DPDK_AF_XDP, set kernel interface name here, ex: enp175s0f0.
-   * */
+   * For MTL_PMD_DPDK_AF_XDP, use afxdp + ifname, ex: afxdp:enp175s0f0.
+   */
   char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
   /** Mandatory. The element number in the port array, 1 to MTL_PORT_MAX_LEN */
   uint8_t num_ports;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -730,7 +730,9 @@ struct mt_admin {
 
 struct mt_kport_info {
   /* dpdk port name for kernel port(MTL_PMD_DPDK_AF_XDP) */
-  char port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  char dpdk_port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
+  /* kernel interface name */
+  char kernel_if[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
 };
 
 struct mt_map_item {

--- a/lib/src/mt_socket.h
+++ b/lib/src/mt_socket.h
@@ -7,12 +7,12 @@
 
 #include "mt_main.h"
 
-int mt_socket_get_if_ip(char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
+int mt_socket_get_if_ip(const char* if_name, uint8_t ip[MTL_IP_ADDR_LEN],
                         uint8_t netmask[MTL_IP_ADDR_LEN]);
 
-int mt_socket_get_if_gateway(char* if_name, uint8_t gateway[MTL_IP_ADDR_LEN]);
+int mt_socket_get_if_gateway(const char* if_name, uint8_t gateway[MTL_IP_ADDR_LEN]);
 
-int mt_socket_get_if_mac(char* if_name, struct rte_ether_addr* ea);
+int mt_socket_get_if_mac(const char* if_name, struct rte_ether_addr* ea);
 
 int mt_socket_join_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group);
 

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -794,3 +794,20 @@ uint16_t mt_random_port(uint16_t base_port) {
 
   return port;
 }
+
+static const char* mtl_afxdp_port_prefix = "afxdp:";
+
+enum mtl_pmd_type mtl_pmd_by_port_name(const char* port) {
+  if (strncmp(port, mtl_afxdp_port_prefix, strlen(mtl_afxdp_port_prefix)) == 0)
+    return MTL_PMD_DPDK_AF_XDP;
+  else
+    return MTL_PMD_DPDK_USER; /* default */
+}
+
+const char* mt_afxdp_port2if(const char* port) {
+  if (mtl_pmd_by_port_name(port) != MTL_PMD_DPDK_AF_XDP) {
+    err("%s, port %s is not afxdp\n", __func__, port);
+    return NULL;
+  }
+  return port + strlen(mtl_afxdp_port_prefix);
+}

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -205,4 +205,6 @@ static inline void mt_mbuf_refcnt_inc_bulk(struct rte_mbuf** mbufs, uint16_t nb)
   }
 }
 
+const char* mt_afxdp_port2if(const char* port);
+
 #endif

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -775,11 +775,6 @@ uint64_t st10_media_clk_to_ns(uint32_t media_ts, uint32_t sampling_rate) {
   return ts;
 }
 
-enum mtl_pmd_type mtl_pmd_by_port_name(const char* port) {
-  char* bdf = strstr(port, ":");
-  return bdf ? MTL_PMD_DPDK_USER : MTL_PMD_DPDK_AF_XDP;
-}
-
 int st_draw_logo(struct st_frame* frame, struct st_frame* logo, uint32_t x, uint32_t y) {
   if (frame->fmt != logo->fmt) {
     err("%s, mismatch fmt %d %d\n", __func__, frame->fmt, logo->fmt);

--- a/tests/script/afxdp_json/1080p59_1v.json
+++ b/tests/script/afxdp_json/1080p59_1v.json
@@ -1,10 +1,10 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0",
+            "name": "afxdp:enp175s0f0np0",
         },
         {
-            "name": "enp175s0f1np1",
+            "name": "afxdp:enp175s0f1np1",
         }
     ],
     "tx_sessions": [

--- a/tests/script/afxdp_json/mix_port.json
+++ b/tests/script/afxdp_json/mix_port.json
@@ -5,7 +5,7 @@
             "ip": "192.168.17.101"
         },
         {
-            "name": "enp175s0f1np1",
+            "name": "afxdp:enp175s0f1np1",
         }
     ],
     "tx_sessions": [

--- a/tests/script/afxdp_json/mix_port2.json
+++ b/tests/script/afxdp_json/mix_port2.json
@@ -1,7 +1,7 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0",
+            "name": "afxdp:enp175s0f0np0",
         },
         {
             "name": "0000:af:01.1",

--- a/tests/script/afxdp_json/multicast_1v_1a_1anc.json
+++ b/tests/script/afxdp_json/multicast_1v_1a_1anc.json
@@ -1,10 +1,10 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0",
+            "name": "afxdp:enp175s0f0np0",
         },
         {
-            "name": "enp175s0f1np1",
+            "name": "afxdp:enp175s0f1np1",
         }
     ],
     "tx_sessions": [

--- a/tests/script/afxdp_json/multicast_redundant_1v_1a_1anc.json
+++ b/tests/script/afxdp_json/multicast_redundant_1v_1a_1anc.json
@@ -1,10 +1,10 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0",
+            "name": "afxdp:enp175s0f0np0",
         },
         {
-            "name": "enp175s0f1np1",
+            "name": "afxdp:enp175s0f1np1",
         }
     ],
     "tx_sessions": [

--- a/tests/script/afxdp_json/rtp_1080p59_1v.json
+++ b/tests/script/afxdp_json/rtp_1080p59_1v.json
@@ -1,10 +1,10 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0",
+            "name": "afxdp:enp175s0f0np0",
         },
         {
-            "name": "enp175s0f1np1",
+            "name": "afxdp:enp175s0f1np1",
         }
     ],
     "tx_sessions": [

--- a/tests/script/afxdp_json/rtp_multicast_1v_1a_1anc.json
+++ b/tests/script/afxdp_json/rtp_multicast_1v_1a_1anc.json
@@ -1,10 +1,10 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0",
+            "name": "afxdp:enp175s0f0np0",
         },
         {
-            "name": "enp175s0f1np1",
+            "name": "afxdp:enp175s0f1np1",
         }
     ],
     "tx_sessions": [

--- a/tests/script/afxdp_json/rtp_redundant_1v_1a_1anc.json
+++ b/tests/script/afxdp_json/rtp_redundant_1v_1a_1anc.json
@@ -1,10 +1,10 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0",
+            "name": "afxdp:enp175s0f0np0",
         },
         {
-            "name": "enp175s0f1np1",
+            "name": "afxdp:enp175s0f1np1",
         }
     ],
     "tx_sessions": [

--- a/tests/script/afxdp_json/ufd_client.json
+++ b/tests/script/afxdp_json/ufd_client.json
@@ -1,7 +1,7 @@
 {
     "interfaces": [
         {
-            "port": "enp175s0f1np1",
+            "port": "afxdp:enp175s0f1np1",
         }
     ],
     "nb_udp_sockets": "64",

--- a/tests/script/afxdp_json/ufd_server.json
+++ b/tests/script/afxdp_json/ufd_server.json
@@ -1,7 +1,7 @@
 {
     "interfaces": [
         {
-            "port": "enp175s0f0np0",
+            "port": "afxdp:enp175s0f0np0",
         }
     ],
     "nb_udp_sockets": "64",

--- a/tests/script/afxdp_json/unicast_1080p59_1v.json
+++ b/tests/script/afxdp_json/unicast_1080p59_1v.json
@@ -1,10 +1,10 @@
 {
     "interfaces": [
         {
-            "name": "enp175s0f0np0"
+            "name": "afxdp:enp175s0f0np0"
         },
         {
-            "name": "enp175s0f1np1"
+            "name": "afxdp:enp175s0f1np1"
         }
     ],
     "tx_sessions": [


### PR DESCRIPTION
to support other future kernel based PMD.