### PR TITLE
tools/ebpf: add support for loading custom AF_XDP prog

### DIFF
--- a/tools/ebpf/README.md
+++ b/tools/ebpf/README.md
@@ -23,3 +23,9 @@ xdp: a privileged program to load afxdp bpf program and send the xsk_map_fd to o
 ```bash
 sudo ./et --prog xdp --ifname ens785f0
 ```
+
+load a custom program for xdp:
+
+```bash
+sudo ./et --prog xdp --ifname ens785f0 --xdp_path /path/to/xdp.o
+```

--- a/tools/ebpf/et.h
+++ b/tools/ebpf/et.h
@@ -21,6 +21,7 @@ enum et_args_cmd {
   ET_ARG_PRINT_LIBBPF = 0x100, /* start from end of ascii */
   ET_ARG_PROG,
   ET_ARG_IFNAME,
+  ET_ARG_XDP_PATH,
   ET_ARG_HELP,
 };
 
@@ -43,6 +44,7 @@ struct et_ctx {
   enum et_prog_type prog_type;
   int xdp_ifindex[8];
   int xdp_if_cnt;
+  char* xdp_path;
 };
 
 #endif /* __ET_H */


### PR DESCRIPTION
This commit introduces the capability to load custom eBPF programs for
AF_XDP sockets within the tool. This enhancement allows users to specify
their own XDP programs, further extending the flexibility and usability
of the eBPF tools provided.

Usage: sudo ./et --prog xdp --ifname eth0,eth1 --xdp_path /path/to/xdp.o