### PR TITLE
tx/video: use tx_no_chain mode if packets is less than buffered

### DIFF
--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -238,7 +238,6 @@ struct st22_tx_video_info {
 
   struct st22_boxes st22_boxes;
   int st22_total_pkts;
-  int st22_min_pkts;
 };
 
 struct st_vsync_info {
@@ -270,8 +269,6 @@ struct st_tx_video_session_impl {
   struct mt_txq_entry* queue[MTL_SESSION_PORT_MAX];
   int idx; /* index for current tx_session */
   uint64_t advice_sleep_us;
-  uint16_t queue_burst_pkts[MTL_SESSION_PORT_MAX];
-  uint16_t tx_done_cleanup[MTL_SESSION_PORT_MAX];
   int recovery_idx;
 
   struct st_tx_video_session_handle_impl* st20_handle;
@@ -379,7 +376,6 @@ struct st_tx_video_session_impl {
   uint32_t stat_user_busy;       /* get_next_frame or dequeue_bulk from rtp ring fail */
   uint32_t stat_lines_not_ready; /* query app lines not ready */
   uint32_t stat_vsync_mismatch;
-  uint32_t stat_tx_done_cleanup;
   uint64_t stat_bytes_tx[MTL_SESSION_PORT_MAX];
   uint32_t stat_user_meta_cnt;
   uint32_t stat_user_meta_pkt_cnt;

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -2504,12 +2504,15 @@ static bool tv_pkts_capable_chain(struct mtl_main_impl* impl,
   struct st20_tx_ops* ops = &s->ops;
   int num_ports = ops->num_port;
 
+  /* true for rtp type */
+  if (!st20_is_frame_type(ops->type)) return true;
+
   for (int port = 0; port < num_ports; port++) {
     enum mtl_port s_port = mt_port_logic2phy(s->port_maps, port);
     uint16_t max_buffer_nb = mt_if_nb_tx_desc(impl, s_port);
-    max_buffer_nb += s->ring_count;
+    // max_buffer_nb += s->ring_count;
     /* at least two swap buffer */
-    if ((s->st20_total_pkts * 3 / 2) < max_buffer_nb) {
+    if ((s->st20_total_pkts * (s->st20_frames_cnt - 1)) < max_buffer_nb) {
       warn("%s(%d), max_buffer_nb %u on s_port %d too large, st20_total_pkts %d\n",
            __func__, s->idx, max_buffer_nb, s_port, s->st20_total_pkts);
       return false;

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -1272,7 +1272,7 @@ TEST(St20p, digest_1080p_packet_convert_s2) {
   para.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
   para.check_fps = false;
   para.pkt_convert = true;
-  para.send_done_check = true;
+  para.send_done_check = false;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }


### PR DESCRIPTION
remove the tx_done_cleanup and st22_min_pkts WA

test with:
./build/tests/KahawaiTest --auto_start_stop --p_port 0000:ac:01.2 --r_port 0000:ac:01.3 --nb_tx_desc 4096