### PR TITLE
rx: rename sip to ip

### DIFF
--- a/app/sample/experimental/rx_st20_redundant_combined_sample.c
+++ b/app/sample/experimental/rx_st20_redundant_combined_sample.c
@@ -166,9 +166,9 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20rc_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 2;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_R], ctx.rx_sip_addr[MTL_PORT_R],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_R], ctx.rx_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/ext_frame/rx_st20_pipeline_dyn_ext_frame_sample.c
+++ b/app/sample/ext_frame/rx_st20_pipeline_dyn_ext_frame_sample.c
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/ext_frame/rx_st20p_hdr_split_gpu_direct.c
+++ b/app/sample/ext_frame/rx_st20p_hdr_split_gpu_direct.c
@@ -221,7 +221,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/fwd/rx_st20_tx_st20_split_fwd.c
+++ b/app/sample/fwd/rx_st20_tx_st20_split_fwd.c
@@ -219,8 +219,7 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20_fwd";
   ops_rx.priv = &app;
   ops_rx.num_port = 1;
-  memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
-         MTL_IP_ADDR_LEN);
+  memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
   snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx.param.port[MTL_PORT_P]);
   ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;  // user config the udp port.

--- a/app/sample/fwd/rx_st20p_tx_st20p_downsample_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_downsample_fwd.c
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_test";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+  memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx.param.port[MTL_PORT_P]);

--- a/app/sample/fwd/rx_st20p_tx_st20p_downsample_merge_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_downsample_merge_fwd.c
@@ -225,7 +225,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_rx";
     ops_rx.priv = rx;
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
@@ -259,7 +259,7 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_test";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+  memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx.param.port[MTL_PORT_P]);

--- a/app/sample/fwd/rx_st20p_tx_st20p_merge_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_merge_fwd.c
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_rx";
     ops_rx.priv = rx;
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/fwd/rx_st20p_tx_st20p_split_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_split_fwd.c
@@ -151,7 +151,7 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_rx";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+  memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx.param.port[MTL_PORT_P]);

--- a/app/sample/fwd/rx_st20p_tx_st22p_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st22p_fwd.c
@@ -184,7 +184,7 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20p_test";
   ops_rx.priv = &app;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+  memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx.param.port[MTL_PORT_P]);

--- a/app/sample/legacy/rx_st20_tx_st20_fwd.c
+++ b/app/sample/legacy/rx_st20_tx_st20_fwd.c
@@ -335,8 +335,7 @@ int main(int argc, char** argv) {
   ops_rx.name = "st20_fwd";
   ops_rx.priv = &app;
   ops_rx.num_port = 1;
-  memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
-         MTL_IP_ADDR_LEN);
+  memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
   snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx.param.port[MTL_PORT_P]);
   ops_rx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port;  // user config the udp port.

--- a/app/sample/legacy/rx_st22_video_sample.c
+++ b/app/sample/legacy/rx_st22_video_sample.c
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st22_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/legacy/rx_video_sample.c
+++ b/app/sample/legacy/rx_video_sample.c
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20_rx";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/low_level/rx_rtp_video_sample.c
+++ b/app/sample/low_level/rx_rtp_video_sample.c
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/low_level/rx_slice_video_sample.c
+++ b/app/sample/low_level/rx_slice_video_sample.c
@@ -177,7 +177,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/rx_st20_pipeline_sample.c
+++ b/app/sample/rx_st20_pipeline_sample.c
@@ -147,13 +147,13 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.port.num_port = ctx.param.num_ports;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);
     ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i * 2;
     if (ops_rx.port.num_port > 1) {
-      memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_R], ctx.rx_sip_addr[MTL_PORT_R],
+      memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_R], ctx.rx_ip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
       snprintf(ops_rx.port.port[MTL_SESSION_PORT_R], MTL_PORT_MAX_LEN, "%s",
                ctx.param.port[MTL_PORT_R]);

--- a/app/sample/rx_st20p_timing_parser_sample.c
+++ b/app/sample/rx_st20p_timing_parser_sample.c
@@ -188,13 +188,13 @@ int main(int argc, char** argv) {
     ops_rx.name = "st20p_test";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.port.num_port = app[i]->num_port;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);
     ops_rx.port.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i * 2;
     if (ops_rx.port.num_port > 1) {
-      memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_R], ctx.rx_sip_addr[MTL_PORT_R],
+      memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_R], ctx.rx_ip_addr[MTL_PORT_R],
              MTL_IP_ADDR_LEN);
       snprintf(ops_rx.port.port[MTL_SESSION_PORT_R], MTL_PORT_MAX_LEN, "%s",
                ctx.param.port[MTL_PORT_R]);

--- a/app/sample/rx_st22_pipeline_sample.c
+++ b/app/sample/rx_st22_pipeline_sample.c
@@ -142,7 +142,7 @@ int main(int argc, char** argv) {
     ops_rx.name = "st22p_sample";
     ops_rx.priv = app[i];  // app handle register to lib
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx.rx_sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx.rx_ip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx.param.port[MTL_PORT_P]);

--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -202,10 +202,10 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         inet_pton(AF_INET, optarg, ctx->tx_dip_addr[MTL_PORT_R]);
         break;
       case SAMPLE_ARG_P_RX_IP:
-        inet_pton(AF_INET, optarg, ctx->rx_sip_addr[MTL_PORT_P]);
+        inet_pton(AF_INET, optarg, ctx->rx_ip_addr[MTL_PORT_P]);
         break;
       case SAMPLE_ARG_R_RX_IP:
-        inet_pton(AF_INET, optarg, ctx->rx_sip_addr[MTL_PORT_R]);
+        inet_pton(AF_INET, optarg, ctx->rx_ip_addr[MTL_PORT_R]);
         break;
       case SAMPLE_ARG_P_FWD_IP:
         inet_pton(AF_INET, optarg, ctx->fwd_dip_addr[MTL_PORT_P]);
@@ -418,13 +418,13 @@ int sample_parse_args(struct st_sample_context* ctx, int argc, char** argv, bool
   if (unicast) {
     inet_pton(AF_INET, "192.168.85.80", ctx->tx_dip_addr[MTL_PORT_P]);
     inet_pton(AF_INET, "192.168.85.81", ctx->tx_dip_addr[MTL_PORT_R]);
-    inet_pton(AF_INET, "192.168.85.60", ctx->rx_sip_addr[MTL_PORT_P]);
-    inet_pton(AF_INET, "192.168.85.61", ctx->rx_sip_addr[MTL_PORT_R]);
+    inet_pton(AF_INET, "192.168.85.60", ctx->rx_ip_addr[MTL_PORT_P]);
+    inet_pton(AF_INET, "192.168.85.61", ctx->rx_ip_addr[MTL_PORT_R]);
   } else {
     inet_pton(AF_INET, "239.168.85.20", ctx->tx_dip_addr[MTL_PORT_P]);
     inet_pton(AF_INET, "239.168.85.21", ctx->tx_dip_addr[MTL_PORT_R]);
-    inet_pton(AF_INET, "239.168.85.20", ctx->rx_sip_addr[MTL_PORT_P]);
-    inet_pton(AF_INET, "239.168.85.21", ctx->rx_sip_addr[MTL_PORT_R]);
+    inet_pton(AF_INET, "239.168.85.20", ctx->rx_ip_addr[MTL_PORT_P]);
+    inet_pton(AF_INET, "239.168.85.21", ctx->rx_ip_addr[MTL_PORT_R]);
   }
   inet_pton(AF_INET, "239.168.86.20", ctx->fwd_dip_addr[MTL_PORT_P]);
   inet_pton(AF_INET, "239.168.86.21", ctx->fwd_dip_addr[MTL_PORT_R]);

--- a/app/sample/sample_util.h
+++ b/app/sample/sample_util.h
@@ -73,7 +73,7 @@ struct st_sample_context {
   mtl_handle st;
   struct mtl_init_params param;
   uint8_t tx_dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];  /* tx destination IP */
-  uint8_t rx_sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];  /* rx source IP */
+  uint8_t rx_ip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];   /* rx source IP */
   uint8_t fwd_dip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN]; /* fwd destination IP */
   char tx_url[ST_SAMPLE_URL_MAX_LEN];
   char rx_url[ST_SAMPLE_URL_MAX_LEN];

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -545,7 +545,7 @@ struct st_app_context {
   struct st_app_tx_st20p_session* tx_st20p_sessions;
   int tx_st20p_session_cnt;
 
-  uint8_t rx_sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];       /* rx source IP */
+  uint8_t rx_ip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN];        /* rx IP */
   uint8_t rx_mcast_sip_addr[MTL_PORT_MAX][MTL_IP_ADDR_LEN]; /* rx multicast source IP */
 
   struct st_app_rx_video_session* rx_video_sessions;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -420,10 +420,10 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         inet_pton(AF_INET, optarg, ctx->tx_dip_addr[MTL_PORT_R]);
         break;
       case ST_ARG_P_RX_IP:
