### PR TITLE
python: fix the mtl_init support

### DIFF
--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -284,173 +284,140 @@ enum st21_tx_pacing_way {
   ST21_TX_PACING_WAY_MAX,
 };
 
-/**
- * Flag bit in flags of struct mtl_init_params.
- * If set, lib will call numa_bind to bind app thread and memory to NIC socket also.
- */
-#define MTL_FLAG_BIND_NUMA (MTL_BIT64(0))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable built-in PTP implementation, only for PF now.
- * If not enable, it will use system time as the PTP source.
- */
-#define MTL_FLAG_PTP_ENABLE (MTL_BIT64(1))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Separated lcore for RX video(st2110-20/st2110-22) session.
- */
-#define MTL_FLAG_RX_SEPARATE_VIDEO_LCORE (MTL_BIT64(2))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable migrate mode for tx video session if current LCORE is too busy to handle the
- * tx video tasklet, the busy session may be migrated to a new LCORE.
- * If not enable, tx video will always use static mapping based on quota.
- */
-#define MTL_FLAG_TX_VIDEO_MIGRATE (MTL_BIT64(3))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable migrate mode for rx video session if current LCORE is too busy to handle the
- * rx video tasklet, the busy session may be migrated to a new LCORE.
- * If not enable, rx video will always use static mapping based on quota.
- */
-#define MTL_FLAG_RX_VIDEO_MIGRATE (MTL_BIT64(4))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Run the tasklet inside one thread instead of a pinned lcore.
- */
-#define MTL_FLAG_TASKLET_THREAD (MTL_BIT64(5))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable the tasklet sleep if routine report task done.
- */
-#define MTL_FLAG_TASKLET_SLEEP (MTL_BIT64(6))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Set the supported SIMD bitwidth of rx/tx burst to 512 bit(AVX512).
- */
-#define MTL_FLAG_RXTX_SIMD_512 (MTL_BIT64(7))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Use PI controller for built-in PTP implementation, only for PF now.
- */
-#define MTL_FLAG_PTP_PI (MTL_BIT64(9))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable background lcore mode for MTL_TRANSPORT_UDP.
- */
-#define MTL_FLAG_UDP_LCORE (MTL_BIT64(10))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable random source port for MTL_TRANSPORT_ST2110 tx.
- */
-#define MTL_FLAG_RANDOM_SRC_PORT (MTL_BIT64(11))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable multiple source port for MTL_TRANSPORT_ST2110 20 tx.
- */
-#define MTL_FLAG_MULTI_SRC_PORT (MTL_BIT64(12))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable shared queue for tx.
- */
-#define MTL_FLAG_SHARED_TX_QUEUE (MTL_BIT64(13))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable shared queue for rx.
- */
-#define MTL_FLAG_SHARED_RX_QUEUE (MTL_BIT64(14))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable built-in PHC2SYS implementation.
- * CAP_SYS_TIME is needed.
- */
-#define MTL_FLAG_PHC2SYS_ENABLE (MTL_BIT64(15))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Enable virtio_user as exception path.
- * CAP_NET_ADMIN is needed.
- */
-#define MTL_FLAG_VIRTIO_USER (MTL_BIT64(16))
-/**
- * Flag bit in flags of struct mtl_init_params.
- * Do mtl_start in mtl_init, mtl_stop in mtl_uninit, and skip the mtl_start/mtl_stop
- */
-#define MTL_FLAG_DEV_AUTO_START_STOP (MTL_BIT64(17))
+/** MTL init flag */
+enum mtl_init_flag {
+  /** lib will call numa_bind to bind app thread and memory to NIC socket also.*/
+  MTL_FLAG_BIND_NUMA = (MTL_BIT64(0)),
+  /** Enable built-in PTP implementation */
+  MTL_FLAG_PTP_ENABLE = (MTL_BIT64(1)),
+  /** Separated lcore for RX video(st2110-20/st2110-22) sessions. */
+  MTL_FLAG_RX_SEPARATE_VIDEO_LCORE = (MTL_BIT64(2)),
+  /**
+   * Enable migrate mode for rx video session if current LCORE is too busy to handle the
+   * rx video tasklet, the busy session may be migrated to a new LCORE.
+   * If not enable, rx video will always use static mapping based on quota.
+   */
+  MTL_FLAG_TX_VIDEO_MIGRATE = (MTL_BIT64(3)),
+  /**
+   * Enable migrate mode for rx video session if current LCORE is too busy to handle the
+   * rx video tasklet, the busy session may be migrated to a new LCORE.
+   * If not enable, rx video will always use static mapping based on quota.
+   */
+  MTL_FLAG_RX_VIDEO_MIGRATE = (MTL_BIT64(4)),
+  /**
+   * Run the tasklet inside one thread instead of a pinned lcore.
+   */
+  MTL_FLAG_TASKLET_THREAD = (MTL_BIT64(5)),
+  /**
+   * Enable the tasklet sleep if routine report task done.
+   */
+  MTL_FLAG_TASKLET_SLEEP = (MTL_BIT64(6)),
+  /**
+   * Set the supported SIMD bitwidth of rx/tx burst to 512 bit(AVX512).
+   */
+  MTL_FLAG_RXTX_SIMD_512 = (MTL_BIT64(7)),
+  /**
+   * Use PI controller for built-in PTP implementation, only for PF now.
+   */
+  MTL_FLAG_PTP_PI = (MTL_BIT64(9)),
+  /**
+   * Enable background lcore mode for MTL_TRANSPORT_UDP.
+   */
+  MTL_FLAG_UDP_LCORE = (MTL_BIT64(10)),
+  /**
 
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * dedicate thread for cni message
- */
-#define MTL_FLAG_CNI_THREAD (MTL_BIT64(32))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Enable HW offload timestamp for all RX packets target the compliance analyze. Only can
- * work for PF on E810 now.
- */
-#define MTL_FLAG_ENABLE_HW_TIMESTAMP (MTL_BIT64(33))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Enable NIC promiscuous mode for RX
- */
-#define MTL_FLAG_NIC_RX_PROMISCUOUS (MTL_BIT64(34))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * use unicast address for ptp PTP_DELAY_REQ message
- */
-#define MTL_FLAG_PTP_UNICAST_ADDR (MTL_BIT64(35))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Mono memory pool for all rx queue(sessions)
- */
-#define MTL_FLAG_RX_MONO_POOL (MTL_BIT64(36))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Enable tasklet time measurement, report status if tasklet run time longer than
- * tasklet_time_thresh_us in mtl_init_params.
- */
-#define MTL_FLAG_TASKLET_TIME_MEASURE (MTL_BIT64(38))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Disable the zero copy for af_xdp tx video session
- */
-#define MTL_FLAG_AF_XDP_ZC_DISABLE (MTL_BIT64(39))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Mono memory pool for all tx queue(session)
- */
-#define MTL_FLAG_TX_MONO_POOL (MTL_BIT64(40))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Disable system rx queues, pls use mcast or manual TX mac.
- */
-#define MTL_FLAG_DISABLE_SYSTEM_RX_QUEUES (MTL_BIT64(41))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Force to get ptp time from tsc source.
- */
-#define MTL_FLAG_PTP_SOURCE_TSC (MTL_BIT64(42))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Disable TX chain mbuf, use same mbuf for header and payload.
- * Will do memcpy from framebuffer to packet payload.
- */
-#define MTL_FLAG_TX_NO_CHAIN (MTL_BIT64(43))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Disable the pkt check for TX burst API.
- */
-#define MTL_FLAG_TX_NO_BURST_CHK (MTL_BIT64(44))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * Use CNI based queue for RX.
- */
-#define MTL_FLAG_RX_USE_CNI (MTL_BIT64(45))
-/**
- * Flag bit in flags of struct mtl_init_params, debug usage only.
- * To exclusively use port only for flow, the application must ensure that all RX streams
- * have unique UDP port numbers.
- */
-#define MTL_FLAG_RX_UDP_PORT_ONLY (MTL_BIT64(46))
+   * Enable random source port for MTL_TRANSPORT_ST2110 tx.
+   */
+  MTL_FLAG_RANDOM_SRC_PORT = (MTL_BIT64(11)),
+  /**
+   * Enable multiple source port for MTL_TRANSPORT_ST2110 20 tx.
+   */
+  MTL_FLAG_MULTI_SRC_PORT = (MTL_BIT64(12)),
+  /**
+   * Enable shared queue for tx.
+   */
+  MTL_FLAG_SHARED_TX_QUEUE = (MTL_BIT64(13)),
+  /**
+   * Enable shared queue for rx.
+   */
+  MTL_FLAG_SHARED_RX_QUEUE = (MTL_BIT64(14)),
+  /**
+   * Enable built-in PHC2SYS implementation.
+   * CAP_SYS_TIME is needed.
+   */
+  MTL_FLAG_PHC2SYS_ENABLE = (MTL_BIT64(15)),
+  /**
+   * Enable virtio_user as exception path.
+   * CAP_NET_ADMIN is needed.
+   */
+  MTL_FLAG_VIRTIO_USER = (MTL_BIT64(16)),
+  /**
+   * Do mtl_start in mtl_init, mtl_stop in mtl_uninit, and skip the mtl_start/mtl_stop
+   */
+  MTL_FLAG_DEV_AUTO_START_STOP = (MTL_BIT64(17)),
+
+  /**
+   * dedicate thread for cni message
+   */
+  MTL_FLAG_CNI_THREAD = (MTL_BIT64(32)),
+  /**
+   * Enable HW offload timestamp for all RX packets target the compliance analyze. Only
+   * can work for PF on E810 now.
+   */
+  MTL_FLAG_ENABLE_HW_TIMESTAMP = (MTL_BIT64(33)),
+  /**
+   * Enable NIC promiscuous mode for RX
+   */
+  MTL_FLAG_NIC_RX_PROMISCUOUS = (MTL_BIT64(34)),
+  /**
+   * use unicast address for ptp PTP_DELAY_REQ message
+   */
+  MTL_FLAG_PTP_UNICAST_ADDR = (MTL_BIT64(35)),
+  /**
+   * Mono memory pool for all rx queue(sessions)
+   */
+  MTL_FLAG_RX_MONO_POOL = (MTL_BIT64(36)),
+  /**
+   * Enable tasklet time measurement, report status if tasklet run time longer than
+   * tasklet_time_thresh_us in mtl_init_params.
+   */
+  MTL_FLAG_TASKLET_TIME_MEASURE = (MTL_BIT64(38)),
+  /**
+   * Disable the zero copy for af_xdp tx video session
+   */
+  MTL_FLAG_AF_XDP_ZC_DISABLE = (MTL_BIT64(39)),
+  /**
+   * Mono memory pool for all tx queue(session)
+   */
+  MTL_FLAG_TX_MONO_POOL = (MTL_BIT64(40)),
+  /**
+   * Disable system rx queues, pls use mcast or manual TX mac.
+   */
+  MTL_FLAG_DISABLE_SYSTEM_RX_QUEUES = (MTL_BIT64(41)),
+  /**
+
+   * Force to get ptp time from tsc source.
+   */
+  MTL_FLAG_PTP_SOURCE_TSC = (MTL_BIT64(42)),
+  /**
+   * Disable TX chain mbuf, use same mbuf for header and payload.
+   * Will do memcpy from framebuffer to packet payload.
+   */
+  MTL_FLAG_TX_NO_CHAIN = (MTL_BIT64(43)),
+  /**
+   * Disable the pkt check for TX burst API.
+   */
+  MTL_FLAG_TX_NO_BURST_CHK = (MTL_BIT64(44)),
+  /**
+   * Use CNI based queue for RX.
+   */
+  MTL_FLAG_RX_USE_CNI = (MTL_BIT64(45)),
+  /**
+   * To exclusively use port only for flow, the application must ensure that all RX
+   * streams have unique UDP port numbers.
+   */
+  MTL_FLAG_RX_UDP_PORT_ONLY = (MTL_BIT64(46)),
+};
 
 /**
  * The structure describing how to init af_xdp interface.
@@ -754,6 +721,25 @@ int mtl_get_port_stats(mtl_handle mt, enum mtl_port port, struct mtl_port_status
  *   - <0: Error code if fail.
  */
 int mtl_reset_port_stats(mtl_handle mt, enum mtl_port port);
