### PR TITLE
rss: support xdp

### DIFF
--- a/lib/src/datapath/mt_queue.c
+++ b/lib/src/datapath/mt_queue.c
@@ -324,9 +324,11 @@ int mt_dp_queue_uinit(struct mtl_main_impl* impl) {
     }
   }
 
+  /*  uinit srss before tsq as srss has sch dependency */
+  mt_srss_uinit(impl);
+
   mt_rsq_uinit(impl);
   mt_tsq_uinit(impl);
-  mt_srss_uinit(impl);
 
   for (int i = 0; i < num_ports; i++) {
     struct mt_dp_impl* dp = impl->dp[i];

--- a/lib/src/datapath/mt_shared_queue.c
+++ b/lib/src/datapath/mt_shared_queue.c
@@ -179,7 +179,7 @@ struct mt_rsq_entry* mt_rsq_get(struct mtl_main_impl* impl, enum mtl_port port,
   entry->parent = rsqm;
   rte_memcpy(&entry->flow, flow, sizeof(entry->flow));
 
-  if (rsqm->queue_mode == MT_SQ_MODE_XDP) {
+  if (rsqm->queue_mode == MT_QUEUE_MODE_XDP) {
     rsq_lock(rsq_queue);
     if (!rsq_queue->xdp) {
       /* get a 1:1 mapped queue */
@@ -357,7 +357,7 @@ int mt_rsq_init(struct mtl_main_impl* impl) {
     impl->rsq[i]->port = i;
     impl->rsq[i]->nb_rsq_queues = mt_if(impl, i)->nb_rx_q;
     impl->rsq[i]->queue_mode =
-        mt_pmd_is_native_af_xdp(impl, i) ? MT_SQ_MODE_XDP : MT_SQ_MODE_DPDK;
+        mt_pmd_is_native_af_xdp(impl, i) ? MT_QUEUE_MODE_XDP : MT_QUEUE_MODE_DPDK;
     ret = rsq_init(impl, impl->rsq[i]);
     if (ret < 0) {
       err("%s(%d), rsq init fail\n", __func__, i);
@@ -562,7 +562,7 @@ struct mt_tsq_entry* mt_tsq_get(struct mtl_main_impl* impl, enum mtl_port port,
     }
     tsq_queue->tx_pool = pool;
   }
-  if (tsqm->queue_mode == MT_SQ_MODE_XDP) {
+  if (tsqm->queue_mode == MT_QUEUE_MODE_XDP) {
     if (!tsq_queue->xdp) {
       /* get a 1:1 mapped queue */
       struct mt_tx_xdp_get_args args;
@@ -701,7 +701,7 @@ int mt_tsq_init(struct mtl_main_impl* impl) {
     impl->tsq[i]->port = i;
     impl->tsq[i]->nb_tsq_queues = mt_if(impl, i)->nb_tx_q;
     impl->tsq[i]->queue_mode =
-        mt_pmd_is_native_af_xdp(impl, i) ? MT_SQ_MODE_XDP : MT_SQ_MODE_DPDK;
+        mt_pmd_is_native_af_xdp(impl, i) ? MT_QUEUE_MODE_XDP : MT_QUEUE_MODE_DPDK;
     ret = tsq_init(impl, impl->tsq[i]);
     if (ret < 0) {
       err("%s(%d), tsq init fail\n", __func__, i);

--- a/lib/src/dev/mt_af_xdp.h
+++ b/lib/src/dev/mt_af_xdp.h
@@ -21,6 +21,8 @@ struct mt_rx_xdp_get_args {
 
 #ifdef MTL_HAS_XDP_BACKEND
 
+int mt_dev_xdp_get_combined(struct mt_interface* inf, uint16_t* combined);
+
 int mt_dev_xdp_init(struct mt_interface* inf);
 int mt_dev_xdp_uinit(struct mt_interface* inf);
 
@@ -40,6 +42,12 @@ uint16_t mt_rx_xdp_burst(struct mt_rx_xdp_entry* entry, struct rte_mbuf** rx_pkt
 #else
 
 #include "../mt_log.h"
+
+int mt_dev_xdp_get_combined(struct mt_interface* inf, uint16_t* combined) {
+  err("%s(%d), no xdp support for this build\n", __func__, inf->port);
+  *combined = 0;
+  return -ENOTSUP;
+}
 
 static inline int mt_dev_xdp_init(struct mt_interface* inf) {
   err("%s(%d), no xdp support for this build\n", __func__, inf->port);

--- a/lib/src/dev/mt_af_xdp.h
+++ b/lib/src/dev/mt_af_xdp.h
@@ -43,7 +43,7 @@ uint16_t mt_rx_xdp_burst(struct mt_rx_xdp_entry* entry, struct rte_mbuf** rx_pkt
 
 #include "../mt_log.h"
 
-int mt_dev_xdp_get_combined(struct mt_interface* inf, uint16_t* combined) {
+static inline int mt_dev_xdp_get_combined(struct mt_interface* inf, uint16_t* combined) {
   err("%s(%d), no xdp support for this build\n", __func__, inf->port);
   *combined = 0;
   return -ENOTSUP;

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -2101,8 +2101,14 @@ int mt_dev_if_init(struct mtl_main_impl* impl) {
       inf->nb_rx_q = queue_pair_cnt;
       inf->system_rx_queues_end = 0;
     } else if (mt_pmd_is_native_af_xdp(impl, i)) {
-      /* one more for the sys tx queue */
-      queue_pair_cnt = RTE_MAX(p->tx_queues_cnt[i] + 1, p->rx_queues_cnt[i]);
+      if (mt_has_srss(impl, i)) {
+        uint16_t combined = 1;
+        mt_dev_xdp_get_combined(inf, &combined);
+        queue_pair_cnt = combined; /* rss loop all queues */
+      } else {
+        /* one more for the sys tx queue */
+        queue_pair_cnt = RTE_MAX(p->tx_queues_cnt[i] + 1, p->rx_queues_cnt[i]);
+      }
       inf->nb_tx_q = queue_pair_cnt;
       inf->nb_rx_q = queue_pair_cnt;
       inf->system_rx_queues_end = 0;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -827,10 +827,10 @@ struct mt_stat_mgr {
   rte_atomic32_t stat_stop;
 };
 
-enum mt_sq_mode {
-  MT_SQ_MODE_DPDK = 0,
-  MT_SQ_MODE_XDP,
-  MT_SQ_MODE_MAX,
+enum mt_queue_mode {
+  MT_QUEUE_MODE_DPDK = 0,
+  MT_QUEUE_MODE_XDP,
+  MT_QUEUE_MODE_MAX,
 };
 
 struct mt_rsq_impl; /* forward delcare */
@@ -872,7 +872,7 @@ struct mt_rsq_impl {
   /* sq rx queue resources */
   uint16_t nb_rsq_queues;
   struct mt_rsq_queue* rsq_queues;
-  enum mt_sq_mode queue_mode;
+  enum mt_queue_mode queue_mode;
 };
 
 /* used for sys queue */
@@ -930,7 +930,7 @@ struct mt_tsq_impl {
   /* sq tx queue resources */
   uint16_t nb_tsq_queues;
   struct mt_tsq_queue* tsq_queues;
-  enum mt_sq_mode queue_mode;
+  enum mt_queue_mode queue_mode;
 };
 
 struct mt_srss_entry {
@@ -950,6 +950,8 @@ struct mt_srss_impl {
   struct mtl_main_impl* parent;
   rte_spinlock_t mutex; /* protect struct mt_srss_entrys_list head */
   enum mtl_port port;
+  enum mt_queue_mode queue_mode;
+
   struct mt_srss_entrys_list head;
   pthread_t tid;
   rte_atomic32_t stop_thread;
@@ -957,6 +959,9 @@ struct mt_srss_impl {
   struct mt_sch_impl* sch;
   struct mt_srss_entry* cni_entry;
   int entry_idx;
+
+  /* for native xdp based srss */
+  struct mt_rx_xdp_entry** xdps;
 };
 
 #define MT_DP_SOCKET_THREADS_MAX (4)

--- a/tests/script/native_af_xdp_json/rss.json
+++ b/tests/script/native_af_xdp_json/rss.json
@@ -1,0 +1,102 @@
+{
+    "shared_tx_queues": "1",
+    "rss_mode": "l3_l4",
+    "interfaces": [
+        {
+            "name": "native_af_xdp:enp0s3np0",
+        },
+        {
+            "name": "native_af_xdp:enp0s4np0",
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "local:1"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "video_url": "./test.yuv"
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "start_port": 40000,
+                    "payload_type": 113,
+                    "type": "frame",
+                    "ancillary_format": "closed_caption",
+                    "ancillary_url": "./test.txt",
+                    "ancillary_fps": "p59"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "local:0",
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_10bit",
+                    "display": false
+                }
+            ],
+            "audio": [
+                {
+                    "replicas": 2,
+                    "type": "frame",
+                    "start_port": 30000,
+                    "payload_type": 111,
+                    "audio_format": "PCM16",
+                    "audio_channel": ["ST"],
+                    "audio_sampling": "48kHz",
+                    "audio_ptime": "1",
+                    "audio_url": "./test.wav"
+                }
+            ],
+            "ancillary": [
+                {
+                    "replicas": 2,
+                    "payload_type": 113,
+                    "start_port": 40000
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
To use rss on XDP, please make sure the combined queue count is less than the CPU cores.

test with:
sudo ethtool -L enp0s3np0 combined 8
sudo ethtool -L enp0s4np0 combined 8
./build/app/RxTxApp --config_file tests/script/native_af_xdp_json/rss.json