### PR TITLE
app/args: allow override the port name when json config is used

### DIFF
--- a/python/example/st20p_rx.py
+++ b/python/example/st20p_rx.py
@@ -66,7 +66,7 @@ def main():
     output_fmt = mtl.ST_FRAME_FMT_YUV422PLANAR8
     interlaced = False
 
-    args = arg_util.parse_args(True)
+    args = arg_util.parse_args(False)
 
     # Init para
     init_para = mtl.mtl_init_params()

--- a/python/example/st20p_rx_encode.py
+++ b/python/example/st20p_rx_encode.py
@@ -20,7 +20,7 @@ def main():
     current_datetime = datetime.now()
     output_file = current_datetime.strftime("%Y_%m_%d_%H_%M_%S") + "_output.mp4"
 
-    args = arg_util.parse_args(True)
+    args = arg_util.parse_args(False)
 
     # Init para
     init_para = mtl.mtl_init_params()


### PR DESCRIPTION
test with:
./build/app/RxTxApp --config_file tests/script/loop_json/1080p59_1v.json --p_port 0000:ac:01.1 --r_port 0000:ac:01.0