### PR TITLE
rust: add unsafe rust bindings

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "imtl-rs"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "imtl"
+path = "src/imtl/lib.rs"
+
+[dependencies]
+
+[dependencies.imtl-sys]
+path = "imtl-sys"
+version = "^0.1.0"
+
+[features]
+convert = ["imtl-sys/convert"]
+pipeline = ["imtl-sys/pipeline"]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,21 @@
+# Rust
+
+Bindings for IMTL in Rust.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+imtl = "0.1.0"
+```
+
+## Example
+
+```rust
+cargo run --example version
+
+cd imtl-sys
+cargo run --example no_std
+```

--- a/rust/README.md
+++ b/rust/README.md
@@ -13,7 +13,7 @@ imtl = "0.1.0"
 
 ## Example
 
-```rust
+```bash
 cargo run --example version
 
 cd imtl-sys

--- a/rust/examples/version.rs
+++ b/rust/examples/version.rs
@@ -1,0 +1,6 @@
+use imtl::version;
+
+fn main () {
+    let v = version::version();
+    println!("current imtl version is {}", v);
+}

--- a/rust/imtl-sys/Cargo.toml
+++ b/rust/imtl-sys/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "imtl-sys"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "imtl_sys"
+path = "src/lib.rs"
+
+[dependencies]
+
+[dev-dependencies]
+rand = "0.8.5"
+
+[build-dependencies]
+bindgen = "0.69.1"
+pkg-config = "0.3.27"
+
+[features]
+convert = []
+pipeline = []

--- a/rust/imtl-sys/build.rs
+++ b/rust/imtl-sys/build.rs
@@ -1,0 +1,44 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    pkg_config::Config::new().probe("mtl").unwrap();
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("mtl_bindings.rs"))
+        .expect("Couldn't write bindings!");
+
+    if cfg!(feature = "convert") {
+        let bindings = bindgen::Builder::default()
+            .header("wrapper_convert.h")
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+            .generate()
+            .expect("Unable to generate bindings");
+
+        bindings
+            .write_to_file(out_path.join("mtl_convert_bindings.rs"))
+            .expect("Couldn't write bindings!");
+    }
+
+    if cfg!(feature = "pipeline") {
+        let bindings = bindgen::Builder::default()
+            .header("wrapper_pipeline.h")
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+            .generate()
+            .expect("Unable to generate bindings");
+
+        bindings
+            .write_to_file(out_path.join("mtl_pipeline_bindings.rs"))
+            .expect("Couldn't write bindings!");
+    }
+}

--- a/rust/imtl-sys/examples/no_std.rs
+++ b/rust/imtl-sys/examples/no_std.rs
@@ -1,0 +1,63 @@
+#![no_std]
+
+use core::ptr::null_mut;
+use imtl_sys::*;
+
+fn main() {
+    unsafe {
+        let port_str = b"0000:4b:01.0" as *const _ as *const i8;
+        let mut port_p = [0 as i8; 64];
+        for i in 0..12 {
+            port_p[i] = *port_str.add(i);
+        }
+        let mut param = mtl_init_params {
+            port: [port_p; 8],
+            num_ports: 1,
+            pmd: [0; 8],
+            xdp_info: [mtl_af_xdp_params { start_queue: 0 }; 8],
+            sip_addr: [[192, 168, 96, 1]; 8],
+            netmask: [[255, 255, 255, 0]; 8],
+            gateway: [[192, 168, 96, 1]; 8],
+            tx_sessions_cnt_max: 1,
+            rx_sessions_cnt_max: 1,
+            lcores: null_mut(),
+            dma_dev_port: [[0; 64]; 8],
+            num_dma_dev_port: 0,
+            log_level: mtl_log_level_MTL_LOG_LEVEL_INFO,
+            flags: 0,
+            priv_: null_mut(),
+            ptp_get_time_fn: None,
+            dump_period_s: 0,
+            stat_dump_cb_fn: None,
+            data_quota_mbs_per_sch: 0,
+            nb_tx_desc: 0,
+            nb_rx_desc: 0,
+            pkt_udp_suggest_max_size: 0,
+            nb_rx_hdr_split_queues: 0,
+            rx_pool_data_size: 0,
+            pacing: st21_tx_pacing_way_ST21_TX_PACING_WAY_AUTO,
+            ki: 0.0,
+            kp: 0.0,
+            rss_mode: 0,
+            iova_mode: 0,
+            net_proto: [0; 8],
+            tx_queues_cnt: [8; 8],
+            rx_queues_cnt: [8; 8],
+            tasklets_nb_per_sch: 8,
+            tx_audio_sessions_max_per_sch: 8,
+            rx_audio_sessions_max_per_sch: 8,
+            arp_timeout_s: 0,
+            ptp_sync_notify: None,
+            rss_sch_nb: [0; 8],
+        };
+
+        /* initialize dev handle */
+        let dev_handle = mtl_init(&mut param as *mut _);
+        if dev_handle == null_mut() {
+            panic!("st_init fail");
+        }
+
+        /* destroy dev handle */
+        mtl_uninit(dev_handle);
+    }
+}

--- a/rust/imtl-sys/src/convert.rs
+++ b/rust/imtl-sys/src/convert.rs
@@ -1,0 +1,47 @@
+include!(concat!(env!("OUT_DIR"), "/mtl_convert_bindings.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cvt_rfc4175_422be10_to_v210(w: u32, h: u32, cvt_level: mtl_simd_level) {
+        let mut ret;
+        let src_fb_size = w * h * 5 / 2;
+        let dst_fb_size = w * h * 8 / 3;
+
+        let mut src_buf: Vec<u8> = vec![0; src_fb_size as usize];
+        let mut dst_buf: Vec<u8> = vec![0; dst_fb_size as usize];
+        let mut rev_buf: Vec<u8> = vec![0; src_fb_size as usize];
+
+        use rand::{thread_rng, Rng};
+        thread_rng().fill(&mut src_buf[..]);
+        unsafe {
+            ret = st20_rfc4175_422be10_to_v210_simd(
+                src_buf.as_mut_ptr() as *mut st20_rfc4175_422_10_pg2_be,
+                dst_buf.as_mut_ptr(),
+                w,
+                h,
+                cvt_level,
+            );
+            assert_eq!(0, ret);
+
+            ret = st20_v210_to_rfc4175_422be10_simd(
+                dst_buf.as_mut_ptr(),
+                rev_buf.as_mut_ptr() as *mut st20_rfc4175_422_10_pg2_be,
+                w,
+                h,
+                cvt_level,
+            );
+            assert_eq!(0, ret);
+        }
+        assert_eq!(src_buf, rev_buf);
+        println!("src 100:{}, rev 100: {}", src_buf[100], rev_buf[100]);
+    }
+
+    #[test]
+    fn rfc_422be_to_v210() {
+        cvt_rfc4175_422be10_to_v210(1920, 1080, mtl_simd_level_MTL_SIMD_LEVEL_NONE);
+        cvt_rfc4175_422be10_to_v210(1920, 1080, mtl_simd_level_MTL_SIMD_LEVEL_AVX512);
+        cvt_rfc4175_422be10_to_v210(1920, 1080, mtl_simd_level_MTL_SIMD_LEVEL_AVX512_VBMI2);
+    }
+}

--- a/rust/imtl-sys/src/lib.rs
+++ b/rust/imtl-sys/src/lib.rs
@@ -1,0 +1,42 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!(concat!(env!("OUT_DIR"), "/mtl_bindings.rs"));
+
+#[cfg(feature = "convert")]
+pub mod convert;
+
+#[cfg(feature = "pipeline")]
+pub mod pipeline;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::ffi::CStr;
+
+    #[test]
+    fn print_version() {
+        unsafe {
+            let version_slice = CStr::from_ptr(mtl_version());
+            eprintln!("version: {}", version_slice.to_str().unwrap());
+            assert_ne!(0, version_slice.to_bytes().len());
+        }
+    }
+
+    #[test]
+    fn simd_level() {
+        unsafe {
+            let cpu_level = mtl_get_simd_level();
+            let name = mtl_get_simd_level_name(cpu_level as u32);
+
+            let name_slice = CStr::from_ptr(name);
+            println!(
+                "simd level by cpu: {}({})",
+                cpu_level,
+                name_slice.to_str().unwrap()
+            );
+            assert!(cpu_level < mtl_simd_level_MTL_SIMD_LEVEL_MAX);
+        }
+    }
+}

--- a/rust/imtl-sys/src/pipeline.rs
+++ b/rust/imtl-sys/src/pipeline.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/mtl_pipeline_bindings.rs"));

--- a/rust/imtl-sys/wrapper.h
+++ b/rust/imtl-sys/wrapper.h
@@ -1,0 +1,3 @@
+#include <mtl/mtl_api.h>
+#include <mtl/st_api.h>
+#include <mtl/st20_api.h>

--- a/rust/imtl-sys/wrapper.h
+++ b/rust/imtl-sys/wrapper.h
@@ -1,3 +1,3 @@
 #include <mtl/mtl_api.h>
-#include <mtl/st_api.h>
 #include <mtl/st20_api.h>
+#include <mtl/st_api.h>

--- a/rust/imtl-sys/wrapper_convert.h
+++ b/rust/imtl-sys/wrapper_convert.h
@@ -1,0 +1,1 @@
+#include <mtl/st_convert_api.h>

--- a/rust/imtl-sys/wrapper_pipeline.h
+++ b/rust/imtl-sys/wrapper_pipeline.h
@@ -1,0 +1,1 @@
+#include <mtl/st_pipeline_api.h>

--- a/rust/src/imtl/convert/mod.rs
+++ b/rust/src/imtl/convert/mod.rs
@@ -1,0 +1,30 @@
+//!
+//! A binding for `st_convert_api`
+//!
+//!
+//! Note that you need to build with the
+//! feature `convert` for this module to be enabled,
+//! like so:
+//!
+//! ```bash
+//! $ cargo build --features "convert"
+//! ```
+//!
+//! If you want to use this with from inside your own
+//! crate, you will need to add this in your Cargo.toml
+//!
+//! ```toml
+//! [dependencies.imtl]
+//! version = ...
+//! default-features = false
+//! features = ["convert"]
+//! ```
+
+use format;
+use sys;
+use sys::convert;
+
+pub trait ToRFC {
+    fn to_rfc4175() -> () {}
+    fn from_rfc4175() -> () {}
+}

