### PR TITLE
lcore: add LcoreMgr tool to manage the legacy lcore manager status

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -111,6 +111,14 @@ executable('ConvApp', conv_sources,
   dependencies: [asan_dep, mtl]
 )
 
+# Legacy lcore manager
+executable('LcoreMgr', lcore_mgr_sources,
+  c_args : app_c_args,
+  link_args: app_ld_args,
+  # asan should be always the first dep
+  dependencies: [asan_dep, mtl]
+)
+
 # Performance benchmarks for color convert
 executable('PerfRfc4175422be10ToP10Le', perf_rfc4175_422be10_to_p10le_sources,
   c_args : app_c_args,

--- a/app/tools/lcore_shmem_mgr.c
+++ b/app/tools/lcore_shmem_mgr.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+#include <mtl/mtl_lcore_shm_api.h>
+
+#include "log.h"
+
+int main(int argc, char** argv) {
+  MTL_MAY_UNUSED(argc);
+  MTL_MAY_UNUSED(argv);
+
+  mtl_lcore_shm_print();
+  return 0;
+}

--- a/app/tools/lcore_shmem_mgr.c
+++ b/app/tools/lcore_shmem_mgr.c
@@ -2,14 +2,94 @@
  * Copyright(c) 2023 Intel Corporation
  */
 
+#include <errno.h>
+#include <getopt.h>
 #include <mtl/mtl_lcore_shm_api.h>
+#include <stdlib.h>
 
 #include "log.h"
 
-int main(int argc, char** argv) {
-  MTL_MAY_UNUSED(argc);
-  MTL_MAY_UNUSED(argv);
+enum lsm_args_cmd {
+  LSM_ARG_UNKNOWN = 0,
+  LSM_ARG_HELP = 0x100, /* start from end of ascii */
+  LSM_ARG_INFO,
+  LSM_ARG_CLEAN_PID_AUTO_CHECK,
+  LSM_ARG_CLEAN_LCORE,
+  LSM_ARG_MAX,
+};
 
-  mtl_lcore_shm_print();
+/*
+struct option {
+   const char *name;
+   int has_arg;
+   int *flag;
+   int val;
+};
+*/
+static struct option lsm_args_options[] = {
+    {"help", no_argument, 0, LSM_ARG_HELP},
+    {"info", no_argument, 0, LSM_ARG_INFO},
+    {"clean_pid_auto_check", no_argument, 0, LSM_ARG_CLEAN_PID_AUTO_CHECK},
+    {"clean_lcore", required_argument, 0, LSM_ARG_CLEAN_LCORE},
+    {0, 0, 0, 0},
+};
+
+static void lsm_print_help() {
+  printf("\n");
+  printf("##### Usage: #####\n\n");
+
+  printf("Params:\n");
+  printf(" --help: Print the help information\n");
+  printf(" --info: Print lcore shared manager detail info\n");
+  printf(" --info: Print lcore shared manager detail info\n");
+  printf(" --clean_pid_auto_check: Clean the dead entries if PID is not active\n");
+  printf(" --clean_lcore <lcore id>: Clean the entry by lcore ID\n");
+
+  printf("\n");
+}
+
+int main(int argc, char** argv) {
+  int cmd = -1, opt_idx = 0;
+  int ret;
+
+  while (1) {
+    cmd = getopt_long_only(argc, argv, "hv", lsm_args_options, &opt_idx);
+    if (cmd == -1) break;
+
+    switch (cmd) {
+      case LSM_ARG_INFO:
+        mtl_lcore_shm_print();
+        break;
+      case LSM_ARG_CLEAN_PID_AUTO_CHECK:
+        ret = mtl_lcore_shm_clean(MTL_LCORE_CLEAN_PID_AUTO_CHECK, NULL, 0);
+        if (ret > 0)
+          info("Total %d dead lcores detected and deleted\n", ret);
+        else if (ret == 0)
+          info("No dead lcores detected\n");
+        else
+          err("Fail %d to clean shm by auto PID check\n", ret);
+        break;
+      case LSM_ARG_CLEAN_LCORE:
+        int lcore = atoi(optarg);
+        if (lcore < 0) {
+          err("lcore %d is not valid\n", lcore);
+          return -EIO;
+        }
+        struct mtl_lcore_clean_pid_info pid;
+        pid.lcore = lcore;
+        ret = mtl_lcore_shm_clean(MTL_LCORE_CLEAN_LCORE, &pid, sizeof(pid));
+        if (ret >= 0)
+          info("Succ to delete lcore %d\n", lcore);
+        else
+          err("Fail %d to delete lcore %d\n", ret, lcore);
+        break;
+        break;
+      case LSM_ARG_HELP:
+      default:
+        lsm_print_help();
+        return -1;
+    }
+  }
+
   return 0;
 }

--- a/app/tools/lcore_shmem_mgr.c
+++ b/app/tools/lcore_shmem_mgr.c
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
         else
           err("Fail %d to clean shm by auto PID check\n", ret);
         break;
-      case LSM_ARG_CLEAN_LCORE:
+      case LSM_ARG_CLEAN_LCORE: {
         int lcore = atoi(optarg);
         if (lcore < 0) {
           err("lcore %d is not valid\n", lcore);
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
         else
           err("Fail %d to delete lcore %d\n", ret, lcore);
         break;
-        break;
+      }
       case LSM_ARG_HELP:
       default:
         lsm_print_help();

--- a/app/tools/lcore_shmem_mgr.c
+++ b/app/tools/lcore_shmem_mgr.c
@@ -41,7 +41,6 @@ static void lsm_print_help() {
   printf("Params:\n");
   printf(" --help: Print the help information\n");
   printf(" --info: Print lcore shared manager detail info\n");
-  printf(" --info: Print lcore shared manager detail info\n");
   printf(" --clean_pid_auto_check: Clean the dead entries if PID is not active\n");
   printf(" --clean_lcore <lcore id>: Clean the entry by lcore ID\n");
 

--- a/app/tools/meson.build
+++ b/app/tools/meson.build
@@ -2,3 +2,5 @@
 # Copyright 2022 Intel Corporation
 
 conv_sources = files('convert_app.c', 'convert_app_args.c')
+
+lcore_mgr_sources = files('lcore_shmem_mgr.c')

--- a/doc/lcore.md
+++ b/doc/lcore.md
@@ -8,7 +8,8 @@ It minimizes the impact of OS scheduler decisions, reduces cache-related issues,
 
 ## 2. Lcore manager for multi process
 
-IMTL supports multi-process deployment based on SR-IOV VF isolation. To manage the dispatching of lcores among multiple processes, it introduces shared memory mapping to maintain the status of lcore usage. Each process searches the mapping and allocates a new lcore slot from it, freeing the slot when it is no longer in use. The last user attached to the shared memory will reset the mapping to an initial status during the `shmdt` operation as part of the release routine.
+IMTL supports multi-process deployment based on SR-IOV VF isolation. To manage the dispatching of lcores among multiple processes, it introduces shared memory mapping to maintain the status of lcore usage. Each process searches the mapping and allocates a new lcore slot from it, freeing the slot when it is no longer in use.
+The last user attached to the shared memory will reset the mapping to an initial status during the `shmdt` operation as part of the release routine.
 
 IMTL also provides a tool which can be find from `./build/app/LcoreMgr` for manually cleaning up lcore entries. This tool is typically used when a process fails to release lcores due to panic issues or other failures that prevent the regular free routine from running. Below is the usage information:
 

--- a/doc/lcore.md
+++ b/doc/lcore.md
@@ -1,0 +1,23 @@
+# Lcore Guide
+
+## 1. Introduction
+
+In DPDK (Data Plane Development Kit), an "lcore" stands for "logical core," and it represents a logical CPU core on a multi-core processor. Binding a thread to a specific logical core (lcore) is a technique used to achieve better control over the execution of packet processing tasks and to optimize the performance of networking applications.
+
+It minimizes the impact of OS scheduler decisions, reduces cache-related issues, and allows for fine-grained control over CPU resources, all of which are critical for meeting the stringent performance requirements of networking workloads. Intel® Media Transport Library scheduler used pinned lcore also as performance consideration.
+
+## 2. Lcore manager for multi process
+
+IMTL supports multi-process deployment based on SR-IOV VF isolation. To manage the dispatching of lcores among multiple processes, it introduces shared memory mapping to maintain the status of lcore usage. Each process searches the mapping and allocates a new lcore slot from it, freeing the slot when it is no longer in use. The last user attached to the shared memory will reset the mapping to an initial status during the `shmdt` operation as part of the release routine.
+
+IMTL also provides a tool which can be find from `./build/app/LcoreMgr` for manually cleaning up lcore entries. This tool is typically used when a process fails to release lcores due to panic issues or other failures that prevent the regular free routine from running. Below is the usage information:
+
+```bash
+  --info: Print lcore shared manager detail info
+  --clean_pid_auto_check: Clean the dead entries if PID is not active
+  --clean_lcore <lcore id>: Clean the entry by lcore ID
+```
+
+When you use the `--clean_pid_auto_check` option, the tool will perform a loop check for all the active entries in the map. It checks whether the hostname and user match the current login environment and then verifies if the PID is still running. If the tool detects that the PID is no longer active, it will proceed to remove the lcore from the mapping.
+
+If you are deploying in a multi-container environment, the PID check becomes less useful as each container has its own process namespace. In such cases, you can use the --clean_lcore option to remove an entry based on the lcore ID. However, it's important to confirm that the lcore is not active before using this option.

--- a/doc/run.md
+++ b/doc/run.md
@@ -557,7 +557,7 @@ The VFIO driver can run without the IOMMU feature, enable it with below command 
 sudo bash -c 'echo 1 > /sys/module/vfio/parameters/enable_unsafe_noiommu_mode'
 ```
 
-### 8.13 Fail to loading shared libraries
+### 8.14 Fail to loading shared libraries
 
 If you get below similar message when runing the RxTxApp, it's likely a ld library path problem.
 

--- a/include/meson.build
+++ b/include/meson.build
@@ -2,7 +2,7 @@
 # Copyright 2022 Intel Corporation
 
 mtl_header_files = files('mtl_api.h', 'st_api.h', 'st_convert_api.h', 'st_convert_internal.h', 'st_pipeline_api.h', 'st20_api.h', 'st30_api.h', 'st40_api.h',
-  'st20_redundant_api.h', 'mudp_api.h', 'mudp_sockfd_api.h', 'mudp_sockfd_internal.h')
+  'st20_redundant_api.h', 'mudp_api.h', 'mudp_sockfd_api.h', 'mudp_sockfd_internal.h', 'mtl_lcore_shm_api.h')
 
 if is_windows
   mtl_header_files += files('mudp_win.h')

--- a/include/mtl_lcore_shm_api.h
+++ b/include/mtl_lcore_shm_api.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+/**
+ * @file mtl_lcore_shm_api.h
+ *
+ * Interfaces to the legacy lcore shared memory manager.
+ *
+ */
+
+#include "mtl_api.h"
+
+#ifndef _MTL_LCORE_SHM_API_HEAD_H_
+#define _MTL_LCORE_SHM_API_HEAD_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Print out the legacy lcore manager(shared memory) status.
+ *
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if fail.
+ */
+int mtl_lcore_shm_print(void);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/mtl_lcore_shm_api.h
+++ b/include/mtl_lcore_shm_api.h
@@ -18,6 +18,22 @@
 extern "C" {
 #endif
 
+struct mtl_lcore_clean_pid_info {
+  uint32_t lcore;
+};
+
+/** lcore clean action */
+enum mtl_lcore_clean_action {
+  /** auto, no args.
+   * Remove lcore usage if the PID is inactive under the same hostname and user.
+   */
+  MTL_LCORE_CLEAN_PID_AUTO_CHECK = 0,
+  /** clean as PID info, args to struct mtl_lcore_clean_pid_info */
+  MTL_LCORE_CLEAN_LCORE,
+  /** max value of this enum */
+  MTL_LCORE_CLEAN_MAX,
+};
+
 /**
  * Print out the legacy lcore manager(shared memory) status.
  *
@@ -26,6 +42,21 @@ extern "C" {
  *   - <0: Error code if fail.
  */
 int mtl_lcore_shm_print(void);
+
+/**
+ * Clean the unused lcore from the legacy lcore manager(shared memory).
+ * @param action
+ *   The action type.
+ * @param args
+ *   The args to the action type.
+ * @param args_sz
+ *   The size of the args.
+ *
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if fail.
+ */
+int mtl_lcore_shm_clean(enum mtl_lcore_clean_action action, void* args, size_t args_sz);
 
 #if defined(__cplusplus)
 }

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -4,7 +4,9 @@
 
 #include "mt_main.h"
 
+#ifndef WINDOWSENV
 #include <pwd.h>
+#endif
 
 #include "datapath/mt_queue.h"
 #include "dev/mt_dev.h"
@@ -401,9 +403,14 @@ static int _mt_stop(struct mtl_main_impl* impl) {
 }
 
 static int mt_user_info_init(struct mtl_main_impl* impl) {
-  int ret;
+  int ret = -EIO;
   struct mt_user_info* info = &impl->u_info;
 
+#ifdef WINDOWSENV /* todo */
+  MTL_MAY_UNUSED(ret);
+  snprintf(info->hostname, sizeof(info->hostname), "%s", "unknow");
+  snprintf(info->user, sizeof(info->user), "%s", "unknow");
+#else
   ret = gethostname(info->hostname, sizeof(info->hostname));
   if (ret < 0) {
     warn("%s, gethostname fail %d\n", __func__, ret);
@@ -413,6 +420,7 @@ static int mt_user_info_init(struct mtl_main_impl* impl) {
   struct passwd* user_info = getpwuid(uid);
   snprintf(info->user, sizeof(info->user), "%s",
            user_info ? user_info->pw_name : "unknow");
+#endif
 
   info->pid = getpid();
 

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -4,6 +4,8 @@
 
 #include "mt_main.h"
 
+#include <pwd.h>
+
 #include "datapath/mt_queue.h"
 #include "dev/mt_dev.h"
 #include "mt_admin.h"
@@ -398,6 +400,25 @@ static int _mt_stop(struct mtl_main_impl* impl) {
   return 0;
 }
 
+static int mt_user_info_init(struct mtl_main_impl* impl) {
+  int ret;
+  struct mt_user_info* info = &impl->u_info;
+
+  ret = gethostname(info->hostname, sizeof(info->hostname));
+  if (ret < 0) {
+    warn("%s, gethostname fail %d\n", __func__, ret);
+    snprintf(info->hostname, sizeof(info->hostname), "%s", "unknow");
+  }
+  uid_t uid = getuid();
+  struct passwd* user_info = getpwuid(uid);
+  snprintf(info->user, sizeof(info->user), "%s",
+           user_info ? user_info->pw_name : "unknow");
+
+  info->pid = getpid();
+
+  return 0;
+}
+
 mtl_handle mtl_init(struct mtl_init_params* p) {
   struct mtl_main_impl* impl = NULL;
   int socket[MTL_PORT_MAX], ret;
@@ -463,6 +484,8 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
 
   impl = mt_rte_zmalloc_socket(sizeof(*impl), socket[MTL_PORT_P]);
   if (!impl) goto err_exit;
+
+  mt_user_info_init(impl);
 
 #ifndef WINDOWSENV
   if (geteuid() == 0)

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -545,14 +545,18 @@ struct mt_sch_impl {
   uint64_t stat_sleep_ns_max;
 };
 
+struct mt_lcore_mgr {
+  struct mt_lcore_shm* lcore_shm;
+  int lcore_shm_id;
+};
+
 struct mt_sch_mgr {
   struct mt_sch_impl sch[MT_MAX_SCH_NUM];
   /* active sch cnt */
   rte_atomic32_t sch_cnt;
   pthread_mutex_t mgr_mutex; /* protect sch mgr */
 
-  struct mt_lcore_shm* lcore_shm;
-  int lcore_shm_id;
+  struct mt_lcore_mgr lcore_mgr;
   int lcore_lock_fd;
   bool local_lcores_active[RTE_MAX_LCORE]; /* local lcores active map */
 };
@@ -707,9 +711,18 @@ struct mt_interface {
   void* xdp;
 };
 
+struct mt_lcore_shm_entry {
+  char hostname[64];
+  char user[32];
+  pid_t pid;
+  bool active;
+};
+
 struct mt_lcore_shm {
-  int used;                          /* number of used lcores */
-  bool lcores_active[RTE_MAX_LCORE]; /* lcores active map */
+  /* number of used lcores */
+  int used;
+  /* lcores map info */
+  struct mt_lcore_shm_entry lcores_info[RTE_MAX_LCORE];
 };
 
 typedef int (*mt_dma_drop_mbuf_cb)(void* priv, struct rte_mbuf* mbuf);
@@ -1078,6 +1091,12 @@ struct mt_dp_impl {
   rte_spinlock_t txq_sys_entry_lock; /* protect txq_sys_entry */
 };
 
+struct mt_user_info {
+  char hostname[64];
+  char user[32];
+  pid_t pid;
+};
+
 struct mtl_main_impl {
   struct mt_interface inf[MTL_PORT_MAX];
 
@@ -1138,6 +1157,8 @@ struct mtl_main_impl {
 
   /* st plugin dev mgr */
   struct st_plugin_mgr plugin_mgr;
+
+  struct mt_user_info u_info;
 
   void* mudp_rxq_mgr[MTL_PORT_MAX];
 

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -429,14 +429,79 @@ static int sch_filelock_unlock(struct mt_sch_mgr* mgr) {
   return 0;
 }
 
-static int sch_uinit_lcores(struct mtl_main_impl* impl, struct mt_sch_mgr* mgr) {
+static int sch_lcore_shm_init(struct mt_lcore_mgr* mgr, bool clear_on_first) {
+  struct mt_lcore_shm* lcore_shm = NULL;
   int ret;
-  int shm_id = mgr->lcore_shm_id;
-  struct mt_lcore_shm* lcore_shm = mgr->lcore_shm;
-  if (!lcore_shm || shm_id == -1) {
-    err("%s, no lcore shm attached\n", __func__);
+
+  mgr->lcore_shm_id = -1;
+
+  key_t key = ftok("/dev/null", 21);
+  if (key < 0) {
+    err("%s, ftok error: %s\n", __func__, strerror(errno));
     return -EIO;
   }
+  int shm_id = shmget(key, sizeof(*lcore_shm), 0666 | IPC_CREAT);
+  if (shm_id < 0) {
+    err("%s, can not get shared memory for lcore, %s\n", __func__, strerror(errno));
+    return -EIO;
+  }
+  mgr->lcore_shm_id = shm_id;
+
+  lcore_shm = shmat(shm_id, NULL, 0);
+  if (lcore_shm == (void*)-1) {
+    err("%s, can not attach shared memory for lcore, %s\n", __func__, strerror(errno));
+    return -EIO;
+  }
+
+  struct shmid_ds stat;
+  ret = shmctl(shm_id, IPC_STAT, &stat);
+  if (ret < 0) {
+    err("%s, shmctl fail\n", __func__);
+    shmdt(lcore_shm);
+    return ret;
+  }
+
+  if (clear_on_first && (stat.shm_nattch == 1)) {
+    info("%s, clear shm as we are the first user\n", __func__);
+    memset(lcore_shm, 0, sizeof(*lcore_shm));
+  }
+
+  mgr->lcore_shm = lcore_shm;
+  info("%s, shared memory attached at %p nattch %d shm_id %d key 0x%x\n", __func__,
+       mgr->lcore_shm, (int)stat.shm_nattch, shm_id, (int)key);
+  return 0;
+}
+
+static int sch_lcore_shm_uinit(struct mt_lcore_mgr* mgr) {
+  int ret;
+
+  if (mgr->lcore_shm) {
+    ret = shmdt(mgr->lcore_shm);
+    if (ret < 0) err("%s, shared memory detach failed, %s\n", __func__, strerror(errno));
+    mgr->lcore_shm = NULL;
+  }
+
+  if (mgr->lcore_shm_id >= 0) {
+    struct shmid_ds shmds;
+    ret = shmctl(mgr->lcore_shm_id, IPC_STAT, &shmds);
+    if (ret < 0) {
+      err("%s, can not stat shared memory, %s\n", __func__, strerror(errno));
+    } else {
+      if (shmds.shm_nattch == 0) { /* remove ipc if we are the last user */
+        ret = shmctl(mgr->lcore_shm_id, IPC_RMID, NULL);
+        if (ret < 0) {
+          warn("%s, can not remove shared memory, %s\n", __func__, strerror(errno));
+        }
+      }
+    }
+    mgr->lcore_shm_id = -1;
+  }
+
+  return 0;
+}
+
+static int sch_uinit_lcores(struct mtl_main_impl* impl, struct mt_sch_mgr* mgr) {
+  int ret;
 
   for (unsigned int lcore = 0; lcore < RTE_MAX_LCORE; lcore++) {
     if (mgr->local_lcores_active[lcore]) {
@@ -451,106 +516,56 @@ static int sch_uinit_lcores(struct mtl_main_impl* impl, struct mt_sch_mgr* mgr) 
     return ret;
   }
 
-  ret = shmdt(mgr->lcore_shm);
-  if (ret == -1) {
-    err("%s, shared memory detach failed, %s\n", __func__, strerror(errno));
-    goto err_unlock;
-  }
-
-  struct shmid_ds shmds;
-  ret = shmctl(shm_id, IPC_STAT, &shmds);
+  ret = sch_lcore_shm_uinit(&mgr->lcore_mgr);
   if (ret < 0) {
-    err("%s, can not stat shared memory, %s\n", __func__, strerror(errno));
-    goto err_unlock;
-  }
-  if (shmds.shm_nattch == 0) { /* remove ipc if we are the last user */
-    ret = shmctl(shm_id, IPC_RMID, NULL);
-    if (ret < 0) {
-      warn("%s, can not remove shared memory, %s\n", __func__, strerror(errno));
-      goto err_unlock;
-    }
+    err("%s, lcore shm uinit fail %d\n", __func__, ret);
   }
 
-  mgr->lcore_shm_id = -1;
-  mgr->lcore_shm = NULL;
   ret = sch_filelock_unlock(mgr);
   if (ret < 0) {
     err("%s, sch_filelock_unlock fail\n", __func__);
     return ret;
   }
-  return 0;
 
-err_unlock:
-  sch_filelock_unlock(mgr);
-  return ret;
+  return 0;
 }
 
 static int sch_init_lcores(struct mt_sch_mgr* mgr) {
   int ret;
-  struct mt_lcore_shm* lcore_shm;
 
-  if (mgr->lcore_shm) {
+  if (mgr->lcore_mgr.lcore_shm) {
     err("%s, lcore_shm attached\n", __func__);
     return -EIO;
   }
 
   ret = sch_filelock_lock(mgr);
   if (ret < 0) {
-    err("%s, sch_filelock_lock fail\n", __func__);
+    err("%s, sch_filelock_lock fail %d\n", __func__, ret);
     return ret;
   }
 
-  key_t key = ftok("/dev/null", 21);
-  if (key < 0) {
-    err("%s, ftok error: %s\n", __func__, strerror(errno));
-    ret = -EIO;
-    goto err_unlock;
-  }
-  int shm_id = shmget(key, sizeof(*lcore_shm), 0666 | IPC_CREAT);
-  if (shm_id < 0) {
-    err("%s, can not get shared memory for lcore, %s\n", __func__, strerror(errno));
-    ret = -EIO;
-    goto err_unlock;
-  }
-  mgr->lcore_shm_id = shm_id;
-
-  lcore_shm = shmat(shm_id, NULL, 0);
-  if (lcore_shm == (void*)-1) {
-    err("%s, can not attach shared memory for lcore, %s\n", __func__, strerror(errno));
-    ret = -EIO;
-    goto err_unlock;
-  }
-
-  struct shmid_ds stat;
-  ret = shmctl(shm_id, IPC_STAT, &stat);
+  ret = sch_lcore_shm_init(&mgr->lcore_mgr, true);
   if (ret < 0) {
-    err("%s, shmctl fail\n", __func__);
-    shmdt(lcore_shm);
-    goto err_unlock;
+    err("%s, lcore init fail %d\n", __func__, ret);
+    sch_filelock_unlock(mgr);
+    return ret;
   }
-  if (stat.shm_nattch == 1) /* clear shm as we are the first user */
-    memset(lcore_shm, 0, sizeof(*lcore_shm));
 
-  mgr->lcore_shm = lcore_shm;
-  info("%s, shared memory attached at %p nattch %d shm_id %d key 0x%x\n", __func__,
-       mgr->lcore_shm, (int)stat.shm_nattch, shm_id, (int)key);
   ret = sch_filelock_unlock(mgr);
   if (ret < 0) {
-    err("%s, sch_filelock_unlock fail\n", __func__);
+    err("%s, sch_filelock_unlock fail %d\n", __func__, ret);
     return ret;
   }
   return 0;
-
-err_unlock:
-  sch_filelock_unlock(mgr);
-  return ret;
 }
 
 int mt_sch_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore) {
   struct mt_sch_mgr* mgr = mt_sch_get_mgr(impl);
+  struct mt_user_info* info = &impl->u_info;
   unsigned int cur_lcore = 0;
   int ret;
-  struct mt_lcore_shm* lcore_shm = mgr->lcore_shm;
+  struct mt_lcore_shm* lcore_shm = mgr->lcore_mgr.lcore_shm;
+  struct mt_lcore_shm_entry* shm_entry;
 
   ret = sch_filelock_lock(mgr);
   if (ret < 0) {
@@ -560,12 +575,16 @@ int mt_sch_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore) {
 
   do {
     cur_lcore = rte_get_next_lcore(cur_lcore, 1, 0);
+    shm_entry = &lcore_shm->lcores_info[cur_lcore];
 
     if ((cur_lcore < RTE_MAX_LCORE) && mt_socket_match(rte_lcore_to_socket_id(cur_lcore),
                                                        mt_socket_id(impl, MTL_PORT_P))) {
-      if (!lcore_shm->lcores_active[cur_lcore]) {
+      if (!shm_entry->active) {
         *lcore = cur_lcore;
-        lcore_shm->lcores_active[cur_lcore] = true;
+        shm_entry->active = true;
+        strncpy(shm_entry->hostname, info->hostname, sizeof(shm_entry->hostname));
+        strncpy(shm_entry->user, info->user, sizeof(shm_entry->user));
+        shm_entry->pid = info->pid;
         lcore_shm->used++;
         rte_atomic32_inc(&impl->lcore_cnt);
         mgr->local_lcores_active[cur_lcore] = true;
@@ -588,7 +607,7 @@ int mt_sch_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore) {
 int mt_sch_put_lcore(struct mtl_main_impl* impl, unsigned int lcore) {
   int ret;
   struct mt_sch_mgr* mgr = mt_sch_get_mgr(impl);
-  struct mt_lcore_shm* lcore_shm = mgr->lcore_shm;
+  struct mt_lcore_shm* lcore_shm = mgr->lcore_mgr.lcore_shm;
 
   if (lcore >= RTE_MAX_LCORE) {
     err("%s, invalid lcore %d\n", __func__, lcore);
@@ -603,13 +622,13 @@ int mt_sch_put_lcore(struct mtl_main_impl* impl, unsigned int lcore) {
     err("%s, sch_filelock_lock fail\n", __func__);
     return ret;
   }
-  if (!lcore_shm->lcores_active[lcore]) {
+  if (!lcore_shm->lcores_info[lcore].active) {
     err("%s, lcore %d not active\n", __func__, lcore);
     ret = -EIO;
     goto err_unlock;
   }
 
-  lcore_shm->lcores_active[lcore] = false;
+  lcore_shm->lcores_info[lcore].active = false;
   lcore_shm->used--;
   rte_atomic32_dec(&impl->lcore_cnt);
   mgr->local_lcores_active[lcore] = false;
@@ -628,7 +647,7 @@ err_unlock:
 
 bool mt_sch_lcore_valid(struct mtl_main_impl* impl, unsigned int lcore) {
   struct mt_sch_mgr* mgr = mt_sch_get_mgr(impl);
-  struct mt_lcore_shm* lcore_shm = mgr->lcore_shm;
+  struct mt_lcore_shm* lcore_shm = mgr->lcore_mgr.lcore_shm;
 
   if (lcore >= RTE_MAX_LCORE) {
     err("%s, invalid lcore %d\n", __func__, lcore);
@@ -639,7 +658,7 @@ bool mt_sch_lcore_valid(struct mtl_main_impl* impl, unsigned int lcore) {
     return -EIO;
   }
 
-  return lcore_shm->lcores_active[lcore];
+  return lcore_shm->lcores_info[lcore].active;
 }
 
 int mt_sch_unregister_tasklet(struct mt_sch_tasklet_impl* tasklet) {
@@ -1003,5 +1022,27 @@ int mt_sch_stop_all(struct mtl_main_impl* impl) {
   }
 
   info("%s, succ\n", __func__);
+  return 0;
+}
+
+int mtl_lcore_shm_print(void) {
+  struct mt_lcore_mgr lcore_mgr;
+  struct mt_lcore_shm_entry* shm_entry;
+
+  int ret = sch_lcore_shm_init(&lcore_mgr, false);
+  if (ret < 0) return ret;
+
+  struct mt_lcore_shm* lcore_shm = lcore_mgr.lcore_shm;
+  info("%s, MTL used lcores %d\n", __func__, lcore_shm->used);
+
+  for (int i = 0; i < RTE_MAX_LCORE; i++) {
+    shm_entry = &lcore_shm->lcores_info[i];
+    if (shm_entry->active) {
+      info("%s, lcore %d active on %s@%s with pid: %d\n", __func__, i, shm_entry->user,
+           shm_entry->hostname, shm_entry->pid);
+    }
+  }
+
+  sch_lcore_shm_uinit(&lcore_mgr);
   return 0;
 }

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -1051,6 +1051,14 @@ int mtl_lcore_shm_print(void) {
   return 0;
 }
 
+#ifdef WINDOWSENV
+static int lcore_shm_clean_auto_pid(struct mt_lcore_mgr* lcore_mgr) {
+  MTL_MAY_UNUSED(lcore_mgr);
+  err("%s, not support on windows\n", __func__);
+  return -EINVAL;
+}
+#else
+
 static int lcore_shm_clean_auto_pid(struct mt_lcore_mgr* lcore_mgr) {
   struct mt_user_info u_info;
   int clean = 0;
@@ -1077,6 +1085,7 @@ static int lcore_shm_clean_auto_pid(struct mt_lcore_mgr* lcore_mgr) {
 
   return clean;
 }
+#endif
 
 static int lcore_shm_clean_id(struct mt_lcore_mgr* lcore_mgr, void* args,
                               size_t args_sz) {

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -488,6 +488,7 @@ static int sch_lcore_shm_uinit(struct mt_lcore_mgr* mgr) {
       err("%s, can not stat shared memory, %s\n", __func__, strerror(errno));
     } else {
       if (shmds.shm_nattch == 0) { /* remove ipc if we are the last user */
+        notice("%s, remove shared memory as we are the last user\n", __func__);
         ret = shmctl(mgr->lcore_shm_id, IPC_RMID, NULL);
         if (ret < 0) {
           warn("%s, can not remove shared memory, %s\n", __func__, strerror(errno));
@@ -1039,7 +1040,7 @@ int mtl_lcore_shm_print(void) {
     shm_entry = &lcore_shm->lcores_info[i];
     if (shm_entry->active) {
       info("%s, lcore %d active on %s@%s with pid: %d\n", __func__, i, shm_entry->user,
-           shm_entry->hostname, shm_entry->pid);
+           shm_entry->hostname, (int)shm_entry->pid);
     }
   }
 

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -251,4 +251,6 @@ const char* mt_dpdk_afpkt_port2if(const char* port);
 const char* mt_kernel_port2if(const char* port);
 const char* mt_native_afxdp_port2if(const char* port);
 
+int mt_user_info_init(struct mt_user_info* info);
+
 #endif


### PR DESCRIPTION
usage:
  --info: Print lcore shared manager detail info
  --clean_pid_auto_check: Clean the dead entries if PID is not active
  --clean_lcore <lcore id>: Clean the entry by lcore ID