### PR TITLE
lcore: add cpu usage info LcoreMgr info command

### DIFF
--- a/doc/lcore.md
+++ b/doc/lcore.md
@@ -23,7 +23,8 @@ When you use the `--clean_pid_auto_check` option, the tool will perform a loop c
 
 If you are deploying in a multi-container environment, the PID check becomes less useful as each container has its own process namespace. In such cases, you can use the `--clean_lcore` option to remove an entry based on the lcore ID. However, it's important to confirm that the lcore is not active before using this option.
 
-Before using the `--clean_lcore` option, please ensure that you double-check the current lcore status by running `./build/app/LcoreMgr --info`. An example output list is provided below. Pay close attention to the lcore usage details, including user, host, PID, process name, allocation information, and, most importantly, CPU usage. Typically, an active lcore allocated by the IMTL library should utilize 100% of the CPU resources.
+Before using the `--clean_lcore` option, please ensure that you double-check the current lcore status by running `./build/app/LcoreMgr --info`. An example output list is provided below. Pay close attention to the lcore usage details, including user, host, PID, process name, allocation information, and, most importantly, CPU usage.
+Typically, an active lcore allocated by the IMTL library should utilize 100% of the CPU resources.
 
 ```bash
 MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, MTL used lcores 3

--- a/doc/lcore.md
+++ b/doc/lcore.md
@@ -21,4 +21,17 @@ IMTL also provides a tool which can be find from `./build/app/LcoreMgr` for manu
 
 When you use the `--clean_pid_auto_check` option, the tool will perform a loop check for all the active entries in the map. It checks whether the hostname and user match the current login environment and then verifies if the PID is still running. If the tool detects that the PID is no longer active, it will proceed to remove the lcore from the mapping.
 
-If you are deploying in a multi-container environment, the PID check becomes less useful as each container has its own process namespace. In such cases, you can use the --clean_lcore option to remove an entry based on the lcore ID. However, it's important to confirm that the lcore is not active before using this option.
+If you are deploying in a multi-container environment, the PID check becomes less useful as each container has its own process namespace. In such cases, you can use the `--clean_lcore` option to remove an entry based on the lcore ID. However, it's important to confirm that the lcore is not active before using this option.
+
+Before using the `--clean_lcore` option, please ensure that you double-check the current lcore status by running `./build/app/LcoreMgr --info`. An example output list is provided below. Pay close attention to the lcore usage details, including user, host, PID, process name, allocation information, and, most importantly, CPU usage. Typically, an active lcore allocated by the IMTL library should utilize 100% of the CPU resources.
+
+```bash
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, MTL used lcores 3
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 28 active by frank@media-frankdu-kahawai-node2, pid: 236759(comm: RxTxApp) type: app_allocated
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 29 active by frank@media-frankdu-kahawai-node2, pid: 236759(comm: RxTxApp) type: lib_sch
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 30 active by frank@media-frankdu-kahawai-node2, pid: 236759(comm: RxTxApp) type: lib_sch
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, collecting cpu usage
+MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 28 cpu usage 4.08%
+MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 29 cpu usage 100.00%
+MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 30 cpu usage 100.00%
+```

--- a/doc/lcore.md
+++ b/doc/lcore.md
@@ -28,9 +28,9 @@ Typically, an active lcore allocated by the IMTL library should utilize 100% of 
 
 ```bash
 MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, MTL used lcores 3
-MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 28 active by frank@media-frankdu-kahawai-node2, pid: 236759(comm: RxTxApp) type: app_allocated
-MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 29 active by frank@media-frankdu-kahawai-node2, pid: 236759(comm: RxTxApp) type: lib_sch
-MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 30 active by frank@media-frankdu-kahawai-node2, pid: 236759(comm: RxTxApp) type: lib_sch
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 28 active by xxx@xxx, pid: 236759(comm: RxTxApp) type: app_allocated
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 29 active by xxx@xxx, pid: 236759(comm: RxTxApp) type: lib_sch
+MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 30 active by xxx@xxx, pid: 236759(comm: RxTxApp) type: lib_sch
 MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, collecting cpu usage
 MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 28 cpu usage 4.08%
 MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 29 cpu usage 100.00%

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -674,7 +674,7 @@ int mtl_get_lcore(mtl_handle mt, unsigned int* lcore) {
     return -EIO;
   }
 
