### PR TITLE
manager: add queue management

### DIFF
--- a/.github/path_filters.yml
+++ b/.github/path_filters.yml
@@ -67,3 +67,8 @@ afxdp_build: &afxdp_build
   - .github/workflows/afxdp_build.yml
   - *src
   - *build
+
+afxdp_test: &afxdp_test
+  - .github/workflows/afxdp_build_with_gtest.yml
+  - *src
+  - *build

--- a/.github/workflows/afxdp_build_with_gtest.yml
+++ b/.github/workflows/afxdp_build_with_gtest.yml
@@ -124,7 +124,3 @@ jobs:
       - name: Run st2110 test case
         run: |
           sudo ./build/tests/KahawaiTest --auto_start_stop --mcast_only --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --pacing_way tsc --gtest_filter=St*:-St22_?x.*:*pacing*:*ext*:*create_free_max*:*detect*:*rtcp*
-
-      - name: Run st2110 st20p test case in simulation ENA environment
-        run: |
-          sudo ./build/tests/KahawaiTest --auto_start_stop --mcast_only --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --rss_mode l3_l4 --pacing_way tsc --iova_mode pa --multi_src_port --gtest_filter=St20p*:-*pacing*:*ext*:*create_free_max*:*rtcp*

--- a/.github/workflows/afxdp_build_with_gtest.yml
+++ b/.github/workflows/afxdp_build_with_gtest.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      changed: ${{ steps.filter.outputs.linux_gtest == 'true' }}
+      changed: ${{ steps.filter.outputs.afxdp_test == 'true' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       
@@ -94,10 +94,10 @@ jobs:
     runs-on: [Linux, self-hosted, XDP]
     env:
       LD_LIBRARY_PATH: /usr/local/lib:/usr/lib64
-      TEST_PORT_P: native_af_xdp:enp24s0f0
-      TEST_PORT_R: native_af_xdp:enp24s0f1
-      INTERFACE_P: enp24s0f0
-      INTERFACE_R: enp24s0f1
+      TEST_PORT_P: native_af_xdp:ens785f0
+      TEST_PORT_R: native_af_xdp:ens785f1
+      INTERFACE_P: ens785f0
+      INTERFACE_R: ens785f1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1

--- a/.github/workflows/afxdp_build_with_gtest.yml
+++ b/.github/workflows/afxdp_build_with_gtest.yml
@@ -123,8 +123,8 @@ jobs:
 
       - name: Run st2110 test case
         run: |
-          sudo ./build/tests/KahawaiTest --auto_start_stop --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --pacing_way tsc --gtest_filter=St*:-St22_?x.*:*pacing*:*ext*:*create_free_max*:*detect*:*rtcp*
+          sudo ./build/tests/KahawaiTest --auto_start_stop --mcast_only --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --pacing_way tsc --gtest_filter=St*:-St22_?x.*:*pacing*:*ext*:*create_free_max*:*detect*:*rtcp*
 
       - name: Run st2110 st20p test case in simulation ENA environment
         run: |
-          sudo ./build/tests/KahawaiTest --auto_start_stop --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --rss_mode l3_l4 --pacing_way tsc --iova_mode pa --multi_src_port --gtest_filter=St20p*:-*pacing*:*ext*:*create_free_max*:*rtcp*
+          sudo ./build/tests/KahawaiTest --auto_start_stop --mcast_only --p_port ${{  env.TEST_PORT_P  }} --r_port ${{  env.TEST_PORT_R  }} --rss_mode l3_l4 --pacing_way tsc --iova_mode pa --multi_src_port --gtest_filter=St20p*:-*pacing*:*ext*:*create_free_max*:*rtcp*

--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -382,8 +382,6 @@ static int sample_set_afxdp(struct st_sample_context* ctx) {
 
   for (uint8_t i = 0; i < p->num_ports; i++) {
     p->pmd[i] = mtl_pmd_by_port_name(p->port[i]);
-    if (!mtl_pmd_is_af_xdp(p->pmd[i])) continue;
-    p->xdp_info[i].start_queue = 1;
   }
 
   return 0;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -218,9 +218,6 @@ static struct option st_app_args_options[] = {
     {"runtime_session", no_argument, 0, ST_ARG_RUNTIME_SESSION},
     {"ttf_file", required_argument, 0, ST_ARG_TTF_FILE},
     {"afxdp_zc_disable", no_argument, 0, ST_ARG_AF_XDP_ZC_DISABLE},
-    {"start_queue", required_argument, 0, ST_ARG_START_QUEUE},
-    {"p_start_queue", required_argument, 0, ST_ARG_P_START_QUEUE},
-    {"r_start_queue", required_argument, 0, ST_ARG_R_START_QUEUE},
     {"tasklet_time", no_argument, 0, ST_ARG_TASKLET_TIME},
     {"utc_offset", required_argument, 0, ST_ARG_UTC_OFFSET},
     {"no_srq", no_argument, 0, ST_ARG_NO_SYSTEM_RX_QUEUES},
@@ -678,16 +675,6 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_AF_XDP_ZC_DISABLE:
         p->flags |= MTL_FLAG_AF_XDP_ZC_DISABLE;
-        break;
-      case ST_ARG_START_QUEUE:
-        p->xdp_info[MTL_PORT_P].start_queue = atoi(optarg);
-        p->xdp_info[MTL_PORT_R].start_queue = atoi(optarg);
-        break;
-      case ST_ARG_P_START_QUEUE:
-        p->xdp_info[MTL_PORT_P].start_queue = atoi(optarg);
-        break;
-      case ST_ARG_R_START_QUEUE:
-        p->xdp_info[MTL_PORT_R].start_queue = atoi(optarg);
         break;
       case ST_ARG_TASKLET_TIME:
         p->flags |= MTL_FLAG_TASKLET_TIME_MEASURE;

--- a/app/src/rxtx_app.c
+++ b/app/src/rxtx_app.c
@@ -148,9 +148,6 @@ static void user_param_init(struct st_app_context* ctx, struct mtl_init_params* 
 
   p->pmd[MTL_PORT_P] = MTL_PMD_DPDK_USER;
   p->pmd[MTL_PORT_R] = MTL_PMD_DPDK_USER;
-  /* default start queue set to 1 */
-  p->xdp_info[MTL_PORT_P].start_queue = 1;
-  p->xdp_info[MTL_PORT_R].start_queue = 1;
   p->flags |= MTL_FLAG_BIND_NUMA; /* default bind to numa */
   p->flags |= MTL_FLAG_TX_VIDEO_MIGRATE;
   p->flags |= MTL_FLAG_RX_VIDEO_MIGRATE;

--- a/app/v4l2_to_ip/v4l2_to_ip.c
+++ b/app/v4l2_to_ip/v4l2_to_ip.c
@@ -1831,7 +1831,6 @@ int main(int argc, char* argv[]) {
   // init st20
   st_v4l2_tx->param.num_ports = 1;
   st_v4l2_tx->param.pmd[MTL_PORT_P] = TX_VIDEO_PMD;
-  st_v4l2_tx->param.xdp_info[MTL_PORT_P].start_queue = 1;
   strncpy(st_v4l2_tx->param.port[MTL_PORT_P], port, MTL_PORT_MAX_LEN);
   memcpy(st_v4l2_tx->param.sip_addr[MTL_PORT_P], g_tx_video_local_ip, MTL_IP_ADDR_LEN);
   st_v4l2_tx->param.flags =

--- a/doc/xdp.md
+++ b/doc/xdp.md
@@ -157,7 +157,6 @@ To configure the network interface in your own app, here is the example code:
 /* struct mtl_init_params* p */
 snprintf(p->port[i], sizeof(p->port[i]), "%s", "native_af_xdp:ens785f0");
 p->pmd[i] = mtl_pmd_by_port_name(p->port[i]);
-p->xdp_info[i].start_queue = 1;
 ...
 mtl_init(p);
 ```

--- a/ecosystem/obs_mtl/linux-mtl/mtl-input.c
+++ b/ecosystem/obs_mtl/linux-mtl/mtl-input.c
@@ -322,7 +322,6 @@ static void mtl_input_init(struct mtl_rx_session* s) {
   snprintf(param.port[MTL_PORT_P], MTL_PORT_MAX_LEN, "%s", s->port);
   inet_pton(AF_INET, s->sip, param.sip_addr[MTL_PORT_P]);
   param.pmd[MTL_PORT_P] = MTL_PMD_DPDK_USER;
-  param.xdp_info[MTL_PORT_P].start_queue = 1;
   param.flags = MTL_FLAG_BIND_NUMA;  // default bind to numa
   param.log_level = s->log_level;    // mtl lib log level
   param.priv = s;                    // usr ctx pointer

--- a/ecosystem/obs_mtl/linux-mtl/mtl-output.c
+++ b/ecosystem/obs_mtl/linux-mtl/mtl-output.c
@@ -131,7 +131,6 @@ static void mtl_output_init(struct mtl_tx_session* s) {
   snprintf(param.port[MTL_PORT_P], MTL_PORT_MAX_LEN, "%s", s->port);
   inet_pton(AF_INET, s->sip, param.sip_addr[MTL_PORT_P]);
   param.pmd[MTL_PORT_P] = MTL_PMD_DPDK_USER;
-  param.xdp_info[MTL_PORT_P].start_queue = 1;
   param.flags = MTL_FLAG_BIND_NUMA;  // default bind to numa
   param.log_level = s->log_level;    // mtl lib log level
   param.priv = s;                    // usr ctx pointer

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -443,15 +443,6 @@ enum mtl_init_flag {
   MTL_FLAG_RX_UDP_PORT_ONLY = (MTL_BIT64(46)),
 };
 
-/**
- * The structure describing how to init af_xdp interface.
- * See https://doc.dpdk.org/guides/nics/af_xdp.html for detail.
- */
-struct mtl_af_xdp_params {
-  /** starting netdev queue id, must > 0, 0 is reserved for system usage */
-  uint8_t start_queue;
-};
-
 struct mtl_ptp_sync_notify_meta {
   /** offset to UTC of current master PTP */
   int16_t master_utc_offset;
@@ -512,11 +503,6 @@ struct mtl_init_params {
    * User can use "route -n" to get gateway before bind the port to DPDK PMD.
    */
   uint8_t gateway[MTL_PORT_MAX][MTL_IP_ADDR_LEN];
-
-  /**
-   * Mandatory only for MTL_PMD_DPDK_AF_XDP. af_xdp port init info.
-   */
-  struct mtl_af_xdp_params xdp_info[MTL_PORT_MAX];
 
   /** Optional. Flags to control MTL behaviors. See MTL_FLAG_* for possible value */
   uint64_t flags;

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -184,8 +184,6 @@ struct st_pcap_dump_meta {
 struct st_queue_meta {
   /** 1 or 2, num of ports this session attached to */
   uint8_t num_port;
-  /** starting netdev queue id for afxdp */
-  uint8_t start_queue[MTL_PORT_MAX];
   /** queue id this session attached to */
   uint8_t queue_id[MTL_PORT_MAX];
 };

--- a/lib/src/dev/mt_af_xdp.h
+++ b/lib/src/dev/mt_af_xdp.h
@@ -21,8 +21,6 @@ struct mt_rx_xdp_get_args {
 
 #ifdef MTL_HAS_XDP_BACKEND
 
-int mt_dev_xdp_get_combined(struct mt_interface* inf, uint16_t* combined);
-
 int mt_dev_xdp_init(struct mt_interface* inf);
 int mt_dev_xdp_uinit(struct mt_interface* inf);
 
@@ -42,12 +40,6 @@ uint16_t mt_rx_xdp_burst(struct mt_rx_xdp_entry* entry, struct rte_mbuf** rx_pkt
 #else
 
 #include "../mt_log.h"
-
-static inline int mt_dev_xdp_get_combined(struct mt_interface* inf, uint16_t* combined) {
-  err("%s(%d), no xdp support for this build\n", __func__, inf->port);
-  *combined = 0;
-  return -ENOTSUP;
-}
 
 static inline int mt_dev_xdp_init(struct mt_interface* inf) {
   err("%s(%d), no xdp support for this build\n", __func__, inf->port);

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -360,8 +360,8 @@ static int dev_eal_init(struct mtl_init_params* p, struct mt_kport_info* kport_i
       const char* if_name = mt_dpdk_afxdp_port2if(p->port[i]);
       if (!if_name) return -EINVAL;
       snprintf(port_param, 2 * MTL_PORT_MAX_LEN,
-               "net_af_xdp%d,iface=%s,start_queue=%u,queue_count=%u", i, if_name,
-               p->xdp_info[i].start_queue, queue_pair_cnt);
+               "net_af_xdp%d,iface=%s,start_queue=%u,queue_count=%u", i, if_name, 1,
+               queue_pair_cnt);
       /* save kport info */
       snprintf(kport_info->dpdk_port[i], MTL_PORT_MAX_LEN, "net_af_xdp%d", i);
       snprintf(kport_info->kernel_if[i], MTL_PORT_MAX_LEN, "%s", if_name);

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -2112,14 +2112,10 @@ int mt_dev_if_init(struct mtl_main_impl* impl) {
       inf->nb_rx_q = queue_pair_cnt;
       inf->system_rx_queues_end = 0;
     } else if (mt_pmd_is_native_af_xdp(impl, i)) {
-      if (mt_has_srss(impl, i)) {
-        uint16_t combined = 1;
-        mt_dev_xdp_get_combined(inf, &combined);
-        queue_pair_cnt = combined; /* rss loop all queues */
-      } else {
-        /* one more for the sys tx queue */
-        queue_pair_cnt = RTE_MAX(p->tx_queues_cnt[i] + 1, p->rx_queues_cnt[i]);
-      }
+      /* todo: handle for rss */
+      /* one more for the sys tx queue */
+      queue_pair_cnt = RTE_MAX(p->tx_queues_cnt[i] + 1, p->rx_queues_cnt[i]);
+
       inf->nb_tx_q = queue_pair_cnt;
       inf->nb_rx_q = queue_pair_cnt;
       inf->system_rx_queues_end = 0;

--- a/lib/src/mt_flow.c
+++ b/lib/src/mt_flow.c
@@ -201,7 +201,7 @@ static struct mt_rx_flow_rsp* rx_flow_create(struct mt_interface* inf, uint16_t 
   struct mtl_main_impl* impl = inf->parent;
   uint8_t* ip = flow->dip_addr;
 
-  if (q >= inf->nb_rx_q) {
+  if (!mt_drv_kernel_based(impl, port) && q >= inf->nb_rx_q) {
     err("%s(%d), invalid q %u\n", __func__, port, q);
     return NULL;
   }
@@ -279,7 +279,7 @@ struct mt_rx_flow_rsp* mt_rx_flow_create(struct mtl_main_impl* impl, enum mtl_po
   struct mt_rx_flow_rsp* rsp;
   struct mt_flow_impl* flow_impl = impl->flow[port];
 
-  if (q >= inf->nb_rx_q) {
+  if (!mt_drv_kernel_based(impl, port) && q >= inf->nb_rx_q) {
     err("%s(%d), invalid q %u max allowed %u\n", __func__, port, q, inf->nb_rx_q);
     return NULL;
   }

--- a/lib/src/mt_instance.c
+++ b/lib/src/mt_instance.c
@@ -248,7 +248,6 @@ int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifi
 int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(ifindex);
-  MTL_MAY_UNUSED(queue_id);
   return -ENOTSUP;
 }
 

--- a/lib/src/mt_instance.c
+++ b/lib/src/mt_instance.c
@@ -147,6 +147,58 @@ int mt_instance_update_udp_dp_filter(struct mtl_main_impl* impl, unsigned int if
   return -response;
 }
 
+int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
+                          unsigned int queue_id) {
+  int ret;
+  int sock = impl->instance_fd;
+
+  mtl_message_t msg;
+  msg.header.magic = htonl(MTL_MANAGER_MAGIC);
+  msg.header.type = htonl(MTL_MSG_TYPE_GET_QUEUE);
+  msg.body.queue_msg.ifindex = htonl(ifindex);
+  msg.body.queue_msg.queue_id = htons(queue_id);
+  msg.header.body_len = htonl(sizeof(mtl_queue_message_t));
+
+  ret = send(sock, &msg, sizeof(mtl_message_t), 0);
+  if (ret < 0) {
+    err("%s(%u), send message fail\n", __func__, ifindex);
+    return ret;
+  }
+
+  ret = recv(sock, &msg, sizeof(mtl_message_t), 0);
+  if (ret < 0 || ntohl(msg.header.magic) != MTL_MANAGER_MAGIC ||
+      ntohl(msg.header.type) != MTL_MSG_TYPE_RESPONSE) {
+    err("%s, recv response fail\n", __func__);
+    return -EIO;
+  }
+
+  int response = msg.body.response_msg.response;
+
+  /* return negative value incase user check with < 0 */
+  return -response;
+}
+
+int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
+                          unsigned int queue_id) {
+  int ret;
+  int sock = impl->instance_fd;
+
+  mtl_message_t msg;
+  msg.header.magic = htonl(MTL_MANAGER_MAGIC);
+  msg.header.type = htonl(MTL_MSG_TYPE_PUT_QUEUE);
+  msg.body.queue_msg.ifindex = htonl(ifindex);
+  msg.body.queue_msg.queue_id = htons(queue_id);
+  msg.header.body_len = htonl(sizeof(mtl_queue_message_t));
+
+  ret = send(sock, &msg, sizeof(mtl_message_t), 0);
+  if (ret < 0) {
+    err("%s(%u), send message fail\n", __func__, ifindex);
+    return ret;
+  }
+
+  return 0;
+}
+
 int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p) {
   impl->instance_fd = -1;
   int sock = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -252,6 +304,22 @@ int mt_instance_put_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
 int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifindex) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(ifindex);
+  return -ENOTSUP;
+}
+
+int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
+                          unsigned int queue_id) {
+  MTL_MAY_UNUSED(impl);
+  MTL_MAY_UNUSED(ifindex);
+  MTL_MAY_UNUSED(queue_id);
+  return -ENOTSUP;
+}
+
+int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
+                          unsigned int queue_id) {
+  MTL_MAY_UNUSED(impl);
+  MTL_MAY_UNUSED(ifindex);
+  MTL_MAY_UNUSED(queue_id);
   return -ENOTSUP;
 }
 

--- a/lib/src/mt_instance.c
+++ b/lib/src/mt_instance.c
@@ -12,8 +12,26 @@
 #include "mt_log.h"
 #include "mt_util.h"
 
+static int instance_send_and_receive_message(int sock, mtl_message_t* msg,
+                                             mtl_message_type_t response_type) {
+  int ret = send(sock, msg, sizeof(*msg), 0);
+  if (ret < 0) {
+    err("%s, send message fail\n", __func__);
+    return ret;
+  }
+
+  memset(msg, 0, sizeof(*msg));
+  ret = recv(sock, msg, sizeof(*msg), 0);
+  if (ret < 0 || ntohl(msg->header.magic) != MTL_MANAGER_MAGIC ||
+      ntohl(msg->header.type) != response_type) {
+    err("%s, recv response fail\n", __func__);
+    return -EIO;
+  }
+
+  return ntohl(msg->body.response_msg.response);
+}
+
 int mt_instance_put_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
-  int ret;
   int sock = impl->instance_fd;
 
   mtl_message_t msg;
@@ -22,17 +40,10 @@ int mt_instance_put_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
   msg.body.lcore_msg.lcore = htons(lcore_id);
   msg.header.body_len = sizeof(msg.body.lcore_msg);
 
-  ret = send(sock, &msg, sizeof(msg), 0);
-  if (ret < 0) {
-    err("%s, send message fail\n", __func__);
-    return ret;
-  }
-
-  return 0;
+  return instance_send_and_receive_message(sock, &msg, MTL_MSG_TYPE_RESPONSE);
 }
 
 int mt_instance_get_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
-  int ret;
   int sock = impl->instance_fd;
 
   mtl_message_t msg;
@@ -41,23 +52,7 @@ int mt_instance_get_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
   msg.body.lcore_msg.lcore = htons(lcore_id);
   msg.header.body_len = htonl(sizeof(mtl_lcore_message_t));
 
-  ret = send(sock, &msg, sizeof(mtl_message_t), 0);
-  if (ret < 0) {
-    err("%s, send message fail\n", __func__);
-    return ret;
-  }
-
-  ret = recv(sock, &msg, sizeof(mtl_message_t), 0);
-  if (ret < 0 || ntohl(msg.header.magic) != MTL_MANAGER_MAGIC ||
-      ntohl(msg.header.type) != MTL_MSG_TYPE_RESPONSE) {
-    err("%s, recv response fail\n", __func__);
-    return -EIO;
-  }
-
-  int response = msg.body.response_msg.response;
-
-  /* return negative value incase user check with < 0 */
-  return -response;
+  return instance_send_and_receive_message(sock, &msg, MTL_MSG_TYPE_RESPONSE);
 }
 
 int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifindex) {
@@ -67,11 +62,11 @@ int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifi
 
   mtl_message_t mtl_msg;
   mtl_msg.header.magic = htonl(MTL_MANAGER_MAGIC);
-  mtl_msg.header.type = htonl(MTL_MSG_TYPE_REQUEST_MAP_FD);
-  mtl_msg.body.request_map_fd_msg.ifindex = htonl(ifindex);
-  mtl_msg.header.body_len = htonl(sizeof(mtl_request_map_fd_message_t));
+  mtl_msg.header.type = htonl(MTL_MSG_TYPE_IF_XSK_MAP_FD);
+  mtl_msg.body.if_msg.ifindex = htonl(ifindex);
+  mtl_msg.header.body_len = htonl(sizeof(mtl_if_message_t));
 
-  ret = send(sock, &mtl_msg, sizeof(mtl_message_t), 0);
+  ret = send(sock, &mtl_msg, sizeof(mtl_msg), 0);
   if (ret < 0) {
     err("%s(%u), send message fail\n", __func__, ifindex);
     return ret;
@@ -117,7 +112,6 @@ int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifi
 
 int mt_instance_update_udp_dp_filter(struct mtl_main_impl* impl, unsigned int ifindex,
                                      uint16_t dst_port, bool add) {
-  int ret;
   int sock = impl->instance_fd;
 
   mtl_message_t msg;
@@ -128,75 +122,33 @@ int mt_instance_update_udp_dp_filter(struct mtl_main_impl* impl, unsigned int if
   msg.body.udp_dp_filter_msg.port = htons(dst_port);
   msg.header.body_len = htonl(sizeof(mtl_udp_dp_filter_message_t));
 
-  ret = send(sock, &msg, sizeof(mtl_message_t), 0);
-  if (ret < 0) {
-    err("%s(%u), send message fail\n", __func__, ifindex);
-    return ret;
-  }
-
-  ret = recv(sock, &msg, sizeof(mtl_message_t), 0);
-  if (ret < 0 || ntohl(msg.header.magic) != MTL_MANAGER_MAGIC ||
-      ntohl(msg.header.type) != MTL_MSG_TYPE_RESPONSE) {
-    err("%s, recv response fail\n", __func__);
-    return -EIO;
-  }
-
-  int response = msg.body.response_msg.response;
-
-  /* return negative value incase user check with < 0 */
-  return -response;
+  return instance_send_and_receive_message(sock, &msg, MTL_MSG_TYPE_RESPONSE);
 }
 
-int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          uint16_t queue_id) {
-  int ret;
+int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex) {
   int sock = impl->instance_fd;
 
   mtl_message_t msg;
   msg.header.magic = htonl(MTL_MANAGER_MAGIC);
-  msg.header.type = htonl(MTL_MSG_TYPE_GET_QUEUE);
-  msg.body.queue_msg.ifindex = htonl(ifindex);
-  msg.body.queue_msg.queue_id = htons(queue_id);
-  msg.header.body_len = htonl(sizeof(mtl_queue_message_t));
+  msg.header.type = htonl(MTL_MSG_TYPE_IF_GET_QUEUE);
+  msg.body.if_msg.ifindex = htonl(ifindex);
+  msg.header.body_len = htonl(sizeof(mtl_if_message_t));
 
-  ret = send(sock, &msg, sizeof(mtl_message_t), 0);
-  if (ret < 0) {
-    err("%s(%u), send message fail\n", __func__, ifindex);
-    return ret;
-  }
-
-  ret = recv(sock, &msg, sizeof(mtl_message_t), 0);
-  if (ret < 0 || ntohl(msg.header.magic) != MTL_MANAGER_MAGIC ||
-      ntohl(msg.header.type) != MTL_MSG_TYPE_RESPONSE) {
-    err("%s, recv response fail\n", __func__);
-    return -EIO;
-  }
-
-  int response = msg.body.response_msg.response;
-
-  /* return negative value incase user check with < 0 */
-  return -response;
+  return instance_send_and_receive_message(sock, &msg, MTL_MSG_TYPE_IF_QUEUE_ID);
 }
 
 int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
                           uint16_t queue_id) {
-  int ret;
   int sock = impl->instance_fd;
 
   mtl_message_t msg;
   msg.header.magic = htonl(MTL_MANAGER_MAGIC);
-  msg.header.type = htonl(MTL_MSG_TYPE_PUT_QUEUE);
-  msg.body.queue_msg.ifindex = htonl(ifindex);
-  msg.body.queue_msg.queue_id = htons(queue_id);
-  msg.header.body_len = htonl(sizeof(mtl_queue_message_t));
+  msg.header.type = htonl(MTL_MSG_TYPE_IF_PUT_QUEUE);
+  msg.body.if_msg.ifindex = htonl(ifindex);
+  msg.body.if_msg.queue_id = htons(queue_id);
+  msg.header.body_len = htonl(sizeof(mtl_if_message_t));
 
-  ret = send(sock, &msg, sizeof(mtl_message_t), 0);
-  if (ret < 0) {
-    err("%s(%u), send message fail\n", __func__, ifindex);
-    return ret;
-  }
-
-  return 0;
+  return instance_send_and_receive_message(sock, &msg, MTL_MSG_TYPE_RESPONSE);
 }
 
 int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p) {
@@ -227,7 +179,8 @@ int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p) {
   mtl_register_message_t* reg_msg = &msg.body.register_msg;
   reg_msg->pid = htonl(u_info->pid);
   reg_msg->uid = htonl(getuid());
-  snprintf(reg_msg->hostname, sizeof(reg_msg->hostname), "%s", u_info->hostname);
+  strncpy(reg_msg->hostname, u_info->hostname, sizeof(reg_msg->hostname) - 1);
+  reg_msg->hostname[sizeof(reg_msg->hostname) - 1] = '\0';
 
   /* manager will load xdp program for afxdp interfaces */
   uint16_t num_xdp_if = 0;
@@ -240,22 +193,7 @@ int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p) {
   }
   reg_msg->num_if = htons(num_xdp_if);
 
-  ret = send(sock, &msg, sizeof(msg), 0);
-  if (ret < 0) {
-    err("%s, send message fail\n", __func__);
-    close(sock);
-    return ret;
-  }
-
-  ret = recv(sock, &msg, sizeof(msg), 0);
-  if (ret < 0 || ntohl(msg.header.magic) != MTL_MANAGER_MAGIC ||
-      ntohl(msg.header.type) != MTL_MSG_TYPE_RESPONSE) {
-    err("%s, recv response fail\n", __func__);
-    close(sock);
-    return ret;
-  }
-
-  int response = msg.body.response_msg.response;
+  int response = instance_send_and_receive_message(sock, &msg, MTL_MSG_TYPE_RESPONSE);
   if (response != 0) {
     err("%s, register fail\n", __func__);
     close(sock);
@@ -307,8 +245,7 @@ int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifi
   return -ENOTSUP;
 }
 
-int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          uint16_t queue_id) {
+int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(ifindex);
   MTL_MAY_UNUSED(queue_id);

--- a/lib/src/mt_instance.c
+++ b/lib/src/mt_instance.c
@@ -12,7 +12,7 @@
 #include "mt_log.h"
 #include "mt_util.h"
 
-int mt_instance_put_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
+int mt_instance_put_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
   int ret;
   int sock = impl->instance_fd;
 
@@ -31,7 +31,7 @@ int mt_instance_put_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
   return 0;
 }
 
-int mt_instance_get_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
+int mt_instance_get_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
   int ret;
   int sock = impl->instance_fd;
 
@@ -148,7 +148,7 @@ int mt_instance_update_udp_dp_filter(struct mtl_main_impl* impl, unsigned int if
 }
 
 int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          unsigned int queue_id) {
+                          uint16_t queue_id) {
   int ret;
   int sock = impl->instance_fd;
 
@@ -179,7 +179,7 @@ int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
 }
 
 int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          unsigned int queue_id) {
+                          uint16_t queue_id) {
   int ret;
   int sock = impl->instance_fd;
 
@@ -289,13 +289,13 @@ int mt_instance_uinit(struct mtl_main_impl* impl) {
   return -ENOTSUP;
 }
 
-int mt_instance_get_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
+int mt_instance_get_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(lcore_id);
   return -ENOTSUP;
 }
 
-int mt_instance_put_lcore(struct mtl_main_impl* impl, unsigned int lcore_id) {
+int mt_instance_put_lcore(struct mtl_main_impl* impl, uint16_t lcore_id) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(lcore_id);
   return -ENOTSUP;
@@ -308,7 +308,7 @@ int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifi
 }
 
 int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          unsigned int queue_id) {
+                          uint16_t queue_id) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(ifindex);
   MTL_MAY_UNUSED(queue_id);
@@ -316,7 +316,7 @@ int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
 }
 
 int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          unsigned int queue_id) {
+                          uint16_t queue_id) {
   MTL_MAY_UNUSED(impl);
   MTL_MAY_UNUSED(ifindex);
   MTL_MAY_UNUSED(queue_id);

--- a/lib/src/mt_instance.h
+++ b/lib/src/mt_instance.h
@@ -15,8 +15,7 @@ int mt_instance_put_lcore(struct mtl_main_impl* impl, uint16_t lcore_id);
 int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifindex);
 int mt_instance_update_udp_dp_filter(struct mtl_main_impl* impl, unsigned int ifindex,
                                      uint16_t dst_port, bool add);
-int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          uint16_t queue_id);
+int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex);
 int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
                           uint16_t queue_id);
 

--- a/lib/src/mt_instance.h
+++ b/lib/src/mt_instance.h
@@ -15,5 +15,9 @@ int mt_instance_put_lcore(struct mtl_main_impl* impl, unsigned int lcore_id);
 int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifindex);
 int mt_instance_update_udp_dp_filter(struct mtl_main_impl* impl, unsigned int ifindex,
                                      uint16_t dst_port, bool add);
+int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
+                          unsigned int queue_id);
+int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
+                          unsigned int queue_id);
 
 #endif

--- a/lib/src/mt_instance.h
+++ b/lib/src/mt_instance.h
@@ -10,14 +10,14 @@
 int mt_instance_init(struct mtl_main_impl* impl, struct mtl_init_params* p);
 int mt_instance_uinit(struct mtl_main_impl* impl);
 
-int mt_instance_get_lcore(struct mtl_main_impl* impl, unsigned int lcore_id);
-int mt_instance_put_lcore(struct mtl_main_impl* impl, unsigned int lcore_id);
+int mt_instance_get_lcore(struct mtl_main_impl* impl, uint16_t lcore_id);
+int mt_instance_put_lcore(struct mtl_main_impl* impl, uint16_t lcore_id);
 int mt_instance_request_xsks_map_fd(struct mtl_main_impl* impl, unsigned int ifindex);
 int mt_instance_update_udp_dp_filter(struct mtl_main_impl* impl, unsigned int ifindex,
                                      uint16_t dst_port, bool add);
 int mt_instance_get_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          unsigned int queue_id);
+                          uint16_t queue_id);
 int mt_instance_put_queue(struct mtl_main_impl* impl, unsigned int ifindex,
-                          unsigned int queue_id);
+                          uint16_t queue_id);
 
 #endif

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -277,11 +277,6 @@ static int mt_user_params_check(struct mtl_init_params* p) {
 
     /* af xdp check */
     if (mtl_pmd_is_af_xdp(p->pmd[i])) {
-      if (p->xdp_info[i].start_queue <= 0) {
-        err("%s(%d), invalid afxdp start_queue %u\n", __func__, i,
-            p->xdp_info[i].start_queue);
-        return -EINVAL;
-      }
       if (p->pmd[i] == MTL_PMD_NATIVE_AF_XDP)
         if_name = mt_native_afxdp_port2if(p->port[i]);
       else

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1346,11 +1346,6 @@ static inline int mt_num_ports(struct mtl_main_impl* impl) {
 
 bool mt_is_valid_socket(struct mtl_main_impl* impl, int soc_id);
 
-static inline uint8_t mt_afxdp_start_queue(struct mtl_main_impl* impl,
-                                           enum mtl_port port) {
-  return impl->user_para.xdp_info[port].start_queue;
-}
-
 /* if user enable the phc2sys service */
 static inline bool mt_user_phc2sys_service(struct mtl_main_impl* impl) {
   if (mt_get_user_params(impl)->flags & MTL_FLAG_PHC2SYS_ENABLE)

--- a/lib/src/mt_socket.c
+++ b/lib/src/mt_socket.c
@@ -354,7 +354,6 @@ int mt_socket_add_flow(struct mtl_main_impl* impl, enum mtl_port port, uint16_t 
   struct ifreq ifr;
   int ret, fd;
   int free_loc = -1, flow_id = -1;
-  uint8_t start_queue = mt_afxdp_start_queue(impl, port);
   const char* if_name = mt_kernel_if_name(impl, port);
   bool has_ip_flow = true;
 
@@ -455,14 +454,14 @@ int mt_socket_add_flow(struct mtl_main_impl* impl, enum mtl_port port, uint16_t 
       rte_memcpy(&fs->h_u.udp_ip4_spec.ip4dst, flow->sip_addr, MTL_IP_ADDR_LEN);
     }
   }
-  fs->ring_cookie = queue_id + start_queue;
+  fs->ring_cookie = queue_id;
   fs->location = free_loc; /* for some NICs the location must be set */
 
   ifr.ifr_data = (void*)&cmd;
   ret = ioctl(fd, SIOCETHTOOL, &ifr);
   if (ret < 0) {
-    err("%s(%d), cannot insert classifier: %s, start_queue %u, if %s\n", __func__, port,
-        strerror(errno), start_queue, if_name);
+    err("%s(%d), cannot insert classifier: %s, if %s\n", __func__, port, strerror(errno),
+        if_name);
     if (ret == -EPERM)
       err("%s(%d), please add capability for the app: sudo setcap 'cap_net_admin+ep' "
           "<app>\n",

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -929,8 +929,6 @@ void st40_rx_put_mbuf(st40_rx_handle handle, void* mbuf) {
 int st40_rx_get_queue_meta(st40_rx_handle handle, struct st_queue_meta* meta) {
   struct st_rx_ancillary_session_handle_impl* s_impl = handle;
   struct st_rx_ancillary_session_impl* s;
-  struct mtl_main_impl* impl;
-  enum mtl_port port;
 
   if (s_impl->type != MT_HANDLE_RX_ANC) {
     err("%s, invalid type %d\n", __func__, s_impl->type);
@@ -938,17 +936,10 @@ int st40_rx_get_queue_meta(st40_rx_handle handle, struct st_queue_meta* meta) {
   }
 
   s = s_impl->impl;
-  impl = s_impl->parent;
 
   memset(meta, 0x0, sizeof(*meta));
   meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
-    port = mt_port_logic2phy(s->port_maps, i);
-
-    if (mt_pmd_is_dpdk_af_xdp(impl, port)) {
-      /* af_xdp pmd */
-      meta->start_queue[i] = mt_afxdp_start_queue(impl, port);
-    }
     meta->queue_id[i] = rx_ancillary_queue_id(s, i);
   }
 

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -1208,8 +1208,6 @@ void st30_rx_put_mbuf(st30_rx_handle handle, void* mbuf) {
 int st30_rx_get_queue_meta(st30_rx_handle handle, struct st_queue_meta* meta) {
   struct st_rx_audio_session_handle_impl* s_impl = handle;
   struct st_rx_audio_session_impl* s;
-  struct mtl_main_impl* impl;
-  enum mtl_port port;
 
   if (s_impl->type != MT_HANDLE_RX_AUDIO) {
     err("%s, invalid type %d\n", __func__, s_impl->type);
@@ -1217,17 +1215,10 @@ int st30_rx_get_queue_meta(st30_rx_handle handle, struct st_queue_meta* meta) {
   }
 
   s = s_impl->impl;
-  impl = s_impl->parent;
 
   memset(meta, 0x0, sizeof(*meta));
   meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
-    port = mt_port_logic2phy(s->port_maps, i);
-
-    if (mt_pmd_is_dpdk_af_xdp(impl, port)) {
-      /* af_xdp pmd */
-      meta->start_queue[i] = mt_afxdp_start_queue(impl, port);
-    }
     meta->queue_id[i] = rx_audio_queue_id(s, i);
   }
 

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -4214,8 +4214,6 @@ bool st20_rx_dma_enabled(st20_rx_handle handle) {
 int st20_rx_get_queue_meta(st20_rx_handle handle, struct st_queue_meta* meta) {
   struct st_rx_video_session_handle_impl* s_impl = handle;
   struct st_rx_video_session_impl* s;
-  struct mtl_main_impl* impl;
-  enum mtl_port port;
 
   if (s_impl->type != MT_HANDLE_RX_VIDEO) {
     err("%s, invalid type %d\n", __func__, s_impl->type);
@@ -4223,17 +4221,10 @@ int st20_rx_get_queue_meta(st20_rx_handle handle, struct st_queue_meta* meta) {
   }
 
   s = s_impl->impl;
-  impl = s_impl->parent;
 
   memset(meta, 0x0, sizeof(*meta));
   meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
-    port = mt_port_logic2phy(s->port_maps, i);
-
-    if (mt_pmd_is_dpdk_af_xdp(impl, port)) {
-      /* af_xdp pmd */
-      meta->start_queue[i] = mt_afxdp_start_queue(impl, port);
-    }
     meta->queue_id[i] = rv_queue_id(s, i);
   }
 
@@ -4576,8 +4567,6 @@ void* st22_rx_get_fb_addr(st22_rx_handle handle, uint16_t idx) {
 int st22_rx_get_queue_meta(st22_rx_handle handle, struct st_queue_meta* meta) {
   struct st22_rx_video_session_handle_impl* s_impl = handle;
   struct st_rx_video_session_impl* s;
-  struct mtl_main_impl* impl;
-  enum mtl_port port;
 
   if (s_impl->type != MT_ST22_HANDLE_RX_VIDEO) {
     err("%s, invalid type %d\n", __func__, s_impl->type);
@@ -4585,17 +4574,10 @@ int st22_rx_get_queue_meta(st22_rx_handle handle, struct st_queue_meta* meta) {
   }
 
   s = s_impl->impl;
-  impl = s_impl->parent;
 
   memset(meta, 0x0, sizeof(*meta));
   meta->num_port = RTE_MIN(s->ops.num_port, MTL_SESSION_PORT_MAX);
   for (uint8_t i = 0; i < meta->num_port; i++) {
-    port = mt_port_logic2phy(s->port_maps, i);
-
-    if (mt_pmd_is_dpdk_af_xdp(impl, port)) {
-      /* af_xdp pmd */
-      meta->start_queue[i] = mt_afxdp_start_queue(impl, port);
-    }
     meta->queue_id[i] = rv_queue_id(s, i);
   }
 

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -359,8 +359,6 @@ static int ufd_set_afxdp(struct ufd_mt_ctx* ctx) {
 
   for (uint8_t i = 0; i < p->num_ports; i++) {
     p->pmd[i] = mtl_pmd_by_port_name(p->port[i]);
-    if (!mtl_pmd_is_af_xdp(p->pmd[i])) continue;
-    p->xdp_info[i].start_queue = 1;
   }
 
   return 0;

--- a/manager/meson.build
+++ b/manager/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2023 Intel Corporation
 
-project('mtl_manager', 'cpp', default_options: ['buildtype=release', 'cpp_std=c++17'], version: '0.2.0')
+project('mtl_manager', 'cpp', default_options: ['buildtype=release', 'cpp_std=c++17'], version: '0.3.0')
 
 exec_env = host_machine.system()
 set_variable('is_windows', exec_env == 'windows')

--- a/manager/mtl_interface.hpp
+++ b/manager/mtl_interface.hpp
@@ -102,7 +102,7 @@ int mtl_interface::update_udp_dp_filter(uint16_t dst_port, bool add) {
   if (add && udp4_dp_refcnt[dst_port] > 1) {
     /* Port already in the map, no need to update */
     return 0;
-  } else if (!add && udp4_dp_refcnt[dst_port] >= 0) {
+  } else if (!add && udp4_dp_refcnt[dst_port] > 0) {
     /* There are still references to the port, no need to update */
     return 0;
   }

--- a/manager/mtl_mproto.h
+++ b/manager/mtl_mproto.h
@@ -32,6 +32,10 @@ typedef enum {
   MTL_MSG_TYPE_PUT_LCORE,
   MTL_MSG_TYPE_ADD_UDP_DP_FILTER,
   MTL_MSG_TYPE_DEL_UDP_DP_FILTER,
+  MTL_MSG_TYPE_GET_QUEUE,
+  MTL_MSG_TYPE_PUT_QUEUE,
+  MTL_MSG_TYPE_ADD_RX_FLOW,
+  MTL_MSG_TYPE_DEL_RX_FLOW,
   /* server to client */
   MTL_MSG_TYPE_SC = 200,
   MTL_MSG_TYPE_RESPONSE,
@@ -70,6 +74,11 @@ typedef struct {
 } mtl_udp_dp_filter_message_t;
 
 typedef struct {
+  unsigned int ifindex;
+  uint16_t queue_id;
+} mtl_queue_message_t;
+
+typedef struct {
   uint8_t response; /* 0 for success, 1 for error */
 } mtl_response_message_t;
 
@@ -81,6 +90,7 @@ typedef struct {
     mtl_request_map_fd_message_t request_map_fd_msg;
     mtl_lcore_message_t lcore_msg;
     mtl_udp_dp_filter_message_t udp_dp_filter_msg;
+    mtl_queue_message_t queue_msg;
     mtl_response_message_t response_msg;
   } body;
 } mtl_message_t;

--- a/manager/mtl_mproto.h
+++ b/manager/mtl_mproto.h
@@ -27,18 +27,19 @@ typedef enum {
   MTL_MSG_TYPE_CS = 100,
   MTL_MSG_TYPE_REGISTER,
   MTL_MSG_TYPE_HEARTBEAT,
-  MTL_MSG_TYPE_REQUEST_MAP_FD,
   MTL_MSG_TYPE_GET_LCORE,
   MTL_MSG_TYPE_PUT_LCORE,
   MTL_MSG_TYPE_ADD_UDP_DP_FILTER,
   MTL_MSG_TYPE_DEL_UDP_DP_FILTER,
-  MTL_MSG_TYPE_GET_QUEUE,
-  MTL_MSG_TYPE_PUT_QUEUE,
-  MTL_MSG_TYPE_ADD_RX_FLOW,
-  MTL_MSG_TYPE_DEL_RX_FLOW,
+  MTL_MSG_TYPE_IF_XSK_MAP_FD,
+  MTL_MSG_TYPE_IF_GET_QUEUE,
+  MTL_MSG_TYPE_IF_PUT_QUEUE,
+  MTL_MSG_TYPE_IF_ADD_FLOW,
+  MTL_MSG_TYPE_IF_DEL_FLOW,
   /* server to client */
   MTL_MSG_TYPE_SC = 200,
   MTL_MSG_TYPE_RESPONSE,
+  MTL_MSG_TYPE_IF_QUEUE_ID,
 } mtl_message_type_t;
 
 /* message header */
@@ -62,7 +63,8 @@ typedef struct {
 
 typedef struct {
   unsigned int ifindex;
-} mtl_request_map_fd_message_t;
+  uint16_t queue_id;
+} mtl_if_message_t;
 
 typedef struct {
   uint16_t lcore;
@@ -74,12 +76,7 @@ typedef struct {
 } mtl_udp_dp_filter_message_t;
 
 typedef struct {
-  unsigned int ifindex;
-  uint16_t queue_id;
-} mtl_queue_message_t;
-
-typedef struct {
-  uint8_t response; /* 0 for success, 1 for error */
+  int response; /* 0 for success, negative for error, positive for other use */
 } mtl_response_message_t;
 
 typedef struct {
@@ -87,10 +84,9 @@ typedef struct {
   union {
     mtl_register_message_t register_msg;
     mtl_heartbeat_message_t heartbeat_msg;
-    mtl_request_map_fd_message_t request_map_fd_msg;
+    mtl_if_message_t if_msg;
     mtl_lcore_message_t lcore_msg;
     mtl_udp_dp_filter_message_t udp_dp_filter_msg;
-    mtl_queue_message_t queue_msg;
     mtl_response_message_t response_msg;
   } body;
 } mtl_message_t;

--- a/rust/imtl-sys/examples/no_std.rs
+++ b/rust/imtl-sys/examples/no_std.rs
@@ -14,7 +14,6 @@ fn main() {
             port: [port_p; 8],
             num_ports: 1,
             pmd: [0; 8],
-            xdp_info: [mtl_af_xdp_params { start_queue: 0 }; 8],
             sip_addr: [[192, 168, 96, 1]; 8],
             netmask: [[255, 255, 255, 0]; 8],
             gateway: [[192, 168, 96, 1]; 8],

--- a/rust/src/imtl/netdev.rs
+++ b/rust/src/imtl/netdev.rs
@@ -56,9 +56,6 @@ pub struct NetDev {
     tx_queues_cnt: u16,
     /// The number of receive queues for the device.
     rx_queues_cnt: u16,
-    /// The starting queue index for XDP.
-    #[builder(default)]
-    xdp_start_queue: u8,
 }
 
 /// The `impl` block provides getter methods for `NetDev` properties, allowing
@@ -102,10 +99,5 @@ impl NetDev {
     /// Returns the number of receive queues for the device.
     pub fn get_rx_queues_cnt(&self) -> u16 {
         self.rx_queues_cnt
-    }
-
-    /// Returns the XDP start queue for the device.
-    pub fn get_xdp_start_queue(&self) -> u8 {
-        self.xdp_start_queue
     }
 }

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -69,10 +69,7 @@ static struct option test_args_options[] = {
     {"nb_rx_desc", required_argument, 0, TEST_ARG_NB_RX_DESC},
     {"auto_start_stop", no_argument, 0, TEST_ARG_AUTO_START_STOP},
     {"afxdp_zc_disable", no_argument, 0, TEST_ARG_AF_XDP_ZC_DISABLE},
-    {"start_queue", required_argument, 0, TEST_ARG_START_QUEUE},
     {"queue_cnt", required_argument, 0, TEST_ARG_QUEUE_CNT},
-    {"p_start_queue", required_argument, 0, TEST_ARG_P_START_QUEUE},
-    {"r_start_queue", required_argument, 0, TEST_ARG_R_START_QUEUE},
     {"hdr_split", no_argument, 0, TEST_ARG_HDR_SPLIT},
     {"tasklet_thread", no_argument, 0, TEST_ARG_TASKLET_THREAD},
     {"tsc", no_argument, 0, TEST_ARG_TSC_PACING},
@@ -201,16 +198,6 @@ static int test_parse_args(struct st_tests_context* ctx, struct mtl_init_params*
         break;
       case TEST_ARG_AF_XDP_ZC_DISABLE:
         p->flags |= MTL_FLAG_AF_XDP_ZC_DISABLE;
-        break;
-      case TEST_ARG_START_QUEUE:
-        p->xdp_info[MTL_PORT_P].start_queue = atoi(optarg);
-        p->xdp_info[MTL_PORT_R].start_queue = atoi(optarg);
-        break;
-      case TEST_ARG_P_START_QUEUE:
-        p->xdp_info[MTL_PORT_P].start_queue = atoi(optarg);
-        break;
-      case TEST_ARG_R_START_QUEUE:
-        p->xdp_info[MTL_PORT_R].start_queue = atoi(optarg);
         break;
       case TEST_ARG_QUEUE_CNT: {
         uint16_t cnt = atoi(optarg);
@@ -373,9 +360,6 @@ static void test_ctx_init(struct st_tests_context* ctx) {
   p->tx_queues_cnt[MTL_PORT_R] = 16;
   p->rx_queues_cnt[MTL_PORT_P] = 16;
   p->rx_queues_cnt[MTL_PORT_R] = 16;
-  /* default start queue set to 1 */
-  p->xdp_info[MTL_PORT_P].start_queue = 1;
-  p->xdp_info[MTL_PORT_R].start_queue = 1;
 
   /* build default lcore list */
   pos += snprintf(lcores_list + pos, TEST_LCORE_LIST_MAX_LEN - pos, "0-%d",


### PR DESCRIPTION
1. Add (combined) queue management for interface sharing.
2. Fixed invalid udp4_dp_filter_fd after xdp re-loaded.
3. Add refcnt for udp port filter.
4. Move combined info to manager.