### PR TITLE
doc: use group to control access to vfio devices

### DIFF
--- a/doc/run.md
+++ b/doc/run.md
@@ -87,7 +87,8 @@ For Intel® E810 Series Ethernet Adapter, refer to [Intel® E810 Series Ethernet
 
 ## 3. DPDK PMD setup
 
-DPDK utilizes the Linux kernel's VFIO module to enable direct NIC (Network Interface Card) hardware access from user space with the assistance of an IOMMU (Input/Output Memory Management Unit). To use DPDK's Poll Mode Drivers (PMDs), NICs must be bound to the `vfio-pci` driver. Before manipulating VFIO devices, it's necessary to configure user permissions and system rules to allow the current user to access VFIO interfaces.
+DPDK utilizes the Linux kernel's VFIO module to enable direct NIC hardware access from user space with the assistance of an IOMMU (Input/Output Memory Management Unit).
+To use DPDK's Poll Mode Drivers (PMDs), NICs must be bound to the `vfio-pci` driver. Before manipulating VFIO devices, it's necessary to configure user permissions and system rules to allow the current user to access VFIO devices.
 
 ### 3.1 Allow current user to access /dev/vfio/* devices
 

--- a/doc/run.md
+++ b/doc/run.md
@@ -81,24 +81,58 @@ Some operating systems, including CentOS stream and RHEL 9, has a small limit to
 
 Reboot the system to let the settings take effect.
 
-## 2. NIC driver setup
+## 2. Kernel mode NIC driver setup
 
 For Intel® E810 Series Ethernet Adapter, refer to [Intel® E810 Series Ethernet Adapter driver guide](e810.md). For other NIC, you may need follow the steps on the DPDK site <http://doc.dpdk.org/guides/nics/overview.html>.
 
-## 3. Create DPDK PMD
+## 3. DPDK PMD setup
+
+DPDK utilizes the Linux kernel's VFIO module to enable direct NIC (Network Interface Card) hardware access from user space with the assistance of an IOMMU (Input/Output Memory Management Unit). To use DPDK's Poll Mode Drivers (PMDs), NICs must be bound to the `vfio-pci` driver. Before manipulating VFIO devices, it's necessary to configure user permissions and system rules to allow the current user to access VFIO interfaces.
+
+### 3.1 Allow current user to access /dev/vfio/* devices
+
+This section guides you through creating a dedicated group, granting the appropriate permissions, and setting up udev rules to maintain these settings across system reboots and devices re-creations.
+
+Add a new group named `vfio` with GID `2110` to control the VFIO devices, and add your current user to that group. If GID `2110` is in use, consider using a different one.
+
+```bash
+getent group 2110 || sudo groupadd -g 2110 vfio
+sudo usermod -aG vfio $USER
+```
+
+Re-login and check the group successfully added using `groups`.
+
+Create or edit a udev rules file, for example, /etc/udev/rules.d/10-vfio.rules, with your preferred text editor. For instance, using vim:
+
+```bash
+sudo vim /etc/udev/rules.d/10-vfio.rules
+```
+
+Add the following line to set the group ownership to vfio and enable read/write access for the group to any VFIO devices that appear:
+
+```bash
+SUBSYSTEM=="vfio", GROUP="vfio", MODE="0660"
+```
+
+Then reload the udev rules with:
+
+```bash
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+### 3.2 Bind NICs to DPDK PMD
 
 Note: It is important to repeat this operation again after rebooting the system. The steps mentioned should be followed again to ensure that the desired configuration is maintained after a reboot.
 
-### 3.1 Create DPDK PMD
-
-For the Intel® E810 Series Ethernet Adapter, which supports Virtual Functions (VFs) based on Single Root I/O Virtualization (SR-IOV), please refer to section `### 3.1.1` to learn how to create VFs and bind them to the DPDK Poll Mode Driver (PMD).
+For the Intel® E810 Series Ethernet Adapter, which supports Virtual Functions (VFs) based on Single Root I/O Virtualization (SR-IOV), please refer to [Create Intel E810 VFs and bind to DPDK PMD](#321-create-intel-e810-vfs-and-bind-to-dpdk-pmd) to learn how to create VFs and bind them to the DPDK Poll Mode Driver (PMD).
 
 For other Network Interface Cards (NICs), please verify if your NIC is supported by DPDK by referring to the following link: <https://doc.dpdk.org/guides/nics/>. If it is, follow the guide provided there for further instructions.
 
 If your NIC is not supported by DPDK's native Poll Mode Driver (PMD), MTL provides an alternative in the form of kernel socket-based transport support. This enables an MTL application to send and receive UDP packets via the Kernel.
 Please refer to [kernel tx config](../tests/script/kernel_socket_json/tx.json) and [kernel rx config](../tests/script/kernel_socket_json/rx.json) for how to config the kernel transport in json config. However, it's important to note that this is an experimental feature intended solely for trial usage. Consequently, its performance and pacing accuracy may be limited.
 
-#### 3.1.1 Create Intel® E810 VFs PMD
+#### 3.2.1 Create Intel® E810 VFs and bind to DPDK PMD
 
 Get Device to Bus info mapping
 
@@ -139,21 +173,13 @@ If the creation of VF BDFs fails, you can check the kernel dmesg log to find pos
 sudo dmesg
 ```
 
-#### 3.1.2 Bind PF DPDK PMD
+#### 3.2.2 Bind PF to DPDK PMD
 
 If your Network Interface Card (NIC) is not from the Intel® E810 Series, but is supported by DPDK, you have the option to directly bind the Physical Function (PF) to the DPDK Poll Mode Driver (PMD) for Bus Device Function (BDF) 0000:32:00.0 using the command provided below.
 
 ```bash
 cd $imtl_source_code
 sudo ./script/nicctl.sh bind_pmd 0000:32:00.0
-```
-
-### 3.2 Grant /dev/vfio/* access to current user
-
-If you are not running the sample application from the root user, you can execute the following command to add VFIO device permissions for the current user:
-
-```bash
-sudo chown -R $USER:$USER /dev/vfio/
 ```
 
 ## 4. Setup Hugepage

--- a/docker/README.md
+++ b/docker/README.md
@@ -106,7 +106,7 @@ docker run -it \
   mtl:latest
 ```
 
-### 3.2.3 Run with docker-compose
+#### 3.2.3 Run with docker-compose
 
 Edit the `docker-compose.yml` file to specify the configuration.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,11 @@
 
 Docker guide for Intel® Media Transport Library.
 
-## 1. Build Docker image
+## 1. DPDK NIC PMD and env setup on host
+
+Follow [run guide](../doc/run.md) to setup the hugepages, driver of NIC PFs, vfio(2110) user group and vfio driver mode for VFs.
+
+## 2. Build Docker image
 
 ```bash
 docker build -t mtl:latest -f ubuntu.dockerfile ./
@@ -15,10 +19,6 @@ http_proxy=http://proxy.xxx.com:xxx
 https_proxy=https://proxy.xxx.com:xxx
 docker build -t mtl:latest -f ubuntu.dockerfile --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy ./
 ```
-
-## 2. DPDK NIC PMD and env setup on host
-
-Follow [run guide](../doc/run.md) to setup the hugepages, driver of NIC PFs, vfio driver mode for VFs.
 
 ## 3. Run and login into the docker container
 
@@ -46,6 +46,7 @@ docker run -it \
   --cap-add SYS_NICE \
   --cap-add IPC_LOCK \
   -v /var/run/imtl:/var/run/imtl \
+  --ulimit memlock=-1 \
   mtl:latest
 ```
 
@@ -71,7 +72,7 @@ Explanation of `docker run` arguments:
 | `--net host` | For AF_XDP backend to access NICs |
 | `-v /var/run/imtl:/var/run/imtl` | For connection with MTL Manager |
 | `--device /dev/vfio` | For DPDK eal to access the VFIO devices |
-| `--ulimit memlock=-1` | For AF_XDP backend to create UMEM |
+| `--ulimit memlock=-1` | For DPDK PMD to do DMA remapping or AF_XDP backend to create UMEM |
 | `--cap-add SYS_NICE` | For DPDK eal to set NUMA memory policy |
 | `--cap-add IPC_LOCK` | For DPDK PMD to do DMA mapping |
 | `--cap-add NET_ADMIN` | For kernel NIC configuration |
@@ -101,6 +102,7 @@ docker run -it \
   --cap-add SYS_NICE \
   --cap-add IPC_LOCK \
   -v /var/run/imtl:/var/run/imtl \
+  --ulimit memlock=-1 \
   mtl:latest
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -123,6 +123,5 @@ docker-compose run imtl
 # Run below command to generate a fake yuv file or follow "#### 3.3 Prepare source files:" in [run guide](../doc/run.md)
 # dd if=/dev/urandom of=test.yuv count=2160 bs=4800
 # Edit and Run the loop json file.
-# For DPDK PMD backend, need to run with sudo.
 ./build/app/RxTxApp --config_file tests/script/loop_json/1080p60_1v.json
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,10 @@ version: '3'
 services:
   imtl:
     image: mtl:latest
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     devices:
       - "/dev/vfio:/dev/vfio" # or add /dev/vfio/vfio and /dev/vfio/<specific_device>
     volumes:
@@ -16,6 +20,7 @@ services:
       # For kernel / AF_XDP backend
       # - NET_ADMIN
       # - NET_RAW
+      # - CAP_BPF
       
       # For Adjtime
       # - SYS_TIME

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -47,7 +47,8 @@ RUN git clone --recurse-submodules https://github.com/xdp-project/xdp-tools.git 
     cd lib/libbpf/src && sudo make install
 
 # Build IMTL
-RUN cd $MTL_REPO && ./build.sh
+RUN cd $MTL_REPO && ./build.sh && \
+    sudo setcap 'cap_net_admin+ep cap_net_raw+ep' ./build/app/RxTxApp
 
 # Drop the sudo permission
 RUN sudo deluser imtl sudo

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -6,12 +6,6 @@ FROM ubuntu@sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7c
 
 LABEL maintainer="frank.du@intel.com,ming3.li@intel.com"
 
-ENV MTL_REPO=Media-Transport-Library
-ENV DPDK_REPO=dpdk
-ENV DPDK_VER=23.11
-ENV IMTL_USER=imtl
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
-
 # Install dependencies and debug tools
 RUN apt-get update -y && \
     apt-get install -y git gcc meson python3 python3-pip pkg-config libnuma-dev libjson-c-dev libpcap-dev libgtest-dev libsdl2-dev libsdl2-ttf-dev libssl-dev && \
@@ -21,19 +15,23 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Add user: imtl
-RUN adduser $IMTL_USER && \
-    usermod -G sudo $IMTL_USER && \
+# Add user: imtl with group vfio(2110)
+RUN groupadd -g 2110 vfio && \
+    useradd -m -G vfio,sudo imtl && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-USER $IMTL_USER
+USER imtl
 
-WORKDIR /home/$IMTL_USER/
+WORKDIR /home/imtl/
+
+ENV MTL_REPO=Media-Transport-Library
+ENV DPDK_VER=23.11
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 # Clone and build DPDK before bpf and xdp
 RUN git clone https://github.com/OpenVisualCloud/$MTL_REPO.git && \
-    git clone https://github.com/DPDK/$DPDK_REPO.git && \
-    cd $DPDK_REPO && \
+    git clone https://github.com/DPDK/dpdk.git && \
+    cd dpdk && \
     git checkout v$DPDK_VER && \
     git switch -c v$DPDK_VER && \
     git config --global user.email "you@example.com" && \
@@ -49,9 +47,11 @@ RUN git clone --recurse-submodules https://github.com/xdp-project/xdp-tools.git 
     cd lib/libbpf/src && sudo make install
 
 # Build IMTL
-RUN cd $MTL_REPO && ./build.sh && \
-    sudo setcap 'cap_net_admin+ep cap_net_raw+ep' ./build/app/RxTxApp
+RUN cd $MTL_REPO && ./build.sh
 
-WORKDIR /home/$IMTL_USER/$MTL_REPO
+# Drop the sudo permission
+RUN sudo deluser imtl sudo
+
+WORKDIR /home/imtl/$MTL_REPO
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
1. Update the run guide to use group for vfio access.
2. Update the Dockerfile to remove sudo for running.
3. Update the docker compose file.