### PR TITLE
rx_timing_parser/audio: add callback notify support for application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * manager: add a daemon server for privileged control management, see manager/README.md.
 * backend/xdp: add UDP port filter XDP program for splitting data path traffic.
 * ice: update driver to 1.13.7
+* rx/timing_parser: add timing_parser for audio, see `ST30_RX_FLAG_TIMING_PARSER_STAT` and `ST30_RX_FLAG_TIMING_PARSER_META`
 
 ## Changelog for 23.12
 

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -299,6 +299,7 @@ struct st_app_rx_audio_session {
   int stat_frame_total_received;
   uint64_t stat_frame_first_rx_time;
   double expect_fps;
+  uint32_t stat_dump_cnt;
 
   bool enable_timing_parser_meta;
   uint32_t stat_compliant_result[ST_RX_TP_COMPLIANT_MAX];
@@ -543,6 +544,7 @@ struct st_app_context {
   int tx_audio_rtp_ring_size; /* the ring size for tx audio rtp type */
   bool tx_audio_build_pacing;
   int tx_audio_fifo_size;
+  int tx_audio_rl_accuracy_us;
   enum st30_tx_pacing_way tx_audio_pacing_way;
 
   struct st_app_tx_anc_session* tx_anc_sessions;

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -299,6 +299,10 @@ struct st_app_rx_audio_session {
   int stat_frame_total_received;
   uint64_t stat_frame_first_rx_time;
   double expect_fps;
+
+  bool enable_timing_parser_meta;
+  uint32_t stat_compliant_result[ST_RX_TP_COMPLIANT_MAX];
+  int32_t ipt_max;
 };
 
 struct st_app_rx_anc_session {
@@ -508,6 +512,7 @@ struct st_app_context {
   bool tx_copy_once;
   bool app_thread;
   bool enable_timing_parser;
+  bool enable_timing_parser_meta;
   bool tx_display;
   bool rx_display;
   uint16_t rx_burst_size;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -117,6 +117,7 @@ enum st_args_cmd {
   ST_ARG_MULTI_SRC_PORT,
   ST_ARG_AUDIO_BUILD_PACING,
   ST_ARG_AUDIO_TX_PACING,
+  ST_ARG_AUDIO_RL_ACCURACY_US,
   ST_ARG_AUDIO_FIFO_SIZE,
   ST_ARG_TX_NO_BURST_CHECK,
   ST_ARG_DHCP,
@@ -243,6 +244,7 @@ static struct option st_app_args_options[] = {
     {"multi_src_port", no_argument, 0, ST_ARG_MULTI_SRC_PORT},
     {"audio_build_pacing", no_argument, 0, ST_ARG_AUDIO_BUILD_PACING},
     {"audio_tx_pacing", required_argument, 0, ST_ARG_AUDIO_TX_PACING},
+    {"audio_rl_accuracy", required_argument, 0, ST_ARG_AUDIO_RL_ACCURACY_US},
     {"audio_fifo_size", required_argument, 0, ST_ARG_AUDIO_FIFO_SIZE},
     {"tx_no_burst_check", no_argument, 0, ST_ARG_TX_NO_BURST_CHECK},
     {"dhcp", no_argument, 0, ST_ARG_DHCP},
@@ -765,6 +767,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
           ctx->tx_audio_pacing_way = ST30_TX_PACING_WAY_TSC;
         else
           err("%s, unknow audio tx pacing %s\n", __func__, optarg);
+        break;
+      case ST_ARG_AUDIO_RL_ACCURACY_US:
+        ctx->tx_audio_rl_accuracy_us = atoi(optarg);
         break;
       case ST_ARG_AUDIO_FIFO_SIZE:
         ctx->tx_audio_fifo_size = atoi(optarg);

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -65,7 +65,8 @@ enum st_args_cmd {
   ST_ARG_TEST_TIME,
   ST_ARG_PTP_UNICAST_ADDR,
   ST_ARG_CNI_THREAD,
-  ST_ARG_RX_TIMING_PARSER,
+  ST_ARG_RX_TIMING_PARSER_STAT,
+  ST_ARG_RX_TIMING_PARSER_META,
   ST_ARG_RX_BURST_SZ,
   ST_ARG_USER_LCORES,
   ST_ARG_SCH_DATA_QUOTA,
@@ -193,7 +194,8 @@ static struct option st_app_args_options[] = {
     {"test_time", required_argument, 0, ST_ARG_TEST_TIME},
     {"ptp_unicast", no_argument, 0, ST_ARG_PTP_UNICAST_ADDR},
     {"cni_thread", no_argument, 0, ST_ARG_CNI_THREAD},
-    {"rx_timing_parser", no_argument, 0, ST_ARG_RX_TIMING_PARSER},
+    {"rx_timing_parser", no_argument, 0, ST_ARG_RX_TIMING_PARSER_STAT},
+    {"rx_timing_parser_meta", no_argument, 0, ST_ARG_RX_TIMING_PARSER_META},
     {"rx_burst_size", required_argument, 0, ST_ARG_RX_BURST_SZ},
     {"lcores", required_argument, 0, ST_ARG_USER_LCORES},
     {"sch_data_quota", required_argument, 0, ST_ARG_SCH_DATA_QUOTA},
@@ -579,8 +581,12 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
       case ST_ARG_TEST_TIME:
         ctx->test_time_s = atoi(optarg);
         break;
-      case ST_ARG_RX_TIMING_PARSER:
+      case ST_ARG_RX_TIMING_PARSER_STAT:
         ctx->enable_timing_parser = true;
+        p->flags |= MTL_FLAG_ENABLE_HW_TIMESTAMP;
+        break;
+      case ST_ARG_RX_TIMING_PARSER_META:
+        ctx->enable_timing_parser_meta = true;
         p->flags |= MTL_FLAG_ENABLE_HW_TIMESTAMP;
         break;
       case ST_ARG_RX_BURST_SZ:

--- a/app/src/rx_audio_app.c
+++ b/app/src/rx_audio_app.c
@@ -179,6 +179,23 @@ static int app_rx_audio_rtp_ready(void* priv) {
   return 0;
 }
 
+static int app_rx_audio_timing_parser_result(void* priv, enum mtl_session_port port,
+                                             struct st30_rx_tp_meta* tp) {
+  struct st_app_rx_audio_session* s = priv;
+
+  s->stat_compliant_result[tp->compliant]++;
+  s->ipt_max = ST_MAX(s->ipt_max, tp->ipt_max);
+  if (tp->compliant != ST_RX_TP_COMPLIANT_NARROW) {
+    warn("%s(%d,%d), failed cause %s, pkts_cnt %u\n", __func__, s->idx, port,
+         tp->failed_cause, tp->pkts_cnt);
+    warn("%s(%d,%d), tsdf %dus, ipt(ns) min %d max %d avg %f\n", __func__, s->idx, port,
+         tp->tsdf, tp->ipt_min, tp->ipt_max, tp->ipt_avg);
+    dbg("%s(%d,%d), dpvr(us) min %d max %d avg %f\n", __func__, s->idx, port,
+        tp->dpvr_min, tp->dpvr_max, tp->dpvr_avg);
+  }
+  return 0;
+}
+
 static int app_rx_audio_uinit(struct st_app_rx_audio_session* s) {
   int ret, idx = s->idx;
 
@@ -217,6 +234,18 @@ static int app_rx_audio_result(struct st_app_rx_audio_session* s) {
            ST_APP_EXPECT_NEAR(framerate, s->expect_fps, s->expect_fps * 0.05) ? "OK"
                                                                               : "FAILED",
            framerate, s->stat_frame_total_received);
+  return 0;
+}
+
+static int app_rx_audio_stat(struct st_app_rx_audio_session* s) {
+  if (s->enable_timing_parser_meta) {
+    warn("%s(%d), COMPLIANT NARROW %d WIDE %d FAILED %d, ipt max %fus\n", __func__,
+         s->idx, s->stat_compliant_result[ST_RX_TP_COMPLIANT_NARROW],
+         s->stat_compliant_result[ST_RX_TP_COMPLIANT_WIDE],
+         s->stat_compliant_result[ST_RX_TP_COMPLIANT_FAILED], (float)s->ipt_max / 1000);
+    memset(s->stat_compliant_result, 0, sizeof(s->stat_compliant_result));
+    s->ipt_max = 0;
+  }
   return 0;
 }
 
@@ -286,7 +315,12 @@ static int app_rx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   ops.framebuff_cnt = s->framebuff_cnt;
   ops.rtp_ring_size = ctx->rx_audio_rtp_ring_size ? ctx->rx_audio_rtp_ring_size : 16;
   if (audio && audio->enable_rtcp) ops.flags |= ST30_RX_FLAG_ENABLE_RTCP;
-  if (ctx->enable_timing_parser) ops.flags |= ST30_RX_FLAG_ENABLE_TIMING_PARSER;
+  if (ctx->enable_timing_parser) ops.flags |= ST30_RX_FLAG_TIMING_PARSER_STAT;
+  if (ctx->enable_timing_parser_meta) {
+    ops.notify_timing_parser_result = app_rx_audio_timing_parser_result;
+    ops.flags |= ST30_RX_FLAG_TIMING_PARSER_META;
+    s->enable_timing_parser_meta = true;
+  }
 
   st_pthread_mutex_init(&s->st30_wake_mutex, NULL);
   st_pthread_cond_init(&s->st30_wake_cond, NULL);
@@ -366,6 +400,19 @@ int st_app_rx_audio_sessions_result(struct st_app_context* ctx) {
   for (i = 0; i < ctx->rx_audio_session_cnt; i++) {
     s = &ctx->rx_audio_sessions[i];
     ret += app_rx_audio_result(s);
+  }
+
+  return ret;
+}
+
+int st_app_rx_audio_sessions_stat(struct st_app_context* ctx) {
+  int i, ret = 0;
+  struct st_app_rx_audio_session* s;
+
+  if (!ctx->rx_audio_sessions) return 0;
+  for (i = 0; i < ctx->rx_audio_session_cnt; i++) {
+    s = &ctx->rx_audio_sessions[i];
+    ret += app_rx_audio_stat(s);
   }
 
   return ret;

--- a/app/src/rx_audio_app.c
+++ b/app/src/rx_audio_app.c
@@ -238,13 +238,17 @@ static int app_rx_audio_result(struct st_app_rx_audio_session* s) {
 }
 
 static int app_rx_audio_stat(struct st_app_rx_audio_session* s) {
+  s->stat_dump_cnt++;
   if (s->enable_timing_parser_meta) {
-    warn("%s(%d), COMPLIANT NARROW %d WIDE %d FAILED %d, ipt max %fus\n", __func__,
-         s->idx, s->stat_compliant_result[ST_RX_TP_COMPLIANT_NARROW],
-         s->stat_compliant_result[ST_RX_TP_COMPLIANT_WIDE],
-         s->stat_compliant_result[ST_RX_TP_COMPLIANT_FAILED], (float)s->ipt_max / 1000);
-    memset(s->stat_compliant_result, 0, sizeof(s->stat_compliant_result));
-    s->ipt_max = 0;
+    if ((s->stat_dump_cnt % 6) == 0) {
+      /* report every 1 min */
+      warn("%s(%d), COMPLIANT NARROW %d WIDE %d FAILED %d, ipt max %fus\n", __func__,
+           s->idx, s->stat_compliant_result[ST_RX_TP_COMPLIANT_NARROW],
+           s->stat_compliant_result[ST_RX_TP_COMPLIANT_WIDE],
+           s->stat_compliant_result[ST_RX_TP_COMPLIANT_FAILED], (float)s->ipt_max / 1000);
+      memset(s->stat_compliant_result, 0, sizeof(s->stat_compliant_result));
+      s->ipt_max = 0;
+    }
   }
   return 0;
 }

--- a/app/src/rx_audio_app.h
+++ b/app/src/rx_audio_app.h
@@ -19,4 +19,6 @@ int st_app_rx_audio_sessions_uinit(struct st_app_context* ctx);
 
 int st_app_rx_audio_sessions_result(struct st_app_context* ctx);
 
+int st_app_rx_audio_sessions_stat(struct st_app_context* ctx);
+
 #endif

--- a/app/src/rxtx_app.c
+++ b/app/src/rxtx_app.c
@@ -86,6 +86,7 @@ static void app_stat(void* priv) {
   st_app_rx_st22p_sessions_stat(ctx);
   st_app_rx_st20p_sessions_stat(ctx);
   st_app_rx_st20r_sessions_stat(ctx);
+  st_app_rx_audio_sessions_stat(ctx);
 
   if (ctx->ptp_systime_sync) {
     app_dump_ptp_sync_stat(ctx);

--- a/app/src/tx_audio_app.c
+++ b/app/src/tx_audio_app.c
@@ -469,6 +469,7 @@ static int app_tx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
       ops.rtp_ring_size = 16;
   }
   if (audio && audio->enable_rtcp) ops.flags |= ST30_TX_FLAG_ENABLE_RTCP;
+  ops.rl_accuracy_ns = ctx->tx_audio_rl_accuracy_us * 1000;
 
   handle = st30_tx_create(ctx->st, &ops);
   if (!handle) {

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -389,6 +389,8 @@ struct st30_tx_ops {
    * tasklet routine.
    */
   int (*notify_rtp_done)(void* priv);
+  /** Optional for ST30_TX_PACING_WAY_RL, the required accuracy for warmup check point */
+  uint32_t rl_accuracy_ns;
 
   /**
    * size for each sample group,

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -74,9 +74,14 @@ typedef struct st_rx_audio_session_handle_impl* st30_rx_handle;
 #define ST30_RX_FLAG_ENABLE_RTCP (MTL_BIT32(1))
 /**
  * Flag bit in flags of struct st30_rx_ops.
- * Enable the timing analyze
+ * Enable the timing analyze in the stat dump
  */
-#define ST30_RX_FLAG_ENABLE_TIMING_PARSER (MTL_BIT32(16))
+#define ST30_RX_FLAG_TIMING_PARSER_STAT (MTL_BIT32(16))
+/**
+ * Flag bit in flags of struct st30_rx_ops.
+ * Enable the timing analyze info by st30_rx_tp_meta of notify_timing_parser_result
+ */
+#define ST30_RX_FLAG_TIMING_PARSER_META (MTL_BIT32(17))
 
 /** default time in the fifo between packet builder and pacing */
 #define ST30_TX_FIFO_DEFAULT_TIME_MS (10)
@@ -264,6 +269,38 @@ struct st30_rx_frame_meta {
 };
 
 /**
+ * st30 rx timing parser meta for every 200ms
+ *
+ * dpvr: Delta Packet vs RTP, us.
+ * ipt: Inter-packet time, ns
+ * tsdf: Timestamped Delay Factor, us.
+ */
+struct st30_rx_tp_meta {
+  /** the max of dpvr(us) for current report period */
+  int32_t dpvr_max;
+  /** the min of dpvr(us) for current report period */
+  int32_t dpvr_min;
+  /** the average of dpvr(us) for current report period */
+  float dpvr_avg;
+  /** the max of ipt(ns) for current report period */
+  int32_t ipt_max;
+  /** the min of ipt(ns) for current report period */
+  int32_t ipt_min;
+  /** the average of ipt(ns) for current report period */
+  float ipt_avg;
+  /** the tsdf(us) for current report period */
+  int32_t tsdf;
+
+  /** RX timing parser compliant result */
+  enum st_rx_tp_compliant compliant;
+  /** the failed cause if compliant is not ST_RX_TP_COMPLIANT_NARROW */
+  char failed_cause[64];
+
+  /* packets count in current report period */
+  uint32_t pkts_cnt;
+};
+
+/**
  * The structure describing how to create a tx st2110-30(audio) session.
  * Include the PCIE port and other required info
  */
@@ -440,6 +477,13 @@ struct st30_rx_ops {
    * routine.
    */
   int (*notify_rtp_ready)(void* priv);
+  /**
+   * Mandatory for ST30_RX_FLAG_TIMING_PARSER_META. The callback to notify the rx timing
+   * parser result for every 200ms . And only non-block method can be used in this
+   * callback as it run from lcore tasklet routine.
+   */
+  int (*notify_timing_parser_result)(void* priv, enum mtl_session_port port,
+                                     struct st30_rx_tp_meta* tp);
 
   /**
    * size for each sample group,

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -767,6 +767,7 @@ struct st_tx_audio_session_rl_port {
   uint32_t stat_warmup_pkts_burst;
   uint32_t stat_mismatch_sync_point;
   uint32_t stat_recalculate_warmup;
+  uint32_t stat_hit_backup_cp;
 };
 
 struct st_tx_audio_session_rl_info {

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -898,18 +898,12 @@ struct st_audio_transmitter_impl {
 
 /* tp for every 200ms */
 struct st_ra_tp_slot {
-  uint32_t pkt_cnt;
-  int32_t dpvr_min;
-  int32_t dpvr_max;
+  struct st30_rx_tp_meta meta;
+
   int32_t dpvr_first;
   int64_t dpvr_sum;
-  enum st_rx_tp_compliant compliant;
-
   /* Inter-packet time(ns), packet level check */
   int64_t ipt_sum;
-  int32_t ipt_max;
-  int32_t ipt_min;
-  float ipt_avg;
 };
 
 struct st_ra_tp_stat {
@@ -955,7 +949,11 @@ struct st_rx_audio_session_impl {
   struct st_rx_session_priv priv[MTL_SESSION_PORT_MAX];
   struct st_rx_audio_session_handle_impl* st30_handle;
   bool time_measure;
+
   bool enable_timing_parser;
+  bool enable_timing_parser_stat;
+  bool enable_timing_parser_meta;
+  struct st_rx_audio_tp* tp;
 
   enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
   struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
@@ -982,8 +980,6 @@ struct st_rx_audio_session_impl {
   struct st30_rx_frame_meta meta; /* only for frame type */
 
   struct mt_rtcp_rx* rtcp_rx[MTL_SESSION_PORT_MAX];
-
-  struct st_rx_audio_tp* tp;
 
   /* status */
   int st30_stat_pkts_dropped;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3044,12 +3044,12 @@ static int rv_attach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
 
   s->st22_expect_frame_size = 0;
   s->burst_loss_cnt = 0;
-  if (s->ops.flags & ST20_RX_FLAG_TIMING_PARSER_STAT) {
+  if (ops->flags & ST20_RX_FLAG_TIMING_PARSER_STAT) {
     info("%s(%d), enable the timing analyze stat\n", __func__, idx);
     s->enable_timing_parser = true;
     s->enable_timing_parser_stat = true;
   }
-  if (s->ops.flags & ST20_RX_FLAG_TIMING_PARSER_META) {
+  if (ops->flags & ST20_RX_FLAG_TIMING_PARSER_META) {
     info("%s(%d), enable the timing analyze meta\n", __func__, idx);
     s->enable_timing_parser = true;
     s->enable_timing_parser_meta = true;


### PR DESCRIPTION
test with:
./build/app/RxTxApp --config_file tests/script/audio_json/loop_125us_u32_96k.json --rx_timing_parser_meta --log_level warning --p_port 0000:af:00.0 --r_port 0000:af:00.1