### PR TITLE
api: move st20_redundant_combined to experimental

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -286,13 +286,6 @@ executable('TxVideoSplitSample', video_tx_split_sample_sources,
   dependencies: [asan_dep, mtl, ws2_32_dep, mman_dep]
 )
 
-executable('RxSt20RedundantSample', redundant_rx_st20_sample_sources,
-  c_args : app_c_args,
-  link_args: app_ld_args,
-  # asan should be always the first dep
-  dependencies: [asan_dep, mtl, libpthread, ws2_32_dep, mman_dep]
-)
-
 # Legacy video samples app
 executable('TxVideoSample', video_tx_sample_sources,
   c_args : app_c_args,
@@ -378,6 +371,14 @@ executable('RxSliceVideoSample', video_rx_slice_sample_sources,
   link_args: app_ld_args,
   # asan should be always the first dep
   dependencies: [asan_dep, mtl, libpthread, ws2_32_dep]
+)
+
+# experimental
+executable('RxSt20CombinedRedundantSample', redundant_rx_st20_combined_sample_sources,
+  c_args : app_c_args,
+  link_args: app_ld_args,
+  # asan should be always the first dep
+  dependencies: [asan_dep, mtl, libpthread, ws2_32_dep, mman_dep]
 )
 
 # Dma sample app

--- a/app/sample/experimental/rx_st20_redundant_combined_sample.c
+++ b/app/sample/experimental/rx_st20_redundant_combined_sample.c
@@ -184,7 +184,7 @@ int main(int argc, char** argv) {
     ops_rx.framebuff_cnt = app[i]->framebuff_cnt;
     ops_rx.payload_type = ctx.payload_type;
     ops_rx.notify_frame_ready = rx_video_frame_ready;
-    if (ctx.hdr_split) ops_rx.flags |= ST20R_RX_FLAG_HDR_SPLIT;
+    if (ctx.hdr_split) ops_rx.flags |= ST20RC_RX_FLAG_HDR_SPLIT;
 
     rx_handle[i] = st20rc_rx_create(ctx.st, &ops_rx);
     if (!rx_handle[i]) {

--- a/app/sample/meson.build
+++ b/app/sample/meson.build
@@ -18,7 +18,6 @@ rx_st20p_tx_st20p_downsample_merge_fwd_sources = files('fwd/rx_st20p_tx_st20p_do
 
 # misc
 video_tx_split_sample_sources = files('tx_video_split_sample.c', 'sample_util.c')
-redundant_rx_st20_sample_sources = files('rx_st20_redundant_sample.c', 'sample_util.c')
 
 # ext frame
 pipeline_tx_st20_ext_frame_sample_sources = files('ext_frame/tx_st20_pipeline_ext_frame_sample.c', 'sample_util.c')
@@ -40,3 +39,7 @@ video_tx_slice_sample_sources = files('low_level/tx_slice_video_sample.c', 'samp
 
 # dma
 dma_sample_sources = files('dma/dma_sample.c', 'sample_util.c')
+
+# experimental
+redundant_rx_st20_combined_sample_sources = files('experimental/rx_st20_redundant_combined_sample.c',
+    'sample_util.c')

--- a/app/sample/sample_util.h
+++ b/app/sample/sample_util.h
@@ -8,7 +8,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
-#include <mtl/st20_redundant_api.h>
+#include <mtl/experimental/st20_combined_api.h>
 #include <mtl/st_convert_api.h>
 #include <mtl/st_pipeline_api.h>
 #include <pthread.h>

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -9,8 +9,8 @@
 #include <SDL2/SDL_ttf.h>
 #endif
 #include <errno.h>
+#include <mtl/experimental/st20_combined_api.h>
 #include <mtl/st20_api.h>
-#include <mtl/st20_redundant_api.h>
 #include <mtl/st30_api.h>
 #include <mtl/st40_api.h>
 #include <mtl/st_pipeline_api.h>
@@ -226,7 +226,7 @@ struct st_app_rx_video_session {
   int idx;
   mtl_handle st;
   st20_rx_handle handle;
-  st20r_rx_handle st20r_handle; /* for st20r */
+  st20rc_rx_handle st20r_handle; /* for st20r */
   int framebuff_cnt;
   int st20_frame_size;
   bool slice;

--- a/app/src/rx_st20r_app.c
+++ b/app/src/rx_st20r_app.c
@@ -281,7 +281,7 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
     ops.udp_port[MTL_SESSION_PORT_R] = video ? video->base.udp_port : (10000 + s->idx);
   }
   ops.pacing = ST21_PACING_NARROW;
-  ops.flags = ST20R_RX_FLAG_DMA_OFFLOAD;
+  ops.flags = ST20RC_RX_FLAG_DMA_OFFLOAD;
   ops.width = video ? st_app_get_width(video->info.video_format) : 1920;
   ops.height = video ? st_app_get_height(video->info.video_format) : 1080;
   ops.fps = video ? st_app_get_fps(video->info.video_format) : ST_FPS_P59_94;
@@ -290,7 +290,7 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
   ops.payload_type = video ? video->base.payload_type : ST_APP_PAYLOAD_TYPE_VIDEO;
   ops.notify_frame_ready = app_rx_st20r_frame_ready;
   ops.framebuff_cnt = s->framebuff_cnt;
-  if (ctx->enable_hdr_split) ops.flags |= ST20R_RX_FLAG_HDR_SPLIT;
+  if (ctx->enable_hdr_split) ops.flags |= ST20RC_RX_FLAG_HDR_SPLIT;
 
   st_pthread_mutex_init(&s->st20_wake_mutex, NULL);
   st_pthread_cond_init(&s->st20_wake_cond, NULL);

--- a/app/src/rx_st20r_app.c
+++ b/app/src/rx_st20r_app.c
@@ -74,7 +74,7 @@ static void* app_rx_st20r_frame_thread(void* arg) {
 
     dbg("%s(%d), frame idx %d\n", __func__, idx, consumer_idx);
     app_rx_st20r_consume_frame(s, framebuff->frame, framebuff->size);
-    st20r_rx_put_frame(s->st20r_handle, framebuff->frame);
+    st20rc_rx_put_frame(s->st20r_handle, framebuff->frame);
     /* point to next */
     st_pthread_mutex_lock(&s->st20_wake_mutex);
     framebuff->frame = NULL;
@@ -164,7 +164,7 @@ static int app_rx_st20r_frame_ready(void* priv, void* frame,
 
   /* incomplete frame */
   if (!st_is_frame_complete(meta->status)) {
-    st20r_rx_put_frame(s->st20r_handle, frame);
+    st20rc_rx_put_frame(s->st20r_handle, frame);
     return 0;
   }
 
@@ -190,7 +190,7 @@ static int app_rx_st20r_frame_ready(void* priv, void* frame,
 
   if (s->st20_dst_fd < 0 && s->display == NULL) {
     /* free the queue directly as no read thread is running */
-    st20r_rx_put_frame(s->st20r_handle, frame);
+    st20rc_rx_put_frame(s->st20r_handle, frame);
     return 0;
   }
 
@@ -198,7 +198,7 @@ static int app_rx_st20r_frame_ready(void* priv, void* frame,
   ret = app_rx_st20r_enqueue_frame(s, frame, meta->frame_total_size);
   if (ret < 0) {
     /* free the queue */
-    st20r_rx_put_frame(s->st20r_handle, frame);
+    st20rc_rx_put_frame(s->st20r_handle, frame);
     st_pthread_mutex_unlock(&s->st20_wake_mutex);
     return ret;
   }
@@ -230,8 +230,8 @@ static int app_rx_st20r_uinit(struct st_app_rx_video_session* s) {
   st_pthread_cond_destroy(&s->st20_wake_cond);
 
   if (s->st20r_handle) {
-    ret = st20r_rx_free(s->st20r_handle);
-    if (ret < 0) err("%s(%d), st20r_rx_free fail %d\n", __func__, idx, ret);
+    ret = st20rc_rx_free(s->st20r_handle);
+    if (ret < 0) err("%s(%d), st20rc_rx_free fail %d\n", __func__, idx, ret);
     s->st20r_handle = NULL;
   }
   app_rx_st20r_close_source(s);
@@ -246,9 +246,9 @@ static int app_rx_st20r_uinit(struct st_app_rx_video_session* s) {
 static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t* video,
                              struct st_app_rx_video_session* s) {
   int idx = s->idx, ret;
-  struct st20r_rx_ops ops;
+  struct st20rc_rx_ops ops;
   char name[32];
-  st20r_rx_handle st20r_handle;
+  st20rc_rx_handle st20r_handle;
   memset(&ops, 0, sizeof(ops));
 
   snprintf(name, 32, "app_rx_st20r_%d", idx);
@@ -335,15 +335,15 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
 
   s->measure_latency = video ? video->measure_latency : true;
 
-  st20r_handle = st20r_rx_create(ctx->st, &ops);
+  st20r_handle = st20rc_rx_create(ctx->st, &ops);
   if (!st20r_handle) {
-    err("%s(%d), st20r_rx_create fail\n", __func__, idx);
+    err("%s(%d), st20rc_rx_create fail\n", __func__, idx);
     app_rx_st20r_uinit(s);
     return -EIO;
   }
   s->st20r_handle = st20r_handle;
 
-  s->st20_frame_size = st20r_rx_get_framebuffer_size(st20r_handle);
+  s->st20_frame_size = st20rc_rx_get_framebuffer_size(st20r_handle);
 
   ret = app_rx_st20r_open_source(s);
   if (ret < 0) {
@@ -400,7 +400,7 @@ static int app_rx_st20r_result(struct st_app_rx_video_session* s) {
 
 static int app_rx_st20r_pcap(struct st_app_rx_video_session* s) {
   if (s->pcapng_max_pkts)
-    st20r_rx_pcapng_dump(s->st20r_handle, s->pcapng_max_pkts, false, NULL);
+    st20rc_rx_pcapng_dump(s->st20r_handle, s->pcapng_max_pkts, false, NULL);
   return 0;
 }
 

--- a/include/experimental/st20_combined_api.h
+++ b/include/experimental/st20_combined_api.h
@@ -3,52 +3,52 @@
  */
 
 /**
- * @file st20_redundant_api.h
+ * @file st20_redundant_combined.h
  *
- * Interfaces for st2110-20 redundant transport.
+ * Interfaces for st2110-20 combined redundant transport, experimental feature only.
  *
  */
 
-#include "st20_api.h"
+#include "../st20_api.h"
 
-#ifndef _ST20_REDUNDANT_API_HEAD_H_
+#ifndef _ST20_COMBINED_API_HEAD_H_
 /** Marco for re-include protect */
-#define _ST20_REDUNDANT_API_HEAD_H_
+#define _ST20_COMBINED_API_HEAD_H_
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
 /** Handle to rx st2110-22 pipeline session of lib */
-typedef struct st20r_rx_ctx* st20r_rx_handle;
+typedef struct st20rc_rx_ctx* st20rc_rx_handle;
 
 /**
- * Flag bit in flags of struct st20r_rx_ops, for non MTL_PMD_DPDK_USER.
+ * Flag bit in flags of struct st20rc_rx_ops, for non MTL_PMD_DPDK_USER.
  * If set, it's application duty to set the rx flow(queue) and multicast join/drop.
  * Use st20p_rx_get_queue_meta to get the queue meta(queue number etc) info.
  */
 #define ST20R_RX_FLAG_DATA_PATH_ONLY (MTL_BIT32(0))
 /**
- * Flag bit in flags of struct st20r_rx_ops.
+ * Flag bit in flags of struct st20rc_rx_ops.
  * If enabled, lib will pass ST_EVENT_VSYNC by the notify_event on every epoch start.
  */
 #define ST20R_RX_FLAG_ENABLE_VSYNC (MTL_BIT32(1))
 
 /**
- * Flag bit in flags of struct st20r_rx_ops.
+ * Flag bit in flags of struct st20rc_rx_ops.
  * If set, lib will pass the incomplete frame to app also.
  * User can check st_frame_status data for the frame integrity
  */
 #define ST20R_RX_FLAG_RECEIVE_INCOMPLETE_FRAME (MTL_BIT32(16))
 /**
- * Flag bit in flags of struct st20r_rx_ops.
+ * Flag bit in flags of struct st20rc_rx_ops.
  * If set, lib will try to allocate DMA memory copy offload from
  * dma_dev_port(mtl_init_params) list.
  * Pls note it could fallback to CPU if no DMA device is available.
  */
 #define ST20R_RX_FLAG_DMA_OFFLOAD (MTL_BIT32(17))
 /**
- * Flag bit in flags of struct st20r_rx_ops.
+ * Flag bit in flags of struct st20rc_rx_ops.
  * Only ST20_PACKING_BPM stream can enable this offload as software limit
  * Try to enable header split offload feature.
  */
@@ -58,7 +58,7 @@ typedef struct st20r_rx_ctx* st20r_rx_handle;
  * The structure describing how to create a rx st2110-20(redundant) session.
  * Frame based.
  */
-struct st20r_rx_ops {
+struct st20rc_rx_ops {
   /** name */
   const char* name;
   /** private data to the callback function */
@@ -106,9 +106,9 @@ struct st20r_rx_ops {
    * frame: point to the address of the frame buf.
    * meta: point to the meta data.
    * return:
-   *   - 0: if app consume the frame successful. App should call st20r_rx_put_frame
+   *   - 0: if app consume the frame successful. App should call st20rc_rx_put_frame
    * to return the frame when it finish the handling
-   *   < 0: the error code if app can't handle, lib will call st20r_rx_put_frame then.
+   *   < 0: the error code if app can't handle, lib will call st20rc_rx_put_frame then.
    * Only for ST20_TYPE_FRAME_LEVEL/ST20_TYPE_SLICE_LEVEL.
    * And only non-block method can be used in this callback as it run from lcore tasklet
    * routine.
@@ -134,7 +134,7 @@ struct st20r_rx_ops {
  *   - NULL on error.
  *   - Otherwise, the handle to the rx st2110-20(redundant) session.
  */
-st20r_rx_handle st20r_rx_create(mtl_handle mt, struct st20r_rx_ops* ops);
+st20rc_rx_handle st20rc_rx_create(mtl_handle mt, struct st20rc_rx_ops* ops);
 
 /**
  * Free the rx st2110-20(redundant) session.
@@ -145,7 +145,7 @@ st20r_rx_handle st20r_rx_create(mtl_handle mt, struct st20r_rx_ops* ops);
  *   - 0: Success.
  *   - <0: Error code.
  */
-int st20r_rx_free(st20r_rx_handle handle);
+int st20rc_rx_free(st20rc_rx_handle handle);
 
 /**
  * Put back the received buff get from notify_frame_ready.
@@ -158,7 +158,7 @@ int st20r_rx_free(st20r_rx_handle handle);
  *   - 0: Success.
  *   - <0: Error code.
  */
-int st20r_rx_put_frame(st20r_rx_handle handle, void* frame);
+int st20rc_rx_put_frame(st20rc_rx_handle handle, void* frame);
 
 /**
  * Get the framebuffer size for the rx st2110-20(redundant) session.
@@ -168,7 +168,7 @@ int st20r_rx_put_frame(st20r_rx_handle handle, void* frame);
  * @return
  *   - size.
  */
-size_t st20r_rx_get_framebuffer_size(st20r_rx_handle handle);
+size_t st20rc_rx_get_framebuffer_size(st20rc_rx_handle handle);
 
 /**
  * Get the framebuffer count for the rx st2110-20(redundant) session.
@@ -178,7 +178,7 @@ size_t st20r_rx_get_framebuffer_size(st20r_rx_handle handle);
  * @return
  *   - count.
  */
-int st20r_rx_get_framebuffer_count(st20r_rx_handle handle);
+int st20rc_rx_get_framebuffer_count(st20rc_rx_handle handle);
 
 /**
  * Dump st2110-20(redundant) packets to pcapng file.
@@ -196,8 +196,8 @@ int st20r_rx_get_framebuffer_count(st20r_rx_handle handle);
  *   - 0: Success, rx st2110-20(redundant) session pcapng dump succ.
  *   - <0: Error code of the rx st2110-20(redundant) session pcapng dump.
  */
-int st20r_rx_pcapng_dump(st20r_rx_handle handle, uint32_t max_dump_packets, bool sync,
-                         struct st_pcap_dump_meta* meta);
+int st20rc_rx_pcapng_dump(st20rc_rx_handle handle, uint32_t max_dump_packets, bool sync,
+                          struct st_pcap_dump_meta* meta);
 
 #if defined(__cplusplus)
 }

--- a/include/experimental/st20_combined_api.h
+++ b/include/experimental/st20_combined_api.h
@@ -27,32 +27,32 @@ typedef struct st20rc_rx_ctx* st20rc_rx_handle;
  * If set, it's application duty to set the rx flow(queue) and multicast join/drop.
  * Use st20p_rx_get_queue_meta to get the queue meta(queue number etc) info.
  */
-#define ST20R_RX_FLAG_DATA_PATH_ONLY (MTL_BIT32(0))
+#define ST20RC_RX_FLAG_DATA_PATH_ONLY (MTL_BIT32(0))
 /**
  * Flag bit in flags of struct st20rc_rx_ops.
  * If enabled, lib will pass ST_EVENT_VSYNC by the notify_event on every epoch start.
  */
-#define ST20R_RX_FLAG_ENABLE_VSYNC (MTL_BIT32(1))
+#define ST20RC_RX_FLAG_ENABLE_VSYNC (MTL_BIT32(1))
 
 /**
  * Flag bit in flags of struct st20rc_rx_ops.
  * If set, lib will pass the incomplete frame to app also.
  * User can check st_frame_status data for the frame integrity
  */
-#define ST20R_RX_FLAG_RECEIVE_INCOMPLETE_FRAME (MTL_BIT32(16))
+#define ST20RC_RX_FLAG_RECEIVE_INCOMPLETE_FRAME (MTL_BIT32(16))
 /**
  * Flag bit in flags of struct st20rc_rx_ops.
  * If set, lib will try to allocate DMA memory copy offload from
  * dma_dev_port(mtl_init_params) list.
  * Pls note it could fallback to CPU if no DMA device is available.
  */
-#define ST20R_RX_FLAG_DMA_OFFLOAD (MTL_BIT32(17))
+#define ST20RC_RX_FLAG_DMA_OFFLOAD (MTL_BIT32(17))
 /**
  * Flag bit in flags of struct st20rc_rx_ops.
  * Only ST20_PACKING_BPM stream can enable this offload as software limit
  * Try to enable header split offload feature.
  */
-#define ST20R_RX_FLAG_HDR_SPLIT (MTL_BIT32(19))
+#define ST20RC_RX_FLAG_HDR_SPLIT (MTL_BIT32(19))
 
 /**
  * The structure describing how to create a rx st2110-20(redundant) session.
@@ -94,7 +94,7 @@ struct st20rc_rx_ops {
   /** Optional. source filter IP address of multicast */
   uint8_t mcast_sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
 
-  /** flags, value in ST20R_RX_FLAG_* */
+  /** flags, value in ST20RC_RX_FLAG_* */
   uint32_t flags;
   /**
    * the ST20_TYPE_FRAME_LEVEL frame buffer count requested,

--- a/include/meson.build
+++ b/include/meson.build
@@ -2,7 +2,7 @@
 # Copyright 2022 Intel Corporation
 
 mtl_header_files = files('mtl_api.h', 'st_api.h', 'st_convert_api.h', 'st_convert_internal.h',
-  'st_pipeline_api.h', 'st20_api.h', 'st30_api.h', 'st40_api.h', 'st20_redundant_api.h',
+  'st_pipeline_api.h', 'st20_api.h', 'st30_api.h', 'st40_api.h',
   'mudp_api.h', 'mudp_sockfd_api.h', 'mudp_sockfd_internal.h', 'mtl_lcore_shm_api.h',
   'mtl_sch_api.h')
 
@@ -11,3 +11,10 @@ if is_windows
 endif
 
 install_headers(mtl_header_files, subdir : meson.project_name())
+
+# experimental features
+mtl_experimental_header_files = files('experimental/st20_combined_api.h')
+
+experimental_header_install_path = meson.project_name() + '/experimental'
+
+install_headers(mtl_experimental_header_files, subdir : experimental_header_install_path)

--- a/lib/src/st2110/experimental/meson.build
+++ b/lib/src/st2110/experimental/meson.build
@@ -2,5 +2,5 @@
 # Copyright 2022 Intel Corporation
 
 sources += files(
-	'st20_redundant_rx.c',
+	'st20_redundant_combined_rx.c',
 )

--- a/lib/src/st2110/experimental/st20_redundant_combined_rx.c
+++ b/lib/src/st2110/experimental/st20_redundant_combined_rx.c
@@ -154,15 +154,15 @@ static int rx_st20rc_create_transport(struct st20rc_rx_ctx* ctx,
   snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s", ops->port[port]);
   ops_rx.udp_port[MTL_SESSION_PORT_P] = ops->udp_port[port];
 
-  if (ops->flags & ST20R_RX_FLAG_DATA_PATH_ONLY)
+  if (ops->flags & ST20RC_RX_FLAG_DATA_PATH_ONLY)
     ops_rx.flags |= ST20_RX_FLAG_DATA_PATH_ONLY;
   /* always enable incomplete frame */
   ops_rx.flags |= ST20_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
   /* disable migrate since it may migrate the two sessions into one sch */
   ops_rx.flags |= ST20_RX_FLAG_DISABLE_MIGRATE;
-  if (ops->flags & ST20R_RX_FLAG_DMA_OFFLOAD) ops_rx.flags |= ST20_RX_FLAG_DMA_OFFLOAD;
-  if (ops->flags & ST20R_RX_FLAG_HDR_SPLIT) ops_rx.flags |= ST20_RX_FLAG_HDR_SPLIT;
-  if (ops->flags & ST20R_RX_FLAG_ENABLE_VSYNC) ops_rx.flags |= ST20_RX_FLAG_ENABLE_VSYNC;
+  if (ops->flags & ST20RC_RX_FLAG_DMA_OFFLOAD) ops_rx.flags |= ST20_RX_FLAG_DMA_OFFLOAD;
+  if (ops->flags & ST20RC_RX_FLAG_HDR_SPLIT) ops_rx.flags |= ST20_RX_FLAG_HDR_SPLIT;
+  if (ops->flags & ST20RC_RX_FLAG_ENABLE_VSYNC) ops_rx.flags |= ST20_RX_FLAG_ENABLE_VSYNC;
 
   ops_rx.pacing = ops->pacing;
   ops_rx.width = ops->width;
@@ -280,7 +280,7 @@ st20rc_rx_handle st20rc_rx_create(mtl_handle mt, struct st20rc_rx_ops* ops) {
   if (ops->name) {
     snprintf(ctx->ops_name, sizeof(ctx->ops_name), "%s", ops->name);
   } else {
-    snprintf(ctx->ops_name, sizeof(ctx->ops_name), "ST20R_RX_%d", idx);
+    snprintf(ctx->ops_name, sizeof(ctx->ops_name), "ST20RC_RX_%d", idx);
   }
   ctx->ops = *ops;
 

--- a/lib/src/st2110/experimental/st20_redundant_combined_rx.h
+++ b/lib/src/st2110/experimental/st20_redundant_combined_rx.h
@@ -1,46 +1,48 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  * Copyright(c) 2022 Intel Corporation
+ *
+ * st2110-20 combined redundant transport, experimental feature only.
  */
 
-#ifndef _ST_LIB_REDUNDANT_ST20_RX_HEAD_H_
-#define _ST_LIB_REDUNDANT_ST20_RX_HEAD_H_
+#ifndef _ST_LIB_REDUNDANT_COMBINED_ST20_RX_HEAD_H_
+#define _ST_LIB_REDUNDANT_COMBINED_ST20_RX_HEAD_H_
 
-#include <st20_redundant_api.h>
+#include <experimental/st20_combined_api.h>
 
 #include "../st_main.h"
 
-struct st20r_rx_ctx;
+struct st20rc_rx_ctx;
 
-struct st20r_rx_transport {
+struct st20rc_rx_transport {
   st20_rx_handle handle;
   enum mtl_session_port port; /* port this handle attached */
-  struct st20r_rx_ctx* parent;
+  struct st20rc_rx_ctx* parent;
 };
 
-struct st20r_rx_frame {
+struct st20rc_rx_frame {
   void* frame;
   enum mtl_session_port port;
   struct st20_rx_frame_meta meta;
 };
 
-struct st20r_rx_ctx {
+struct st20rc_rx_ctx {
   struct mtl_main_impl* impl;
   int idx;
   enum mt_handle_type type; /* for sanity check, must be MT_HANDLE_RX_VIDEO_R */
 
   char ops_name[ST_MAX_NAME_LEN];
-  struct st20r_rx_ops ops;
+  struct st20rc_rx_ops ops;
 
   pthread_mutex_t lock;
   bool ready;
-  struct st20r_rx_transport* transport[MTL_SESSION_PORT_MAX];
+  struct st20rc_rx_transport* transport[MTL_SESSION_PORT_MAX];
 
   /* global status for current frame */
   void* cur_frame;
   uint64_t cur_timestamp;
   bool cur_frame_complete;
   /* the frames passed to user */
-  struct st20r_rx_frame* frames;
+  struct st20rc_rx_frame* frames;
   int frames_cnt;
 };
 

--- a/lib/src/st2110/meson.build
+++ b/lib/src/st2110/meson.build
@@ -21,4 +21,4 @@ sources += files(
 )
 
 subdir('pipeline')
-subdir('redundant')
+subdir('experimental')


### PR DESCRIPTION
It only used for the experimental header split. Rename to avoid the confuse from user side.