--- a/rust/src/imtl/lib.rs
+++ b/rust/src/imtl/lib.rs
@@ -1,0 +1,12 @@
+#![crate_name = "imtl"]
+#![crate_type = "lib"]
+
+pub extern crate imtl_sys as sys;
+
+pub mod version;
+
+// modules
+#[cfg(feature = "convert")]
+pub mod convert;
+#[cfg(feature = "pipeline")]
+pub mod pipeline;

--- a/rust/src/imtl/pipeline/mod.rs
+++ b/rust/src/imtl/pipeline/mod.rs
@@ -1,0 +1,2 @@
+use sys;
+use sys::pipeline;

--- a/rust/src/imtl/version.rs
+++ b/rust/src/imtl/version.rs
@@ -1,0 +1,39 @@
+/*!
+Querying IMTL Version
+ */
+
+use std::fmt;
+
+use crate::sys;
+
+/// A structure that contains information about the version in use.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Version {
+    /// major version
+    pub major: u8,
+    /// minor version
+    pub minor: u8,
+    /// update version (patchlevel)
+    pub patch: u8,
+}
+
+impl Version {
+    /// Convert const numbers to Version.
+    pub fn from_const() -> Version {
+        Version {
+            major: sys::MTL_VERSION_MAJOR as u8,
+            minor: sys::MTL_VERSION_MINOR as u8,
+            patch: sys::MTL_VERSION_LAST as u8,
+        }
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+pub fn version() -> Version {
+    Version::from_const()
+}


### PR DESCRIPTION
Only add the unsafe imtl-sys bindings, will add safer wrappers in the future.