### PR TITLE
sch: add allow across numa core option

### DIFF
--- a/app/src/args.c
+++ b/app/src/args.c
@@ -128,6 +128,7 @@ enum st_args_cmd {
   ST_ARG_VIDEO_SHA_CHECK,
   ST_ARG_ARP_TIMEOUT_S,
   ST_ARG_RSS_SCH_NB,
+  ST_ARG_ALLOW_ACROSS_NUMA_CORE,
   ST_ARG_MAX,
 };
 
@@ -252,6 +253,7 @@ static struct option st_app_args_options[] = {
     {"video_sha_check", no_argument, 0, ST_ARG_VIDEO_SHA_CHECK},
     {"arp_timeout_s", required_argument, 0, ST_ARG_ARP_TIMEOUT_S},
     {"rss_sch_nb", required_argument, 0, ST_ARG_RSS_SCH_NB},
+    {"allow_across_numa_core", no_argument, 0, ST_ARG_ALLOW_ACROSS_NUMA_CORE},
 
     {0, 0, 0, 0}};
 
@@ -791,6 +793,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         for (enum mtl_port port = MTL_PORT_P; port < MTL_PORT_MAX; port++) {
           p->rss_sch_nb[port] = atoi(optarg);
         }
+        break;
+      case ST_ARG_ALLOW_ACROSS_NUMA_CORE:
+        p->flags |= MTL_FLAG_ALLOW_ACROSS_NUMA_CORE;
         break;
       case '?':
         break;

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -384,7 +384,11 @@ enum mtl_init_flag {
    * Do mtl_start in mtl_init, mtl_stop in mtl_uninit, and skip the mtl_start/mtl_stop
    */
   MTL_FLAG_DEV_AUTO_START_STOP = (MTL_BIT64(17)),
-
+  /**
+   * Enable the use of cores across NUMA nodes; by default, only cores within the same
+   * NUMA node as the NIC are used due to the high cost of cross-NUMA communication.
+   */
+  MTL_FLAG_ALLOW_ACROSS_NUMA_CORE = (MTL_BIT64(18)),
   /**
    * dedicate thread for cni message
    */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1382,6 +1382,14 @@ static inline bool mt_user_auto_start_stop(struct mtl_main_impl* impl) {
     return false;
 }
 
+/* if user enable the auto start/stop */
+static inline bool mt_user_across_numa_core(struct mtl_main_impl* impl) {
+  if (mt_get_user_params(impl)->flags & MTL_FLAG_ALLOW_ACROSS_NUMA_CORE)
+    return true;
+  else
+    return false;
+}
+
 /* if user disable the af xdp zc */
 static inline bool mt_user_af_xdp_zc(struct mtl_main_impl* impl) {
   if (mt_get_user_params(impl)->flags & MTL_FLAG_AF_XDP_ZC_DISABLE)

--- a/tests/src/tests.cpp
+++ b/tests/src/tests.cpp
@@ -46,6 +46,7 @@ enum test_args_cmd {
   TEST_ARG_MULTI_SRC_PORT,
   TEST_ARG_DHCP,
   TEST_ARG_MCAST_ONLY,
+  TEST_ARG_ALLOW_ACROSS_NUMA_CORE,
 };
 
 static struct option test_args_options[] = {
@@ -81,6 +82,7 @@ static struct option test_args_options[] = {
     {"multi_src_port", no_argument, 0, TEST_ARG_MULTI_SRC_PORT},
     {"dhcp", no_argument, 0, TEST_ARG_DHCP},
     {"mcast_only", no_argument, 0, TEST_ARG_MCAST_ONLY},
+    {"allow_across_numa_core", no_argument, 0, TEST_ARG_ALLOW_ACROSS_NUMA_CORE},
 
     {0, 0, 0, 0}};
 
@@ -266,6 +268,9 @@ static int test_parse_args(struct st_tests_context* ctx, struct mtl_init_params*
         break;
       case TEST_ARG_MCAST_ONLY:
         ctx->mcast_only = true;
+        break;
+      case TEST_ARG_ALLOW_ACROSS_NUMA_CORE:
+        p->flags |= MTL_FLAG_ALLOW_ACROSS_NUMA_CORE;
         break;
       default:
         break;


### PR DESCRIPTION
For case cores for the bind NUMA are all used, but please expect performance may drop as cross-numa ipi is expensive.

Test with:
./build/tests/KahawaiTest --p_port 0000:af:01.0 --r_port 0000:af:01.1 --gtest_filter=Sch.create_max --lcores 1,2,3,4,5 --allow_across_numa_core
