### PR TITLE
lcore_monitor: add hook for irq entry/exit

### DIFF
--- a/tools/ebpf/lcore_monitor.h
+++ b/tools/ebpf/lcore_monitor.h
@@ -12,14 +12,23 @@ struct lcore_tid_cfg {
 };
 
 enum lcore_tid_event_type {
-  LCORE_SCHED_IN,
-  LCORE_SCHED_OUT,
+  /* hook on tracepoint/sched/sched_switch */
+  LCORE_SCHED_IN,  /* the t_pid was scheduled in */
+  LCORE_SCHED_OUT, /* the t_pid was scheduled out */
+  /* note: irq hook is only for io interrupt, not for system irq like timer */
+  /* hook on tracepoint/irq/irq_handler_entry */
+  LCORE_IRQ_ENTRY,
+  /* hook on tracepoint/irq/irq_handler_exit */
+  LCORE_IRQ_EXIT,
 };
 
 struct lcore_tid_event {
   enum lcore_tid_event_type type;
   uint64_t ns;
-  int next_pid;
+  union {
+    int next_pid; /* for LCORE_SCHED_IN/LCORE_SCHED_OUT */
+    int irq;      /* for LCORE_IRQ_ENTRY/LCORE_IRQ_EXIT */
+  };
 };
 
 #endif

--- a/tools/ebpf/lcore_monitor_kern.c
+++ b/tools/ebpf/lcore_monitor_kern.c
@@ -23,8 +23,15 @@ struct {
   __uint(max_entries, 512 * 1024);
 } lm_events_map SEC(".maps");
 
-static int lm_event_submit(enum lcore_tid_event_type type,
-                           struct trace_event_raw_sched_switch* args) {
+static struct lcore_tid_cfg* lm_get_cfg(void) {
+  struct lcore_tid_cfg* cfg;
+  uint32_t key = 0;
+  cfg = bpf_map_lookup_elem(&lm_cfg_map, &key);
+  return cfg;
+}
+
+static int lm_switch_event_submit(enum lcore_tid_event_type type,
+                                  struct trace_event_raw_sched_switch* args) {
   struct lcore_tid_event* e;
 
   e = bpf_ringbuf_reserve(&lm_events_map, sizeof(*e), 0);
@@ -44,25 +51,79 @@ static int lm_event_submit(enum lcore_tid_event_type type,
 
 SEC("tracepoint/sched/sched_switch")
 int bpf_prog_sched_switch(struct trace_event_raw_sched_switch* args) {
-  uint32_t key = 0;
-  struct lcore_tid_cfg* cfg = bpf_map_lookup_elem(&lm_cfg_map, &key);
+  struct lcore_tid_cfg* cfg = lm_get_cfg();
   if (!cfg) return 0;
 
   /* core id check */
   if (bpf_get_smp_processor_id() != cfg->core_id) return 0;
 
   if (cfg->bpf_trace) {
-    char fmt[] = "prev_pid %d next_pid in\n";
+    char fmt[] = "sched_switch: prev_pid %d next_pid in\n";
     bpf_trace_printk(fmt, sizeof(fmt), args->prev_pid, args->next_pid);
   }
 
   if (args->prev_pid == cfg->t_pid) {
-    lm_event_submit(LCORE_SCHED_OUT, args);
+    lm_switch_event_submit(LCORE_SCHED_OUT, args);
   }
 
   if (args->next_pid == cfg->t_pid) {
-    lm_event_submit(LCORE_SCHED_IN, args);
+    lm_switch_event_submit(LCORE_SCHED_IN, args);
   }
+
+  return 0;
+}
+
+static int lm_irq_event_submit(enum lcore_tid_event_type type,
+                               struct trace_event_raw_irq_handler_entry* args) {
+  struct lcore_tid_event* e;
+
+  e = bpf_ringbuf_reserve(&lm_events_map, sizeof(*e), 0);
+  if (!e) {
+    char fmt[] = "lm event ringbuf reserve fail\n";
+    bpf_trace_printk(fmt, sizeof(fmt));
+    return 0;
+  }
+
+  e->type = type;
+  e->ns = bpf_ktime_get_ns();
+  e->irq = args->irq;
+
+  bpf_ringbuf_submit(e, 0);
+  return 0;
+}
+
+SEC("tracepoint/irq/irq_handler_entry")
+int bpf_prog_irq_handler_entry(struct trace_event_raw_irq_handler_entry* args) {
+  struct lcore_tid_cfg* cfg = lm_get_cfg();
+  if (!cfg) return 0;
+
+  /* core id check */
+  if (bpf_get_smp_processor_id() != cfg->core_id) return 0;
+
+  if (cfg->bpf_trace) {
+    char fmt[] = "irq_handler_entry, irq %d\n";
+    bpf_trace_printk(fmt, sizeof(fmt), args->irq);
+  }
+
+  lm_irq_event_submit(LCORE_IRQ_ENTRY, args);
+
+  return 0;
+}
+
+SEC("tracepoint/irq/irq_handler_exit")
+int bpf_prog_irq_handler_exit(struct trace_event_raw_irq_handler_entry* args) {
+  struct lcore_tid_cfg* cfg = lm_get_cfg();
+  if (!cfg) return 0;
+
+  /* core id check */
+  if (bpf_get_smp_processor_id() != cfg->core_id) return 0;
+
+  if (cfg->bpf_trace) {
+    char fmt[] = "irq_handler_exit, irq %d\n";
+    bpf_trace_printk(fmt, sizeof(fmt), args->irq);
+  }
+
+  lm_irq_event_submit(LCORE_IRQ_EXIT, args);
 
   return 0;
 }


### PR DESCRIPTION
output like below:
lm_event_handler: sched out 5.315us as comm: migration/30
lm_event_handler: sched out 4.640us as comm: migration/30
lm_event_handler: sched out 5.304us as comm: migration/30
lm_event_handler: sched out 0.787us as irq: 348
lm_event_handler: sched out 1.248us as irq: 348