### PR TITLE
lib: fix the use of ipv4 packet id

### DIFF
--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -762,7 +762,7 @@ static void ptp_delay_req_task(struct mt_ptp_impl* ptp) {
     ipv4_hdr->udp.dst_port = ipv4_hdr->udp.src_port;
     ipv4_hdr->udp.dgram_cksum = 0;
     ipv4_hdr->ip.time_to_live = 255;
-    ipv4_hdr->ip.packet_id = htons(ptp->t3_sequence_id);
+    ipv4_hdr->ip.fragment_offset = MT_IP_DONT_FRAGMENT_FLAG;
     ipv4_hdr->ip.next_proto_id = IPPROTO_UDP;
     ipv4_hdr->ip.hdr_checksum = 0;
     mt_mbuf_init_ipv4(m);

--- a/lib/src/mt_rtcp.c
+++ b/lib/src/mt_rtcp.c
@@ -250,7 +250,6 @@ int mt_rtcp_rx_send_nack_packet(struct mt_rtcp_rx* rx) {
   udp = &hdr->udp;
 
   rte_memcpy(hdr, &rx->udp_hdr, sizeof(*hdr));
-  ipv4->packet_id = htons(rx->ipv4_packet_id++);
   mt_mbuf_init_ipv4(pkt);
   pkt->data_len = sizeof(*hdr);
 
@@ -401,7 +400,6 @@ struct mt_rtcp_tx* mt_rtcp_tx_create(struct mtl_main_impl* impl,
   }
   tx->mbuf_ring = ring;
 
-  tx->ipv4_packet_id = 0;
   tx->ssrc = ops->ssrc;
   snprintf(tx->name, sizeof(tx->name) - 1, "%s", ops->name);
   rte_memcpy(&tx->udp_hdr, ops->udp_hdr, sizeof(tx->udp_hdr));
@@ -455,7 +453,6 @@ struct mt_rtcp_rx* mt_rtcp_rx_create(struct mtl_main_impl* impl,
 
   rx->parent = impl;
   rx->port = ops->port;
-  rx->ipv4_packet_id = 0;
   rx->ssrc = 0;
   rx->nacks_send_interval = ops->nacks_send_interval;
   rx->nacks_send_time = mt_get_tsc(impl);

--- a/lib/src/mt_rtcp.h
+++ b/lib/src/mt_rtcp.h
@@ -63,7 +63,6 @@ struct mt_rtcp_tx {
   bool active;
   enum mt_rtp_payload_format payload_format;
 
-  uint16_t ipv4_packet_id;
   uint16_t last_seq_num;
 
   /* stat */
@@ -86,7 +85,6 @@ struct mt_rtcp_rx {
   uint32_t ssrc;
   bool active;
 
-  uint16_t ipv4_packet_id;
   uint64_t nacks_send_time;
 
   uint16_t last_seq;

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -277,7 +277,6 @@ struct st_tx_video_session_impl {
   struct st_tx_video_session_handle_impl* st20_handle;
   struct st22_tx_video_session_handle_impl* st22_handle;
 
-  uint16_t st20_ipv4_packet_id;
   uint16_t st20_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
   uint16_t st20_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
   struct st_rfc4175_video_hdr s_hdr[MTL_SESSION_PORT_MAX];
@@ -802,7 +801,6 @@ struct st_tx_audio_session_impl {
   uint16_t st30_frame_idx;  /* current frame index */
   enum st30_tx_frame_status st30_frame_stat;
 
-  uint16_t st30_ipv4_packet_id;
   uint16_t st30_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
   uint16_t st30_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
   struct st_rfc3550_audio_hdr hdr[MTL_SESSION_PORT_MAX];
@@ -1020,7 +1018,6 @@ struct st_tx_ancillary_session_impl {
   uint16_t st40_frame_idx; /* current frame index */
   enum st40_tx_frame_status st40_frame_stat;
 
-  uint16_t st40_ipv4_packet_id;
   uint16_t st40_src_port[MTL_SESSION_PORT_MAX]; /* udp port */
   uint16_t st40_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
   struct st_rfc8331_anc_hdr hdr[MTL_SESSION_PORT_MAX];

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -352,8 +352,7 @@ static int tx_ancillary_sessions_tasklet_start(void* priv) {
 }
 
 static int tx_ancillary_session_update_redundant(struct st_tx_ancillary_session_impl* s,
-                                                 struct rte_mbuf* pkt_r,
-                                                 const struct rte_mbuf* pkt_base) {
+                                                 struct rte_mbuf* pkt_r) {
   struct mt_udp_hdr* hdr = rte_pktmbuf_mtod(pkt_r, struct mt_udp_hdr*);
   struct rte_ipv4_hdr* ipv4 = &hdr->ipv4;
   struct rte_udp_hdr* udp = &hdr->udp;
@@ -825,7 +824,7 @@ static int tx_ancillary_session_tasklet_frame(struct mtl_main_impl* impl,
         s->stat_build_ret_code = -STI_FRAME_PKT_ALLOC_FAIL;
         return MT_TASKLET_ALL_DONE;
       }
-      tx_ancillary_session_update_redundant(s, pkt_r, pkt);
+      tx_ancillary_session_update_redundant(s, pkt_r);
     }
   }
 
@@ -990,7 +989,7 @@ static int tx_ancillary_session_tasklet_rtp(struct mtl_main_impl* impl,
         s->stat_build_ret_code = -STI_RTP_PKT_ALLOC_FAIL;
         return MT_TASKLET_ALL_DONE;
       }
-      tx_ancillary_session_update_redundant(s, pkt_r, pkt);
+      tx_ancillary_session_update_redundant(s, pkt_r);
     } else {
       tx_ancillary_session_build_packet_chain(impl, s, pkt_r, pkt_rtp,
                                               MTL_SESSION_PORT_R);

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -164,6 +164,7 @@ static int tx_audio_session_init_hdr(struct mtl_main_impl* impl,
   ipv4->version_ihl = (4 << 4) | (sizeof(struct rte_ipv4_hdr) / 4);
   ipv4->time_to_live = 64;
   ipv4->type_of_service = 0;
+  ipv4->packet_id = 0;
   ipv4->fragment_offset = MT_IP_DONT_FRAGMENT_FLAG;
   ipv4->total_length = htons(s->pkt_len + ST_PKT_AUDIO_HDR_LEN);
   ipv4->next_proto_id = IPPROTO_UDP;
@@ -366,15 +367,12 @@ static int tx_audio_session_update_redundant(struct st_tx_audio_session_impl* s,
                                              struct rte_mbuf* pkt_r,
                                              const struct rte_mbuf* pkt_base) {
   struct mt_udp_hdr* hdr = rte_pktmbuf_mtod(pkt_r, struct mt_udp_hdr*);
-  struct mt_udp_hdr* hdr_base = rte_pktmbuf_mtod(pkt_base, struct mt_udp_hdr*);
   struct rte_ipv4_hdr* ipv4 = &hdr->ipv4;
-  struct rte_ipv4_hdr* ipv4_base = &hdr_base->ipv4;
   struct rte_udp_hdr* udp = &hdr->udp;
 
   /* update the hdr: eth, ip, udp */
   rte_memcpy(hdr, &s->hdr[MTL_SESSION_PORT_R], sizeof(*hdr));
 
-  ipv4->packet_id = ipv4_base->packet_id;
   ipv4->total_length = htons(pkt_r->pkt_len - pkt_r->l2_len);
 
   udp->dgram_len = htons(pkt_r->pkt_len - pkt_r->l2_len - pkt_r->l3_len);
@@ -402,10 +400,6 @@ static int tx_audio_session_build_packet(struct st_tx_audio_session_impl* s,
   rte_memcpy(&hdr->eth, &s->hdr[MTL_SESSION_PORT_P].eth, sizeof(hdr->eth));
   rte_memcpy(ipv4, &s->hdr[MTL_SESSION_PORT_P].ipv4, sizeof(hdr->ipv4));
   rte_memcpy(udp, &s->hdr[MTL_SESSION_PORT_P].udp, sizeof(hdr->udp));
-
-  /* update ipv4 hdr */
-  ipv4->packet_id = htons(s->st30_ipv4_packet_id);
-  s->st30_ipv4_packet_id++;
 
   /* update mbuf */
   mt_mbuf_init_ipv4(pkt);
@@ -487,10 +481,6 @@ static int tx_audio_session_rtp_update_packet(struct st_tx_audio_session_impl* s
   rte_memcpy(ipv4, &s->hdr[MTL_SESSION_PORT_P].ipv4, sizeof(hdr->ipv4));
   rte_memcpy(udp, &s->hdr[MTL_SESSION_PORT_P].udp, sizeof(hdr->udp));
 
-  /* update ipv4 hdr */
-  ipv4->packet_id = htons(s->st30_ipv4_packet_id);
-  s->st30_ipv4_packet_id++;
-
   if (rtp->tmstamp != s->st30_rtp_time_app) {
     /* start of a new epoch */
     s->st30_rtp_time_app = rtp->tmstamp;
@@ -536,10 +526,8 @@ static int tx_audio_session_build_packet_chain(struct st_tx_audio_session_impl* 
   rte_memcpy(udp, &s->hdr[s_port].udp, sizeof(hdr->udp));
 
   /* update ipv4 hdr */
-  ipv4->packet_id = htons(s->st30_ipv4_packet_id);
   /* update only for primary */
   if (s_port == MTL_SESSION_PORT_P) {
-    s->st30_ipv4_packet_id++;
     /* update rtp time for rtp path */
     if (ops->type == ST30_TYPE_RTP_LEVEL) {
       struct st_rfc3550_rtp_hdr* rtp =
@@ -1438,7 +1426,6 @@ static int tx_audio_session_attach(struct mtl_main_impl* impl,
   s->tx_mono_pool = mt_has_tx_mono_pool(impl);
   /* manually disable chain or any port can't support chain */
   s->tx_no_chain = mt_has_tx_no_chain(impl) || !tx_audio_session_has_chain_buf(s);
-  s->st30_ipv4_packet_id = 0;
 
   s->st30_frames_cnt = ops->framebuff_cnt;
 

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -364,8 +364,7 @@ static int tx_audio_sessions_tasklet_start(void* priv) {
 }
 
 static int tx_audio_session_update_redundant(struct st_tx_audio_session_impl* s,
-                                             struct rte_mbuf* pkt_r,
-                                             const struct rte_mbuf* pkt_base) {
+                                             struct rte_mbuf* pkt_r) {
   struct mt_udp_hdr* hdr = rte_pktmbuf_mtod(pkt_r, struct mt_udp_hdr*);
   struct rte_ipv4_hdr* ipv4 = &hdr->ipv4;
   struct rte_udp_hdr* udp = &hdr->udp;
@@ -738,7 +737,7 @@ static int tx_audio_session_tasklet_frame(struct mtl_main_impl* impl,
         s->stat_build_ret_code = -STI_FRAME_PKT_ALLOC_FAIL;
         return MT_TASKLET_ALL_DONE;
       }
-      tx_audio_session_update_redundant(s, pkt_r, pkt);
+      tx_audio_session_update_redundant(s, pkt_r);
     }
   }
 
@@ -909,7 +908,7 @@ static int tx_audio_session_tasklet_rtp(struct mtl_main_impl* impl,
         s->stat_build_ret_code = -STI_RTP_PKT_ALLOC_FAIL;
         return MT_TASKLET_ALL_DONE;
       }
-      tx_audio_session_update_redundant(s, pkt_r, pkt);
+      tx_audio_session_update_redundant(s, pkt_r);
     } else {
       tx_audio_session_build_packet_chain(s, pkt_r, pkt_rtp, MTL_SESSION_PORT_R);
     }

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -174,8 +174,6 @@ static int udp_build_tx_pkt(struct mtl_main_impl* impl, struct mudp_impl* s,
   }
 
   /* ip */
-  ipv4->packet_id = htons(s->ipv4_packet_id);
-  s->ipv4_packet_id++;
   mtl_memcpy(&ipv4->dst_addr, dip, MTL_IP_ADDR_LEN);
 
   /* udp */
@@ -276,8 +274,6 @@ static int udp_build_tx_msg_pkt(struct mtl_main_impl* impl, struct mudp_impl* s,
     /* update dst mac */
     rte_memcpy(mt_eth_d_addr(eth), &d_addr, sizeof(d_addr));
     /* ip */
-    ipv4->packet_id = htons(s->ipv4_packet_id);
-    s->ipv4_packet_id++;
     mtl_memcpy(&ipv4->dst_addr, dip, MTL_IP_ADDR_LEN);
     /* udp */
     udp->dst_port = addr_in->sin_port;

--- a/lib/src/udp/udp_main.h
+++ b/lib/src/udp/udp_main.h
@@ -48,7 +48,6 @@ struct mudp_impl {
 
   enum mtl_port port;
   struct mt_udp_hdr hdr;
-  uint16_t ipv4_packet_id;
   uint16_t bind_port;
 
   int fallback_fd; /* for MTL_PMD_KERNEL_SOCKET */


### PR DESCRIPTION
The packet id is set to 0 when IP_DF flag set,
which is identical to the kernel behavior.