### PR TITLE
app: default video fb cnt to 3

### DIFF
--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -42,6 +42,8 @@
 
 #define ST_APP_MAX_LCORES (32)
 
+#define ST_APP_DEFAULT_FB_CNT (3)
+
 #define ST_APP_EXPECT_NEAR(val, expect, delta) \
   ((val > (expect - delta)) && (val < (expect + delta)))
 

--- a/app/src/rx_st20p_app.c
+++ b/app/src/rx_st20p_app.c
@@ -314,6 +314,8 @@ static int app_rx_st20p_pcap(struct st_app_rx_st20p_session* s) {
 int st_app_rx_st20p_sessions_init(struct st_app_context* ctx) {
   int ret = 0, i = 0;
   struct st_app_rx_st20p_session* s;
+  int fb_cnt = ctx->rx_video_fb_cnt;
+  if (fb_cnt <= 0) fb_cnt = ST_APP_DEFAULT_FB_CNT;
 
   dbg("%s(%d), rx_st20p_session_cnt %d\n", __func__, i, ctx->rx_st20p_session_cnt);
   ctx->rx_st20p_sessions = (struct st_app_rx_st20p_session*)st_app_zmalloc(
@@ -323,7 +325,7 @@ int st_app_rx_st20p_sessions_init(struct st_app_context* ctx) {
     s = &ctx->rx_st20p_sessions[i];
     s->idx = i;
     s->st = ctx->st;
-    s->framebuff_cnt = 3;
+    s->framebuff_cnt = fb_cnt;
 
     ret = app_rx_st20p_init(
         ctx, ctx->json_ctx ? &ctx->json_ctx->rx_st20p_sessions[i] : NULL, s);

--- a/app/src/rx_st22p_app.c
+++ b/app/src/rx_st22p_app.c
@@ -256,6 +256,8 @@ static int app_rx_st22p_pcap(struct st_app_rx_st22p_session* s) {
 int st_app_rx_st22p_sessions_init(struct st_app_context* ctx) {
   int ret = 0, i = 0;
   struct st_app_rx_st22p_session* s;
+  int fb_cnt = ctx->rx_video_fb_cnt;
+  if (fb_cnt <= 0) fb_cnt = ST_APP_DEFAULT_FB_CNT;
 
   dbg("%s(%d), rx_st22p_session_cnt %d\n", __func__, i, ctx->rx_st22p_session_cnt);
   ctx->rx_st22p_sessions = (struct st_app_rx_st22p_session*)st_app_zmalloc(
@@ -265,7 +267,7 @@ int st_app_rx_st22p_sessions_init(struct st_app_context* ctx) {
     s = &ctx->rx_st22p_sessions[i];
     s->idx = i;
     s->st = ctx->st;
-    s->framebuff_cnt = 3;
+    s->framebuff_cnt = fb_cnt;
 
     ret = app_rx_st22p_init(
         ctx, ctx->json_ctx ? &ctx->json_ctx->rx_st22p_sessions[i] : NULL, s);

--- a/app/src/rx_video_app.c
+++ b/app/src/rx_video_app.c
@@ -700,7 +700,7 @@ int st_app_rx_video_sessions_init(struct st_app_context* ctx) {
   int ret, i;
   struct st_app_rx_video_session* s;
   int fb_cnt = ctx->rx_video_fb_cnt;
-  if (fb_cnt <= 0) fb_cnt = 6;
+  if (fb_cnt <= 0) fb_cnt = ST_APP_DEFAULT_FB_CNT;
 
   ctx->rx_video_sessions = (struct st_app_rx_video_session*)st_app_zmalloc(
       sizeof(struct st_app_rx_video_session) * ctx->rx_video_session_cnt);


### PR DESCRIPTION
can be customized by args: `--rx_video_fb_cnt xxx`

Signed-off-by: Frank Du <frank.du@intel.com>
(cherry picked from commit 03cff2776079889a47e98e30feb09087d39b2944)