### PR TITLE
manager: allow register with interfaces

### DIFF
--- a/lib/src/mt_instance.c
+++ b/lib/src/mt_instance.c
@@ -94,7 +94,7 @@ int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p) {
   /* manager will load xdp program for afxdp interfaces */
   uint16_t num_xdp_if = 0;
   for (int i = 0; i < p->num_ports; i++) {
-    if (p->pmd[i] == MTL_PMD_NATIVE_AF_XDP) {
+    if (mtl_pmd_is_af_xdp(p->pmd[i])) {
       const char* if_name = mt_native_afxdp_port2if(p->port[i]);
       reg_msg->ifindex[i] = htonl(if_nametoindex(if_name));
       num_xdp_if++;

--- a/lib/src/mt_instance.c
+++ b/lib/src/mt_instance.c
@@ -10,6 +10,7 @@
 
 #include "../manager/mtl_mproto.h"
 #include "mt_log.h"
+#include "mt_util.h"
 
 int mt_instance_put_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
   int ret;
@@ -60,7 +61,7 @@ int mt_instance_get_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
   return -response;
 }
 
-int mt_instance_init(struct mtl_main_impl* impl) {
+int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p) {
   impl->instance_fd = -1;
   int sock = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sock < 0) {
@@ -73,7 +74,7 @@ int mt_instance_init(struct mtl_main_impl* impl) {
   strncpy(addr.sun_path, MTL_MANAGER_SOCK_PATH, sizeof(addr.sun_path) - 1);
   int ret = connect(sock, (struct sockaddr*)&addr, sizeof(addr));
   if (ret < 0) {
-    err("%s, connect to manager fail\n", __func__);
+    warn("%s, connect to manager fail, assume single instance mode\n", __func__);
     close(sock);
     return ret;
   }
@@ -89,6 +90,17 @@ int mt_instance_init(struct mtl_main_impl* impl) {
   reg_msg->pid = htonl(u_info->pid);
   reg_msg->uid = htonl(getuid());
   strncpy(reg_msg->hostname, u_info->hostname, sizeof(reg_msg->hostname));
+
+  /* manager will load xdp program for afxdp interfaces */
+  uint16_t num_xdp_if = 0;
+  for (int i = 0; i < p->num_ports; i++) {
+    if (p->pmd[i] == MTL_PMD_NATIVE_AF_XDP) {
+      const char* if_name = mt_native_afxdp_port2if(p->port[i]);
+      reg_msg->ifindex[i] = htonl(if_nametoindex(if_name));
+      num_xdp_if++;
+    }
+  }
+  reg_msg->num_if = htons(num_xdp_if);
 
   ret = send(sock, &msg, sizeof(msg), 0);
   if (ret < 0) {
@@ -128,8 +140,9 @@ int mt_instance_uinit(struct mtl_main_impl* impl) {
 
 #else /* not supported on Windows */
 
-int mt_instance_init(struct mtl_main_impl* impl) {
+int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p) {
   impl->instance_fd = -1;
+  MTL_MAY_UNUSED(p);
   return -ENOTSUP;
 }
 

--- a/lib/src/mt_instance.h
+++ b/lib/src/mt_instance.h
@@ -7,7 +7,7 @@
 
 #include "mt_main.h"
 
-int mt_instance_init(struct mtl_main_impl* impl);
+int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p);
 int mt_instance_uinit(struct mtl_main_impl* impl);
 
 int mt_instance_get_lcore(struct mtl_main_impl* impl, unsigned int lcore_id);

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -476,7 +476,7 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
   impl->privileged = true;
 #endif
 
-  mt_instance_init(impl);
+  mt_instance_init(impl, p);
 
   rte_memcpy(&impl->user_para, p, sizeof(*p));
   impl->var_para.sch_default_sleep_us = 1 * US_PER_MS; /* default 1ms */

--- a/manager/mtl_instance.hpp
+++ b/manager/mtl_instance.hpp
@@ -148,7 +148,6 @@ int mtl_instance::handle_message_register(mtl_register_message_t* register_msg) 
 
 std::shared_ptr<mtl_interface> mtl_instance::get_interface(const unsigned int ifindex) {
   auto it = interfaces.find(ifindex);
-
   if (it != interfaces.end()) {
     log(log_level::INFO, "Returning existing interface.");
     return it->second;
@@ -163,9 +162,9 @@ std::shared_ptr<mtl_interface> mtl_instance::get_interface(const unsigned int if
     }
   }
 
-  // Interface does not exist, create and initialize it
+  /* Interface does not exist, create and initialize it */
   log(log_level::INFO, "Initializing a new interface " + std::to_string(ifindex));
-  std::shared_ptr<mtl_interface> new_interface = std::make_shared<mtl_interface>(ifindex);
+  auto new_interface = std::make_shared<mtl_interface>(ifindex);
   g_interfaces[ifindex] = new_interface;
   interfaces[ifindex] = new_interface;
   return new_interface;

--- a/manager/mtl_instance.hpp
+++ b/manager/mtl_instance.hpp
@@ -11,9 +11,11 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include "logging.hpp"
+#include "mtl_interface.hpp"
 #include "mtl_lcore.hpp"
 #include "mtl_mproto.h"
 
@@ -24,11 +26,16 @@ class mtl_instance {
   int pid;
   int uid;
   std::string hostname;
-  std::vector<int> ifindex;
   std::vector<uint16_t> lcore_ids;
   std::shared_ptr<mtl_lcore> lcore_manager_sp;
+  std::unordered_map<unsigned int, std::shared_ptr<mtl_interface>> interfaces;
 
  private:
+  void log(log_level level, const std::string& message) {
+    logger::log(level,
+                "[Instance " + hostname + ":" + std::to_string(pid) + "] " + message);
+  }
+
   int handle_message_get_lcore(mtl_lcore_message_t* lcore_msg);
   int handle_message_put_lcore(mtl_lcore_message_t* lcore_msg);
   int handle_message_register(mtl_register_message_t* register_msg);
@@ -40,12 +47,18 @@ class mtl_instance {
     msg.body.response_msg.response = success ? 0 : 1;
     return send(conn_fd, &msg, sizeof(mtl_message_t), 0);
   }
+  std::shared_ptr<mtl_interface> get_interface(unsigned int ifindex);
 
  public:
   mtl_instance(int conn_fd, std::shared_ptr<mtl_lcore> lcore_manager)
-      : conn_fd(conn_fd), is_registered(false), lcore_manager_sp(lcore_manager) {}
+      : conn_fd(conn_fd),
+        is_registered(false),
+        pid(-1),
+        uid(-1),
+        hostname("unknown"),
+        lcore_manager_sp(lcore_manager) {}
   ~mtl_instance() {
-    logger::log(log_level::INFO, "Remove client " + hostname + ":" + std::to_string(pid));
+    log(log_level::INFO, "Remove client.");
     for (const auto& lcore_id : lcore_ids) lcore_manager_sp->put_lcore(lcore_id);
 
     close(conn_fd);
@@ -55,7 +68,6 @@ class mtl_instance {
   int get_pid() { return pid; }
   int get_uid() { return uid; }
   std::string get_hostname() { return hostname; }
-  std::vector<int> get_ifindex() { return ifindex; }
   int handle_message(const char* buf, int len);
 };
 
@@ -63,7 +75,7 @@ int mtl_instance::handle_message(const char* buf, int len) {
   if ((size_t)len < sizeof(mtl_message_t)) return -1;
   mtl_message_t* msg = (mtl_message_t*)buf;
   if (ntohl(msg->header.magic) != MTL_MANAGER_MAGIC) {
-    logger::log(log_level::INFO, "Invalid magic");
+    log(log_level::ERROR, "Invalid magic");
     return -1;
   }
 
@@ -78,7 +90,7 @@ int mtl_instance::handle_message(const char* buf, int len) {
       handle_message_put_lcore(&msg->body.lcore_msg);
       break;
     default:
-      logger::log(log_level::INFO, "Unknown message type");
+      log(log_level::ERROR, "Unknown message type");
       break;
   }
 
@@ -87,7 +99,7 @@ int mtl_instance::handle_message(const char* buf, int len) {
 
 int mtl_instance::handle_message_get_lcore(mtl_lcore_message_t* lcore_msg) {
   if (!is_registered) {
-    logger::log(log_level::INFO, "Instance is not registered");
+    log(log_level::WARNING, "Instance is not registered");
     return -1;
   }
   uint16_t lcore_id = ntohs(lcore_msg->lcore);
@@ -97,15 +109,14 @@ int mtl_instance::handle_message_get_lcore(mtl_lcore_message_t* lcore_msg) {
     return -1;
   }
   lcore_ids.push_back(lcore_id);
-  logger::log(log_level::INFO, "Add lcore " + std::to_string(lcore_id) + " to instance " +
-                                   hostname + ":" + std::to_string(pid));
+  log(log_level::INFO, "Add lcore " + std::to_string(lcore_id));
   send_response(true);
   return 0;
 }
 
 int mtl_instance::handle_message_put_lcore(mtl_lcore_message_t* lcore_msg) {
   if (!is_registered) {
-    logger::log(log_level::INFO, "Instance is not registered");
+    log(log_level::INFO, "Instance is not registered");
     return -1;
   }
   uint16_t lcore_id = ntohs(lcore_msg->lcore);
@@ -114,9 +125,7 @@ int mtl_instance::handle_message_put_lcore(mtl_lcore_message_t* lcore_msg) {
                          [lcore_id](uint16_t id) { return id == lcore_id; });
   if (it != lcore_ids.end()) lcore_ids.erase(it);
 
-  logger::log(log_level::INFO, "Remove lcore " + std::to_string(lcore_id) +
-                                   " from instance " + hostname + ":" +
-                                   std::to_string(pid));
+  log(log_level::INFO, "Remove lcore " + std::to_string(lcore_id));
   return 0;
 }
 
@@ -126,16 +135,46 @@ int mtl_instance::handle_message_register(mtl_register_message_t* register_msg) 
   hostname = std::string(register_msg->hostname, 64);
   uint16_t num_if = ntohs(register_msg->num_if);
   for (int i = 0; i < num_if; i++) {
-    ifindex.push_back(ntohs(register_msg->ifindex[i]));
+    unsigned int ifindex = ntohl(register_msg->ifindex[i]);
+    auto interface = get_interface(ifindex);
+    if (interface == nullptr) {
+      log(log_level::ERROR, "Could not get interface " + std::to_string(ifindex));
+      send_response(false);
+      return -1;
+    }
   }
 
-  logger::log(log_level::INFO,
-              "Register instance " + hostname + ":" + std::to_string(pid));
+  log(log_level::INFO, "Registered.");
 
   is_registered = true;
   send_response(true);
 
   return 0;
+}
+
+std::shared_ptr<mtl_interface> mtl_instance::get_interface(unsigned int ifindex) {
+  auto it = interfaces.find(ifindex);
+
+  if (it != interfaces.end()) {
+    log(log_level::INFO, "Returning existing interface.");
+    return it->second;
+  }
+
+  auto g_it = g_interfaces.find(ifindex);
+  if (g_it != g_interfaces.end()) {
+    if (auto g_interface = g_it->second.lock()) {
+      log(log_level::INFO, "Acquiring global interface " + std::to_string(ifindex));
+      interfaces[ifindex] = g_interface;
+      return g_interface;
+    }
+  }
+
+  // Interface does not exist, create and initialize it
+  log(log_level::INFO, "Initializing a new interface " + std::to_string(ifindex));
+  std::shared_ptr<mtl_interface> new_interface = std::make_shared<mtl_interface>(ifindex);
+  g_interfaces[ifindex] = new_interface;
+  interfaces[ifindex] = new_interface;
+  return new_interface;
 }
 
 #endif

--- a/manager/mtl_interface.hpp
+++ b/manager/mtl_interface.hpp
@@ -5,12 +5,19 @@
 #ifndef _MTL_INTERFACE_HPP_
 #define _MTL_INTERFACE_HPP_
 
+#if 0 /* TODO: add xdp loader/unloader */
 #include <bpf/libbpf.h>
 #include <xdp/libxdp.h>
 #include <xdp/xsk.h>
+#endif
 
+#include <memory>
 #include <string>
-#include <vector>
+#include <unordered_map>
+
+#include "logging.hpp"
+
+static const std::string xdp_prog_path = "/var/run/imtl/xdp_prog.o";
 
 class mtl_interface {
  private:
@@ -20,27 +27,17 @@ class mtl_interface {
  public:
   mtl_interface(int ifindex);
   ~mtl_interface();
-
-  int attach_xdp_prog(std::string xdp_prog_path);
-  int detach_xdp_prog();
-  int get_ifindex();
 };
 
-mtl_interface::mtl_interface(int ifindex) {
-  this->ifindex = ifindex;
-  this->xdp_prog = nullptr;
+mtl_interface::mtl_interface(int ifindex) : ifindex(ifindex) {
+  logger::log(log_level::INFO, "Add interface " + std::to_string(ifindex));
+  xdp_prog = nullptr;
 }
 
 mtl_interface::~mtl_interface() {
-  if (this->xdp_prog != nullptr) {
-    this->detach_xdp_prog();
-  }
+  logger::log(log_level::INFO, "Remove interface " + std::to_string(ifindex));
 }
 
-int mtl_interface::get_ifindex() { return this->ifindex; }
-
-int mtl_interface::attach_xdp_prog(std::string xdp_prog_path) { return 0; }
-
-int mtl_interface::detach_xdp_prog() { return 0; }
+std::unordered_map<unsigned int, std::weak_ptr<mtl_interface>> g_interfaces;
 
 #endif

--- a/manager/mtl_interface.hpp
+++ b/manager/mtl_interface.hpp
@@ -2,6 +2,9 @@
  * Copyright(c) 2023 Intel Corporation
  */
 
+#ifndef _MTL_INTERFACE_HPP_
+#define _MTL_INTERFACE_HPP_
+
 #include <bpf/libbpf.h>
 #include <xdp/libxdp.h>
 #include <xdp/xsk.h>
@@ -39,3 +42,5 @@ int mtl_interface::get_ifindex() { return this->ifindex; }
 int mtl_interface::attach_xdp_prog(std::string xdp_prog_path) { return 0; }
 
 int mtl_interface::detach_xdp_prog() { return 0; }
+
+#endif

--- a/manager/mtl_interface.hpp
+++ b/manager/mtl_interface.hpp
@@ -21,7 +21,7 @@ static const std::string xdp_prog_path = "/var/run/imtl/xdp_prog.o";
 
 class mtl_interface {
  private:
-  int ifindex;
+  const int ifindex;
   struct xdp_program* xdp_prog;
 
  public:

--- a/manager/mtl_lcore.hpp
+++ b/manager/mtl_lcore.hpp
@@ -2,6 +2,9 @@
  * Copyright(c) 2023 Intel Corporation
  */
 
+#ifndef __MTL_LCORE_HPP__
+#define __MTL_LCORE_HPP__
+
 #include <bitset>
 #include <mutex>
 
@@ -40,3 +43,5 @@ int mtl_lcore::put_lcore(uint16_t lcore_id) {
     bs.set(lcore_id, false);
   return 0;
 }
+
+#endif

--- a/manager/mtl_lcore.hpp
+++ b/manager/mtl_lcore.hpp
@@ -15,16 +15,21 @@ class mtl_lcore {
   std::bitset<MTL_MAX_LCORE> bs;
   std::mutex bs_mtx;
 
+  mtl_lcore() { bs.reset(); }
+  ~mtl_lcore() {}
+
  public:
-  mtl_lcore();
-  ~mtl_lcore();
+  mtl_lcore(const mtl_lcore&) = delete;
+  mtl_lcore& operator=(const mtl_lcore&) = delete;
+
+  static mtl_lcore& get_instance() {
+    static mtl_lcore instance;
+    return instance;
+  }
+
   int get_lcore(uint16_t lcore_id);
   int put_lcore(uint16_t lcore_id);
 };
-
-mtl_lcore::mtl_lcore() { bs.reset(); }
-
-mtl_lcore::~mtl_lcore() {}
 
 int mtl_lcore::get_lcore(uint16_t lcore_id) {
   std::lock_guard<std::mutex> lock(bs_mtx);

--- a/manager/mtl_manager.cpp
+++ b/manager/mtl_manager.cpp
@@ -179,12 +179,12 @@ int main() {
       }
     }
   }
+  logger::log(log_level::INFO, "MTL Manager exited.");
 
 out:
   if (signal_fd >= 0) close(signal_fd);
   if (epfd >= 0) close(epfd);
   if (sockfd >= 0) close(sockfd);
 
-  logger::log(log_level::INFO, "MTL Manager exited.");
   return ret;
 }

--- a/manager/mtl_manager.cpp
+++ b/manager/mtl_manager.cpp
@@ -25,7 +25,6 @@ int main() {
   bool is_running = true;
   int epfd = -1, sockfd = -1;
   std::vector<std::unique_ptr<mtl_instance>> clients;
-  auto lcore_manager = std::make_shared<mtl_lcore>();
 
   logger::set_log_level(log_level::INFO);
 
@@ -135,7 +134,7 @@ int main() {
           continue;
         }
 
-        auto client = std::make_unique<mtl_instance>(client_sockfd, lcore_manager);
+        auto client = std::make_unique<mtl_instance>(client_sockfd);
         clients.push_back(std::move(client));
         logger::log(log_level::INFO,
                     "New client connected. fd: " + std::to_string(client_sockfd));

--- a/manager/mtl_mproto.h
+++ b/manager/mtl_mproto.h
@@ -49,7 +49,7 @@ typedef struct {
   uid_t uid;
   char hostname[64];
   uint16_t num_if;
-  uint16_t ifindex[8];
+  unsigned int ifindex[8];
 } mtl_register_message_t;
 
 typedef struct {

--- a/manager/mtl_mproto.h
+++ b/manager/mtl_mproto.h
@@ -2,12 +2,12 @@
  * Copyright(c) 2023 Intel Corporation
  */
 
+#ifndef _MTL_MPROTO_HEAD_H_
+#define _MTL_MPROTO_HEAD_H_
+
 #include <net/if.h>
 #include <stdint.h>
 #include <unistd.h>
-
-#ifndef _MTL_MPROTO_HEAD_H_
-#define _MTL_MPROTO_HEAD_H_
 
 #if defined(__cplusplus)
 extern "C" {
@@ -30,7 +30,8 @@ typedef enum {
   MTL_MSG_TYPE_REQUEST_MAP_FD,
   MTL_MSG_TYPE_GET_LCORE,
   MTL_MSG_TYPE_PUT_LCORE,
-  MTL_MSG_TYPE_UDP_PORT_OPERATION,
+  MTL_MSG_TYPE_ADD_UDP_DP_FILTER,
+  MTL_MSG_TYPE_DEL_UDP_DP_FILTER,
   /* server to client */
   MTL_MSG_TYPE_SC = 200,
   MTL_MSG_TYPE_RESPONSE,
@@ -47,8 +48,8 @@ typedef struct {
   pid_t pid;
   uid_t uid;
   char hostname[64];
-  uint16_t ifindex[8];
   uint16_t num_if;
+  uint16_t ifindex[8];
 } mtl_register_message_t;
 
 typedef struct {
@@ -66,11 +67,10 @@ typedef struct {
 typedef struct {
   int ifindex;
   uint16_t port;
-  uint8_t action;  // 1 for add, 0 for remove
-} mtl_udp_port_operation_message_t;
+} mtl_udp_dp_filter_message_t;
 
 typedef struct {
-  uint8_t response;  // 0 for success, 1 for error
+  uint8_t response; /* 0 for success, 1 for error */
 } mtl_response_message_t;
 
 typedef struct {
@@ -80,7 +80,7 @@ typedef struct {
     mtl_heartbeat_message_t heartbeat_msg;
     mtl_request_map_fd_message_t request_map_fd_msg;
     mtl_lcore_message_t lcore_msg;
-    mtl_udp_port_operation_message_t udp_port_op_msg;
+    mtl_udp_dp_filter_message_t udp_dp_filter_msg;
     mtl_response_message_t response_msg;
   } body;
 } mtl_message_t;


### PR DESCRIPTION
1. Add interface module to manage NICs with kernel driver.
2. Use unique pointer for clients.
3. Refine log for instance.
4. Use singleton for lcore manager.

Next: add the XDP loader and replace the et tool.