### PR TITLE
doc: add dpdk-devbind.py hint if the port is not set to vfio-pci

### DIFF
--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -415,6 +415,12 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
       socket[i] = mt_dev_get_socket_id(p->port[i]);
     if (socket[i] < 0) {
       err("%s, get socket fail %d for pmd %d\n", __func__, socket[i], p->pmd[i]);
+#ifndef WINDOWSENV
+      if (pmd == MTL_PMD_DPDK_USER) {
+        err("Run \"dpdk-devbind.py -s | grep Ethernet\" to check if other port driver is "
+            "ready as vfio-pci mode\n");
+      }
+#endif
       goto err_exit;
     }
   }


### PR DESCRIPTION
MT: Error: mt_dev_get_socket_id, failed to get port for 0000:af:00.0
MT: Error: mt_dev_get_socket_id, please make sure the driver of 0000:af:00.0 is configured rightly
MT: Error: mtl_init, get socket fail -19 for pmd 0
MT: Error: mtl_init, run "dpdk-devbind.py -s | grep Ethernet" to check if other port driver is ready as vfio-pci mode