### PR TITLE
ecosystem/ffmpeg_plugin: use video_size, fps, pix_fmt as option name for rx

### DIFF
--- a/ecosystem/ffmpeg_plugin/README.md
+++ b/ecosystem/ffmpeg_plugin/README.md
@@ -43,20 +43,20 @@ Note, for ffmpeg 4.4 version, replace 6.1 with 4.4 for above example commands.
 Single session input example, please start the st2110-20 10bit YUV422 tx stream on "239.168.85.20:20000" before using:
 
 ```bash
-ffmpeg -total_sessions 1 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -framerate 59.94 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20000 -payload_type 112 -f mtl_st20p -i "k" -vframes 2000 -f rawvideo /dev/null -y
+ffmpeg -total_sessions 1 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -fps 59.94 -pix_fmt yuv422p10le -video_size 1920x1080 -udp_port 20000 -payload_type 112 -f mtl_st20p -i "k" -vframes 2000 -f rawvideo /dev/null -y
 ```
 
 Two sessions input example, one on "239.168.85.20:20000" and the second on "239.168.85.20:20002":
 
 ```bash
 <!-- markdownlint-disable line-length -->
-ffmpeg -total_sessions 2 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -framerate 59.94 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20000 -payload_type 112 -f mtl_st20p -i "1" -port 0000:af:01.0 -rx_addr "239.168.85.20" -framerate 59.94 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20002 -payload_type 112 -f mtl_st20p -i "2" -map 0:0 -vframes 2000 -f rawvideo /dev/null -y -map 1:0 -vframes 2000 -f rawvideo /dev/null -y
+ffmpeg -total_sessions 2 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -fps 59.94 -pix_fmt yuv422p10le -video_size 1920x1080 -udp_port 20000 -payload_type 112 -f mtl_st20p -i "1" -port 0000:af:01.0 -rx_addr "239.168.85.20" -fps 59.94 -pix_fmt yuv422p10le -video_size 1920x1080 -udp_port 20002 -payload_type 112 -f mtl_st20p -i "2" -map 0:0 -vframes 2000 -f rawvideo /dev/null -y -map 1:0 -vframes 2000 -f rawvideo /dev/null -y
 ```
 
 Open-h264 encoder example on stream "239.168.85.20:20000":
 
 ```bash
-ffmpeg -total_sessions 1 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -framerate 59.94 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20000 -payload_type 112 -f mtl_st20p -i "k" -vframes 2000 -c:v libopenh264 out.264 -y
+ffmpeg -total_sessions 1 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -fps 59.94 -pix_fmt yuv422p10le -video_size 1920x1080 -udp_port 20000 -payload_type 112 -f mtl_st20p -i "k" -vframes 2000 -c:v libopenh264 out.264 -y
 ```
 
 ### 2.2 St20p output example
@@ -72,7 +72,7 @@ ffmpeg -stream_loop -1 -video_size 1920x1080 -f rawvideo -pix_fmt yuv422p10le -i
 Single session input example, please start the st2110-22 jpegxs tx stream on "239.168.85.20:20000" before using:
 
 ```bash
-ffmpeg -total_sessions 1 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -framerate 59.94 -pixel_format yuv422p10le -width 1920 -height 1080 -udp_port 20000 -payload_type 112 -f mtl_st22p -i "k" -vframes 2000 -f rawvideo /dev/null -y
+ffmpeg -total_sessions 1 -port 0000:af:01.0 -local_addr "192.168.96.2" -rx_addr "239.168.85.20" -fps 59.94 -pix_fmt yuv422p10le -video_size 1920x1080 -udp_port 20000 -payload_type 112 -f mtl_st22p -i "k" -vframes 2000 -f rawvideo /dev/null -y
 ```
 
 ### 2.4 St22p output example

