### PR TITLE
log: add custom log printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * dpdk: upgrade dpdk version to 23.11.
 * st22: add interlaced support.
+* log: add custom log printer, see mtl_set_log_printer.
 
 ## Changelog for 23.12
 

--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -232,7 +232,7 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         else if (!strcmp(optarg, "warning"))
           p->log_level = MTL_LOG_LEVEL_WARNING;
         else if (!strcmp(optarg, "error"))
-          p->log_level = MTL_LOG_LEVEL_ERROR;
+          p->log_level = MTL_LOG_LEVEL_ERR;
         else
           err("%s, unknow log level %s\n", __func__, optarg);
         break;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -78,6 +78,7 @@ enum st_args_cmd {
   ST_ARG_LOG_LEVEL,
   ST_ARG_LOG_FILE,
   ST_ARG_LOG_TIME_MS,
+  ST_ARG_LOG_PRINTER,
   ST_ARG_NB_TX_DESC,
   ST_ARG_NB_RX_DESC,
   ST_ARG_DMA_DEV,
@@ -192,6 +193,7 @@ static struct option st_app_args_options[] = {
     {"log_level", required_argument, 0, ST_ARG_LOG_LEVEL},
     {"log_file", required_argument, 0, ST_ARG_LOG_FILE},
     {"log_time_ms", no_argument, 0, ST_ARG_LOG_TIME_MS},
+    {"log_printer", no_argument, 0, ST_ARG_LOG_PRINTER},
     {"ptp", no_argument, 0, ST_ARG_LIB_PTP},
     {"phc2sys", no_argument, 0, ST_ARG_LIB_PHC2SYS},
     {"ptp_sync_sys", no_argument, 0, ST_ARG_LIB_PTP_SYNC_SYS},
@@ -350,6 +352,18 @@ static void log_prefix_time_ms(char* buf, size_t sz) {
   localtime_r(&ts.tv_sec, &tm);
   strftime(time_s_buf, sizeof(time_s_buf), "%Y-%m-%d %H:%M:%S", &tm);
   snprintf(buf, sz, "%s.%u, ", time_s_buf, (uint32_t)(ts.tv_nsec / NS_PER_MS));
+}
+
+static void log_user_printer(enum mtl_log_level level, const char* format, ...) {
+  MTL_MAY_UNUSED(level);
+  va_list args;
+
+  /* Init variadic argument list */
+  va_start(args, format);
+  /* Use vprintf to pass the variadic arguments to printf */
+  vprintf(format, args);
+  /* End variadic argument list */
+  va_end(args);
 }
 
 int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int argc,
@@ -597,7 +611,7 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         else if (!strcmp(optarg, "warning"))
           p->log_level = MTL_LOG_LEVEL_WARNING;
         else if (!strcmp(optarg, "error"))
-          p->log_level = MTL_LOG_LEVEL_ERROR;
+          p->log_level = MTL_LOG_LEVEL_ERR;
         else
           err("%s, unknow log level %s\n", __func__, optarg);
         app_set_log_level(p->log_level);
@@ -607,6 +621,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_LOG_TIME_MS:
         mtl_set_log_prefix_formatter(log_prefix_time_ms);
+        break;
+      case ST_ARG_LOG_PRINTER:
+        mtl_set_log_printer(log_user_printer);
         break;
       case ST_ARG_NB_TX_DESC:
         p->nb_tx_desc = atoi(optarg);

--- a/app/src/log.h
+++ b/app/src/log.h
@@ -34,9 +34,9 @@ enum mtl_log_level app_get_log_level(void);
   do {                                                                     \
     if (app_get_log_level() <= MTL_LOG_LEVEL_WARNING) printf(__VA_ARGS__); \
   } while (0)
-#define err(...)                                                         \
-  do {                                                                   \
-    if (app_get_log_level() <= MTL_LOG_LEVEL_ERROR) printf(__VA_ARGS__); \
+#define err(...)                                                       \
+  do {                                                                 \
+    if (app_get_log_level() <= MTL_LOG_LEVEL_ERR) printf(__VA_ARGS__); \
   } while (0)
 #define critical(...)    \
   do {                   \

--- a/ecosystem/obs_mtl/linux-mtl/mtl-input.c
+++ b/ecosystem/obs_mtl/linux-mtl/mtl-input.c
@@ -155,7 +155,7 @@ static void mtl_input_defaults(obs_data_t* settings) {
   obs_data_set_default_int(settings, "t_fmt", ST20_FMT_YUV_420_10BIT);
   obs_data_set_default_int(settings, "v_fmt", VIDEO_FORMAT_UYVY);
   obs_data_set_default_int(settings, "framebuffer_cnt", 3);
-  obs_data_set_default_int(settings, "log_level", MTL_LOG_LEVEL_ERROR);
+  obs_data_set_default_int(settings, "log_level", MTL_LOG_LEVEL_ERR);
 }
 
 /**
@@ -263,7 +263,7 @@ static obs_properties_t* mtl_input_properties(void* vptr) {
   obs_property_t* log_level_list =
       obs_properties_add_list(props, "log_level", obs_module_text("LogLevel"),
                               OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-  obs_property_list_add_int(log_level_list, "ERROR", MTL_LOG_LEVEL_ERROR);
+  obs_property_list_add_int(log_level_list, "ERROR", MTL_LOG_LEVEL_ERR);
   obs_property_list_add_int(log_level_list, "INFO", MTL_LOG_LEVEL_INFO);
   obs_property_list_add_int(log_level_list, "NOTICE", MTL_LOG_LEVEL_NOTICE);
   obs_property_list_add_int(log_level_list, "WARNING", MTL_LOG_LEVEL_WARNING);

--- a/ecosystem/obs_mtl/linux-mtl/mtl-output.c
+++ b/ecosystem/obs_mtl/linux-mtl/mtl-output.c
@@ -52,7 +52,7 @@ static void mtl_output_defaults(obs_data_t* settings) {
   obs_data_set_default_int(settings, "payload_type", 112);
   obs_data_set_default_int(settings, "t_fmt", ST20_FMT_YUV_420_10BIT);
   obs_data_set_default_int(settings, "framebuffer_cnt", 3);
-  obs_data_set_default_int(settings, "log_level", MTL_LOG_LEVEL_ERROR);
+  obs_data_set_default_int(settings, "log_level", MTL_LOG_LEVEL_ERR);
 }
 
 static obs_properties_t* mtl_output_properties(void* vptr) {
@@ -85,7 +85,7 @@ static obs_properties_t* mtl_output_properties(void* vptr) {
   obs_property_t* log_level_list =
       obs_properties_add_list(props, "log_level", obs_module_text("LogLevel"),
                               OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-  obs_property_list_add_int(log_level_list, "ERROR", MTL_LOG_LEVEL_ERROR);
+  obs_property_list_add_int(log_level_list, "ERROR", MTL_LOG_LEVEL_ERR);
   obs_property_list_add_int(log_level_list, "INFO", MTL_LOG_LEVEL_INFO);
   obs_property_list_add_int(log_level_list, "NOTICE", MTL_LOG_LEVEL_NOTICE);
   obs_property_list_add_int(log_level_list, "WARNING", MTL_LOG_LEVEL_WARNING);

--- a/ld_preload/udp/udp_preload.h
+++ b/ld_preload/udp/udp_preload.h
@@ -50,9 +50,9 @@ enum mtl_log_level upl_get_log_level(void);
   do {                                                                                  \
     if (upl_get_log_level() <= MTL_LOG_LEVEL_WARNING) printf("UPL: Warn: "__VA_ARGS__); \
   } while (0)
-#define err(...)                                                                       \
-  do {                                                                                 \
-    if (upl_get_log_level() <= MTL_LOG_LEVEL_ERROR) printf("UPL: Error: "__VA_ARGS__); \
+#define err(...)                                                                     \
+  do {                                                                               \
+    if (upl_get_log_level() <= MTL_LOG_LEVEL_ERR) printf("UPL: Error: "__VA_ARGS__); \
   } while (0)
 
 /* On error, -1 is returned, and errno is set appropriately. */

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -428,12 +428,16 @@ static int dev_eal_init(struct mtl_init_params* p, struct mt_kport_info* kport_i
     argv[argc] = "notice";
   } else if (p->log_level == MTL_LOG_LEVEL_WARNING) {
     argv[argc] = "warning";
-  } else if (p->log_level == MTL_LOG_LEVEL_ERROR) {
+  } else if (p->log_level == MTL_LOG_LEVEL_ERR) {
     argv[argc] = "error";
+  } else if (p->log_level == MTL_LOG_LEVEL_CRIT) {
+    argv[argc] = "crit";
   } else {
-    argv[argc] = "info";
+    err("%s, unknown log level %d\n", __func__, p->log_level);
+    return -EINVAL;
   }
   argc++;
+  mt_set_log_global_level(p->log_level);
 
   if (p->flags & MTL_FLAG_RXTX_SIMD_512) {
     argv[argc] = "--force-max-simd-bitwidth=512";

--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -18,6 +18,7 @@ sources = files(
   'mt_rtcp.c',
   'mt_flow.c',
   'mt_instance.c',
+  'mt_log.c',
 )
 
 if is_windows

--- a/lib/src/mt_log.c
+++ b/lib/src/mt_log.c
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+#include "mt_log.h"
+
+#include "mt_main.h"
+
+static void log_default_prefix(char* buf, size_t sz) {
+  time_t now;
+  struct tm tm;
+
+  time(&now);
+  localtime_r(&now, &tm);
+  strftime(buf, sz, "%Y-%m-%d %H:%M:%S, ", &tm);
+}
+
+/* default log prefix format */
+static mtl_log_prefix_formatter_t g_mt_log_prefix_format = log_default_prefix;
+
+int mtl_set_log_prefix_formatter(mtl_log_prefix_formatter_t f) {
+  if (f) {
+    info("%s, new formatter %p\n", __func__, f);
+    g_mt_log_prefix_format = f;
+  } else {
+    info("%s, switch to default as user prefix is null\n", __func__);
+    g_mt_log_prefix_format = log_default_prefix;
+  }
+  return 0;
+}
+
+mtl_log_prefix_formatter_t mt_get_log_prefix_formatter(void) {
+  return g_mt_log_prefix_format;
+}
+
+static mtl_log_printer_t g_mt_log_printer;
+
+int mtl_set_log_printer(mtl_log_printer_t f) {
+  info("%s, new printer %p\n", __func__, f);
+  g_mt_log_printer = f;
+  return 0;
+}
+
+mtl_log_printer_t mt_get_log_printer(void) { return g_mt_log_printer; }
+
+static enum mtl_log_level g_mt_log_level = MTL_LOG_LEVEL_INFO;
+
+int mt_set_log_global_level(enum mtl_log_level level) {
+  g_mt_log_level = level;
+  return 0;
+}
+
+enum mtl_log_level mt_get_log_global_level(void) { return g_mt_log_level; }
+
+int mtl_set_log_level(mtl_handle mt, enum mtl_log_level level) {
+  struct mtl_main_impl* impl = mt;
+  uint32_t rte_level;
+
+  if (impl->type != MT_HANDLE_MAIN) {
+    err("%s, invalid type %d\n", __func__, impl->type);
+    return -EIO;
+  }
+
+  dbg("%s, set log level %d\n", __func__, level);
+  if (level == mtl_get_log_level(mt)) return 0;
+
+  switch (level) {
+    case MTL_LOG_LEVEL_DEBUG:
+      rte_level = RTE_LOG_DEBUG;
+      break;
+    case MTL_LOG_LEVEL_INFO:
+      rte_level = RTE_LOG_INFO;
+      break;
+    case MTL_LOG_LEVEL_NOTICE:
+      rte_level = RTE_LOG_NOTICE;
+      break;
+    case MTL_LOG_LEVEL_WARNING:
+      rte_level = RTE_LOG_WARNING;
+      break;
+    case MTL_LOG_LEVEL_ERR:
+      rte_level = RTE_LOG_ERR;
+      break;
+    case MTL_LOG_LEVEL_CRIT:
+      rte_level = RTE_LOG_CRIT;
+      break;
+    default:
+      err("%s, invalid level %d\n", __func__, level);
+      return -EINVAL;
+  }
+
+  rte_log_set_global_level(rte_level);
+
+  info("%s, set log level %d succ\n", __func__, level);
+  mt_get_user_params(impl)->log_level = level;
+  mt_set_log_global_level(level);
+  return 0;
+}
+
+enum mtl_log_level mtl_get_log_level(mtl_handle mt) {
+  struct mtl_main_impl* impl = mt;
+
+  if (impl->type != MT_HANDLE_MAIN) {
+    err("%s, invalid type %d\n", __func__, impl->type);
+    return -EIO;
+  }
+
+  return mt_get_user_params(impl)->log_level;
+}
+
+int mtl_openlog_stream(FILE* f) { return rte_openlog_stream(f); }

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -260,7 +260,7 @@ static int ufd_parse_json(struct mufd_init_params* init, const char* filename) {
       else if (!strcmp(str, "warning"))
         p->log_level = MTL_LOG_LEVEL_WARNING;
       else if (!strcmp(str, "error"))
-        p->log_level = MTL_LOG_LEVEL_ERROR;
+        p->log_level = MTL_LOG_LEVEL_ERR;
       else
         err("%s, unknow log level %s\n", __func__, str);
     }

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -148,7 +148,7 @@ static int test_parse_args(struct st_tests_context* ctx, struct mtl_init_params*
         else if (!strcmp(optarg, "warning"))
           p->log_level = MTL_LOG_LEVEL_WARNING;
         else if (!strcmp(optarg, "error"))
-          p->log_level = MTL_LOG_LEVEL_ERROR;
+          p->log_level = MTL_LOG_LEVEL_ERR;
         else
           err("%s, unknow log level %s\n", __func__, optarg);
         break;
@@ -353,7 +353,7 @@ static void test_ctx_init(struct st_tests_context* ctx) {
   memset(p, 0x0, sizeof(*p));
   p->flags = MTL_FLAG_BIND_NUMA; /* default bind to numa */
   p->flags |= MTL_FLAG_RANDOM_SRC_PORT;
-  p->log_level = MTL_LOG_LEVEL_ERROR;
+  p->log_level = MTL_LOG_LEVEL_ERR;
   p->priv = ctx;
   p->ptp_get_time_fn = test_ptp_from_real_time;
   p->tx_queues_cnt[MTL_PORT_P] = 16;
@@ -525,7 +525,7 @@ TEST(Misc, log_level) {
   enum mtl_log_level orig_level = mtl_get_log_level(handle);
   ret = mtl_set_log_level(handle, MTL_LOG_LEVEL_INFO);
   EXPECT_GE(ret, 0);
-  ret = mtl_set_log_level(handle, MTL_LOG_LEVEL_ERROR);
+  ret = mtl_set_log_level(handle, MTL_LOG_LEVEL_ERR);
   EXPECT_GE(ret, 0);
   ret = mtl_set_log_level(handle, orig_level);
   EXPECT_GE(ret, 0);

--- a/tests/src/ufd_test.cpp
+++ b/tests/src/ufd_test.cpp
@@ -62,7 +62,7 @@ static int utest_parse_args(struct utest_ctx* ctx, int argc, char** argv) {
         else if (!strcmp(optarg, "warning"))
           p->log_level = MTL_LOG_LEVEL_WARNING;
         else if (!strcmp(optarg, "error"))
-          p->log_level = MTL_LOG_LEVEL_ERROR;
+          p->log_level = MTL_LOG_LEVEL_ERR;
         else
           err("%s, unknow log level %s\n", __func__, optarg);
         break;
@@ -129,7 +129,7 @@ static void utest_ctx_init(struct utest_ctx* ctx) {
   memset(p, 0x0, sizeof(*p));
 
   p->flags |= MTL_FLAG_BIND_NUMA; /* default bind to numa */
-  p->log_level = MTL_LOG_LEVEL_ERROR;
+  p->log_level = MTL_LOG_LEVEL_ERR;
   p->tx_queues_cnt[MTL_PORT_P] = 16;
   p->tx_queues_cnt[MTL_PORT_R] = 16;
   p->rx_queues_cnt[MTL_PORT_P] = 16;


### PR DESCRIPTION
Applications can register a customized log printer using `mtl_set_log_printer`. Whenever MTL needs to log anything, the registered log callback will be invoked.

test with:
./build/app/RxTxApp --config_file tests/script/loop_json/1080p59_1v.json --log_printer