+
+int mtl_para_port_set(struct mtl_init_params* p, enum mtl_port port, char* name);
+int mtl_para_sip_set(struct mtl_init_params* p, enum mtl_port port, char* ip);
+int mtl_para_gateway_set(struct mtl_init_params* p, enum mtl_port port, char* gateway);
+int mtl_para_netmask_set(struct mtl_init_params* p, enum mtl_port port, char* netmask);
+int mtl_para_dma_port_set(struct mtl_init_params* p, enum mtl_port port, char* name);
+
+static inline void mtl_para_tx_queues_cnt_set(struct mtl_init_params* p,
+                                              enum mtl_port port, uint16_t cnt) {
+  p->tx_queues_cnt[port] = cnt;
+}
+static inline void mtl_para_rx_queues_cnt_set(struct mtl_init_params* p,
+                                              enum mtl_port port, uint16_t cnt) {
+  p->rx_queues_cnt[port] = cnt;
+}
+static inline void mtl_para_pmd_set(struct mtl_init_params* p, enum mtl_port port,
+                                    enum mtl_pmd_type pmd) {
+  p->pmd[port] = pmd;
+}
 
 /**
  * Inline function returning primary port pointer from mtl_init_params

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -421,7 +421,7 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
     err("%s, mt_dev_eal_init fail %d\n", __func__, ret);
     return NULL;
   }
-  info("st version: %s, dpdk version: %s\n", mtl_version(), rte_version());
+  info("MTL version: %s, dpdk version: %s\n", mtl_version(), rte_version());
 
   for (int i = 0; i < num_ports; i++) {
     pmd = p->pmd[i];
@@ -1353,3 +1353,32 @@ int mtl_set_log_prefix_formatter(void (*log_prefix_formatter)(char* buf, size_t 
 void mtl_sleep_us(unsigned int us) { return mt_sleep_us(us); }
 
 void mtl_delay_us(unsigned int us) { return mt_delay_us(us); }
+
+int mtl_para_sip_set(struct mtl_init_params* p, enum mtl_port port, char* ip) {
+  int ret = inet_pton(AF_INET, ip, p->sip_addr[port]);
+  if (ret == 1) return 0;
+  err("%s, fail to inet_pton for %s\n", __func__, ip);
+  return -EIO;
+}
+
+int mtl_para_gateway_set(struct mtl_init_params* p, enum mtl_port port, char* gateway) {
+  int ret = inet_pton(AF_INET, gateway, p->gateway[port]);
+  if (ret == 1) return 0;
+  err("%s, fail to inet_pton for %s\n", __func__, gateway);
+  return -EIO;
+}
+
+int mtl_para_netmask_set(struct mtl_init_params* p, enum mtl_port port, char* netmask) {
+  int ret = inet_pton(AF_INET, netmask, p->netmask[port]);
+  if (ret == 1) return 0;
+  err("%s, fail to inet_pton for %s\n", __func__, netmask);
+  return -EIO;
+}
+
+int mtl_para_port_set(struct mtl_init_params* p, enum mtl_port port, char* name) {
+  return snprintf(p->port[port], MTL_PORT_MAX_LEN, "%s", name);
+}
+
+int mtl_para_dma_port_set(struct mtl_init_params* p, enum mtl_port port, char* name) {
+  return snprintf(p->dma_dev_port[port], MTL_PORT_MAX_LEN, "%s", name);
+}

--- a/python/README.md
+++ b/python/README.md
@@ -25,10 +25,10 @@ sudo make install
 
 ```bash
 cd $imtl_source_code/python/swig/
-swig -python -I/usr/local/include pymtl.i
+swig -python -I/usr/local/include -o pymtl_wrap.c pymtl.i
 ```
 
-If you encounter the error `mtl.i:15: Error: Unable to find 'mtl/mtl_api.h'`, this is typically due to an incorrect include path. Use the following command to locate the correct path for `mtl_api.h`:
+If you encounter the error `pymtl.i:15: Error: Unable to find 'mtl/mtl_api.h'`, this is typically due to an incorrect include path. Use the following command to locate the correct path for `mtl_api.h`:
 
 ```bash
 find /usr/ -name mtl_api.h
@@ -52,11 +52,12 @@ Checking the log to see the path installed.
 
 ```bash
 creating /usr/local/lib/python3.10/dist-packages/pymtl-0.1-py3.10-linux-x86_64.egg
+Extracting pymtl-0.1-py3.10-linux-x86_64.egg to /usr/local/lib/python3.10/dist-packages
 ```
 
 ## 3. Run python example code
 
 ```bash
 cd $imtl_source_code/python/example/
-python3 ../example/sample.py
+python3 version.py
 ```

--- a/python/example/st20p_rx.py
+++ b/python/example/st20p_rx.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023 Intel Corporation
+
+import time
+
+import pymtl as mtl
+
+# Init para
+init_para = mtl.mtl_init_params()
+mtl.mtl_para_port_set(init_para, mtl.MTL_PORT_P, "0000:af:01.0")
+init_para.num_ports = 1
+mtl.mtl_para_sip_set(init_para, mtl.MTL_PORT_P, "192.168.108.102")
+init_para.flags = mtl.MTL_FLAG_BIND_NUMA | mtl.MTL_FLAG_DEV_AUTO_START_STOP
+mtl.mtl_para_tx_queues_cnt_set(init_para, mtl.MTL_PORT_P, 0)
+mtl.mtl_para_rx_queues_cnt_set(init_para, mtl.MTL_PORT_P, 1)
+
+# Create MTL instance
+mtl_handle = mtl.mtl_init(init_para)
+
+# loop until ctrl-c
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    print("KeyboardInterrupt")
+
+# Free MTL instance
+mtl.mtl_uninit(mtl_handle)
+
+print("Everythin fine, bye")

--- a/python/example/version.py
+++ b/python/example/version.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2023 Intel Corporation
 
-import _pymtl as pymtl
+import pymtl as mtl
 
-print(f"mtl_version: {pymtl.mtl_version()}")
+print(f"mtl_version: {mtl.mtl_version()}")

--- a/python/swig/.gitignore
+++ b/python/swig/.gitignore
@@ -1,6 +1,7 @@
 # generated file
 *.c
 *.so
+__pycache__
 pymtl.py
 build
 dist

--- a/python/swig/pymtl.i
+++ b/python/swig/pymtl.i
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright 2023 Intel Corporation
 
-// Usage: swig -python -I/usr/local/include mtl.i
+// Usage: swig -python -I/usr/local/include -o pymtl_wrap.c pymtl.i
 
 %module pymtl
 
+%include <stdint.i>
+
+%begin %{
+#define SWIG_PYTHON_CAST_MODE
+%}
+
 %{
-#include "mtl/mtl_api.h"
+#include <mtl/mtl_api.h>
 %}
 
 %define __MTL_LIB_BUILD__
 %enddef
 
-%include "mtl/mtl_api.h"
+%include <mtl/mtl_api.h>

--- a/python/swig/setup.py
+++ b/python/swig/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import Extension, setup
 
-mtl_module = Extension(
+pymtl_module = Extension(
     "_pymtl",
     sources=["pymtl_wrap.c"],
     # include_dirs=['/path/to/include'],
@@ -14,5 +14,7 @@ mtl_module = Extension(
 setup(
     name="pymtl",
     version="0.1",
-    ext_modules=[mtl_module],
+    description="Python bindings for libmtl using SWIG",
+    ext_modules=[pymtl_module],
+    py_modules=["pymtl"],
 )

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -394,7 +394,7 @@ static void test_ctx_uinit(struct st_tests_context* ctx) {
 
 TEST(Misc, version) {
   auto version_display = mtl_version();
-  info("st version: %s\n", version_display);
+  info("MTL version: %s\n", version_display);
 
   uint32_t version_no =
       MTL_VERSION_NUM(MTL_VERSION_MAJOR, MTL_VERSION_MINOR, MTL_VERSION_LAST);


### PR DESCRIPTION
add some helper function for the python binding to array