### PR TITLE
timing_parser: fix timesync on pf without ptp gm

### DIFF
--- a/doc/run_WIN.md
+++ b/doc/run_WIN.md
@@ -136,14 +136,13 @@ The port name can be obtained from the same location. For instance, as shown in 
 
 ## 5. Run and test
 
-You can bind the app to the cpu socket 0 ( if your NIC is inserted into the pcie slot belongs to cpu socket 0 )as following:
-To identify the socket if you do not know it, in the NIC card driver property page, check the bus number, if the number is great than 0x80, then socket 1, else socket 0, for example
-
 Use the following command to execute the program on socket 0. Append `1>log.txt 2>&1` to redirect all logs to a file. This is recommended because on Windows, console output is treated as a high-priority UI task and could interfere with the IMTL tasklet.
 
 ```powershell
 start /Node 0 /B .\build\app\RxTxApp --config_file config\test_tx_1port_1v.json 1>log.txt 2>&1
 ```
+
+To determine the socket if you are not clear, access the NIC card driver's property page and locate the bus number. In a typical two socket system, if the number is greater than 0x80, the corresponding socket is Socket 1; otherwise, it is Socket 0.
 
 Please refer to sections "5. Run the sample application" in the [linux run guide](run.md) for instructions on how to run the sample application. The Windows version shares the same codebase as the Linux version, and the application/library behavior is the same.
 

--- a/doc/run_WIN.md
+++ b/doc/run_WIN.md
@@ -137,11 +137,12 @@ The port name can be obtained from the same location. For instance, as shown in 
 ## 5. Run and test
 
 You can bind the app to the cpu socket 0 ( if your NIC is inserted into the pcie slot belongs to cpu socket 0 )as following:
-To identify the socket if you do not know it, in the NIC card driver property page, check the bus number, if the number is great than
-0x80, then socket 1, else socket 0, for example
+To identify the socket if you do not know it, in the NIC card driver property page, check the bus number, if the number is great than 0x80, then socket 1, else socket 0, for example
+
+Use the following command to execute the program on socket 0. Append `1>log.txt 2>&1` to redirect all logs to a file. This is recommended because on Windows, console output is treated as a high-priority UI task and could interfere with the IMTL tasklet.
 
 ```powershell
-start /Node 0 /B .\build\app\RxTxApp --config_file config\test_tx_1port_1v.json
+start /Node 0 /B .\build\app\RxTxApp --config_file config\test_tx_1port_1v.json 1>log.txt 2>&1
 ```
 
 Please refer to sections "5. Run the sample application" in the [linux run guide](run.md) for instructions on how to run the sample application. The Windows version shares the same codebase as the Linux version, and the application/library behavior is the same.

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -1234,7 +1234,10 @@ static int ptp_init(struct mtl_main_impl* impl, struct mt_ptp_impl* ptp,
 
   if (!mt_user_ptp_service(impl)) {
     if (mt_if_has_offload_timestamp(impl, port)) {
-      ptp->no_timesync = true;
+      if (!mt_if_has_timesync(impl, port)) {
+        ptp->no_timesync = true;
+        warn("%s(%d), ptp running without timesync support\n", __func__, port);
+      }
       info("%s(%d), ptp sync from user for hw offload timestamp\n", __func__, port);
       ptp_sync_from_user(impl, ptp);
       rte_eal_alarm_set(MT_PTP_TP_SYNC_MS * 1000, ptp_sync_from_user_handler, ptp);

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3395,7 +3395,7 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
 
   struct st_rx_video_tp* tp = s->tp;
   if (tp && tp->stat_untrusted_pkts) {
-    info("%s(%d), untrusted pkts time %u for timing parser\n", __func__, idx,
+    info("%s(%d), untrusted %u pkts time for timing parser\n", __func__, idx,
          tp->stat_untrusted_pkts);
     tp->stat_untrusted_pkts = 0;
   }


### PR DESCRIPTION
test with:
./build/app/RxTxApp --config_file tests/script/loop_json/1080p59_1v.json --rx_timing_parser --p_port 0000:af:00.0 --r_port 0000:af:00.0