### PR TITLE
Updated st22 interlace support for plugins.

### DIFF
--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -391,7 +391,7 @@ static int tx_st22p_get_encoder(struct mtl_main_impl* impl, struct st22p_tx_ctx*
   req.req.quality = ops->quality;
   req.req.framebuff_cnt = ops->framebuff_cnt;
   req.req.codec_thread_cnt = ops->codec_thread_cnt;
-
+  req.req.interlaced = ops->interlaced;
   req.priv = ctx;
   req.get_frame = tx_st22p_encode_get_frame;
   req.put_frame = tx_st22p_encode_put_frame;

--- a/tests/script/loop_json/st22p_1v_1080i59.json
+++ b/tests/script/loop_json/st22p_1v_1080i59.json
@@ -25,7 +25,7 @@
                     "width": 1920,
                     "height": 1080,
                     "fps": "p59",
-                    "interlaced": "true",
+                    "interlaced": true,
                     "codec": "JPEG-XS",
                     "device": "AUTO",
                     "quality": "speed",
@@ -53,14 +53,14 @@
                     "width": 1920,
                     "height": 1080,
                     "fps": "p59",
-                    "interlaced": "true",
+                    "interlaced": true,
                     "codec": "JPEG-XS",
                     "device": "AUTO",
                     "pack_type": "codestream",
                     "output_format": "YUV422RFC4175PG2BE10",
                     "codec_thread_count" : 2,
                     "display": false,
-                    "measure_latency": true,
+                    "measure_latency": true
                 }
             ]
         }

--- a/tests/script/loop_json/st22p_interlaced_pcap.json
+++ b/tests/script/loop_json/st22p_interlaced_pcap.json
@@ -49,7 +49,7 @@
                     "width": 1920,
                     "height": 1080,
                     "fps": "p59",
-                    "interlaced": "true",
+                    "interlaced": true,
                     "codec": "JPEG-XS",
                     "device": "AUTO",
                     "pack_type": "codestream",


### PR DESCRIPTION
Following up on https://github.com/OpenVisualCloud/Media-Transport-Library/pull/628, I updated tx_st22p_get_encoder() to set the interlaced parameter in the st22_get_encoder_request struct.  This change is critical for the parameter to get passed to any st22 plugins.

I also updated the interlaced parameter type in the test json configurations, since interlaced is a boolean but was set as a string, and json-c defaults all strings as true.