### PR TITLE
dp/xdp: do not check pkt if xdp prog has done it

### DIFF
--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1073,6 +1073,7 @@ struct mt_rx_xdp_entry {
   struct mt_xdp_queue* xq;
   struct mt_rx_flow_rsp* flow_rsp;
   bool skip_udp_port_check;
+  bool skip_all_check;
 };
 
 struct mt_flow_impl {

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -2414,7 +2414,7 @@ static int tv_init_hw(struct mtl_main_impl* impl, struct st_tx_video_sessions_mg
       }
     }
 
-    if (false & mt_pmd_is_dpdk_af_xdp(impl, port)) {
+    if (false && mt_pmd_is_dpdk_af_xdp(impl, port)) {
       /* disable now, always use no zc mempool for the flush pad */
       pad_mempool = s->mbuf_mempool_hdr[i];
     } else {


### PR DESCRIPTION
In our XDP program, packet headers are already filtered,
no need to do it in userspace again.