-  return mt_sch_get_lcore(impl, lcore);
+  return mt_sch_get_lcore(impl, lcore, MT_LCORE_TYPE_USER);
 }
 
 int mtl_put_lcore(mtl_handle mt, unsigned int lcore) {

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -711,10 +711,26 @@ struct mt_interface {
   void* xdp;
 };
 
-struct mt_lcore_shm_entry {
+struct mt_user_info {
   char hostname[64];
   char user[32];
+  /* the current process name */
+  char comm[64];
   pid_t pid;
+};
+
+enum mt_lcore_type {
+  MT_LCORE_TYPE_SCH = 0, /* lib scheduler used */
+  MT_LCORE_TYPE_TAP,
+  MT_LCORE_TYPE_RXV_RING_LCORE,
+  MT_LCORE_TYPE_USER, /* allocated by application */
+  MT_LCORE_TYPE_MAX,
+};
+
+struct mt_lcore_shm_entry {
+  struct mt_user_info u_info;
+  pid_t pid;
+  enum mt_lcore_type type;
   bool active;
 };
 
@@ -1089,12 +1105,6 @@ struct mt_dp_impl {
   /* the shared tx sys queue */
   struct mt_txq_entry* txq_sys_entry;
   rte_spinlock_t txq_sys_entry_lock; /* protect txq_sys_entry */
-};
-
-struct mt_user_info {
-  char hostname[64];
-  char user[32];
-  pid_t pid;
 };
 
 struct mtl_main_impl {

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -1076,13 +1076,13 @@ int mtl_lcore_shm_print(void) {
     struct mt_cpu_usage prev[found];
     struct mt_cpu_usage cur[found];
 
-    info("%s, collecting cpu usage\n", __func__);
+    info("%s, collecting cpu usage...\n", __func__);
     ret = mt_read_cpu_usage(prev, cpu_ids, found);
     if (ret != found) {
       err("%s, read cpu prev usage fail, expect %d but only %d get\n", __func__, found,
           ret);
     } else {
-      sleep(1);
+      mt_sleep_ms(1000 * 1);
       ret = mt_read_cpu_usage(cur, cpu_ids, found);
       if (ret != found) {
         err("%s, read cpu curr usage fail, expect %d but only %d get\n", __func__, found,

--- a/lib/src/mt_sch.h
+++ b/lib/src/mt_sch.h
@@ -66,7 +66,8 @@ static inline void mt_sch_set_cpu_busy(struct mt_sch_impl* sch, bool busy) {
 }
 
 int mt_sch_put_lcore(struct mtl_main_impl* impl, unsigned int lcore);
-int mt_sch_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore);
+int mt_sch_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore,
+                     enum mt_lcore_type type);
 bool mt_sch_lcore_valid(struct mtl_main_impl* impl, unsigned int lcore);
 
 #endif

--- a/lib/src/mt_tap.c
+++ b/lib/src/mt_tap.c
@@ -900,7 +900,7 @@ int mt_tap_init(struct mtl_main_impl* impl) {
 
   rte_atomic32_set(&cni->stop_tap, 0);
   tap_ctx->has_lcore = false;
-  ret = mt_sch_get_lcore(impl, &lcore);
+  ret = mt_sch_get_lcore(impl, &lcore, MT_LCORE_TYPE_TAP);
   if (ret < 0) {
     err("%s, get lcore fail %d\n", __func__, ret);
     mt_tap_uinit(impl);

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -253,4 +253,19 @@ const char* mt_native_afxdp_port2if(const char* port);
 
 int mt_user_info_init(struct mt_user_info* info);
 
+struct mt_cpu_usage {
+  uint64_t user;
+  uint64_t nice;
+  uint64_t system;
+  uint64_t idle;
+  uint64_t iowait;
+  uint64_t irq;
+  uint64_t softirq;
+  uint64_t steal;
+};
+
+int mt_read_cpu_usage(struct mt_cpu_usage* usages, int* cpu_ids, int num_cpus);
+
+double mt_calculate_cpu_usage(struct mt_cpu_usage* prev, struct mt_cpu_usage* curr);
+
 #endif

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2538,7 +2538,7 @@ static int rv_init_pkt_lcore(struct mtl_main_impl* impl,
   }
   s->pkt_lcore_ring = ring;
 
-  ret = mt_sch_get_lcore(impl, &lcore);
+  ret = mt_sch_get_lcore(impl, &lcore, MT_LCORE_TYPE_RXV_RING_LCORE);
   if (ret < 0) {
     err("%s(%d,%d), get lcore fail %d\n", __func__, mgr_idx, idx, ret);
     rv_uinit_pkt_lcore(impl, s);


### PR DESCRIPTION
output of ./build/app/LcoreMgr --info:

MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, MTL used lcores 3
MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 28 active by xxx@xxx, pid: 236759(comm: RxTxApp) type: app_allocated
MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 29 active by xxx@xxx, pid: 236759(comm: RxTxApp) type: lib_sch
MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, lcore 30 active by xxx@xxx, pid: 236759(comm: RxTxApp) type: lib_sch
MT: 2023-11-14 15:00:03, mtl_lcore_shm_print, collecting cpu usage
MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 28 cpu usage 4.08%
MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 29 cpu usage 100.00%
MT: 2023-11-14 15:00:04, mtl_lcore_shm_print, lcore 30 cpu usage 100.00%