-        inet_pton(AF_INET, optarg, ctx->rx_sip_addr[MTL_PORT_P]);
+        inet_pton(AF_INET, optarg, ctx->rx_ip_addr[MTL_PORT_P]);
         break;
       case ST_ARG_R_RX_IP:
-        inet_pton(AF_INET, optarg, ctx->rx_sip_addr[MTL_PORT_R]);
+        inet_pton(AF_INET, optarg, ctx->rx_ip_addr[MTL_PORT_R]);
         break;
       case ST_ARG_P_NETMASK:
         inet_pton(AF_INET, optarg, p->netmask[MTL_PORT_P]);

--- a/app/src/rx_ancillary_app.c
+++ b/app/src/rx_ancillary_app.c
@@ -126,10 +126,10 @@ static int app_rx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   ops.name = name;
   ops.priv = s;
   ops.num_port = anc ? anc->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
-         anc ? st_json_ip(ctx, &anc->base, MTL_SESSION_PORT_P)
-             : ctx->rx_sip_addr[MTL_PORT_P],
-         MTL_IP_ADDR_LEN);
+  memcpy(
+      ops.ip_addr[MTL_SESSION_PORT_P],
+      anc ? st_json_ip(ctx, &anc->base, MTL_SESSION_PORT_P) : ctx->rx_ip_addr[MTL_PORT_P],
+      MTL_IP_ADDR_LEN);
   memcpy(ops.mcast_sip_addr[MTL_SESSION_PORT_P],
          anc ? anc->base.mcast_src_ip[MTL_PORT_P] : ctx->rx_mcast_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
@@ -137,9 +137,9 @@ static int app_rx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
            anc ? anc->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P]);
   ops.udp_port[MTL_SESSION_PORT_P] = anc ? anc->base.udp_port : (10200 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+    memcpy(ops.ip_addr[MTL_SESSION_PORT_R],
            anc ? st_json_ip(ctx, &anc->base, MTL_SESSION_PORT_R)
-               : ctx->rx_sip_addr[MTL_PORT_R],
+               : ctx->rx_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     memcpy(ops.mcast_sip_addr[MTL_SESSION_PORT_R],
            anc ? anc->base.mcast_src_ip[MTL_PORT_R] : ctx->rx_mcast_sip_addr[MTL_PORT_R],

--- a/app/src/rx_audio_app.c
+++ b/app/src/rx_audio_app.c
@@ -227,9 +227,9 @@ static int app_rx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = audio ? audio->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
+  memcpy(ops.ip_addr[MTL_SESSION_PORT_P],
          audio ? st_json_ip(ctx, &audio->base, MTL_SESSION_PORT_P)
-               : ctx->rx_sip_addr[MTL_PORT_P],
+               : ctx->rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   memcpy(
       ops.mcast_sip_addr[MTL_SESSION_PORT_P],
@@ -240,9 +240,9 @@ static int app_rx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
       audio ? audio->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P]);
   ops.udp_port[MTL_SESSION_PORT_P] = audio ? audio->base.udp_port : (10100 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+    memcpy(ops.ip_addr[MTL_SESSION_PORT_R],
            audio ? st_json_ip(ctx, &audio->base, MTL_SESSION_PORT_R)
-                 : ctx->rx_sip_addr[MTL_PORT_R],
+                 : ctx->rx_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     memcpy(
         ops.mcast_sip_addr[MTL_SESSION_PORT_R],

--- a/app/src/rx_st20p_app.c
+++ b/app/src/rx_st20p_app.c
@@ -181,9 +181,9 @@ static int app_rx_st20p_init(struct st_app_context* ctx,
   ops.name = name;
   ops.priv = s;
   ops.port.num_port = st20p ? st20p->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.port.sip_addr[MTL_SESSION_PORT_P],
+  memcpy(ops.port.ip_addr[MTL_SESSION_PORT_P],
          st20p ? st_json_ip(ctx, &st20p->base, MTL_SESSION_PORT_P)
-               : ctx->rx_sip_addr[MTL_PORT_P],
+               : ctx->rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   memcpy(
       ops.port.mcast_sip_addr[MTL_SESSION_PORT_P],
@@ -194,9 +194,9 @@ static int app_rx_st20p_init(struct st_app_context* ctx,
       st20p ? st20p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P]);
   ops.port.udp_port[MTL_SESSION_PORT_P] = st20p ? st20p->base.udp_port : (10000 + s->idx);
   if (ops.port.num_port > 1) {
-    memcpy(ops.port.sip_addr[MTL_SESSION_PORT_R],
+    memcpy(ops.port.ip_addr[MTL_SESSION_PORT_R],
            st20p ? st_json_ip(ctx, &st20p->base, MTL_SESSION_PORT_R)
-                 : ctx->rx_sip_addr[MTL_PORT_R],
+                 : ctx->rx_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     memcpy(
         ops.port.mcast_sip_addr[MTL_SESSION_PORT_R],

--- a/app/src/rx_st20r_app.c
+++ b/app/src/rx_st20r_app.c
@@ -255,9 +255,9 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
+  memcpy(ops.ip_addr[MTL_SESSION_PORT_P],
          video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_P)
-               : ctx->rx_sip_addr[MTL_PORT_P],
+               : ctx->rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   memcpy(
       ops.mcast_sip_addr[MTL_SESSION_PORT_P],
@@ -267,9 +267,9 @@ static int app_rx_st20r_init(struct st_app_context* ctx, st_json_video_session_t
            video ? video->base.inf[MTL_PORT_P]->name : ctx->para.port[MTL_PORT_P]);
   ops.udp_port[MTL_SESSION_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+    memcpy(ops.ip_addr[MTL_SESSION_PORT_R],
            video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_R)
-                 : ctx->rx_sip_addr[MTL_PORT_R],
+                 : ctx->rx_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     memcpy(
         ops.mcast_sip_addr[MTL_SESSION_PORT_R],

--- a/app/src/rx_st22_app.c
+++ b/app/src/rx_st22_app.c
@@ -191,15 +191,14 @@ static int app_rx_st22_init(struct st_app_context* ctx, struct st22_app_rx_sessi
   ops.name = name;
   ops.priv = s;
   ops.num_port = ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_SESSION_PORT_P], ctx->rx_sip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  memcpy(ops.ip_addr[MTL_SESSION_PORT_P], ctx->rx_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
   memcpy(ops.mcast_sip_addr[MTL_SESSION_PORT_P], ctx->rx_mcast_sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx->para.port[MTL_PORT_P]);
   ops.udp_port[MTL_SESSION_PORT_P] = 15000 + s->idx;
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_SESSION_PORT_R], ctx->rx_sip_addr[MTL_PORT_R],
-           MTL_IP_ADDR_LEN);
+    memcpy(ops.ip_addr[MTL_SESSION_PORT_R], ctx->rx_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
     memcpy(ops.mcast_sip_addr[MTL_SESSION_PORT_R], ctx->rx_mcast_sip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     snprintf(ops.port[MTL_SESSION_PORT_R], MTL_PORT_MAX_LEN, "%s",

--- a/app/src/rx_st22p_app.c
+++ b/app/src/rx_st22p_app.c
@@ -125,9 +125,9 @@ static int app_rx_st22p_init(struct st_app_context* ctx,
   ops.name = name;
   ops.priv = s;
   ops.port.num_port = st22p ? st22p->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.port.sip_addr[MTL_SESSION_PORT_P],
+  memcpy(ops.port.ip_addr[MTL_SESSION_PORT_P],
          st22p ? st_json_ip(ctx, &st22p->base, MTL_SESSION_PORT_P)
-               : ctx->rx_sip_addr[MTL_PORT_P],
+               : ctx->rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   memcpy(
       ops.port.mcast_sip_addr[MTL_SESSION_PORT_P],
@@ -138,9 +138,9 @@ static int app_rx_st22p_init(struct st_app_context* ctx,
       st22p ? st22p->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P]);
   ops.port.udp_port[MTL_SESSION_PORT_P] = st22p ? st22p->base.udp_port : (10000 + s->idx);
   if (ops.port.num_port > 1) {
-    memcpy(ops.port.sip_addr[MTL_SESSION_PORT_R],
+    memcpy(ops.port.ip_addr[MTL_SESSION_PORT_R],
            st22p ? st_json_ip(ctx, &st22p->base, MTL_SESSION_PORT_R)
-                 : ctx->rx_sip_addr[MTL_PORT_R],
+                 : ctx->rx_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     memcpy(
         ops.port.mcast_sip_addr[MTL_SESSION_PORT_R],

--- a/app/src/rx_video_app.c
+++ b/app/src/rx_video_app.c
@@ -498,9 +498,9 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.name = name;
   ops.priv = s;
   ops.num_port = video ? video->base.num_inf : ctx->para.num_ports;
-  memcpy(ops.sip_addr[MTL_SESSION_PORT_P],
+  memcpy(ops.ip_addr[MTL_SESSION_PORT_P],
          video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_P)
-               : ctx->rx_sip_addr[MTL_PORT_P],
+               : ctx->rx_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   memcpy(
       ops.mcast_sip_addr[MTL_SESSION_PORT_P],
@@ -511,9 +511,9 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
       video ? video->base.inf[MTL_SESSION_PORT_P]->name : ctx->para.port[MTL_PORT_P]);
   ops.udp_port[MTL_SESSION_PORT_P] = video ? video->base.udp_port : (10000 + s->idx);
   if (ops.num_port > 1) {
-    memcpy(ops.sip_addr[MTL_SESSION_PORT_R],
+    memcpy(ops.ip_addr[MTL_SESSION_PORT_R],
            video ? st_json_ip(ctx, &video->base, MTL_SESSION_PORT_R)
-                 : ctx->rx_sip_addr[MTL_PORT_R],
+                 : ctx->rx_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     memcpy(
         ops.mcast_sip_addr[MTL_SESSION_PORT_R],

--- a/app/udp/udp_server_sample.c
+++ b/app/udp/udp_server_sample.c
@@ -238,7 +238,7 @@ int main(int argc, char** argv) {
     if (ctx.udp_tx_bps) mudp_set_tx_rate(app[i]->socket, ctx.udp_tx_bps);
     if (ctx.has_tx_dst_mac[MTL_PORT_P])
       mudp_set_tx_mac(app[i]->socket, ctx.tx_dst_mac[MTL_PORT_P]);
-    mudp_init_sockaddr(&app[i]->client_addr, ctx.rx_sip_addr[MTL_PORT_P],
+    mudp_init_sockaddr(&app[i]->client_addr, ctx.rx_ip_addr[MTL_PORT_P],
                        ctx.udp_port + i);
     bool mcast = mudp_is_multicast(&app[i]->client_addr);
 

--- a/app/udp/ufd_server_sample.c
+++ b/app/udp/ufd_server_sample.c
@@ -250,7 +250,7 @@ int main(int argc, char** argv) {
     if (ctx.udp_tx_bps) mufd_set_tx_rate(app[i]->socket, ctx.udp_tx_bps);
     if (ctx.has_tx_dst_mac[MTL_PORT_P])
       mufd_set_tx_mac(app[i]->socket, ctx.tx_dst_mac[MTL_PORT_P]);
-    mufd_init_sockaddr(&app[i]->client_addr, ctx.rx_sip_addr[MTL_PORT_P],
+    mufd_init_sockaddr(&app[i]->client_addr, ctx.rx_ip_addr[MTL_PORT_P],
                        ctx.udp_port + i);
     bool mcast = mudp_is_multicast(&app[i]->client_addr);
 

--- a/app/udp/usocket_server_sample.c
+++ b/app/udp/usocket_server_sample.c
@@ -223,7 +223,7 @@ int main(int argc, char** argv) {
       ret = -EIO;
       goto error;
     }
-    mudp_init_sockaddr(&app[i]->client_addr, ctx.rx_sip_addr[MTL_PORT_P],
+    mudp_init_sockaddr(&app[i]->client_addr, ctx.rx_ip_addr[MTL_PORT_P],
                        ctx.udp_port + i);
     bool mcast = mudp_is_multicast(&app[i]->client_addr);
 

--- a/doc/doxygen/programmers_guide.md
+++ b/doc/doxygen/programmers_guide.md
@@ -214,7 +214,7 @@ for (i = 0; i < session_num; i++)
     ops_rx.priv = app; // app handle register to lib
     ops_rx.num_port = 1;
     uint8_t ip[4]={xx,xx,xx,xx};
-    memcpy(ops_rx.sip_addr[ST_PORT_P], ip, ST_IP_ADDR_LEN); //tx src ip like 239.0.0.1
+    memcpy(ops_rx.ip_addr[ST_PORT_P], ip, ST_IP_ADDR_LEN); //rx ip like 239.0.0.1
     snprintf(ops_rx.port[ST_PORT_P], ST_PORT_MAX_LEN, "%s", "xxxx:xx:xx.x"); // send port interface like 0000:af:00.0
     ops_rx.udp_port[ST_PORT_P] = 10000 + i * 2; // user could config the udp port in this interface.
     ops_rx.pacing = ST21_PACING_NARROW;
@@ -298,7 +298,7 @@ for (i = 0; i < session_num; i++)
     ops_rx.priv = app; // app handle register to lib
     ops_rx.num_port = 1;
     uint8_t ip[4] = {xx,xx,xx,xx};
-    memcpy(ops_rx.sip_addr[ST_PORT_P], ip, ST_IP_ADDR_LEN); //tx src ip like 239.0.0.1
+    memcpy(ops_rx.ip_addr[ST_PORT_P], ip, ST_IP_ADDR_LEN); // rx ip like 239.0.0.1
     snprintf(ops_rx.port[ST_PORT_P], ST_PORT_MAX_LEN, "%s", "xxxx:xx:xx.x"); // send port interface like 0000:af:00.0
     ops_rx.udp_port[ST_PORT_P] = 10000 + i * 2; // user could config the udp port in this interface.
     ops_rx.pacing = ST21_PACING_NARROW;

--- a/ecosystem/ffmpeg_plugin/kahawai_dec.c
+++ b/ecosystem/ffmpeg_plugin/kahawai_dec.c
@@ -99,11 +99,10 @@ static int kahawai_read_header(AVFormatContext* ctx) {
   if (NULL == s->src_addr) {
     av_log(ctx, AV_LOG_ERROR, "Invalid source IP address\n");
     return AVERROR(EINVAL);
-  } else if (sscanf(s->src_addr, "%hhu.%hhu.%hhu.%hhu",
-                    &ops_rx.port.sip_addr[MTL_PORT_P][0],
-                    &ops_rx.port.sip_addr[MTL_PORT_P][1],
-                    &ops_rx.port.sip_addr[MTL_PORT_P][2],
-                    &ops_rx.port.sip_addr[MTL_PORT_P][3]) != MTL_IP_ADDR_LEN) {
+  } else if (sscanf(
+                 s->src_addr, "%hhu.%hhu.%hhu.%hhu", &ops_rx.port.ip_addr[MTL_PORT_P][0],
+                 &ops_rx.port.ip_addr[MTL_PORT_P][1], &ops_rx.port.ip_addr[MTL_PORT_P][2],
+                 &ops_rx.port.ip_addr[MTL_PORT_P][3]) != MTL_IP_ADDR_LEN) {
     av_log(ctx, AV_LOG_ERROR, "Failed to parse source IP address: %s\n", s->src_addr);
     return AVERROR(EINVAL);
   }

--- a/ecosystem/obs_mtl/linux-mtl/mtl-input.c
+++ b/ecosystem/obs_mtl/linux-mtl/mtl-input.c
@@ -345,7 +345,7 @@ static void mtl_input_init(struct mtl_rx_session* s) {
   ops_rx.name = "mtl-input";
   ops_rx.priv = s;  // app handle register to lib
   ops_rx.port.num_port = 1;
-  inet_pton(AF_INET, s->ip, ops_rx.port.sip_addr[MTL_PORT_P]);
+  inet_pton(AF_INET, s->ip, ops_rx.port.ip_addr[MTL_PORT_P]);
   snprintf(ops_rx.port.port[MTL_PORT_P], MTL_PORT_MAX_LEN, "%s", s->port);
   ops_rx.port.udp_port[MTL_PORT_P] = s->udp_port;  // user config the udp port.
   ops_rx.width = s->width;

--- a/include/experimental/st20_combined_api.h
+++ b/include/experimental/st20_combined_api.h
@@ -63,8 +63,13 @@ struct st20rc_rx_ops {
   const char* name;
   /** private data to the callback function */
   void* priv;
-  /** source IP address of sender or multicast IP address */
-  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  union {
+    /** Mandatory. multicast IP address or sender IP for unicast */
+    uint8_t ip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+    /** deprecated, use ip_addr instead, sip_addr is confused */
+    uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN] __mtl_deprecated_msg(
+        "Use ip_addr instead");
+  };
   /** num of ports this session attached to, must be 2 */
   uint8_t num_port;
   /** Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -138,12 +138,8 @@ typedef struct mtl_dma_mem* mtl_dma_mem_handle;
  */
 #define MTL_ALIGN(val, align) (((val) + ((align)-1)) & ~((align)-1))
 
-#ifdef __MTL_LIB_BUILD__
-#define __mtl_deprecated_msg(msg)
-#else
 /** Macro to mark functions and fields to be removal */
 #define __mtl_deprecated_msg(msg) __attribute__((__deprecated__(msg)))
-#endif
 
 #ifndef MTL_MAY_UNUSED
 /** Macro to mark unused-parameter */
@@ -636,14 +632,22 @@ struct mtl_init_params {
    * use mtl_get_fix_info to query the actual count.
    * dpdk context will allocate the hw resources(queues, memory) based on this number.
    */
+#ifdef __MTL_LIB_BUILD__
+  uint16_t tx_sessions_cnt_max;
+#else
   uint16_t tx_sessions_cnt_max __mtl_deprecated_msg("Use tx_queues_cnt instead");
+#endif
   /**
    * deprecated for MTL_TRANSPORT_ST2110.
    * max rx sessions(st20, st22, st30, st40) requested the lib to support,
    * use mtl_get_fix_info to query the actual count.
    * dpdk context will allocate the hw resources(queues, memory) based on this number.
    */
+#ifdef __MTL_LIB_BUILD__
+  uint16_t rx_sessions_cnt_max;
+#else
   uint16_t rx_sessions_cnt_max __mtl_deprecated_msg("Use rx_queues_cnt instead");
+#endif
 };
 
 /**

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -138,8 +138,13 @@ typedef struct mtl_dma_mem* mtl_dma_mem_handle;
  */
 #define MTL_ALIGN(val, align) (((val) + ((align)-1)) & ~((align)-1))
 
+#ifdef __MTL_PYTHON_BUILD__
+/** swig not support __deprecated__ */
+#define __mtl_deprecated_msg(msg)
+#else
 /** Macro to mark functions and fields to be removal */
 #define __mtl_deprecated_msg(msg) __attribute__((__deprecated__(msg)))
+#endif
 
 #ifndef MTL_MAY_UNUSED
 /** Macro to mark unused-parameter */

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1374,8 +1374,13 @@ struct st_rx_rtcp_ops {
  * Include the PCIE port and other required info.
  */
 struct st20_rx_ops {
-  /** Mandatory. source IP address of sender or multicast IP address */
-  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  union {
+    /** Mandatory. multicast IP address or sender IP for unicast */
+    uint8_t ip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+    /** deprecated, use ip_addr instead, sip_addr is confused */
+    uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN] __mtl_deprecated_msg(
+        "Use ip_addr instead");
+  };
   /** Mandatory. 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Mandatory. Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
@@ -1518,8 +1523,13 @@ struct st20_rx_ops {
  * Include the PCIE port and other required info.
  */
 struct st22_rx_ops {
-  /** Mandatory. source IP address of sender or multicast IP address */
-  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  union {
+    /** Mandatory. multicast IP address or sender IP for unicast */
+    uint8_t ip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+    /** deprecated, use ip_addr instead, sip_addr is confused */
+    uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN] __mtl_deprecated_msg(
+        "Use ip_addr instead");
+  };
   /** Mandatory. 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Mandatory. Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -354,8 +354,13 @@ struct st30_tx_ops {
  * Include the PCIE port and other required info
  */
 struct st30_rx_ops {
-  /** Mandatory. source IP address of sender or multicast IP address */
-  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  union {
+    /** Mandatory. multicast IP address or sender IP for unicast */
+    uint8_t ip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+    /** deprecated, use ip_addr instead, sip_addr is confused */
+    uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN] __mtl_deprecated_msg(
+        "Use ip_addr instead");
+  };
   /** Mandatory. 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Mandatory. Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -298,8 +298,13 @@ struct st40_tx_ops {
  * Include the PCIE port and other required info
  */
 struct st40_rx_ops {
-  /** Mandatory. source IP address of sender or multicast IP address */
-  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  union {
+    /** Mandatory. multicast IP address or sender IP for unicast */
+    uint8_t ip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+    /** deprecated, use ip_addr instead, sip_addr is confused */
+    uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN] __mtl_deprecated_msg(
+        "Use ip_addr instead");
+  };
   /** Mandatory. 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Mandatory. Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -155,8 +155,13 @@ struct st_tx_dest_info {
  * Leave redundant info to zero if the session only has primary port.
  */
 struct st_rx_source_info {
-  /** source IP address of sender */
-  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  union {
+    /** Mandatory. multicast IP address or sender IP for unicast */
+    uint8_t ip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+    /** deprecated, use ip_addr instead, sip_addr is confused */
+    uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN] __mtl_deprecated_msg(
+        "Use ip_addr instead");
+  };
   /** UDP port number */
   uint16_t udp_port[MTL_SESSION_PORT_MAX];
   /** Optional. source filter IP address of multicast */

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -730,8 +730,13 @@ struct st_tx_port {
 
 /** The structure info for st rx port, used in creating session. */
 struct st_rx_port {
-  /** Mandatory. source IP address of sender or multicast IP address */
-  uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+  union {
+    /** Mandatory. multicast IP address or sender IP for unicast */
+    uint8_t ip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN];
+    /** deprecated, use ip_addr instead, sip_addr is confused */
+    uint8_t sip_addr[MTL_SESSION_PORT_MAX][MTL_IP_ADDR_LEN] __mtl_deprecated_msg(
+        "Use ip_addr instead");
+  };
   /** Mandatory. 1 or 2, num of ports this session attached to */
   uint8_t num_port;
   /** Mandatory. Pcie BDF path like 0000:af:00.0, should align to BDF of mtl_init */
@@ -2004,8 +2009,8 @@ static inline uint32_t st_frame_data_height(struct st_frame* frame) {
 
 /** Helper to set the port for struct st_rx_port */
 int st_rxp_para_port_set(struct st_rx_port* p, enum mtl_session_port port, char* name);
-/** Helper to set the sip for struct st_rx_port */
-int st_rxp_para_sip_set(struct st_rx_port* p, enum mtl_port port, char* ip);
+/** Helper to set the ip for struct st_rx_port */
+int st_rxp_para_ip_set(struct st_rx_port* p, enum mtl_port port, char* ip);
 /** Helper to set the udp port number for struct st_rx_port */
 static inline void st_rxp_para_udp_port_set(struct st_rx_port* p, enum mtl_port port,
                                             uint16_t udp_port) {

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -749,7 +749,7 @@ int st_rx_source_info_check(struct st_rx_source_info* src, int num_ports) {
   int ret;
 
   for (int i = 0; i < num_ports; i++) {
-    ip = src->sip_addr[i];
+    ip = src->ip_addr[i];
     ret = mt_ip_addr_check(ip);
     if (ret < 0) {
       err("%s(%d), invalid ip %d.%d.%d.%d\n", __func__, i, ip[0], ip[1], ip[2], ip[3]);
@@ -758,7 +758,7 @@ int st_rx_source_info_check(struct st_rx_source_info* src, int num_ports) {
   }
 
   if (num_ports > 1) {
-    if (0 == memcmp(src->sip_addr[0], src->sip_addr[1], MTL_IP_ADDR_LEN)) {
+    if (0 == memcmp(src->ip_addr[0], src->ip_addr[1], MTL_IP_ADDR_LEN)) {
       err("%s, same %d.%d.%d.%d for both ip\n", __func__, ip[0], ip[1], ip[2], ip[3]);
       return -EINVAL;
     }

--- a/lib/src/st2110/experimental/st20_redundant_combined_rx.c
+++ b/lib/src/st2110/experimental/st20_redundant_combined_rx.c
@@ -148,7 +148,7 @@ static int rx_st20rc_create_transport(struct st20rc_rx_ctx* ctx,
   ops_rx.name = ops->name;
   ops_rx.priv = transport;
   ops_rx.num_port = 1;
-  memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ops->sip_addr[port], MTL_IP_ADDR_LEN);
+  memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ops->ip_addr[port], MTL_IP_ADDR_LEN);
   memcpy(ops_rx.mcast_sip_addr[MTL_SESSION_PORT_P], ops->mcast_sip_addr[port],
          MTL_IP_ADDR_LEN);
   snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s", ops->port[port]);
@@ -245,9 +245,9 @@ st20rc_rx_handle st20rc_rx_create(mtl_handle mt, struct st20rc_rx_ops* ops) {
     err("%s, invalid num_port %u\n", __func__, num_port);
     return NULL;
   }
-  if (0 == memcmp(ops->sip_addr[MTL_SESSION_PORT_P], ops->sip_addr[MTL_SESSION_PORT_R],
+  if (0 == memcmp(ops->ip_addr[MTL_SESSION_PORT_P], ops->ip_addr[MTL_SESSION_PORT_R],
                   MTL_IP_ADDR_LEN)) {
-    uint8_t* ip = ops->sip_addr[MTL_SESSION_PORT_P];
+    uint8_t* ip = ops->ip_addr[MTL_SESSION_PORT_P];
     err("%s, same %d.%d.%d.%d for both ip\n", __func__, ip[0], ip[1], ip[2], ip[3]);
     return NULL;
   }

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -409,7 +409,7 @@ static int rx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_rx
   ops_rx.priv = ctx;
   ops_rx.num_port = RTE_MIN(ops->port.num_port, MTL_SESSION_PORT_MAX);
   for (int i = 0; i < ops_rx.num_port; i++) {
-    memcpy(ops_rx.sip_addr[i], ops->port.sip_addr[i], MTL_IP_ADDR_LEN);
+    memcpy(ops_rx.ip_addr[i], ops->port.ip_addr[i], MTL_IP_ADDR_LEN);
     memcpy(ops_rx.mcast_sip_addr[i], ops->port.mcast_sip_addr[i], MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[i], MTL_PORT_MAX_LEN, "%s", ops->port.port[i]);
     ops_rx.udp_port[i] = ops->port.udp_port[i];

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -251,7 +251,7 @@ static int rx_st22p_create_transport(struct mtl_main_impl* impl, struct st22p_rx
   ops_rx.priv = ctx;
   ops_rx.num_port = RTE_MIN(ops->port.num_port, MTL_SESSION_PORT_MAX);
   for (int i = 0; i < ops_rx.num_port; i++) {
-    memcpy(ops_rx.sip_addr[i], ops->port.sip_addr[i], MTL_IP_ADDR_LEN);
+    memcpy(ops_rx.ip_addr[i], ops->port.ip_addr[i], MTL_IP_ADDR_LEN);
     memcpy(ops_rx.mcast_sip_addr[i], ops->port.mcast_sip_addr[i], MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[i], MTL_PORT_MAX_LEN, "%s", ops->port.port[i]);
     ops_rx.udp_port[i] = ops->port.udp_port[i];

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -1244,8 +1244,8 @@ int st_rxp_para_port_set(struct st_rx_port* p, enum mtl_session_port port, char*
   return snprintf(p->port[port], MTL_PORT_MAX_LEN, "%s", name);
 }
 
-int st_rxp_para_sip_set(struct st_rx_port* p, enum mtl_port port, char* ip) {
-  int ret = inet_pton(AF_INET, ip, p->sip_addr[port]);
+int st_rxp_para_ip_set(struct st_rx_port* p, enum mtl_port port, char* ip) {
+  int ret = inet_pton(AF_INET, ip, p->ip_addr[port]);
   if (ret == 1) return 0;
   err("%s, fail to inet_pton for %s\n", __func__, ip);
   return -EIO;

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -239,7 +239,7 @@ static int rx_ancillary_session_init_hw(struct mtl_main_impl* impl,
     s->priv[i].s_port = i;
 
     memset(&flow, 0, sizeof(flow));
-    rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
+    rte_memcpy(flow.dip_addr, s->ops.ip_addr[i], MTL_IP_ADDR_LEN);
     if (mt_is_multicast_ip(flow.dip_addr))
       rte_memcpy(flow.sip_addr, s->ops.mcast_sip_addr[i], MTL_IP_ADDR_LEN);
     else
@@ -273,10 +273,10 @@ static int rx_ancillary_session_uinit_mcast(struct mtl_main_impl* impl,
   enum mtl_port port;
 
   for (int i = 0; i < ops->num_port; i++) {
-    if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
+    if (!mt_is_multicast_ip(ops->ip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
     if (mt_drv_mcast_in_dp(impl, port)) continue;
-    mt_mcast_leave(impl, mt_ip_to_u32(ops->sip_addr[i]),
+    mt_mcast_leave(impl, mt_ip_to_u32(ops->ip_addr[i]),
                    mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
   }
 
@@ -290,14 +290,14 @@ static int rx_ancillary_session_init_mcast(struct mtl_main_impl* impl,
   enum mtl_port port;
 
   for (int i = 0; i < ops->num_port; i++) {
-    if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
+    if (!mt_is_multicast_ip(ops->ip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
     if (mt_drv_mcast_in_dp(impl, port)) continue;
     if (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY) {
       info("%s(%d), skip mcast join for port %d\n", __func__, s->idx, i);
       return 0;
     }
-    ret = mt_mcast_join(impl, mt_ip_to_u32(ops->sip_addr[i]),
+    ret = mt_mcast_join(impl, mt_ip_to_u32(ops->ip_addr[i]),
                         mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
     if (ret < 0) return ret;
   }
@@ -464,7 +464,7 @@ static int rx_ancillary_session_update_src(struct mtl_main_impl* impl,
 
   /* update ip and port */
   for (int i = 0; i < num_port; i++) {
-    memcpy(ops->sip_addr[i], src->sip_addr[i], MTL_IP_ADDR_LEN);
+    memcpy(ops->ip_addr[i], src->ip_addr[i], MTL_IP_ADDR_LEN);
     memcpy(ops->mcast_sip_addr[i], src->mcast_sip_addr[i], MTL_IP_ADDR_LEN);
     ops->udp_port[i] = src->udp_port[i];
     s->st40_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (30000 + idx * 2);
@@ -660,7 +660,7 @@ static int rx_ancillary_ops_check(struct st40_rx_ops* ops) {
   }
 
   for (int i = 0; i < num_ports; i++) {
-    ip = ops->sip_addr[i];
+    ip = ops->ip_addr[i];
     ret = mt_ip_addr_check(ip);
     if (ret < 0) {
       err("%s(%d), invalid ip %d.%d.%d.%d\n", __func__, i, ip[0], ip[1], ip[2], ip[3]);
@@ -669,7 +669,7 @@ static int rx_ancillary_ops_check(struct st40_rx_ops* ops) {
   }
 
   if (num_ports > 1) {
-    if (0 == memcmp(ops->sip_addr[0], ops->sip_addr[1], MTL_IP_ADDR_LEN)) {
+    if (0 == memcmp(ops->ip_addr[0], ops->ip_addr[1], MTL_IP_ADDR_LEN)) {
       err("%s, same %d.%d.%d.%d for both ip\n", __func__, ip[0], ip[1], ip[2], ip[3]);
       return -EINVAL;
     }

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -471,7 +471,7 @@ static int rx_audio_session_init_hw(struct mtl_main_impl* impl,
     s->priv[i].s_port = i;
 
     memset(&flow, 0, sizeof(flow));
-    rte_memcpy(flow.dip_addr, s->ops.sip_addr[i], MTL_IP_ADDR_LEN);
+    rte_memcpy(flow.dip_addr, s->ops.ip_addr[i], MTL_IP_ADDR_LEN);
     if (mt_is_multicast_ip(flow.dip_addr))
       rte_memcpy(flow.sip_addr, s->ops.mcast_sip_addr[i], MTL_IP_ADDR_LEN);
     else
@@ -505,10 +505,10 @@ static int rx_audio_session_uinit_mcast(struct mtl_main_impl* impl,
   enum mtl_port port;
 
   for (int i = 0; i < ops->num_port; i++) {
-    if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
+    if (!mt_is_multicast_ip(ops->ip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
     if (mt_drv_mcast_in_dp(impl, port)) continue;
-    mt_mcast_leave(impl, mt_ip_to_u32(ops->sip_addr[i]),
+    mt_mcast_leave(impl, mt_ip_to_u32(ops->ip_addr[i]),
                    mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
   }
 
@@ -522,14 +522,14 @@ static int rx_audio_session_init_mcast(struct mtl_main_impl* impl,
   enum mtl_port port;
 
   for (int i = 0; i < ops->num_port; i++) {
-    if (!mt_is_multicast_ip(ops->sip_addr[i])) continue;
+    if (!mt_is_multicast_ip(ops->ip_addr[i])) continue;
     port = mt_port_logic2phy(s->port_maps, i);
     if (mt_drv_mcast_in_dp(impl, port)) continue;
     if (ops->flags & ST20_RX_FLAG_DATA_PATH_ONLY) {
       info("%s(%d), skip mcast join for port %d\n", __func__, s->idx, i);
       return 0;
     }
-    ret = mt_mcast_join(impl, mt_ip_to_u32(ops->sip_addr[i]),
+    ret = mt_mcast_join(impl, mt_ip_to_u32(ops->ip_addr[i]),
                         mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
     if (ret < 0) return ret;
   }
@@ -742,7 +742,7 @@ static int rx_audio_session_update_src(struct mtl_main_impl* impl,
 
   /* update ip and port */
   for (int i = 0; i < num_port; i++) {
-    memcpy(ops->sip_addr[i], src->sip_addr[i], MTL_IP_ADDR_LEN);
+    memcpy(ops->ip_addr[i], src->ip_addr[i], MTL_IP_ADDR_LEN);
     memcpy(ops->mcast_sip_addr[i], src->mcast_sip_addr[i], MTL_IP_ADDR_LEN);
     ops->udp_port[i] = src->udp_port[i];
     s->st30_dst_port[i] = (ops->udp_port[i]) ? (ops->udp_port[i]) : (20000 + idx * 2);
@@ -945,7 +945,7 @@ static int rx_audio_ops_check(struct st30_rx_ops* ops) {
   }
 
   for (int i = 0; i < num_ports; i++) {
-    ip = ops->sip_addr[i];
+    ip = ops->ip_addr[i];
     ret = mt_ip_addr_check(ip);
     if (ret < 0) {
       err("%s(%d), invalid ip %d.%d.%d.%d\n", __func__, i, ip[0], ip[1], ip[2], ip[3]);
@@ -954,7 +954,7 @@ static int rx_audio_ops_check(struct st30_rx_ops* ops) {
   }
 
   if (num_ports > 1) {
-    if (0 == memcmp(ops->sip_addr[0], ops->sip_addr[1], MTL_IP_ADDR_LEN)) {
+    if (0 == memcmp(ops->ip_addr[0], ops->ip_addr[1], MTL_IP_ADDR_LEN)) {
       err("%s, same %d.%d.%d.%d for both ip\n", __func__, ip[0], ip[1], ip[2], ip[3]);
       return -EINVAL;
     }

--- a/python/example/st20p_rx.py
+++ b/python/example/st20p_rx.py
@@ -98,7 +98,7 @@ def main():
         mtl.mtl_para_port_get(init_para, mtl.MTL_SESSION_PORT_P),
     )
     rx_port.num_port = 1
-    mtl.st_rxp_para_sip_set(rx_port, mtl.MTL_SESSION_PORT_P, args.p_rx_ip)
+    mtl.st_rxp_para_ip_set(rx_port, mtl.MTL_SESSION_PORT_P, args.p_rx_ip)
     mtl.st_rxp_para_udp_port_set(rx_port, mtl.MTL_SESSION_PORT_P, args.udp_port)
     rx_port.payload_type = args.payload_type
     rx_para.port = rx_port

--- a/python/example/st20p_rx_encode.py
+++ b/python/example/st20p_rx_encode.py
@@ -55,7 +55,7 @@ def main():
         mtl.mtl_para_port_get(init_para, mtl.MTL_SESSION_PORT_P),
     )
     rx_port.num_port = 1
-    mtl.st_rxp_para_sip_set(rx_port, mtl.MTL_SESSION_PORT_P, args.p_rx_ip)
+    mtl.st_rxp_para_ip_set(rx_port, mtl.MTL_SESSION_PORT_P, args.p_rx_ip)
     mtl.st_rxp_para_udp_port_set(rx_port, mtl.MTL_SESSION_PORT_P, args.udp_port)
     rx_port.payload_type = args.payload_type
     rx_para.port = rx_port

--- a/python/example/st22p_rx.py
+++ b/python/example/st22p_rx.py
@@ -103,7 +103,7 @@ def main():
         mtl.mtl_para_port_get(init_para, mtl.MTL_SESSION_PORT_P),
     )
     rx_port.num_port = 1
-    mtl.st_rxp_para_sip_set(rx_port, mtl.MTL_SESSION_PORT_P, args.p_rx_ip)
+    mtl.st_rxp_para_ip_set(rx_port, mtl.MTL_SESSION_PORT_P, args.p_rx_ip)
     mtl.st_rxp_para_udp_port_set(rx_port, mtl.MTL_SESSION_PORT_P, args.udp_port)
     rx_port.payload_type = args.payload_type
     rx_para.port = rx_port

--- a/python/swig/pymtl.i
+++ b/python/swig/pymtl.i
@@ -9,6 +9,7 @@
 
 %begin %{
 #define SWIG_PYTHON_CAST_MODE
+#define __MTL_PYTHON_BUILD__
 %}
 
 %{
@@ -18,8 +19,6 @@
 #include <mtl/st_pipeline_api.h>
 %}
 
-%define __MTL_LIB_BUILD__
-%enddef
 %define __MTL_PYTHON_BUILD__
 %enddef
 

--- a/tests/src/st20_test.cpp
+++ b/tests/src/st20_test.cpp
@@ -559,13 +559,13 @@ static void st20_rx_ops_init(tests_context* st20, struct st20_rx_ops* ops) {
   ops->priv = st20;
   ops->num_port = ctx->para.num_ports;
   if (ctx->same_dual_port) ops->num_port = 1;
-  memcpy(ops->sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops->ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops->port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx->para.port[MTL_PORT_P]);
   ops->udp_port[MTL_SESSION_PORT_P] = 10000 + st20->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->sip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+    memcpy(ops->ip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     snprintf(ops->port[MTL_SESSION_PORT_R], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -968,7 +968,7 @@ static void st20_rx_fps_test(enum st20_type type[], enum st_fps fps[], int width
     ops_rx.name = "st20_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -1373,7 +1373,7 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions,
     ops_rx.name = "st20_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -1410,7 +1410,7 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions,
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 10000 + 2;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   if (tx_update_dst) {
     test_ctx_tx[0]->seq_id = 0; /* reset seq id */
@@ -1450,7 +1450,7 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions,
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
     src.udp_port[MTL_SESSION_PORT_P] = 10000 + 2;
-    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+    memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     test_ctx_tx[2]->seq_id = rand(); /* random seq id */
     for (int i = 0; i < rx_sessions; i++) {
@@ -1479,7 +1479,7 @@ static void st20_rx_update_src_test(enum st20_type type, int tx_sessions,
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 10000 + 0;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   test_ctx_tx[0]->seq_id = rand(); /* random seq id */
   if (tx_update_dst) {
@@ -1949,7 +1949,7 @@ static void st20_rx_digest_test(enum st20_type tx_type[], enum st20_type rx_type
     ops_rx.name = "st20_digest_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -2797,7 +2797,7 @@ static void st20_rx_meta_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st20_meta_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -2974,7 +2974,7 @@ static void st20_rx_after_start_test(enum st20_type type[], enum st_fps fps[],
       ops_rx.name = "st20_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
       snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
                ctx->para.port[MTL_PORT_R]);
@@ -3219,7 +3219,7 @@ static void st20_rx_uframe_test(enum st20_type rx_type[], enum st20_packing pack
     ops_rx.name = "st20_uframe_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -3510,7 +3510,7 @@ static void st20_rx_detect_test(enum st20_type tx_type[], enum st20_type rx_type
     ops_rx.name = "st20_detect_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -3768,7 +3768,7 @@ static void st20_rx_dump_test(enum st20_type type[], enum st_fps fps[], int widt
     ops_rx.name = "st20_dump_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -4049,7 +4049,7 @@ static void st20_tx_ext_frame_rx_digest_test(enum st20_packing packing[],
     ops_rx.name = "st20_ext_frame_digest_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -4336,7 +4336,7 @@ static void st20_tx_user_pacing_test(int width[], int height[], enum st20_fmt fm
     ops_rx.name = "st20_timestamp_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -4603,7 +4603,7 @@ static void st20_linesize_digest_test(enum st20_packing packing[], enum st_fps f
     ops_rx.name = "st20_linesize_digest_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -275,7 +275,7 @@ static void st20p_rx_ops_init(tests_context* st20, struct st20p_rx_ops* ops_rx) 
   ops_rx->name = "st20p_test";
   ops_rx->priv = st20;
   ops_rx->port.num_port = 1;
-  memcpy(ops_rx->port.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops_rx->port.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops_rx->port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx->para.port[MTL_PORT_R]);
@@ -960,7 +960,7 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st20p_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);

--- a/tests/src/st22_test.cpp
+++ b/tests/src/st22_test.cpp
@@ -131,13 +131,13 @@ static void st22_rx_ops_init(tests_context* st22, struct st22_rx_ops* ops) {
   ops->priv = st22;
   ops->num_port = ctx->para.num_ports;
   if (ctx->same_dual_port) ops->num_port = 1;
-  memcpy(ops->sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops->ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops->port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx->para.port[MTL_PORT_P]);
   ops->udp_port[MTL_SESSION_PORT_P] = 10000 + st22->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->sip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+    memcpy(ops->ip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     snprintf(ops->port[MTL_SESSION_PORT_R], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -454,7 +454,7 @@ static void st22_rx_fps_test(enum st22_type type[], enum st_fps fps[], int width
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -656,7 +656,7 @@ static void st22_rx_update_src_test(int tx_sessions, enum st_test_level level) {
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -695,7 +695,7 @@ static void st22_rx_update_src_test(int tx_sessions, enum st_test_level level) {
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 10000 + 1;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st22_rx_update_source(rx_handle[i], &src);
@@ -720,7 +720,7 @@ static void st22_rx_update_src_test(int tx_sessions, enum st_test_level level) {
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
     src.udp_port[MTL_SESSION_PORT_P] = 10000 + 2;
-    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+    memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     for (int i = 0; i < rx_sessions; i++) {
       ret = st22_rx_update_source(rx_handle[i], &src);
@@ -745,7 +745,7 @@ static void st22_rx_update_src_test(int tx_sessions, enum st_test_level level) {
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 10000 + 0;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   for (int i = 0; i < rx_sessions; i++) {
     ret = st22_rx_update_source(rx_handle[i], &src);
@@ -881,7 +881,7 @@ static void st22_rx_after_start_test(enum st_fps fps[], int width[], int height[
       ops_rx.name = "st22_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
       snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
                ctx->para.port[MTL_PORT_R]);
@@ -1048,7 +1048,7 @@ static void st22_rx_dump_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -1291,7 +1291,7 @@ static void st22_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -1488,7 +1488,7 @@ static void st22_tx_user_pacing_test(int width[], int height[], int pkt_data_len
     ops_rx.name = "st22_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);

--- a/tests/src/st22p_test.cpp
+++ b/tests/src/st22p_test.cpp
@@ -519,7 +519,7 @@ static void st22p_rx_ops_init(tests_context* st22, struct st22p_rx_ops* ops_rx) 
   ops_rx->name = "st22p_test";
   ops_rx->priv = st22;
   ops_rx->port.num_port = 1;
-  memcpy(ops_rx->port.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops_rx->port.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops_rx->port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx->para.port[MTL_PORT_R]);
@@ -1006,7 +1006,7 @@ static void st22p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_rx.name = "st22p_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.port.num_port = 1;
-    memcpy(ops_rx.port.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);

--- a/tests/src/st30_test.cpp
+++ b/tests/src/st30_test.cpp
@@ -189,11 +189,11 @@ static void st30_rx_ops_init(tests_context* st30, struct st30_rx_ops* ops) {
   ops->priv = st30;
   ops->num_port = ctx->para.num_ports;
   if (ctx->same_dual_port) ops->num_port = 1;
-  memcpy(ops->sip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
+  memcpy(ops->ip_addr[MTL_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P], MTL_IP_ADDR_LEN);
   snprintf(ops->port[MTL_PORT_P], MTL_PORT_MAX_LEN, "%s", ctx->para.port[MTL_PORT_P]);
   ops->udp_port[MTL_PORT_P] = 20000 + st30->idx;
   if (ops->num_port == 2) {
-    memcpy(ops->sip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
+    memcpy(ops->ip_addr[MTL_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R], MTL_IP_ADDR_LEN);
     snprintf(ops->port[MTL_PORT_R], MTL_PORT_MAX_LEN, "%s", ctx->para.port[MTL_PORT_R]);
     ops->udp_port[MTL_PORT_R] = 20000 + st30->idx;
   }
@@ -504,7 +504,7 @@ static void st30_rx_fps_test(enum st30_type type[], enum st30_sampling sample[],
     ops_rx.name = "st30_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -883,7 +883,7 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
     ops_rx.name = "st30_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -919,7 +919,7 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 20000 + 2;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   if (tx_update_dst) {
     test_ctx_tx[0]->seq_id = 0; /* reset seq id */
@@ -956,7 +956,7 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
     src.udp_port[MTL_SESSION_PORT_P] = 20000 + 2;
-    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+    memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     for (int i = 0; i < rx_sessions; i++) {
       ret = st30_rx_update_source(rx_handle[i], &src);
@@ -982,7 +982,7 @@ static void st30_rx_update_src_test(enum st30_type type, int tx_sessions,
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 20000 + 0;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   test_ctx_tx[0]->seq_id = rand(); /* random seq id */
   if (tx_update_dst) {
@@ -1172,7 +1172,7 @@ static void st30_rx_meta_test(enum st30_fmt fmt[], enum st30_sampling sampling[]
     ops_rx.name = "st30_meta_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -1351,7 +1351,7 @@ static void st30_create_after_start_test(enum st30_type type[],
       ops_rx.name = "st30_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
       snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
                ctx->para.port[MTL_PORT_R]);

--- a/tests/src/st40_test.cpp
+++ b/tests/src/st40_test.cpp
@@ -215,13 +215,13 @@ static void st40_rx_ops_init(tests_context* st40, struct st40_rx_ops* ops) {
   ops->priv = st40;
   ops->num_port = ctx->para.num_ports;
   if (ctx->same_dual_port) ops->num_port = 1;
-  memcpy(ops->sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(ops->ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   snprintf(ops->port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
            ctx->para.port[MTL_PORT_P]);
   ops->udp_port[MTL_SESSION_PORT_P] = 30000 + st40->idx * 2;
   if (ops->num_port == 2) {
-    memcpy(ops->sip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
+    memcpy(ops->ip_addr[MTL_SESSION_PORT_R], ctx->mcast_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     snprintf(ops->port[MTL_SESSION_PORT_R], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -545,7 +545,7 @@ static void st40_rx_fps_test(enum st40_type type[], enum st_fps fps[],
     ops_rx.name = "st40_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -804,7 +804,7 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions,
     ops_rx.name = "st40_test";
     ops_rx.priv = test_ctx_rx[i];
     ops_rx.num_port = 1;
-    memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+    memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
            MTL_IP_ADDR_LEN);
     snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
              ctx->para.port[MTL_PORT_R]);
@@ -826,7 +826,7 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions,
   /* switch to mcast port p(tx_session:1) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 30000 + 2;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   if (tx_update_dst) {
     test_ctx_tx[0]->seq_id = 0; /* reset seq id */
@@ -863,7 +863,7 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions,
     /* switch to mcast port r(tx_session:2) */
     memset(&src, 0, sizeof(src));
     src.udp_port[MTL_SESSION_PORT_P] = 30000 + 4;
-    memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
+    memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_R],
            MTL_IP_ADDR_LEN);
     for (int i = 0; i < rx_sessions; i++) {
       ret = st40_rx_update_source(rx_handle[i], &src);
@@ -889,7 +889,7 @@ static void st40_rx_update_src_test(enum st40_type type, int tx_sessions,
   /* switch to unicast(tx_session:0) */
   memset(&src, 0, sizeof(src));
   src.udp_port[MTL_SESSION_PORT_P] = 30000 + 0;
-  memcpy(src.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+  memcpy(src.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
          MTL_IP_ADDR_LEN);
   test_ctx_tx[0]->seq_id = rand(); /* random seq id */
   if (tx_update_dst) {
@@ -1041,7 +1041,7 @@ static void st40_after_start_test(enum st40_type type[], enum st_fps fps[], int 
       ops_rx.name = "st40_test";
       ops_rx.priv = test_ctx_rx[i];
       ops_rx.num_port = 1;
-      memcpy(ops_rx.sip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+      memcpy(ops_rx.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
              MTL_IP_ADDR_LEN);
       snprintf(ops_rx.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
                ctx->para.port[MTL_PORT_R]);


### PR DESCRIPTION
For rx, the ip can be a multicast IP address or sender IP for unicast.

Mark `sip_addr` as deprecated, it will get a build warning if app still use `sip_addr`