### PR TITLE
mcast: add source filter for kernel based backend

### DIFF
--- a/lib/src/datapath/mt_dp_socket.c
+++ b/lib/src/datapath/mt_dp_socket.c
@@ -478,13 +478,26 @@ static int rx_socket_init_fd(struct mt_rx_socket_entry* entry, int fd, bool reus
   }
 
   if (mt_is_multicast_ip(flow->dip_addr)) {
-    struct ip_mreq mreq;
-    memset(&mreq, 0, sizeof(mreq));
-    /* multicast addr */
-    memcpy(&mreq.imr_multiaddr.s_addr, flow->dip_addr, MTL_IP_ADDR_LEN);
-    /* local nic src ip */
-    memcpy(&mreq.imr_interface.s_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
-    ret = setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
+    uint32_t source = *(uint32_t*)flow->sip_addr;
+    if (source == 0) {
+      struct ip_mreq mreq;
+      memset(&mreq, 0, sizeof(mreq));
+      /* multicast addr */
+      memcpy(&mreq.imr_multiaddr.s_addr, flow->dip_addr, MTL_IP_ADDR_LEN);
+      /* local interface ip */
+      memcpy(&mreq.imr_interface.s_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
+      ret = setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
+    } else {
+      struct ip_mreq_source mreq;
+      memset(&mreq, 0, sizeof(mreq));
+      /* multicast addr */
+      memcpy(&mreq.imr_multiaddr.s_addr, flow->dip_addr, MTL_IP_ADDR_LEN);
+      /* local interface ip */
+      memcpy(&mreq.imr_interface.s_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
+      /* source addr */
+      memcpy(&mreq.imr_sourceaddr.s_addr, flow->sip_addr, MTL_IP_ADDR_LEN);
+      ret = setsockopt(fd, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP, &mreq, sizeof(mreq));
+    }
     if (ret < 0) {
       err("%s(%d,%d), join multicast fail %d\n", __func__, port, fd, ret);
       return ret;
@@ -710,6 +723,43 @@ struct mt_rx_socket_entry* mt_rx_socket_get(struct mtl_main_impl* impl,
   return entry;
 }
 
+static int rx_socket_leave_mcast(struct mt_rx_socket_entry* entry) {
+  int ret;
+  int fd = entry->fd;
+  enum mtl_port port = entry->port;
+  struct mtl_main_impl* impl = entry->parent;
+  struct mt_rxq_flow* flow = &entry->flow;
+
+  if (!mt_is_multicast_ip(flow->dip_addr)) return 0;
+
+  uint32_t source = *(uint32_t*)flow->sip_addr;
+  if (source == 0) {
+    struct ip_mreq mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    /* multicast addr */
+    memcpy(&mreq.imr_multiaddr.s_addr, flow->dip_addr, MTL_IP_ADDR_LEN);
+    /* local interface ip */
+    memcpy(&mreq.imr_interface.s_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
+    ret = setsockopt(fd, IPPROTO_IP, IP_DROP_MEMBERSHIP, &mreq, sizeof(mreq));
+  } else {
+    struct ip_mreq_source mreq;
+    memset(&mreq, 0, sizeof(mreq));
+    /* multicast addr */
+    memcpy(&mreq.imr_multiaddr.s_addr, flow->dip_addr, MTL_IP_ADDR_LEN);
+    /* local interface ip */
+    memcpy(&mreq.imr_interface.s_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
+    /* source addr */
+    memcpy(&mreq.imr_sourceaddr.s_addr, flow->sip_addr, MTL_IP_ADDR_LEN);
+    ret = setsockopt(fd, IPPROTO_IP, IP_DROP_SOURCE_MEMBERSHIP, &mreq, sizeof(mreq));
+  }
+  if (ret < 0) {
+    err("%s(%d,%d), leave multicast fail %d\n", __func__, port, fd, ret);
+    return ret;
+  }
+  info("%s(%d,%d), leave multicast succ\n", __func__, port, fd);
+  return 0;
+}
+
 int mt_rx_socket_put(struct mt_rx_socket_entry* entry) {
   int fd = entry->fd;
   enum mtl_port port = entry->port;
@@ -743,6 +793,7 @@ int mt_rx_socket_put(struct mt_rx_socket_entry* entry) {
   }
   /* close fd */
   if (entry->fd >= 0) {
+    rx_socket_leave_mcast(entry);
     close(entry->fd);
     entry->fd = -1;
   }

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -97,7 +97,7 @@ static const struct mt_dev_driver_info dev_drvs[] = {
         .drv_type = MT_DRV_NATIVE_AF_XDP,
         .flow_type = MT_FLOW_ALL,
         .flags = MT_DRV_F_NOT_DPDK_PMD | MT_DRV_F_NO_CNI | MT_DRV_F_USE_KERNEL_CTL |
-                 MT_DRV_F_RX_POOL_COMMON | MT_DRV_F_KERNEL_BASED,
+                 MT_DRV_F_RX_POOL_COMMON | MT_DRV_F_MCAST_IN_DP | MT_DRV_F_KERNEL_BASED,
     },
 };
 

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1095,6 +1095,7 @@ struct mt_rx_xdp_entry {
   struct mt_rx_flow_rsp* flow_rsp;
   bool skip_udp_port_check;
   bool skip_all_check;
+  int mcast_fd;
 };
 
 struct mt_flow_impl {

--- a/lib/src/mt_mcast.c
+++ b/lib/src/mt_mcast.c
@@ -6,7 +6,6 @@
 
 #include "datapath/mt_queue.h"
 #include "mt_log.h"
-#include "mt_socket.h"
 #include "mt_util.h"
 
 #define MT_MCAST_POOL_INC (32)
@@ -341,7 +340,7 @@ static void mcast_membership_report_cb(void* param) {
 
   for (int port = 0; port < num_ports; port++) {
     struct mt_mcast_impl* mcast = get_mcast(impl, port);
-    if (!mt_drv_use_kernel_ctl(impl, port) && !mcast->has_external_query) {
+    if (!mcast->has_external_query) {
       ret = mcast_membership_report_on_query(impl, port);
       if (ret < 0) {
         err("%s(%d), mcast_membership_report fail %d\n", __func__, port, ret);
@@ -450,7 +449,10 @@ int mt_mcast_init(struct mtl_main_impl* impl) {
   int num_ports = mt_num_ports(impl);
   int socket = mt_socket_id(impl, MTL_PORT_P);
 
+  bool has_dpdk_mcast = false;
+
   for (int i = 0; i < num_ports; i++) {
+    if (mt_drv_use_kernel_ctl(impl, i)) continue;
     struct mt_mcast_impl* mcast = mt_rte_zmalloc_socket(sizeof(*mcast), socket);
     if (!mcast) {
       err("%s(%d), mcast malloc fail\n", __func__, i);
@@ -466,15 +468,21 @@ int mt_mcast_init(struct mtl_main_impl* impl) {
     /* assign mcast instance */
     impl->mcast[i] = mcast;
 
-    if (!mt_drv_use_kernel_ctl(impl, i))
-      mcast_inf_add_mac(mt_if(impl, i), &mcast_mac_all);
+    mcast_inf_add_mac(mt_if(impl, i), &mcast_mac_all);
+
+    has_dpdk_mcast = true;
   }
 
-  int ret =
-      rte_eal_alarm_set(IGMP_JOIN_GROUP_PERIOD_US, mcast_membership_report_cb, impl);
-  if (ret < 0) err("%s, set igmp alarm fail %d\n", __func__, ret);
-  info("%s, report every %d seconds\n", __func__, IGMP_JOIN_GROUP_PERIOD_S);
+  if (has_dpdk_mcast) {
+    int ret =
+        rte_eal_alarm_set(IGMP_JOIN_GROUP_PERIOD_US, mcast_membership_report_cb, impl);
+    if (ret < 0)
+      err("%s, set igmp alarm fail %d\n", __func__, ret);
+    else
+      info("%s, report every %d seconds\n", __func__, IGMP_JOIN_GROUP_PERIOD_S);
+  }
 
+  dbg("%s, succ\n", __func__);
   return 0;
 }
 
@@ -506,12 +514,13 @@ static void mcast_group_clear(struct mt_mcast_group_list* group_list) {
 int mt_mcast_uinit(struct mtl_main_impl* impl) {
   int num_ports = mt_num_ports(impl);
 
+  bool has_dpdk_mcast = false;
+
   for (int i = 0; i < num_ports; i++) {
     struct mt_mcast_impl* mcast = get_mcast(impl, i);
     if (!mcast) continue;
 
-    if (!mt_drv_use_kernel_ctl(impl, i))
-      mcast_inf_remove_mac(mt_if(impl, i), &mcast_mac_all);
+    mcast_inf_remove_mac(mt_if(impl, i), &mcast_mac_all);
 
     /* clear group list */
     mcast_group_clear(&mcast->group_list);
@@ -521,10 +530,14 @@ int mt_mcast_uinit(struct mtl_main_impl* impl) {
     /* free the memory */
     mt_rte_free(mcast);
     impl->mcast[i] = NULL;
+
+    has_dpdk_mcast = true;
   }
 
-  int ret = rte_eal_alarm_cancel(mcast_membership_report_cb, impl);
-  if (ret < 0) err("%s, alarm cancel fail %d\n", __func__, ret);
+  if (has_dpdk_mcast) {
+    int ret = rte_eal_alarm_cancel(mcast_membership_report_cb, impl);
+    if (ret < 0) err("%s, alarm cancel fail %d\n", __func__, ret);
+  }
 
   dbg("%s, succ\n", __func__);
   return 0;
@@ -537,12 +550,11 @@ int mt_mcast_join(struct mtl_main_impl* impl, uint32_t group_addr, uint32_t sour
   struct rte_ether_addr mcast_mac;
   struct mt_interface* inf = mt_if(impl, port);
   uint8_t* ip = (uint8_t*)&group_addr;
-  int ret;
 
   if (mt_drv_mcast_in_dp(impl, port)) return 0;
 
   if (mcast->group_num >= MT_MCAST_GROUP_MAX) {
-    err("%s, reach max multicast group number!\n", __func__);
+    err("%s(%d), reach max multicast group number!\n", __func__, port);
     return -EIO;
   }
 
@@ -561,23 +573,14 @@ int mt_mcast_join(struct mtl_main_impl* impl, uint32_t group_addr, uint32_t sour
 
   /* add new group to the group list */
   if (!found) {
-    if (mt_drv_use_kernel_ctl(impl, port)) {
-      ret = mt_socket_join_mcast(impl, port, group_addr);
-      if (ret < 0) {
-        mt_pthread_mutex_unlock(&mcast->group_mutex);
-        err("%s(%d), fail(%d) to join socket group %d.%d.%d.%d\n", __func__, port, ret,
-            ip[0], ip[1], ip[2], ip[3]);
-        return ret;
-      }
-    } else {
-      /* add mcast mac to dpdk interface */
-      mt_mcast_ip_to_mac(ip, &mcast_mac);
-      mcast_inf_add_mac(inf, &mcast_mac);
-    }
+    /* add mcast mac to dpdk interface */
+    mt_mcast_ip_to_mac(ip, &mcast_mac);
+    mcast_inf_add_mac(inf, &mcast_mac);
+
     group = mt_rte_zmalloc_socket(sizeof(struct mt_mcast_group_entry),
                                   mt_socket_id(impl, port));
     if (group == NULL) {
-      err("%s, malloc group fail\n", __func__);
+      err("%s(%d), malloc group fail\n", __func__, port);
       mt_pthread_mutex_unlock(&mcast->group_mutex);
       return -ENOMEM;
     }
@@ -594,7 +597,7 @@ int mt_mcast_join(struct mtl_main_impl* impl, uint32_t group_addr, uint32_t sour
     struct mt_mcast_src_entry* src;
     TAILQ_FOREACH(src, &group->src_list, entries) {
       if (src->src_ip == source_addr) {
-        dbg("%s, already has source ip in the source list\n", __func__);
+        dbg("%s(%d), already has source ip in the source list\n", __func__, port);
         src->src_ref_cnt++;
         found = true;
         break;
@@ -604,7 +607,7 @@ int mt_mcast_join(struct mtl_main_impl* impl, uint32_t group_addr, uint32_t sour
       src = mt_rte_zmalloc_socket(sizeof(struct mt_mcast_src_entry),
                                   mt_socket_id(impl, port));
       if (src == NULL) {
-        err("%s, mt_mcast_src malloc fail\n", __func__);
+        err("%s(%d), mt_mcast_src malloc fail\n", __func__, port);
         mt_pthread_mutex_unlock(&mcast->group_mutex);
         return -ENOMEM;
       }
@@ -622,10 +625,13 @@ int mt_mcast_join(struct mtl_main_impl* impl, uint32_t group_addr, uint32_t sour
    * then join it again with any source is not allowed.
    */
   if (!found) {
-    if (!mt_drv_use_kernel_ctl(impl, port)) {
-      mcast_membership_report_on_action(impl, port, group_addr, source_addr, MCAST_JOIN);
+    int ret = mcast_membership_report_on_action(impl, port, group_addr, source_addr,
+                                                MCAST_JOIN);
+    if (ret < 0) {
+      err("%s(%d), send membership report fail\n", __func__, port);
+      return ret;
     }
-    info("%s(%d), new group %d.%d.%d.%d\n", __func__, port, ip[0], ip[1], ip[2], ip[3]);
+    info("%s(%d), join group %d.%d.%d.%d\n", __func__, port, ip[0], ip[1], ip[2], ip[3]);
     if (source_addr != 0) {
       ip = (uint8_t*)&source_addr;
       info("%s(%d), with source %d.%d.%d.%d\n", __func__, port, ip[0], ip[1], ip[2],
@@ -651,80 +657,72 @@ int mt_mcast_leave(struct mtl_main_impl* impl, uint32_t group_addr, uint32_t sou
 
   mt_pthread_mutex_lock(&mcast->group_mutex);
   /* find existing group */
-  bool found = false;
+  bool gfound = false;
   struct mt_mcast_group_entry* group;
   TAILQ_FOREACH(group, &mcast->group_list, entries) {
     if (group->group_ip == group_addr) {
-      found = true;
+      gfound = true;
       break;
     }
   }
 
-  if (!found) {
+  if (!gfound) {
     mt_pthread_mutex_unlock(&mcast->group_mutex);
-    warn("%s, group ip not found, nothing to delete\n", __func__);
+    warn("%s(%d), group ip not found, nothing to delete\n", __func__, port);
     return 0;
   }
 
   /* delete source */
+  bool sfound = false;
   if (source_addr != 0) {
-    found = false;
     struct mt_mcast_src_entry* src;
     TAILQ_FOREACH(src, &group->src_list, entries) {
       if (src->src_ip == source_addr) {
-        found = true;
+        sfound = true;
         break;
       }
     }
-    if (found) {
+    if (sfound) {
       src->src_ref_cnt--;
       if (src->src_ref_cnt == 0) {
-        info("%s, delete source %x\n", __func__, source_addr);
+        info("%s(%d), delete source %x\n", __func__, port, source_addr);
         TAILQ_REMOVE(&group->src_list, src, entries);
         mt_rte_free(src);
-        /* send leave report */
-        if (!mt_drv_use_kernel_ctl(impl, port))
-          mcast_membership_report_on_action(impl, port, group_addr, source_addr,
-                                            MCAST_LEAVE);
       }
     }
   }
 
   group->group_ref_cnt--;
   if (group->group_ref_cnt == 0) {
-    info("%s, delete group %x\n", __func__, group_addr);
+    info("%s(%d), delete group %x\n", __func__, port, group_addr);
     TAILQ_REMOVE(&mcast->group_list, group, entries);
     mt_rte_free(group);
 
     mcast->group_num--;
-    if (mt_drv_use_kernel_ctl(impl, port)) {
-      mt_socket_drop_mcast(impl, port, group_addr);
-    } else {
-      /* remove mcast mac from interface */
-      mt_mcast_ip_to_mac(ip, &mcast_mac);
-      mcast_inf_remove_mac(inf, &mcast_mac);
-    }
 
-    /* send leave report */
-    if (!mt_drv_use_kernel_ctl(impl, port))
-      mcast_membership_report_on_action(impl, port, group_addr, source_addr, MCAST_LEAVE);
+    /* remove mcast mac from interface */
+    mt_mcast_ip_to_mac(ip, &mcast_mac);
+    mcast_inf_remove_mac(inf, &mcast_mac);
   }
+
   mt_pthread_mutex_unlock(&mcast->group_mutex);
 
-  return 0;
-}
-
-int mt_mcast_restore(struct mtl_main_impl* impl, enum mtl_port port) {
-  struct mt_interface* inf = mt_if(impl, port);
-  uint16_t port_id = inf->port_id;
-
-  if (inf->drv_info.flags & MT_DRV_F_USE_MC_ADDR_LIST) {
-    rte_eth_dev_set_mc_addr_list(port_id, inf->mcast_mac_lists, inf->mcast_nb);
-  } else {
-    for (uint32_t i = 0; i < inf->mcast_nb; i++)
-      rte_eth_dev_mac_addr_add(port_id, &inf->mcast_mac_lists[i], 0);
+  /* send leave report */
+  if (gfound || sfound) {
+    int ret = mcast_membership_report_on_action(impl, port, group_addr, source_addr,
+                                                MCAST_LEAVE);
+    if (ret < 0) {
+      err("%s(%d), send leave report failed\n", __func__, port);
+      return ret;
+    }
+    info("%s(%d), leave group %d.%d.%d.%d\n", __func__, port, ip[0], ip[1], ip[2], ip[3]);
+    if (source_addr != 0) {
+      ip = (uint8_t*)&source_addr;
+      info("%s(%d), with source %d.%d.%d.%d\n", __func__, port, ip[0], ip[1], ip[2],
+           ip[3]);
+    }
   }
-  mcast_membership_report_on_query(impl, port);
+
   return 0;
 }
 
@@ -740,6 +738,20 @@ int mt_mcast_l2_leave(struct mtl_main_impl* impl, struct rte_ether_addr* addr,
   struct mt_interface* inf = mt_if(impl, port);
   if (mt_drv_use_kernel_ctl(impl, port)) return 0;
   return mcast_inf_remove_mac(inf, addr);
+}
+
+int mt_mcast_restore(struct mtl_main_impl* impl, enum mtl_port port) {
+  struct mt_interface* inf = mt_if(impl, port);
+  uint16_t port_id = inf->port_id;
+
+  if (inf->drv_info.flags & MT_DRV_F_USE_MC_ADDR_LIST) {
+    rte_eth_dev_set_mc_addr_list(port_id, inf->mcast_mac_lists, inf->mcast_nb);
+  } else {
+    for (uint32_t i = 0; i < inf->mcast_nb; i++)
+      rte_eth_dev_mac_addr_add(port_id, &inf->mcast_mac_lists[i], 0);
+  }
+  mcast_membership_report_on_query(impl, port);
+  return 0;
 }
 
 int mt_mcast_parse(struct mtl_main_impl* impl, struct mcast_mb_query_v3* query,

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -1252,7 +1252,7 @@ static int ptp_init(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp,
 
   inet_pton(AF_INET, "224.0.1.129", ptp->mcast_group_addr);
 
-  if (mt_has_cni(impl, port) && !mt_drv_kernel_based(impl, port)) {
+  if (mt_has_cni(impl, port) && !mt_drv_mcast_in_dp(impl, port)) {
     /* join mcast only if cni path, no cni use socket which has mcast in the data path */
     ret = mt_mcast_join(impl, mt_ip_to_u32(ptp->mcast_group_addr), 0, port);
     if (ret < 0) {
@@ -1319,7 +1319,7 @@ static int ptp_uinit(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp) {
 
   if (!ptp->active) return 0;
 
-  if (mt_has_cni(impl, port) && !mt_drv_kernel_based(impl, port)) {
+  if (mt_has_cni(impl, port) && !mt_drv_mcast_in_dp(impl, port)) {
     mt_mcast_l2_leave(impl, &ptp_l2_multicast_eaddr, port);
     mt_mcast_leave(impl, mt_ip_to_u32(ptp->mcast_group_addr), 0, port);
   }

--- a/lib/src/mt_socket.c
+++ b/lib/src/mt_socket.c
@@ -196,48 +196,6 @@ int mt_socket_get_numa(const char* if_name) {
   return numa_node;
 }
 
-int mt_socket_join_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group) {
-  int ret;
-  char cmd[128];
-  uint8_t ip[MTL_IP_ADDR_LEN];
-  const char* if_name = mt_kernel_if_name(impl, port);
-
-  if (!mt_drv_use_kernel_ctl(impl, port)) {
-    err("%s(%d), not kernel based pmd\n", __func__, port);
-    return -EIO;
-  }
-
-  mt_u32_to_ip(group, ip);
-  snprintf(cmd, sizeof(cmd), "ip addr add %u.%u.%u.%u/24 dev %s autojoin", ip[0], ip[1],
-           ip[2], ip[3], if_name);
-  ret = mt_run_cmd(cmd, NULL, 0);
-  if (ret < 0) return ret;
-
-  info("%s, succ, %s\n", __func__, cmd);
-  return 0;
-}
-
-int mt_socket_drop_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group) {
-  int ret;
-  char cmd[128];
-  uint8_t ip[MTL_IP_ADDR_LEN];
-  const char* if_name = mt_kernel_if_name(impl, port);
-
-  if (!mt_drv_use_kernel_ctl(impl, port)) {
-    err("%s(%d), not kernel based pmd\n", __func__, port);
-    return -EIO;
-  }
-
-  mt_u32_to_ip(group, ip);
-  snprintf(cmd, sizeof(cmd), "ip addr del %u.%u.%u.%u/24 dev %s autojoin", ip[0], ip[1],
-           ip[2], ip[3], if_name);
-  ret = mt_run_cmd(cmd, NULL, 0);
-  if (ret < 0) return ret;
-
-  info("%s, succ, %s\n", __func__, cmd);
-  return 0;
-}
-
 static int socket_arp_get(int sfd, in_addr_t ip, struct rte_ether_addr* ea,
                           const char* if_name) {
   struct arpreq arp;
@@ -593,7 +551,8 @@ int mt_socket_join_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_
   return -ENOTSUP;
 }
 
-int mt_socket_drop_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group) {
+int mt_socket_leave_mcast(struct mtl_main_impl* impl, enum mtl_port port,
+                          uint32_t group) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(port);
   MTL_MAY_UNUSED(group);

--- a/lib/src/mt_socket.c
+++ b/lib/src/mt_socket.c
@@ -544,21 +544,6 @@ int mt_socket_get_numa(const char* if_name) {
   return 0;
 }
 
-int mt_socket_join_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group) {
-  MTL_MAY_UNUSED(impl);
-  MTL_MAY_UNUSED(port);
-  MTL_MAY_UNUSED(group);
-  return -ENOTSUP;
-}
-
-int mt_socket_leave_mcast(struct mtl_main_impl* impl, enum mtl_port port,
-                          uint32_t group) {
-  MTL_MAY_UNUSED(impl);
-  MTL_MAY_UNUSED(port);
-  MTL_MAY_UNUSED(group);
-  return -ENOTSUP;
-}
-
 int mt_socket_get_mac(struct mtl_main_impl* impl, const char* if_name,
                       uint8_t dip[MTL_IP_ADDR_LEN], struct rte_ether_addr* ea,
                       int timeout_ms) {

--- a/lib/src/mt_socket.h
+++ b/lib/src/mt_socket.h
@@ -21,10 +21,6 @@ int mt_socket_set_if_up(const char* if_name);
 
 int mt_socket_get_numa(const char* if_name);
 
-int mt_socket_join_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group);
-
-int mt_socket_drop_mcast(struct mtl_main_impl* impl, enum mtl_port port, uint32_t group);
-
 int mt_socket_get_mac(struct mtl_main_impl* impl, const char* if_name,
                       uint8_t dip[MTL_IP_ADDR_LEN], struct rte_ether_addr* ea,
                       int timeout_ms);

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -263,7 +263,7 @@ static int rx_ancillary_session_uinit_mcast(struct mtl_main_impl* impl,
   for (int i = 0; i < ops->num_port; i++) {
     if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    if (mt_drv_mcast_in_dp(impl, port)) continue;
     mt_mcast_leave(impl, mt_ip_to_u32(ops->sip_addr[i]),
                    mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
   }
@@ -280,7 +280,7 @@ static int rx_ancillary_session_init_mcast(struct mtl_main_impl* impl,
   for (int i = 0; i < ops->num_port; i++) {
     if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    if (mt_drv_mcast_in_dp(impl, port)) continue;
     if (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY) {
       info("%s(%d), skip mcast join for port %d\n", __func__, s->idx, i);
       return 0;

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -664,7 +664,7 @@ static int rx_audio_session_uinit_mcast(struct mtl_main_impl* impl,
   for (int i = 0; i < ops->num_port; i++) {
     if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    if (mt_drv_mcast_in_dp(impl, port)) continue;
     mt_mcast_leave(impl, mt_ip_to_u32(ops->sip_addr[i]),
                    mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
   }
@@ -681,7 +681,7 @@ static int rx_audio_session_init_mcast(struct mtl_main_impl* impl,
   for (int i = 0; i < ops->num_port; i++) {
     if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    if (mt_drv_mcast_in_dp(impl, port)) continue;
     if (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY) {
       info("%s(%d), skip mcast join for port %d\n", __func__, s->idx, i);
       return 0;

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -629,7 +629,10 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
 
     memset(&flow, 0, sizeof(flow));
     rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
-    rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
+    if (mt_is_multicast_ip(flow.dip_addr))
+      rte_memcpy(flow.sip_addr, s->ops.mcast_sip_addr[i], MTL_IP_ADDR_LEN);
+    else
+      rte_memcpy(flow.sip_addr, mt_sip_addr(impl, port), MTL_IP_ADDR_LEN);
     flow.dst_port = s->st30_dst_port[i];
     if (mt_has_cni_rx(impl, port)) flow.flags |= MT_RXQ_FLOW_F_FORCE_CNI;
 
@@ -656,12 +659,14 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
 static int rx_audio_session_uinit_mcast(struct mtl_main_impl* impl,
                                         struct st_rx_audio_session_impl* s) {
   struct st30_rx_ops* ops = &s->ops;
+  enum mtl_port port;
 
   for (int i = 0; i < ops->num_port; i++) {
-    if (mt_is_multicast_ip(ops->sip_addr[i]))
-      mt_mcast_leave(impl, mt_ip_to_u32(ops->sip_addr[i]),
-                     mt_ip_to_u32(ops->mcast_sip_addr[i]),
-                     mt_port_logic2phy(s->port_maps, i));
+    if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
+    port = mt_port_logic2phy(s->port_maps, i);
+    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    mt_mcast_leave(impl, mt_ip_to_u32(ops->sip_addr[i]),
+                   mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
   }
 
   return 0;
@@ -671,17 +676,18 @@ static int rx_audio_session_init_mcast(struct mtl_main_impl* impl,
                                        struct st_rx_audio_session_impl* s) {
   struct st30_rx_ops* ops = &s->ops;
   int ret;
+  enum mtl_port port;
 
   for (int i = 0; i < ops->num_port; i++) {
     if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
-
-    if (ops->flags & ST30_RX_FLAG_DATA_PATH_ONLY) {
+    port = mt_port_logic2phy(s->port_maps, i);
+    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    if (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY) {
       info("%s(%d), skip mcast join for port %d\n", __func__, s->idx, i);
       return 0;
     }
     ret = mt_mcast_join(impl, mt_ip_to_u32(ops->sip_addr[i]),
-                        mt_ip_to_u32(ops->mcast_sip_addr[i]),
-                        mt_port_logic2phy(s->port_maps, i));
+                        mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
     if (ret < 0) return ret;
   }
 

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2687,7 +2687,7 @@ static int rv_uinit_mcast(struct mtl_main_impl* impl,
   for (int i = 0; i < ops->num_port; i++) {
     if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    if (mt_drv_mcast_in_dp(impl, port)) continue;
     mt_mcast_leave(impl, mt_ip_to_u32(ops->sip_addr[i]),
                    mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
   }
@@ -2703,7 +2703,7 @@ static int rv_init_mcast(struct mtl_main_impl* impl, struct st_rx_video_session_
   for (int i = 0; i < ops->num_port; i++) {
     if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_drv_use_kernel_ctl(impl, port)) continue;
+    if (mt_drv_mcast_in_dp(impl, port)) continue;
     if (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY) {
       info("%s(%d), skip mcast join for port %d\n", __func__, s->idx, i);
       return 0;


### PR DESCRIPTION
1. Add source filter for kernel based backend.
2. Add multicast support for AF_XDP backend.
3. Fix condition for leave report sending.