### PR TITLE
python/example: add v210 display support

### DIFF
--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -670,6 +670,8 @@ static int parse_video_pg_format(json_object* video_obj, st_json_video_session_t
     video->info.pg_format = ST20_FMT_RGB_16BIT;
   } else if (strcmp(pg_format, "YUV_422_PLANAR10LE") == 0) {
     video->info.pg_format = ST20_FMT_YUV_422_PLANAR10LE;
+  } else if (strcmp(pg_format, "V210") == 0) {
+    video->info.pg_format = ST20_FMT_V210;
   } else {
     err("%s, invalid pixel group format %s\n", __func__, pg_format);
     return -ST_JSON_NOT_VALID;
@@ -1639,6 +1641,8 @@ static int parse_st20p_transport_format(json_object* st20p_obj,
     st20p->info.transport_format = ST20_FMT_RGB_16BIT;
   } else if (strcmp(t_format, "YUV_422_PLANAR10LE") == 0) {
     st20p->info.transport_format = ST20_FMT_YUV_422_PLANAR10LE;
+  } else if (strcmp(t_format, "V210") == 0) {
+    st20p->info.transport_format = ST20_FMT_V210;
   } else {
     err("%s, invalid transport format %s\n", __func__, t_format);
     return -ST_JSON_NOT_VALID;

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -290,6 +290,7 @@ enum st20_fmt {
    */
   ST20_FMT_YUV_422_PLANAR10LE, /**< 10-bit YUV 4:2:2 planar little endian. Experimental
                                   now, how to support ext frame? */
+  ST20_FMT_V210,               /**< 10-bit YUV 422 V210 */
   ST20_FMT_MAX,                /**< max value of this enum */
 };
 

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -120,6 +120,13 @@ static const struct st20_pgroup st20_pgroups[] = {
         .coverage = 1,
         .name = "ST20_FMT_YUV_422_PLANAR10LE",
     },
+    {
+        /* ST20_FMT_V210 */
+        .fmt = ST20_FMT_V210,
+        .size = 8,
+        .coverage = 3,
+        .name = "ST20_FMT_V210",
+    },
 };
 
 static const struct st_fps_timing st_fps_timings[] = {
@@ -810,6 +817,8 @@ enum st_frame_fmt st_frame_fmt_from_transport(enum st20_fmt tfmt) {
       return ST_FRAME_FMT_RGB8;
     case ST20_FMT_YUV_422_PLANAR10LE:
       return ST_FRAME_FMT_YUV422PLANAR10LE;
+    case ST20_FMT_V210:
+      return ST_FRAME_FMT_V210;
     default:
       err("%s, invalid tfmt %d\n", __func__, tfmt);
       return ST_FRAME_FMT_MAX;

--- a/python/example/misc_util.py
+++ b/python/example/misc_util.py
@@ -396,6 +396,21 @@ def frame_display_rfc4175be10(mtl_handle, frame, display_scale_factor):
         mtl.st_frame_free(yuv422p8_frame)
 
 
+def frame_display_v210(mtl_handle, frame, display_scale_factor):
+    rfc4175be10_frame = mtl.st_frame_create(
+        mtl_handle,
+        mtl.ST_FRAME_FMT_YUV422RFC4175PG2BE10,
+        frame.width,
+        frame.height,
+        frame.interlaced,
+    )
+    if rfc4175be10_frame:
+        # It's very slow since it include many converting steps, just demo the usage
+        mtl.st_frame_convert(frame, rfc4175be10_frame)
+        frame_display_rfc4175be10(mtl_handle, rfc4175be10_frame, display_scale_factor)
+        mtl.st_frame_free(rfc4175be10_frame)
+
+
 def frame_display(mtl_handle, frame, display_scale_factor):
     if frame.fmt == mtl.ST_FRAME_FMT_YUV422PLANAR10LE:
         frame_display_yuv422p10le(frame, display_scale_factor)
@@ -407,6 +422,8 @@ def frame_display(mtl_handle, frame, display_scale_factor):
         frame_display_rfc4175be10(mtl_handle, frame, display_scale_factor)
     elif frame.fmt == mtl.ST_FRAME_FMT_YUV420PLANAR8:
         frame_display_yuv420p8(frame, display_scale_factor)
+    elif frame.fmt == mtl.ST_FRAME_FMT_V210:
+        frame_display_v210(mtl_handle, frame, display_scale_factor)
     else:
         print(f"Unknown fmt: {mtl.st_frame_fmt_name(frame.fmt)}")
 

--- a/tests/script/loop_json/v210_st20p_transport.json
+++ b/tests/script/loop_json/v210_st20p_transport.json
@@ -1,0 +1,62 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "local:1"
+            ],
+            "interface": [
+                0
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "packing": "GPM",
+                    "input_format": "V210",
+                    "transport_format": "V210",
+                    "st20p_url": "./v210_1080p.yuv"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "local:0"
+            ],
+            "interface": [
+                1
+            ],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p59",
+                    "device": "AUTO",
+                    "output_format": "V210",
+                    "transport_format": "V210",
+                    "display": false,
+                    "measure_latency": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/script/loop_json/v210_transport.json
+++ b/tests/script/loop_json/v210_transport.json
@@ -1,0 +1,60 @@
+{
+    "interfaces": [
+        {
+            "name": "0000:af:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:af:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "local:1"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "packing": "GPM",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "V210",
+                    "video_url": "./v210_1080p.yuv"
+                }
+            ]
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "local:0"
+            ],
+            "interface": [
+                1
+            ],
+            "video": [
+                {
+                    "replicas": 1,
+                    "type": "frame",
+                    "pacing": "gap",
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "tr_offset": "default",
+                    "video_format": "i1080p59",
+                    "pg_format": "V210",
+                    "display": false,
+                    "measure_latency": true,
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
the display is very slow as the coverting take many steps.

test with:
python3 python/example/st20p_tx.py --tx_url v210_1080p.yuv --pipeline_fmt V210 --transport_fmt ST20_FMT_V210 --packing gpm
python3 python/example/st20p_rx.py --pipeline_fmt V210 --transport_fmt ST20_FMT_V210 --display