### PR TITLE
tx/video: add directly transport ST20_FMT_YUV_422_PLANAR10LE support

### DIFF
--- a/app/sample/legacy/tx_video_sample.c
+++ b/app/sample/legacy/tx_video_sample.c
@@ -202,6 +202,7 @@ int main(int argc, char** argv) {
     if (ctx.ext_frame) ops_tx.flags |= ST20_TX_FLAG_EXT_FRAME;
     ops_tx.udp_port[MTL_SESSION_PORT_P] = ctx.udp_port + i * 2;  // udp port
     ops_tx.pacing = ST21_PACING_NARROW;
+    ops_tx.packing = ctx.packing;
     ops_tx.type = ST20_TYPE_FRAME_LEVEL;
     ops_tx.width = ctx.width;
     ops_tx.height = ctx.height;

--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -56,7 +56,9 @@ enum sample_args_cmd {
   SAMPLE_ARG_SESSIONS_CNT,
   SAMPLE_ARG_EXT_FRAME,
   SAMPLE_ARG_ST22_CODEC,
-  SAMPLE_ARG_PIPELINE_FRAME_FMT,
+  SAMPLE_ARG_PIPELINE_FMT,
+  SAMPLE_ARG_TRANSPORT_FMT,
+  SAMPLE_ARG_PACKING,
   SAMPLE_ARG_GDDR_PA,
   SAMPLE_ARG_RX_DUMP,
   SAMPLE_ARG_USE_CPU_COPY,
@@ -112,7 +114,9 @@ static struct option sample_args_options[] = {
     {"height", required_argument, 0, SAMPLE_ARG_HEIGHT},
     {"ext_frame", no_argument, 0, SAMPLE_ARG_EXT_FRAME},
     {"st22_codec", required_argument, 0, SAMPLE_ARG_ST22_CODEC},
-    {"pipeline_fmt", required_argument, 0, SAMPLE_ARG_PIPELINE_FRAME_FMT},
+    {"pipeline_fmt", required_argument, 0, SAMPLE_ARG_PIPELINE_FMT},
+    {"transport_fmt", required_argument, 0, SAMPLE_ARG_TRANSPORT_FMT},
+    {"packing", required_argument, 0, SAMPLE_ARG_PACKING},
     {"ptp", no_argument, 0, SAMPLE_ARG_LIB_PTP},
 
     {"udp_mode", required_argument, 0, SAMPLE_ARG_UDP_MODE},
@@ -311,7 +315,7 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         else
           err("%s, unknown codec %s\n", __func__, optarg);
         break;
-      case SAMPLE_ARG_PIPELINE_FRAME_FMT: {
+      case SAMPLE_ARG_PIPELINE_FMT: {
         enum st_frame_fmt fmt = st_frame_name_to_fmt(optarg);
         if (fmt < ST_FRAME_FMT_MAX) {
           ctx->input_fmt = fmt;
@@ -321,6 +325,25 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         }
         break;
       }
+      case SAMPLE_ARG_TRANSPORT_FMT: {
+        enum st20_fmt fmt = st20_name_to_fmt(optarg);
+        if (fmt < ST20_FMT_MAX) {
+          ctx->fmt = fmt;
+        } else {
+          err("%s, unknown fmt %s\n", __func__, optarg);
+        }
+        break;
+      }
+      case SAMPLE_ARG_PACKING:
+        if (!strcmp(optarg, "bpm"))
+          ctx->packing = ST20_PACKING_BPM;
+        else if (!strcmp(optarg, "gpm"))
+          ctx->packing = ST20_PACKING_GPM;
+        else if (!strcmp(optarg, "gpm_sl"))
+          ctx->packing = ST20_PACKING_GPM_SL;
+        else
+          err("%s, unknown codec %s\n", __func__, optarg);
+        break;
       case SAMPLE_ARG_UDP_MODE:
         if (!strcmp(optarg, "default"))
           ctx->udp_mode = SAMPLE_UDP_DEFAULT;
@@ -433,6 +456,7 @@ int sample_parse_args(struct st_sample_context* ctx, int argc, char** argv, bool
   ctx->fmt = ST20_FMT_YUV_422_10BIT;
   ctx->input_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
   ctx->output_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
+  ctx->packing = ST20_PACKING_BPM;
   ctx->udp_port = 20000;
   ctx->payload_type = 112;
   snprintf(ctx->tx_url, sizeof(ctx->tx_url), "%s", "test.yuv");

--- a/app/sample/sample_util.h
+++ b/app/sample/sample_util.h
@@ -87,6 +87,7 @@ struct st_sample_context {
   enum st20_fmt fmt;
   enum st_frame_fmt input_fmt;
   enum st_frame_fmt output_fmt;
+  enum st20_packing packing;
   uint16_t framebuff_cnt;
   uint16_t udp_port;
   uint8_t payload_type;

--- a/app/sample/tx_st20_pipeline_sample.c
+++ b/app/sample/tx_st20_pipeline_sample.c
@@ -204,6 +204,7 @@ int main(int argc, char** argv) {
     ops_tx.framebuff_cnt = ctx.framebuff_cnt;
     ops_tx.flags = ST20P_TX_FLAG_BLOCK_GET;
     ops_tx.notify_frame_done = tx_st20p_frame_done;
+    ops_tx.transport_packing = ctx.packing;
 
     st20p_tx_handle tx_handle = st20p_tx_create(ctx.st, &ops_tx);
     if (!tx_handle) {

--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -668,6 +668,8 @@ static int parse_video_pg_format(json_object* video_obj, st_json_video_session_t
     video->info.pg_format = ST20_FMT_RGB_12BIT;
   } else if (strcmp(pg_format, "RGB_16bit") == 0) {
     video->info.pg_format = ST20_FMT_RGB_16BIT;
+  } else if (strcmp(pg_format, "YUV_422_PLANAR10LE") == 0) {
+    video->info.pg_format = ST20_FMT_YUV_422_PLANAR10LE;
   } else {
     err("%s, invalid pixel group format %s\n", __func__, pg_format);
     return -ST_JSON_NOT_VALID;
@@ -1635,6 +1637,8 @@ static int parse_st20p_transport_format(json_object* st20p_obj,
     st20p->info.transport_format = ST20_FMT_RGB_12BIT;
   } else if (strcmp(t_format, "RGB_16bit") == 0) {
     st20p->info.transport_format = ST20_FMT_RGB_16BIT;
+  } else if (strcmp(t_format, "YUV_422_PLANAR10LE") == 0) {
+    st20p->info.transport_format = ST20_FMT_YUV_422_PLANAR10LE;
   } else {
     err("%s, invalid transport format %s\n", __func__, t_format);
     return -ST_JSON_NOT_VALID;

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -283,7 +283,14 @@ enum st20_fmt {
   ST20_FMT_YUV_444_10BIT,     /**< 10-bit YUV 4:4:4 */
   ST20_FMT_YUV_444_12BIT,     /**< 12-bit YUV 4:4:4 */
   ST20_FMT_YUV_444_16BIT,     /**< 16-bit YUV 4:4:4 */
-  ST20_FMT_MAX,               /**< max value of this enum */
+  /*
+   * Below are the formats which not compatible with st2110 rfc4175.
+   * Ex, user want to transport ST_FRAME_FMT_YUV422PLANAR10LE directly with padding on the
+   * network and no color convert required.
+   */
+  ST20_FMT_YUV_422_PLANAR10LE, /**< 10-bit YUV 4:2:2 planar little endian. Experimental
+                                  now, how to support ext frame? */
+  ST20_FMT_MAX,                /**< max value of this enum */
 };
 
 /**
@@ -2293,6 +2300,28 @@ void* st22_rx_get_fb_addr(st22_rx_handle handle, uint16_t idx);
  *   - <0: Error code.
  */
 int st22_rx_get_queue_meta(st22_rx_handle handle, struct st_queue_meta* meta);
+
+/**
+ * Get the name of st20_fmt
+ *
+ * @param fmt
+ *   format.
+ * @return
+ *   The pointer to name.
+ *   NULL: Fail.
+ */
+const char* st20_fmt_name(enum st20_fmt fmt);
+
+/**
+ * Get st20_fmt from name
+ *
+ * @param name
+ *   name.
+ * @return
+ *   The st20_fmt.
+ *   ST20_FMT_MAX: Fail.
+ */
+enum st20_fmt st20_name_to_fmt(const char* name);
 
 #if defined(__cplusplus)
 }

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -467,6 +467,7 @@ static int rx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_rx
   ops_rx.rx_burst_size = ops->rx_burst_size;
   ops_rx.notify_frame_ready = rx_st20p_frame_ready;
   ops_rx.notify_event = rx_st20p_notify_event;
+
   if (ctx->derive) {
     /* ext frame info directly passed down to st20 lib */
     if (ops->ext_frames) {
@@ -883,7 +884,7 @@ st20p_rx_handle st20p_rx_create(mtl_handle mt, struct st20p_rx_ops* ops) {
   /* all ready now */
   ctx->ready = true;
   notice("%s(%d), transport fmt %s, output fmt %s, flags 0x%x\n", __func__, idx,
-         st20_frame_fmt_name(ops->transport_fmt), st_frame_fmt_name(ops->output_fmt),
+         st20_fmt_name(ops->transport_fmt), st_frame_fmt_name(ops->output_fmt),
          ops->flags);
   st20p_rx_idx++;
 

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -754,7 +754,7 @@ st20p_tx_handle st20p_tx_create(mtl_handle mt, struct st20p_tx_ops* ops) {
   /* all ready now */
   ctx->ready = true;
   notice("%s(%d), transport fmt %s, input fmt: %s, flags 0x%x\n", __func__, idx,
-         st20_frame_fmt_name(ops->transport_fmt), st_frame_fmt_name(ops->input_fmt),
+         st20_fmt_name(ops->transport_fmt), st_frame_fmt_name(ops->input_fmt),
          ops->flags);
   st20p_tx_idx++;
 

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -113,6 +113,13 @@ static const struct st20_pgroup st20_pgroups[] = {
         .coverage = 1,
         .name = "ST20_FMT_YUV_444_16BIT",
     },
+    {
+        /* ST20_FMT_YUV_422_PLANAR10LE */
+        .fmt = ST20_FMT_YUV_422_PLANAR10LE,
+        .size = 4, /* assume PLANAR as packed now */
+        .coverage = 1,
+        .name = "ST20_FMT_YUV_422_PLANAR10LE",
+    },
 };
 
 static const struct st_fps_timing st_fps_timings[] = {
@@ -622,7 +629,7 @@ size_t st20_frame_size(enum st20_fmt fmt, uint32_t width, uint32_t height) {
   return size * pg.size / pg.coverage;
 }
 
-const char* st20_frame_fmt_name(enum st20_fmt fmt) {
+const char* st20_fmt_name(enum st20_fmt fmt) {
   struct st20_pgroup pg;
   memset(&pg, 0, sizeof(pg));
 
@@ -632,6 +639,19 @@ const char* st20_frame_fmt_name(enum st20_fmt fmt) {
     return "unknown";
   }
   return pg.name;
+}
+
+enum st20_fmt st20_name_to_fmt(const char* name) {
+  int i;
+
+  for (i = 0; i < MTL_ARRAY_SIZE(st20_pgroups); i++) {
+    if (!strcmp(name, st20_pgroups[i].name)) {
+      return st20_pgroups[i].fmt;
+    }
+  }
+
+  err("%s, invalid name %s\n", __func__, name);
+  return ST20_FMT_MAX;
 }
 
 int st_get_fps_timing(enum st_fps fps, struct st_fps_timing* fps_tm) {
@@ -788,6 +808,8 @@ enum st_frame_fmt st_frame_fmt_from_transport(enum st20_fmt tfmt) {
       return ST_FRAME_FMT_RGBRFC4175PG2BE12;
     case ST20_FMT_RGB_8BIT:
       return ST_FRAME_FMT_RGB8;
+    case ST20_FMT_YUV_422_PLANAR10LE:
+      return ST_FRAME_FMT_YUV422PLANAR10LE;
     default:
       err("%s, invalid tfmt %d\n", __func__, tfmt);
       return ST_FRAME_FMT_MAX;

--- a/lib/src/st2110/st_fmt.h
+++ b/lib/src/st2110/st_fmt.h
@@ -33,7 +33,7 @@ struct st_frame_fmt_desc {
   enum st_frame_sampling sampling;
 };
 
-const char* st20_frame_fmt_name(enum st20_fmt fmt);
+const char* st20_fmt_name(enum st20_fmt fmt);
 
 const char* st_tx_pacing_way_name(enum st21_tx_pacing_way way);
 

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3111,8 +3111,8 @@ static int rv_attach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
        __func__, idx, s->st20_frames_cnt, s->st20_frame_size, s->st20_frame_bitmap_size,
        s->st20_uframe_size, ops->type, ops->interlaced ? "interlace" : "progressive");
   info("%s(%d), w %u h %u fmt %s packing %d pt %d flags 0x%x frame time %fms fps %f\n",
-       __func__, idx, ops->width, ops->height, st20_frame_fmt_name(ops->fmt),
-       ops->packing, ops->payload_type, ops->flags, s->frame_time / NS_PER_MS,
+       __func__, idx, ops->width, ops->height, st20_fmt_name(ops->fmt), ops->packing,
+       ops->payload_type, ops->flags, s->frame_time / NS_PER_MS,
        st_frame_rate(s->ops.fps));
   return 0;
 }

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -2800,6 +2800,11 @@ static int tv_init_pkt(struct mtl_main_impl* impl, struct st_tx_video_session_im
         s->st20_total_pkts - s->st20_pkt_info[ST20_PKT_TYPE_LINE_TAIL].number;
     dbg("%s(%d),  line_last_len: %d\n", __func__, idx, line_last_len);
   } else if (ops->packing == ST20_PACKING_BPM) {
+    if (ST_VIDEO_BPM_SIZE % s->st20_pg.size) {
+      err("%s(%d), bpm size 1260 can not be divide by pg size %u\n", __func__, idx,
+          s->st20_pg.size);
+      return -EIO;
+    }
     s->st20_pkt_len = ST_VIDEO_BPM_SIZE;
     int last_pkt_len = s->st20_frame_size % s->st20_pkt_len;
     s->st20_pkt_size = s->st20_pkt_len + sizeof(struct st_rfc4175_video_hdr);
@@ -3075,8 +3080,8 @@ static int tv_attach(struct mtl_main_impl* impl, struct st_tx_video_sessions_mgr
        s->st20_pkt_len, s->st20_pkt_size, s->st20_total_pkts, s->st20_pkts_in_line,
        ops->type, ops->flags, ops->interlaced ? "interlace" : "progressive");
   info("%s(%d), w %u h %u fmt %s packing %d pt %d, pacing way: %s\n", __func__, idx,
-       ops->width, ops->height, st20_frame_fmt_name(ops->fmt), ops->packing,
-       ops->payload_type, st_tx_pacing_way_name(s->pacing_way[MTL_SESSION_PORT_P]));
+       ops->width, ops->height, st20_fmt_name(ops->fmt), ops->packing, ops->payload_type,
+       st_tx_pacing_way_name(s->pacing_way[MTL_SESSION_PORT_P]));
   return 0;
 }
 

--- a/python/example/misc_util.py
+++ b/python/example/misc_util.py
@@ -15,8 +15,26 @@ import pymtl as mtl
 def parse_pipeline_fmt(name):
     fmt = mtl.st_frame_name_to_fmt(name)
     if fmt >= mtl.ST_FRAME_FMT_MAX:
-        raise argparse.ArgumentTypeError(f"{name} is not a valid fmt name")
+        raise argparse.ArgumentTypeError(f"{name} is not a valid pipeline fmt")
     return fmt
+
+
+def parse_transport_fmt(name):
+    fmt = mtl.st20_name_to_fmt(name)
+    if fmt >= mtl.ST20_FMT_MAX:
+        raise argparse.ArgumentTypeError(f"{name} is not a valid transport fmt")
+    return fmt
+
+
+def parse_packing(name):
+    if name == "bpm":
+        return mtl.ST20_PACKING_BPM
+    if name == "gpm":
+        return mtl.ST20_PACKING_GPM
+    if name == "gpm_sl":
+        return mtl.ST20_PACKING_GPM_SL
+
+    raise argparse.ArgumentTypeError(f"{name} is not a packing name")
 
 
 def parse_st22_codec(name):
@@ -75,6 +93,20 @@ def parse_args(is_tx):
         type=parse_pipeline_fmt,
         default=mtl.ST_FRAME_FMT_YUV422PLANAR10LE,
         help="pipeline_fmt",
+    )
+    # transport_fmt
+    parser.add_argument(
+        "--transport_fmt",
+        type=parse_transport_fmt,
+        default=mtl.ST20_FMT_YUV_422_10BIT,
+        help="transport_fmt",
+    )
+    # packing
+    parser.add_argument(
+        "--packing",
+        type=parse_packing,
+        default=mtl.ST20_PACKING_BPM,
+        help="packing",
     )
     # fps
     parser.add_argument(

--- a/python/example/st20p_rx.py
+++ b/python/example/st20p_rx.py
@@ -91,7 +91,7 @@ def main():
     rx_para.fps = args.fps
     rx_para.interlaced = args.interlaced
     rx_para.framebuff_cnt = 3
-    rx_para.transport_fmt = mtl.ST20_FMT_YUV_422_10BIT
+    rx_para.transport_fmt = args.transport_fmt
     rx_para.output_fmt = args.pipeline_fmt
     # rx port
     rx_port = mtl.st_rx_port()

--- a/python/example/st20p_rx_encode.py
+++ b/python/example/st20p_rx_encode.py
@@ -48,7 +48,7 @@ def main():
     rx_para.height = args.height
     rx_para.fps = args.fps
     rx_para.framebuff_cnt = 3
-    rx_para.transport_fmt = mtl.ST20_FMT_YUV_422_10BIT
+    rx_para.transport_fmt = args.transport_fmt
     rx_para.output_fmt = mtl_output_fmt
     # rx port
     rx_port = mtl.st_rx_port()

--- a/python/example/st20p_tx.py
+++ b/python/example/st20p_tx.py
@@ -46,7 +46,8 @@ def main():
     tx_para.fps = args.fps
     tx_para.interlaced = args.interlaced
     tx_para.framebuff_cnt = 3
-    tx_para.transport_fmt = mtl.ST20_FMT_YUV_422_10BIT
+    tx_para.transport_fmt = args.transport_fmt
+    tx_para.transport_packing = args.packing
     tx_para.input_fmt = args.pipeline_fmt
     # tx port
     tx_port = mtl.st_tx_port()

--- a/python/example/st20p_tx_decode.py
+++ b/python/example/st20p_tx_decode.py
@@ -89,7 +89,8 @@ def main():
     tx_para.height = height
     tx_para.fps = args.fps
     tx_para.framebuff_cnt = 3
-    tx_para.transport_fmt = mtl.ST20_FMT_YUV_422_10BIT
+    tx_para.transport_fmt = args.transport_fmt
+    tx_para.transport_packing = args.packing
     tx_para.input_fmt = mtl_input_fmt
     # tx port
     tx_port = mtl.st_tx_port()

--- a/tests/script/loop_json/yuv422_planar10_transport.json
+++ b/tests/script/loop_json/yuv422_planar10_transport.json
@@ -1,0 +1,60 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "local:1"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_PLANAR10LE",
+                    "video_url": "./yuv422p10le_1080p.yuv"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "local:0"
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "YUV_422_PLANAR10LE",
+                    "display": false,
+                    "measure_latency": true,
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/loop_json/yuv422_st20p_planar10_transport.json
+++ b/tests/script/loop_json/yuv422_st20p_planar10_transport.json
@@ -1,0 +1,61 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "local:1"
+            ],
+            "interface": [
+                0
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "input_format": "YUV422PLANAR10LE",
+                    "transport_format": "YUV_422_PLANAR10LE",
+                    "st20p_url": "./yuv422p10le_1080p.yuv"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "local:0"
+            ],
+            "interface": [
+                1
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "output_format": "YUV422PLANAR10LE",
+                    "transport_format": "YUV_422_PLANAR10LE",
+                    "display": false,
+                    "measure_latency": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/src/st20p_test.cpp
+++ b/tests/src/st20p_test.cpp
@@ -1553,3 +1553,19 @@ TEST(St20p, digest_rtcp_s1) {
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
 }
+
+TEST(St20p, transport_yuv422p10le) {
+  enum st_fps fps[1] = {ST_FPS_P59_94};
+  int width[1] = {1920};
+  int height[1] = {1080};
+  enum st_frame_fmt tx_fmt[1] = {ST_FRAME_FMT_YUV422PLANAR10LE};
+  enum st20_fmt t_fmt[1] = {ST20_FMT_YUV_422_PLANAR10LE};
+  enum st_frame_fmt rx_fmt[1] = {ST_FRAME_FMT_YUV422PLANAR10LE};
+
+  struct st20p_rx_digest_test_para para;
+  test_st20p_init_rx_digest_para(&para);
+  para.level = ST_TEST_LEVEL_ALL;
+  para.packing = ST20_PACKING_BPM;
+
+  st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
+}


### PR DESCRIPTION
For the case may not care the network bandwidth, the upper 6 bit of ST20_FMT_YUV_422_PLANAR10LE is always zero.

test with:
python3 python/example/st20p_tx.py --transport_fmt ST20_FMT_YUV_422_PLANAR10LE python3 python/example/st20p_rx.py --transport_fmt ST20_FMT_YUV_422_PLANAR10LE --display