### PR TITLE
ci: do not rebuild dpdk for msys2

### DIFF
--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -148,7 +148,7 @@ jobs:
         if: ${{ steps.cache-dpdk.outputs.cache-hit == 'true' }}
         run: |
           cd dpdk
-          meson install -C build
+          meson install -C build --no-rebuild
 
       - name: Build
         run: |

--- a/meson.build
+++ b/meson.build
@@ -59,5 +59,5 @@ pkg.generate(
   version : meson.project_version(),
   libraries : mtl_lib,
   filebase : meson.project_name(),
-  description : 'Intel® Media Transport Library based on DPDK'
+  description : 'Intel® Media Transport Library'
 )


### PR DESCRIPTION
The cached DPDK binaries are retrieved but not used to reduce MSYS2 CI time. Add '--no-rebuild' to fix it.