### PR TITLE
docker: mark dockerfile as not for production use

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,8 @@
 
 Docker guide for Intel® Media Transport Library.
 
+Please note that the Dockerfile provided is intended for development use only. It has been tested for functionality, but not for security. Users are advised to review and modify it as necessary before using it in a production environment.
+
 ## 1. DPDK NIC PMD and env setup on host
 
 Follow [run guide](../doc/run.md) to setup the hugepages, driver of NIC PFs, vfio(2110) user group and vfio driver mode for VFs.

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2023 Intel Corporation
 
+# NOTE: This Dockerfile is intended for development purposes only.
+# It has been tested for functionality, but not for security.
+# Please review and modify as necessary before using in a production environment.
+
 # Ubuntu 22.04, build stage
 FROM ubuntu@sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7ca37 AS builder
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2023 Intel Corporation
 
+# NOTE: This Dockerfile is intended for development purposes only.
+# It has been tested for functionality, but not for security.
+# Please review and modify as necessary before using in a production environment.
+
 # Build stage, ubuntu 22.04
 FROM ubuntu@sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7ca37 as builder
 

--- a/manager/README.md
+++ b/manager/README.md
@@ -61,6 +61,8 @@ docker0                <No XDP program loaded!>
 
 ## Run in a Docker container
 
+Please note that the Dockerfile provided is intended for development use only. It has been tested for functionality, but not for security. Users are advised to review and modify it as necessary before using it in a production environment.
+
 Build the Docker image:
 
 ```bash


### PR DESCRIPTION
Indicate that the Dockerfile is not intended for production use. It's important to note that the Dockerfile has only been tested for functionality, not for security. Users are advised to review and modify it as necessary before using it in a production environment.