--- a/ecosystem/ffmpeg_plugin/mtl_st20p_rx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st20p_rx.c
@@ -29,9 +29,8 @@ typedef struct MtlSt20pDemuxerContext {
   char* rx_addr;
   int udp_port;
   int payload_type;
-  int width;
-  int height;
-  char* pixel_format;
+  int width, height;
+  enum AVPixelFormat pixel_format;
   AVRational framerate;
   int fb_cnt;
   int session_cnt;
@@ -105,7 +104,7 @@ static int mtl_st20p_read_header(AVFormatContext* ctx) {
   }
 
   /* transport_fmt is hardcode now */
-  pix_fmt = av_get_pix_fmt(s->pixel_format);
+  pix_fmt = s->pixel_format;
   pix_fmt_desc = av_pix_fmt_desc_get(pix_fmt);
   switch (pix_fmt) {
     case AV_PIX_FMT_YUV422P10LE:
@@ -230,7 +229,7 @@ static int mtl_st20p_read_close(AVFormatContext* ctx) {
 }
 
 #define OFFSET(x) offsetof(MtlSt20pDemuxerContext, x)
-#define DEC AV_OPT_FLAG_DECODING_PARAM
+#define DEC (AV_OPT_FLAG_DECODING_PARAM)
 static const AVOption mtl_st20p_rx_options[] = {
     // mtl port info
     {"port", "mtl port", OFFSET(port), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = DEC},
@@ -263,35 +262,38 @@ static const AVOption mtl_st20p_rx_options[] = {
      -1,
      INT_MAX,
      DEC},
-    {"width",
-     "Video frame width",
+    {"video_size",
+     "Video frame size",
      OFFSET(width),
-     AV_OPT_TYPE_INT,
-     {.i64 = 1920},
-     -1,
-     INT_MAX,
+     AV_OPT_TYPE_IMAGE_SIZE,
+     {.str = "1920x1080"},
+     0,
+     0,
      DEC},
-    {"height",
-     "Video frame height",
-     OFFSET(height),
-     AV_OPT_TYPE_INT,
-     {.i64 = 1080},
-     -1,
-     INT_MAX,
-     DEC},
-    {"pixel_format",
-     "Video frame format",
+    {"pix_fmt",
+     "Pixel format for framebuffer",
      OFFSET(pixel_format),
-     AV_OPT_TYPE_STRING,
-     {.str = NULL},
-     .flags = DEC},
-    {"framerate",
+     AV_OPT_TYPE_PIXEL_FMT,
+     {.i64 = AV_PIX_FMT_YUV422P10LE},
+     -1,
+     INT32_MAX,
+     DEC},
+    /* avoid "Option pixel_format not found." error */
+    {"pixel_format",
+     "Pixel format for framebuffer",
+     OFFSET(pixel_format),
+     AV_OPT_TYPE_PIXEL_FMT,
+     {.i64 = AV_PIX_FMT_YUV422P10LE},
+     -1,
+     INT32_MAX,
+     DEC},
+    {"fps",
      "Video frame rate",
      OFFSET(framerate),
-     AV_OPT_TYPE_VIDEO_RATE,
-     {.str = "59.94"},
+     AV_OPT_TYPE_RATIONAL,
+     {.dbl = 59.94},
      0,
-     INT_MAX,
+     1000,
      DEC},
     {"fb_cnt",
      "Frame buffer count",

--- a/ecosystem/ffmpeg_plugin/mtl_st22p_rx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st22p_rx.c
@@ -31,7 +31,7 @@ typedef struct MtlSt22pDemuxerContext {
   int payload_type;
   int width;
   int height;
-  char* pixel_format;
+  enum AVPixelFormat pixel_format;
   AVRational framerate;
   int fb_cnt;
   int session_cnt;
@@ -111,7 +111,7 @@ static int mtl_st22p_read_header(AVFormatContext* ctx) {
   }
 
   /* transport_fmt is hardcode now */
-  pix_fmt = av_get_pix_fmt(s->pixel_format);
+  pix_fmt = s->pixel_format;
   pix_fmt_desc = av_pix_fmt_desc_get(pix_fmt);
   switch (pix_fmt) {
     case AV_PIX_FMT_YUV422P10LE:
@@ -234,7 +234,7 @@ static int mtl_st22p_read_close(AVFormatContext* ctx) {
 }
 
 #define OFFSET(x) offsetof(MtlSt22pDemuxerContext, x)
-#define DEC AV_OPT_FLAG_DECODING_PARAM
+#define DEC (AV_OPT_FLAG_DECODING_PARAM)
 static const AVOption mtl_st22p_rx_options[] = {
     // mtl port info
     {"port", "mtl port", OFFSET(port), AV_OPT_TYPE_STRING, {.str = NULL}, .flags = DEC},
@@ -267,35 +267,38 @@ static const AVOption mtl_st22p_rx_options[] = {
      -1,
      INT_MAX,
      DEC},
-    {"width",
-     "Video frame width",
+    {"video_size",
+     "Video frame size",
      OFFSET(width),
-     AV_OPT_TYPE_INT,
-     {.i64 = 1920},
-     -1,
-     INT_MAX,
+     AV_OPT_TYPE_IMAGE_SIZE,
+     {.str = "1920x1080"},
+     0,
+     0,
      DEC},
-    {"height",
-     "Video frame height",
-     OFFSET(height),
-     AV_OPT_TYPE_INT,
-     {.i64 = 1080},
-     -1,
-     INT_MAX,
-     DEC},
-    {"pixel_format",
-     "Video frame format",
+    {"pix_fmt",
+     "Pixel format for framebuffer",
      OFFSET(pixel_format),
-     AV_OPT_TYPE_STRING,
-     {.str = NULL},
-     .flags = DEC},
-    {"framerate",
+     AV_OPT_TYPE_PIXEL_FMT,
+     {.i64 = AV_PIX_FMT_YUV422P10LE},
+     -1,
+     INT32_MAX,
+     DEC},
+    /* avoid "Option pixel_format not found." error */
+    {"pixel_format",
+     "Pixel format for framebuffer",
+     OFFSET(pixel_format),
+     AV_OPT_TYPE_PIXEL_FMT,
+     {.i64 = AV_PIX_FMT_YUV422P10LE},
+     -1,
+     INT32_MAX,
+     DEC},
+    {"fps",
      "Video frame rate",
      OFFSET(framerate),
-     AV_OPT_TYPE_VIDEO_RATE,
-     {.str = "59.94"},
+     AV_OPT_TYPE_RATIONAL,
+     {.dbl = 59.94},
      0,
-     INT_MAX,
+     1000,
      DEC},
     {"fb_cnt",
      "Frame buffer count",

--- a/ecosystem/ffmpeg_plugin/mtl_st22p_rx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st22p_rx.c
@@ -29,8 +29,7 @@ typedef struct MtlSt22pDemuxerContext {
   char* rx_addr;
   int udp_port;
   int payload_type;
-  int width;
-  int height;
+  int width, height;
   enum AVPixelFormat pixel_format;
   AVRational framerate;
   int fb_cnt;


### PR DESCRIPTION
align to standard naming of tx