### PR TITLE
rx_timing_parser/audio: fix redundant status report

### DIFF
--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -545,6 +545,7 @@ struct st_app_context {
   bool tx_audio_build_pacing;
   int tx_audio_fifo_size;
   int tx_audio_rl_accuracy_us;
+  int tx_audio_rl_offset_us;
   enum st30_tx_pacing_way tx_audio_pacing_way;
 
   struct st_app_tx_anc_session* tx_anc_sessions;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -118,6 +118,7 @@ enum st_args_cmd {
   ST_ARG_AUDIO_BUILD_PACING,
   ST_ARG_AUDIO_TX_PACING,
   ST_ARG_AUDIO_RL_ACCURACY_US,
+  ST_ARG_AUDIO_RL_OFFSET_US,
   ST_ARG_AUDIO_FIFO_SIZE,
   ST_ARG_TX_NO_BURST_CHECK,
   ST_ARG_DHCP,
@@ -245,6 +246,7 @@ static struct option st_app_args_options[] = {
     {"audio_build_pacing", no_argument, 0, ST_ARG_AUDIO_BUILD_PACING},
     {"audio_tx_pacing", required_argument, 0, ST_ARG_AUDIO_TX_PACING},
     {"audio_rl_accuracy", required_argument, 0, ST_ARG_AUDIO_RL_ACCURACY_US},
+    {"audio_rl_offset", required_argument, 0, ST_ARG_AUDIO_RL_OFFSET_US},
     {"audio_fifo_size", required_argument, 0, ST_ARG_AUDIO_FIFO_SIZE},
     {"tx_no_burst_check", no_argument, 0, ST_ARG_TX_NO_BURST_CHECK},
     {"dhcp", no_argument, 0, ST_ARG_DHCP},
@@ -770,6 +772,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_AUDIO_RL_ACCURACY_US:
         ctx->tx_audio_rl_accuracy_us = atoi(optarg);
+        break;
+      case ST_ARG_AUDIO_RL_OFFSET_US:
+        ctx->tx_audio_rl_offset_us = atoi(optarg);
         break;
       case ST_ARG_AUDIO_FIFO_SIZE:
         ctx->tx_audio_fifo_size = atoi(optarg);

--- a/app/src/rx_audio_app.c
+++ b/app/src/rx_audio_app.c
@@ -186,8 +186,8 @@ static int app_rx_audio_timing_parser_result(void* priv, enum mtl_session_port p
   s->stat_compliant_result[tp->compliant]++;
   s->ipt_max = ST_MAX(s->ipt_max, tp->ipt_max);
   if (tp->compliant != ST_RX_TP_COMPLIANT_NARROW) {
-    warn("%s(%d,%d), failed cause %s, pkts_cnt %u\n", __func__, s->idx, port,
-         tp->failed_cause, tp->pkts_cnt);
+    warn("%s(%d,%d), compliant %d, failed cause %s, pkts_cnt %u\n", __func__, s->idx,
+         port, tp->compliant, tp->failed_cause, tp->pkts_cnt);
     warn("%s(%d,%d), tsdf %dus, ipt(ns) min %d max %d avg %f\n", __func__, s->idx, port,
          tp->tsdf, tp->ipt_min, tp->ipt_max, tp->ipt_avg);
     dbg("%s(%d,%d), dpvr(us) min %d max %d avg %f\n", __func__, s->idx, port,

--- a/app/src/tx_audio_app.c
+++ b/app/src/tx_audio_app.c
@@ -470,6 +470,7 @@ static int app_tx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   }
   if (audio && audio->enable_rtcp) ops.flags |= ST30_TX_FLAG_ENABLE_RTCP;
   ops.rl_accuracy_ns = ctx->tx_audio_rl_accuracy_us * 1000;
+  ops.rl_offset_ns = ctx->tx_audio_rl_offset_us * 1000;
 
   handle = st30_tx_create(ctx->st, &ops);
   if (!handle) {

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -391,6 +391,8 @@ struct st30_tx_ops {
   int (*notify_rtp_done)(void* priv);
   /** Optional for ST30_TX_PACING_WAY_RL, the required accuracy for warmup check point */
   uint32_t rl_accuracy_ns;
+  /** Optional for ST30_TX_PACING_WAY_RL, the offset time(us) for warmup check point */
+  int32_t rl_offset_ns;
 
   /**
    * size for each sample group,

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -298,10 +298,10 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
       uint64_t now = mt_get_tsc(impl);
       if ((now - tp->last_parse_time) > (200 * NS_PER_MS)) {
         for (int sp = 0; sp < ops->num_port; sp++) {
-          struct st_ra_tp_slot* slot = &s->tp->slot[s_port];
+          struct st_ra_tp_slot* slot = &s->tp->slot[sp];
           ra_tp_slot_parse_result(s, sp);
           if (s->enable_timing_parser_meta) {
-            ops->notify_timing_parser_result(ops->priv, s_port, &slot->meta);
+            ops->notify_timing_parser_result(ops->priv, sp, &slot->meta);
           }
           ra_tp_slot_init(slot);
         }

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -2092,8 +2092,8 @@ static void tx_audio_session_stat(struct st_tx_audio_sessions_mgr* mgr,
       rl_port->stat_recalculate_warmup = 0;
     }
     if (rl_port->stat_hit_backup_cp) {
-      warn("TX_AUDIO_SESSION(%d,%d): hit backup warmup checkpoint %u\n", m_idx, idx,
-           rl_port->stat_hit_backup_cp);
+      notice("TX_AUDIO_SESSION(%d,%d): hit backup warmup checkpoint %u\n", m_idx, idx,
+             rl_port->stat_hit_backup_cp);
       rl_port->stat_hit_backup_cp = 0;
     }
   }

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -315,6 +315,8 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
   pacing->pacing_time_stamp = tx_audio_pacing_time_stamp(pacing, epochs);
   pacing->rtp_time_stamp = pacing->pacing_time_stamp;
   pacing->tsc_time_cursor = (double)mt_get_tsc(impl) + to_epoch;
+  dbg("%s(%d), epochs %" PRIu64 ", rtp_time_stamp %u\n", __func__, s->idx, epochs,
+      pacing->rtp_time_stamp);
 
   if (sync) {
     dbg("%s(%d), delay to epoch_time %f, cur %" PRIu64 "\n", __func__, s->idx,
@@ -1147,6 +1149,9 @@ static int tx_audio_session_init_rl(struct mtl_main_impl* impl,
   } else {
     rl->required_accuracy_ns = 40 * NS_PER_US; /* 40us */
   }
+  if (s->ops.rl_offset_ns) {
+    info("%s(%d), user required offset %dns\n", __func__, idx, s->ops.rl_offset_ns);
+  }
   rl->pkts_prepare_warmup = 4;
   rl->pads_per_st30_pkt = 3;
   rl->max_warmup_trs = 4; /* max 4 trs warmup sync */
@@ -1298,7 +1303,7 @@ static uint16_t tx_audio_session_rl_first_pkt(struct mtl_main_impl* impl,
                                               int s_port, struct rte_mbuf* pkt) {
   struct st_tx_audio_session_rl_info* rl = &s->rl;
   struct st_tx_audio_session_rl_port* rl_port = &rl->port_info[s_port];
-  uint64_t target_tsc = rl_port->trs_target_tsc;
+  uint64_t target_tsc = rl_port->trs_target_tsc + s->ops.rl_offset_ns;
   uint64_t cur_tsc;
 
   cur_tsc = mt_get_tsc(impl);


### PR DESCRIPTION
test with:
./build/app/RxTxApp --config_file tests/script/audio_json/loop_redundant_125us_u32_96k.json --rx_timing_parser_meta --log_level warning --p_port 0000:af:00.0 --r_port 0000:af:00.1