### PR TITLE
init: add memzone_max option

### DIFF
--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -610,6 +610,8 @@ struct mtl_init_params {
    * some NICs may need this to avoid mbuf split.
    */
   uint16_t rx_pool_data_size;
+  /** Optional. the maximum number of memzones in DPDK, leave zero to use default 2560 */
+  uint32_t memzone_max;
 
   /** Optional. The number of tasklets for each lcore, 0 means determined by lib */
   uint32_t tasklets_nb_per_sch;

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -1938,6 +1938,12 @@ int mt_dev_get_socket_id(const char* port) {
 int mt_dev_init(struct mtl_init_params* p, struct mt_kport_info* kport_info) {
   int ret;
 
+  if (p->memzone_max) {
+    rte_memzone_max_set(p->memzone_max);
+    info("%s, user preferred memzone_max %u, now %" PRIu64 "\n", __func__, p->memzone_max,
+         rte_memzone_max_get());
+  }
+
   ret = dev_eal_init(p, kport_info);
   if (ret < 0) {
     err("%s, dev_eal_init fail %d\n", __func__, ret);

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -1938,11 +1938,13 @@ int mt_dev_get_socket_id(const char* port) {
 int mt_dev_init(struct mtl_init_params* p, struct mt_kport_info* kport_info) {
   int ret;
 
+#if RTE_VERSION >= RTE_VERSION_NUM(23, 7, 0, 0) /* introduce from 23.07 */
   if (p->memzone_max) {
     rte_memzone_max_set(p->memzone_max);
     info("%s, user preferred memzone_max %u, now %" PRIu64 "\n", __func__, p->memzone_max,
          rte_memzone_max_get());
   }
+#endif
 
   ret = dev_eal_init(p, kport_info);
   if (ret < 0) {


### PR DESCRIPTION
User can customize the maximum number of DPDK memzones by this option.