### PR TITLE
app: fix build fail as va_start in some setup

### DIFF
--- a/app/src/args.c
+++ b/app/src/args.c
@@ -4,6 +4,7 @@
 
 #include <getopt.h>
 #include <inttypes.h>
+#include <stdarg.h>
 
 #include "app_base.h"
 #define DEBUG


### PR DESCRIPTION
fix error: implicit declaration of function ‘va_start’

Signed-off-by: Frank Du <frank.du@intel.com>