### PR TITLE
st20/rx: use dynamic ext frame for both converter and non-converter mode

### DIFF
--- a/app/sample/ext_frame/rx_st20_pipeline_dyn_ext_frame_sample.c
+++ b/app/sample/ext_frame/rx_st20_pipeline_dyn_ext_frame_sample.c
@@ -37,7 +37,7 @@ static int rx_st20p_frame_available(void* priv) {
   return 0;
 }
 
-static int rx_st20p_query_ext_frame(void* priv, struct st20_ext_frame* ext_frame,
+static int rx_st20p_query_ext_frame(void* priv, struct st_ext_frame* ext_frame,
                                     struct st20_rx_frame_meta* meta) {
   struct rx_st20p_sample_ctx* s = priv;
   int i = s->ext_idx;
@@ -45,9 +45,9 @@ static int rx_st20p_query_ext_frame(void* priv, struct st20_ext_frame* ext_frame
 
   /* you can check the timestamp from lib by meta->timestamp */
 
-  ext_frame->buf_addr = s->ext_frames[i].buf_addr;
-  ext_frame->buf_iova = s->ext_frames[i].buf_iova;
-  ext_frame->buf_len = s->ext_frames[i].buf_len;
+  ext_frame->addr[0] = s->ext_frames[i].buf_addr;
+  ext_frame->iova[0] = s->ext_frames[i].buf_iova;
+  ext_frame->size = s->ext_frames[i].buf_len;
 
   /* save your private data here get it from st_frame.opaque */
   /* ext_frame->opaque = ?; */

--- a/doc/external_frame.md
+++ b/doc/external_frame.md
@@ -68,9 +68,40 @@ static int tx_st20p_frame_done(void* priv, struct st_frame*frame) {
 }
 ```
 
+Others follow the general API flow.
+
 ### 2.3 st20p_rx usages
 
-#### 2.3.1 dedicated frames
+#### 2.3.1 dynamic frames
+
+in ops, set the flag and set query_ext_frame callback
+
+```c
+ops_rx.flags |= ST20P_RX_FLAG_EXT_FRAME;
+ops_rx.query_ext_frame = st20p_rx_query_ext_frame;
+//...
+//implement the callback
+static int st20p_rx_query_ext_frame(void* priv, st_ext_frame* ext_frame,
+                                    struct st20_rx_frame_meta* meta) {
+  ctx* s = (ctx*)priv;
+  uint8_t planes = st_frame_fmt_planes(fmt[i]);
+
+  /* fill the ext frame */
+  for (uint8_t plane = 0; plane < planes; plane++) {
+    ext_frame.addr[i] = your_addr[i];
+    ext_frame.iova[i] = your_iova[i]; // must provide IOVA for no convert mode
+    ext_frame.linesize[i] = your_linesize[i];
+  }
+  ext_frame.size = your_frame_size;
+  ext_frame.opaque = your_frame_handle;
+
+  return 0;
+}
+```
+
+User should maintain the lifetime of frames after st22p_rx_get_frame.
+
+#### 2.3.2 dedicated frames
 
 set the ext_frames array in ops
 
@@ -90,57 +121,7 @@ ops_rx.ext_frames = ext_frames;
 rx_handle = st20p_rx_create(st, &ops_rx);
 ```
 
-use as the general API
-
-#### 2.3.2 dynamic frames - convert mode
-
-in ops, set the flag
-
-```c
-ops_rx.flags |= ST20P_RX_FLAG_EXT_FRAME;
-```
-
-when receiving a frame, get the frame with ext_frame info and put the frame
-
-```c
-struct st_ext_frame ext_frame;
-uint8_t planes = st_frame_fmt_planes(frame->fmt);
-for(int i = 0; i < planes; i++) {
-    ext_frame.addr[i] = your_addr[i];
-    ext_frame.linesize[i] = your_linesize[i];
-}
-ext_frame.size = your_frame_size;
-ext_frame.opaque = your_frame_handle;
-frame = st20p_rx_get_ext_frame(rx_handle, &ext_frame);
-st20p_rx_put_frame(rx_handle, frame); // you can put it right away
-use_frame(your_frame_handle);
-```
-
-user should maintain the lifetime of frames
-
-#### 2.3.3 dynamic frames - no convert mode
-
-(the same usage as raw video API 3.3.2)  
-implement and set query_ext_frame callback and set incomplete frame flag
-
-```c
-// set the callback in ops
-// set the incomplete frame flag
-ops_rx.query_ext_frame = st20p_rx_query_ext_frame;
-ops_rx.flags |= ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
-//...
-//implement the callback
-static int st20p_rx_query_ext_frame(void* priv, st20_ext_frame*ext_frame, struct st20_rx_frame_meta* meta) {
-    ctx* s = (ctx*)priv;
-    ext_frame->buf_addr = your_addr[0];
-    ext_frame->buf_iova = your_iova[0];
-    ext_frame->buf_len = your_frame_size;
-    ext_frame->opaque = your_frame_handle;
-    return 0;
-}
-```
-
-use as the general API, user should maintain the lifetime of frames
+Others follow the general API flow.
 
 ### 2.4 st22p_tx usages
 
@@ -183,6 +164,8 @@ static int tx_st22p_frame_done(void* priv, struct st_frame*frame) {
 }
 ```
 
+Others follow the general API flow.
+
 ### 2.5 st22p_rx usages
 
 #### 2.5.1 dynamic frames
@@ -201,17 +184,13 @@ static int st22p_rx_query_ext_frame(void* priv, st_ext_frame* ext_frame,
 
   /* fill the ext frame */
   for (uint8_t plane = 0; plane < planes; plane++) {
-    ext_frame->linesize[plane] = st_frame_least_linesize(fmt[i], width[i], plane);
-    if (plane == 0) {
-      ext_frame->addr[plane] = xxx;
-      ext_frame->iova[plane] = xxx;
-    } else {
-      ext_frame->addr[plane] = xxx;
-      ext_frame->iova[plane] = xxx;
-    }
+    ext_frame.addr[i] = your_addr[i];
+    ext_frame.iova[i] = your_iova[i]; // must provide IOVA for no convert mode
+    ext_frame.linesize[i] = your_linesize[i];
   }
-  ext_frame->size = xxx;
-  ext_frame->opaque = xxx;
+  ext_frame.size = your_frame_size;
+  ext_frame.opaque = your_frame_handle;
+
   return 0;
 }
 ```
@@ -256,25 +235,7 @@ st20_tx_set_ext_frame(s->handle, idx, &ext_frame);
 
 ### 3.3 st20_rx usages
 
-#### 3.3.1 dedicated frames
-
-set the ext_frames array in ops
-
-```c
-struct st20_ext_frame ext_frames[fb_cnt];
-for (int i = 0; i < fb_cnt;++i) {
-    ext_frames[i].buf_addr = your_addr;
-    ext_frames[i].buf_iova = your_iova;
-    ext_frames[i].buf_len = your_frame_size;
-    ext_frames[i].opaque = your_frame_handle;
-}
-ops_rx.ext_frames = ext_frames;
-rx_handle = st20_rx_create(st, &ops_rx);
-```
-
-use as the general API
-
-#### 3.3.2 dynamic frames
+#### 3.3.1 dynamic frames
 
 implement and set query_ext_frame callback and set incomplete frame flag
 
@@ -296,3 +257,21 @@ static int rx_query_ext_frame(void* priv, st20_ext_frame*ext_frame, struct st20_
 ```
 
 use as the general API, user should maintain the lifetime of frames
+
+#### 3.3.2 dedicated frames
+
+set the ext_frames array in ops
+
+```c
+struct st20_ext_frame ext_frames[fb_cnt];
+for (int i = 0; i < fb_cnt;++i) {
+    ext_frames[i].buf_addr = your_addr;
+    ext_frames[i].buf_iova = your_iova;
+    ext_frames[i].buf_len = your_frame_size;
+    ext_frames[i].opaque = your_frame_handle;
+}
+ops_rx.ext_frames = ext_frames;
+rx_handle = st20_rx_create(st, &ops_rx);
+```
+
+Others follow the general API flow.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -369,7 +369,7 @@ enum st22_quality_mode {
 #define ST22P_TX_FLAG_DISABLE_BULK (MTL_BIT32(7))
 /**
  * Flag bit in flags of struct st22p_tx_ops.
- * Lib uses user allocated memory for frames.
+ * Lib uses user dynamic allocated memory for frames.
  * The external frames are provided by calling
  * st22p_tx_put_ext_frame.
  */
@@ -387,7 +387,7 @@ enum st22_quality_mode {
 #define ST20P_TX_FLAG_USER_R_MAC (MTL_BIT32(1))
 /**
  * Flag bit in flags of struct st20p_tx_ops.
- * Lib uses user allocated memory for frames.
+ * Lib uses user dynamic allocated memory for frames.
  * The external frames are provided by calling
  * st20p_tx_put_ext_frame.
  */
@@ -455,8 +455,8 @@ enum st22_quality_mode {
 #define ST22P_RX_FLAG_SIMULATE_PKT_LOSS (MTL_BIT32(3))
 /**
  * Flag bit in flags of struct st22p_rx_ops.
- * Enable the external frame mode, and user must provide a query callback(query_ext_frame
- * in st22p_rx_ops) to let MTL can get the frame when needed.
+ * Enable the dynamic external frame mode, and user must provide a query
+ * callback(query_ext_frame in st22p_rx_ops) to let MTL can get the frame when needed.
  */
 #define ST22P_RX_FLAG_EXT_FRAME (MTL_BIT32(4))
 
@@ -480,9 +480,9 @@ enum st22_quality_mode {
 #define ST20P_RX_FLAG_ENABLE_VSYNC (MTL_BIT32(1))
 /**
  * Flag bit in flags of struct st20p_rx_ops.
- * Only used for internal convert mode.
- * The external frames are provided by calling
- * st20p_rx_get_ext_frame.
+ * Enable the dynamic external frame mode, and user must provide a query
+ * callback(query_ext_frame in st20p_rx_ops) to let MTL can get the frame when needed.
+ * Note to enable ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME also for non-converter mode.
  */
 #define ST20P_RX_FLAG_EXT_FRAME (MTL_BIT32(2))
 /**
@@ -855,11 +855,10 @@ struct st20p_rx_ops {
   struct st_rx_rtcp_ops* rtcp;
   /**
    * Optional. Callback when the lib query next external frame's data address.
-   * Only for non-convert mode with ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME.
    * And only non-block method can be used within this callback as it run from lcore
    * tasklet routine.
    */
-  int (*query_ext_frame)(void* priv, struct st20_ext_frame* ext_frame,
+  int (*query_ext_frame)(void* priv, struct st_ext_frame* ext_frame,
                          struct st20_rx_frame_meta* meta);
   /**
    * Optional. event callback, lib will call this when there is some event happened.
@@ -1549,22 +1548,6 @@ st20p_rx_handle st20p_rx_create(mtl_handle mt, struct st20p_rx_ops* ops);
  *   - <0: Error code of the rx st2110-20 pipeline session free.
  */
 int st20p_rx_free(st20p_rx_handle handle);
-
-/**
- * Get one rx frame from the rx st2110-20 pipeline session with external framebuffer.
- * This is only used for internal convert mode, the convert is done in this call.
- * Call st20p_rx_put_frame to return the frame to session.
- *
- * @param handle
- *   The handle to the rx st2110-20 pipeline session.
- * @param ext_frame
- *   The pointer to the structure describing external framebuffer.
- * @return
- *   - NULL if no available frame in the session.
- *   - Otherwise, the frame pointer.
- */
-struct st_frame* st20p_rx_get_ext_frame(st20p_rx_handle handle,
-                                        struct st_ext_frame* ext_frame);
 
 /**
  * Get one rx frame from the rx st2110-20 pipeline session.

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.h
@@ -48,6 +48,7 @@ struct st20p_rx_ctx {
   struct st_frame_converter* internal_converter;
   bool ready;
   bool derive;
+  bool dynamic_ext_frame;
 
   size_t dst_size;
 

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -1427,6 +1427,7 @@ TEST(St20p, rx_dedicated_ext_digest_1080p_convert_with_padding_s2) {
   test_st20p_init_rx_digest_para(&para);
   para.sessions = 2;
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
+  para.tx_ext = true;
   para.rx_ext = true;
   para.rx_dedicated_ext = true;
   para.check_fps = false;

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -499,25 +499,12 @@ static void test_internal_st20p_rx_frame_thread(void* args) {
 
   dbg("%s(%d), start\n", __func__, s->idx);
   while (!s->stop) {
-    if (s->rx_get_ext) {
-      frame =
-          st20p_rx_get_ext_frame((st20p_rx_handle)handle, &s->p_ext_frames[s->ext_idx]);
-      if (!frame) { /* no frame */
-        lck.lock();
-        if (!s->stop) s->cv.wait(lck);
-        lck.unlock();
-        continue;
-      }
-      s->ext_idx++;
-      if (s->ext_idx >= s->fb_cnt) s->ext_idx = 0;
-    } else {
-      frame = st20p_rx_get_frame((st20p_rx_handle)handle);
-      if (!frame) { /* no frame */
-        lck.lock();
-        if (!s->stop) s->cv.wait(lck);
-        lck.unlock();
-        continue;
-      }
+    frame = st20p_rx_get_frame((st20p_rx_handle)handle);
+    if (!frame) { /* no frame */
+      lck.lock();
+      if (!s->stop) s->cv.wait(lck);
+      lck.unlock();
+      continue;
     }
 
     if (frame->opaque) {
@@ -579,7 +566,7 @@ static void test_internal_st20p_rx_frame_thread(void* args) {
   dbg("%s(%d), stop\n", __func__, s->idx);
 }
 
-static int test_st20p_rx_query_ext_frame(void* priv, st20_ext_frame* ext_frame,
+static int test_st20p_rx_query_ext_frame(void* priv, st_ext_frame* ext_frame,
                                          struct st20_rx_frame_meta* meta) {
   tests_context* s = (tests_context*)priv;
   int i = s->ext_idx;
@@ -590,9 +577,7 @@ static int test_st20p_rx_query_ext_frame(void* priv, st20_ext_frame* ext_frame,
     return -EIO;
   }
 
-  ext_frame->buf_addr = s->p_ext_frames[i].addr[0];
-  ext_frame->buf_iova = s->p_ext_frames[i].iova[0];
-  ext_frame->buf_len = s->p_ext_frames[i].size;
+  *ext_frame = s->p_ext_frames[i];
   s->ext_fb_in_use[i] = true;
 
   ext_frame->opaque = &s->ext_fb_in_use[i];
@@ -610,9 +595,8 @@ struct st20p_rx_digest_test_para {
   int timeout_ms;
   bool tx_ext;
   bool rx_ext;
-  bool rx_get_ext;
+  bool rx_dedicated_ext;
   bool check_fps;
-  bool dynamic;
   enum st_test_level level;
   int fb_cnt;
   bool user_timestamp;
@@ -635,9 +619,8 @@ static void test_st20p_init_rx_digest_para(struct st20p_rx_digest_test_para* par
   para->timeout_ms = 0;
   para->tx_ext = false;
   para->rx_ext = false;
-  para->rx_get_ext = false;
+  para->rx_dedicated_ext = false;
   para->check_fps = true;
-  para->dynamic = false;
   para->level = ST_TEST_LEVEL_MANDATORY;
   para->user_timestamp = false;
   para->vsync = true;
@@ -889,7 +872,6 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     test_ctx_rx[i]->fmt = rx_fmt[i];
     test_ctx_rx[i]->user_timestamp = para->user_timestamp;
     test_ctx_rx[i]->user_meta = para->user_meta;
-    test_ctx_rx[i]->rx_get_ext = para->rx_get_ext;
     test_ctx_rx[i]->frame_size =
         st_frame_size(rx_fmt[i], width[i], height[i], para->interlace);
     /* copy sha */
@@ -963,14 +945,17 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_rx.framebuff_cnt = test_ctx_rx[i]->fb_cnt;
     ops_rx.notify_frame_available = test_st20p_rx_frame_available;
     ops_rx.notify_event = test_ctx_notify_event;
-    if (para->dynamic) {
-      ops_rx.query_ext_frame = test_st20p_rx_query_ext_frame;
-      ops_rx.flags |= ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
-    } else if (para->rx_ext && !para->rx_get_ext) {
-      ops_rx.ext_frames = test_ctx_rx[i]->p_ext_frames;
+    if (para->rx_ext) {
+      if (para->rx_dedicated_ext) {
+        ops_rx.ext_frames = test_ctx_rx[i]->p_ext_frames;
+      } else {
+        ops_rx.flags |= ST20P_RX_FLAG_EXT_FRAME;
+        ops_rx.query_ext_frame = test_st20p_rx_query_ext_frame;
+        if (st_frame_fmt_equal_transport(ops_rx.output_fmt, ops_rx.transport_fmt))
+          ops_rx.flags |= ST20P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
+      }
     }
     if (para->vsync) ops_rx.flags |= ST20P_RX_FLAG_ENABLE_VSYNC;
-    if (para->rx_get_ext) ops_rx.flags |= ST20P_RX_FLAG_EXT_FRAME;
     if (para->pkt_convert) ops_rx.flags |= ST20P_RX_FLAG_PKT_CONVERT;
 
     struct st_rx_rtcp_ops ops_rx_rtcp;
@@ -1075,10 +1060,7 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     info("%s, session %d fb_rec %d framerate %f:%f\n", __func__, i,
          test_ctx_rx[i]->fb_rec, framerate_rx[i], expect_framerate_rx[i]);
     EXPECT_GT(test_ctx_rx[i]->fb_rec, 0);
-    if (para->dynamic)
-      EXPECT_LE(test_ctx_rx[i]->incomplete_frame_cnt, 4);
-    else
-      EXPECT_LE(test_ctx_rx[i]->incomplete_frame_cnt, 2);
+    EXPECT_LE(test_ctx_rx[i]->incomplete_frame_cnt, 4);
     EXPECT_EQ(test_ctx_rx[i]->sha_fail_cnt, 0);
     EXPECT_LE(test_ctx_rx[i]->user_meta_fail_cnt, 2);
     if (para->check_fps) {
@@ -1312,7 +1294,6 @@ TEST(St20p, rx_ext_digest_1080p_no_convert_s2) {
   para.sessions = 2;
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
   para.rx_ext = true;
-  para.level = ST_TEST_LEVEL_ALL;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
@@ -1350,11 +1331,12 @@ TEST(St20p, rx_ext_digest_1080p_packet_convert_s2) {
   para.rx_ext = true;
   para.check_fps = false;
   para.pkt_convert = true;
+  para.level = ST_TEST_LEVEL_ALL;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
 
-TEST(St20p, tx_rx_ext_digest_1080p_no_convert_s2) {
+TEST(St20p, ext_digest_1080p_no_convert_s2) {
   enum st_fps fps[2] = {ST_FPS_P50, ST_FPS_P59_94};
   int width[2] = {1920, 1920};
   int height[2] = {1080, 1080};
@@ -1375,7 +1357,7 @@ TEST(St20p, tx_rx_ext_digest_1080p_no_convert_s2) {
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
 
-TEST(St20p, tx_rx_ext_digest_1080p_convert_s2) {
+TEST(St20p, ext_digest_1080p_convert_s2) {
   enum st_fps fps[2] = {ST_FPS_P50, ST_FPS_P59_94};
   int width[2] = {1920, 1920};
   int height[2] = {1080, 1080};
@@ -1395,27 +1377,7 @@ TEST(St20p, tx_rx_ext_digest_1080p_convert_s2) {
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
 
-TEST(St20p, rx_dynamic_ext_digest_1080p_no_convert_s2) {
-  enum st_fps fps[2] = {ST_FPS_P29_97, ST_FPS_P59_94};
-  int width[2] = {1920, 1280};
-  int height[2] = {1080, 720};
-  enum st_frame_fmt tx_fmt[2] = {ST_FRAME_FMT_YUV422RFC4175PG2BE10,
-                                 ST_FRAME_FMT_YUV422RFC4175PG2BE10};
-  enum st20_fmt t_fmt[2] = {ST20_FMT_YUV_422_10BIT, ST20_FMT_YUV_422_10BIT};
-  enum st_frame_fmt rx_fmt[2] = {ST_FRAME_FMT_YUV422RFC4175PG2BE10,
-                                 ST_FRAME_FMT_YUV422RFC4175PG2BE10};
-
-  struct st20p_rx_digest_test_para para;
-  test_st20p_init_rx_digest_para(&para);
-  para.sessions = 2;
-  para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
-  para.rx_ext = true;
-  para.dynamic = true;
-
-  st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
-}
-
-TEST(St20p, rx_get_ext_digest_1080p_convert_s2) {
+TEST(St20p, rx_dedicated_ext_digest_1080p_convert_s2) {
   enum st_fps fps[2] = {ST_FPS_P29_97, ST_FPS_P59_94};
   int width[2] = {1920, 1280};
   int height[2] = {1080, 720};
@@ -1428,12 +1390,12 @@ TEST(St20p, rx_get_ext_digest_1080p_convert_s2) {
   para.sessions = 2;
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
   para.rx_ext = true;
-  para.rx_get_ext = true;
+  para.rx_dedicated_ext = true;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
 
-TEST(St20p, tx_rx_ext_digest_1080p_convert_with_padding_s2) {
+TEST(St20p, ext_digest_1080p_convert_with_padding_s2) {
   enum st_fps fps[2] = {ST_FPS_P59_94, ST_FPS_P59_94};
   int width[2] = {1920, 1920};
   int height[2] = {1080, 1080};
@@ -1453,7 +1415,7 @@ TEST(St20p, tx_rx_ext_digest_1080p_convert_with_padding_s2) {
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
 
-TEST(St20p, rx_get_ext_digest_1080p_convert_with_padding_s2) {
+TEST(St20p, rx_dedicated_ext_digest_1080p_convert_with_padding_s2) {
   enum st_fps fps[2] = {ST_FPS_P59_94, ST_FPS_P59_94};
   int width[2] = {1920, 1920};
   int height[2] = {1080, 1080};
@@ -1465,16 +1427,15 @@ TEST(St20p, rx_get_ext_digest_1080p_convert_with_padding_s2) {
   test_st20p_init_rx_digest_para(&para);
   para.sessions = 2;
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
-  para.tx_ext = true;
   para.rx_ext = true;
-  para.rx_get_ext = true;
+  para.rx_dedicated_ext = true;
   para.check_fps = false;
   para.line_padding_size = 512;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
 
-TEST(St20p, tx_rx_ext_digest_1080p_packet_convert_with_padding_s2) {
+TEST(St20p, ext_digest_1080p_packet_convert_with_padding_s2) {
   enum st_fps fps[2] = {ST_FPS_P59_94, ST_FPS_P59_94};
   int width[2] = {1920, 1920};
   int height[2] = {1080, 1080};
@@ -1488,6 +1449,7 @@ TEST(St20p, tx_rx_ext_digest_1080p_packet_convert_with_padding_s2) {
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
   para.tx_ext = true;
   para.rx_ext = true;
+  para.rx_dedicated_ext = true;
   para.check_fps = false;
   para.line_padding_size = 1024;
   para.pkt_convert = true;

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -215,7 +215,6 @@ class tests_context {
   int ext_idx = 0;
   bool ext_fb_in_use[3] = {false}; /* assume 3 framebuffer */
   mtl_dma_mem_handle dma_mem = NULL;
-  bool rx_get_ext = false;
 
   bool user_pacing = false;
   /* user timestamp which advanced by 1 for every frame */


### PR DESCRIPTION
Simply the usage, for non-converter use raw st20 dynamic ext mode, for convert, call the ext frame query in the frame ready callback.