### PR TITLE
tools/ebpf: add udp_monitor to sniff all UDP streaming on the network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * backend/xdp: add UDP port filter XDP program for splitting data path traffic.
 * ice: update driver to 1.13.7
 * rx/timing_parser: add timing_parser for audio, see `ST30_RX_FLAG_TIMING_PARSER_STAT` and `ST30_RX_FLAG_TIMING_PARSER_META`
+* tools/ebpf: add lcore_monitor to monitor the lcore status for debug usage
+* tools/ebpf: add udp_monitor to sniff all UDP streaming on the network
 
 ## Changelog for 23.12
 

--- a/tools/ebpf/.gitignore
+++ b/tools/ebpf/.gitignore
@@ -4,3 +4,4 @@ et
 vmlinux.h
 *.o
 lcore_monitor
+udp_monitor

--- a/tools/ebpf/Makefile
+++ b/tools/ebpf/Makefile
@@ -2,11 +2,11 @@
 # Copyright 2023 Intel Corporation
 
 .PHONY: all
-all: et lcore_monitor
+all: et lcore_monitor udp_monitor
 
 .PHONY: clean
 clean:
-	rm -rf lcore_monitor et *.o *.skel.h vmlinux.h
+	rm -rf udp_monitor lcore_monitor et *.o *.skel.h vmlinux.h
 
 vmlinux.h:
 	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $@
@@ -27,5 +27,9 @@ et: et.c fentry.skel.h
 	gcc -Wall -o $@ $(filter %.c,$^) -lxdp -lbpf -lelf -lz
 
 # Build lcore_monitor user prog
-lcore_monitor: lcore_monitor.c lcore_monitor.skel.h
+lcore_monitor: lcore_monitor.c lcore_monitor.skel.h lcore_monitor.h
+	gcc -Wall -o $@ $(filter %.c,$^) -lbpf -lelf -lz
+
+# Build udp_monitor user prog
+udp_monitor: udp_monitor.c udp_monitor.skel.h udp_monitor.h
 	gcc -Wall -o $@ $(filter %.c,$^) -lbpf -lelf -lz

--- a/tools/ebpf/Makefile
+++ b/tools/ebpf/Makefile
@@ -24,12 +24,12 @@ vmlinux.h:
 SKEL_FILES := $(patsubst %.bpf.c,%.skel.h,$(wildcard *.bpf.c))
 
 et: et.c fentry.skel.h
-	gcc -Wall -o $@ $(filter %.c,$^) -lxdp -lbpf -lelf -lz
+	gcc -Wall -o $@ $(filter %.c,$^) -lxdp -l:libbpf.a -lelf -lz
 
 # Build lcore_monitor user prog
 lcore_monitor: lcore_monitor.c lcore_monitor.skel.h lcore_monitor.h
-	gcc -Wall -o $@ $(filter %.c,$^) -lbpf -lelf -lz
+	gcc -Wall -o $@ $(filter %.c,$^) -l:libbpf.a -lelf -lz
 
 # Build udp_monitor user prog
 udp_monitor: udp_monitor.c udp_monitor.skel.h udp_monitor.h
-	gcc -Wall -o $@ $(filter %.c,$^) -lbpf -lelf -lz
+	gcc -Wall -o $@ $(filter %.c,$^) -l:libbpf.a -lelf -lz

--- a/tools/ebpf/README.md
+++ b/tools/ebpf/README.md
@@ -18,7 +18,7 @@ make
 
 ### 3.1 lcore_monitor
 
-lcore_monitor: a tool to monitor the scheduler and interrupt event on one MTL lcore. The IMTL achieves high data packet throughput and low latency by defaulting to busy polling, also referred to as busy-waiting or spinning.
+lcore_monitor: a eBPF based tool to monitor the scheduler and interrupt event on one MTL lcore. The IMTL achieves high data packet throughput and low latency by defaulting to busy polling, also referred to as busy-waiting or spinning.
 To ensure peak performance, it is crucial to verify that no other tasks are running on the same logical core (lcore) that IMTL utilizes. For debugging purposes, the tool provides a status overview via an eBPF (extended Berkeley Packet Filter) trace point hook, which monitors the activities on a single core.
 
 ```bash
@@ -43,7 +43,28 @@ MT: MT: 2024-01-17 15:45:14, SCH(0:sch_0): tasklets 3, lcore 29(t_pid: 190637), 
 MT: MT: 2024-01-17 15:45:14, SCH(1:sch_1): tasklets 1, lcore 30(t_pid: 190638), avg loop 45 ns
 ```
 
-### 3.2 fentry
+### 3.2 udp_monitor
+
+udp_monitor: a eBPF based tool to monitor UDP streaming on the network, please note the promiscuous mode will be enabled on the selected interface.
+"promiscuous mode" means that a network interface card will pass all packets received up to the software for processing, versus the traditional mode of operation wherein only packets destined for the NIC's MAC address are passed to software. Generally, promiscuous mode is used to "sniff" all traffic on the wire.
+
+```bash
+sudo ./udp_monitor --interface enp175s0f0np0 --dump_period_s 5
+```
+
+The dump output is like below:
+
+```bash
+----- DUMP UDP STAT EVERY 5s -----
+192.168.17.101:19873 -> 239.168.17.101:20000, 2610.896736 Mb/s pkts 1233168
+192.168.17.102:19941 -> 239.168.17.102:20000, 2610.922137 Mb/s pkts 1233180
+192.168.17.101:30073 -> 239.168.17.101:30000, 1.967981 Mb/s pkts 5000
+192.168.17.102:29970 -> 239.168.17.102:30000, 1.967981 Mb/s pkts 5000
+192.168.17.102:40003 -> 239.168.17.102:40000, 0.102719 Mb/s pkts 300
+192.168.17.101:39925 -> 239.168.17.101:40000, 0.102719 Mb/s pkts 300
+```
+
+### 3.3 fentry
 
 fentry: a simple program to trace udp_send_skb calls, requires kernel > 5.5.
 

--- a/tools/ebpf/lcore_monitor.c
+++ b/tools/ebpf/lcore_monitor.c
@@ -211,7 +211,6 @@ int main(int argc, char** argv) {
   ret = lcore_monitor_bpf__attach(skel);
   if (ret) {
     err("%s, failed to attach skeleton\n", __func__);
-    lcore_monitor_bpf__destroy(skel);
     goto exit;
   }
   info("%s, attach skeleton succ\n", __func__);

--- a/tools/ebpf/udp_monitor.bpf.c
+++ b/tools/ebpf/udp_monitor.bpf.c
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+ * Copyright(c) 2024 Intel Corporation
+ */
+
+// clang-format off
+#include <stddef.h>
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/in.h>
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+// clang-format on
+
+#include "udp_monitor.h"
+
+struct {
+  __uint(type, BPF_MAP_TYPE_RINGBUF);
+  __uint(max_entries, 512 * 1024);
+} udp_hdr_rb SEC(".maps");
+
+SEC("socket")
+int bpf_socket_handler(struct __sk_buff* skb) {
+  struct udp_pkt_entry* e;
+  __u8 verlen;
+  __u16 proto;
+  __u8 ip_proto;
+  __u32 nhoff = ETH_HLEN;
+
+  bpf_skb_load_bytes(skb, 12, &proto, 2);
+  proto = __bpf_ntohs(proto);
+  if (proto != ETH_P_IP) { /* not ipv4 */
+    return 0;
+  }
+  bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, protocol), &ip_proto, 1);
+  if (ip_proto != IPPROTO_UDP) { /* not udp */
+    return 0;
+  }
+
+  e = bpf_ringbuf_reserve(&udp_hdr_rb, sizeof(*e), 0);
+  if (!e) return 0;
+
+  /* fill src_ip and dst_ip */
+  bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, saddr), &(e->src_ip), 4);
+  bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, daddr), &(e->dst_ip), 4);
+
+  bpf_ringbuf_submit(e, 0);
+
+  return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/tools/ebpf/udp_monitor.bpf.c
+++ b/tools/ebpf/udp_monitor.bpf.c
@@ -41,9 +41,13 @@ int bpf_socket_handler(struct __sk_buff* skb) {
   e = bpf_ringbuf_reserve(&udp_hdr_rb, sizeof(*e), 0);
   if (!e) return 0;
 
-  /* fill src_ip and dst_ip */
-  bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, saddr), &(e->src_ip), 4);
-  bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, daddr), &(e->dst_ip), 4);
+  /* fill src and dst ip */
+  bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, saddr), &(e->tuple.src_ip), 4);
+  bpf_skb_load_bytes(skb, nhoff + offsetof(struct iphdr, daddr), &(e->tuple.dst_ip), 4);
+  /* fill src and dst port */
+  bpf_skb_load_bytes(skb, nhoff + 0, &verlen, 1);
+  bpf_skb_load_bytes(skb, nhoff + ((verlen & 0xF) << 2), &(e->tuple.ports), 4);
+  e->len = skb->len;
 
   bpf_ringbuf_submit(e, 0);
 

--- a/tools/ebpf/udp_monitor.c
+++ b/tools/ebpf/udp_monitor.c
@@ -1,0 +1,236 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Intel Corporation
+ */
+
+// clang-format off
+#include <linux/if_ether.h>
+#include "udp_monitor.h"
+// clang-format on
+
+#include <arpa/inet.h>
+#include <getopt.h>
+#include <linux/if_packet.h>
+#include <net/if.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "log.h"
+#include "udp_monitor.skel.h"
+
+struct udp_monitor_ctx {
+  const char* interface;
+};
+
+enum um_args_cmd {
+  UM_ARG_UNKNOWN = 0,
+  UM_ARG_INTERFACE = 0x100, /* start from end of ascii */
+  UM_ARG_HELP,
+};
+
+static struct option um_args_options[] = {
+    {"interface", required_argument, 0, UM_ARG_INTERFACE},
+    {"help", no_argument, 0, UM_ARG_HELP},
+    {0, 0, 0, 0}};
+
+static void um_print_help() {
+  printf("\n");
+  printf("##### Usage: #####\n\n");
+
+  printf(" Params:\n");
+  printf("  --interface <if>    Set the network interface\n");
+  printf("  --help              Print help info\n");
+
+  printf("\n");
+}
+
+static int um_parse_args(struct udp_monitor_ctx* ctx, int argc, char** argv) {
+  int cmd = -1, opt_idx = 0;
+
+  while (1) {
+    cmd = getopt_long_only(argc, argv, "hv", um_args_options, &opt_idx);
+    if (cmd == -1) break;
+
+    switch (cmd) {
+      case UM_ARG_INTERFACE:
+        ctx->interface = optarg;
+        break;
+      case UM_ARG_HELP:
+      default:
+        um_print_help();
+        return -1;
+    }
+  }
+
+  return 0;
+}
+
+static int udp_hdr_entry_handler(void* pri, void* data, size_t data_sz) {
+  struct udp_monitor_ctx* ctx = pri;
+  const struct udp_pkt_entry* e = data;
+
+  uint8_t* dip = (uint8_t*)&e->dst_ip;
+  uint8_t* sip = (uint8_t*)&e->src_ip;
+
+  info("%s, %u.%u.%u.%u -> %u.%u.%u.%u\n", __func__, sip[0], sip[1], sip[2], sip[3],
+       dip[0], dip[1], dip[2], dip[3]);
+
+  return 0;
+}
+
+static int open_raw_sock(const char* if_name) {
+  struct sockaddr_ll sll;
+  int fd;
+  int ret;
+
+  fd = socket(PF_PACKET, SOCK_RAW | SOCK_NONBLOCK | SOCK_CLOEXEC, htons(ETH_P_ALL));
+  if (fd < 0) {
+    err("%s, failed to create raw socket\n", __func__);
+    return -1;
+  }
+
+  memset(&sll, 0, sizeof(sll));
+  sll.sll_family = AF_PACKET;
+  sll.sll_ifindex = if_nametoindex(if_name);
+  sll.sll_protocol = htons(ETH_P_ALL);
+  ret = bind(fd, (struct sockaddr*)&sll, sizeof(sll));
+  if (ret < 0) {
+    err("%s, failed to bind to %s: %d, %s\n", __func__, if_name, ret, strerror(errno));
+    close(fd);
+    return ret;
+  }
+
+  return fd;
+}
+
+static int enable_promisc(int sock, const char* if_name, int enable) {
+  struct ifreq ifr;
+  int ret;
+
+  memset(&ifr, 0, sizeof(ifr));
+  strncpy(ifr.ifr_name, if_name, sizeof(ifr.ifr_name) - 1);
+
+  ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
+  if (ret < 0) {
+    err("%s, failed to SIOCGIFFLAGS for %s\n", __func__, if_name);
+    return ret;
+  }
+
+  if (enable)
+    ifr.ifr_flags |= IFF_PROMISC;
+  else
+    ifr.ifr_flags &= ~IFF_PROMISC;
+
+  ret = ioctl(sock, SIOCSIFFLAGS, &ifr);
+  if (ret < 0) {
+    err("%s, failed to SIOCSIFFLAGS for %s\n", __func__, if_name);
+    return ret;
+  }
+
+  return 0;
+}
+
+static bool g_um_stop = false;
+
+static void um_sig_handler(int signo) {
+  info("%s, signal %d\n", __func__, signo);
+
+  switch (signo) {
+    case SIGINT: /* Interrupt from keyboard */
+      g_um_stop = true;
+      break;
+  }
+
+  return;
+}
+
+int main(int argc, char** argv) {
+  struct udp_monitor_ctx ctx;
+  int ret;
+  int sock_raw_fd = -1;
+  int sock_fd = -1;
+  struct udp_monitor_bpf* skel = NULL;
+  struct ring_buffer* rb = NULL;
+  int prog_fd = -1;
+
+  memset(&ctx, 0, sizeof(ctx));
+  ret = um_parse_args(&ctx, argc, argv);
+  if (ret < 0) return ret;
+  if (!ctx.interface) {
+    err("%s, no interface assigned\n", __func__);
+    um_print_help();
+    return -1;
+  }
+
+  /* Create raw socket */
+  sock_raw_fd = open_raw_sock(ctx.interface);
+  if (sock_raw_fd < 0) {
+    err("%s, failed to open raw sock %d\n", __func__, sock_raw_fd);
+    goto exit;
+  }
+  sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock_fd < 0) {
+    err("%s, failed to open sock_fd for promisc %d\n", __func__, sock_fd);
+    goto exit;
+  }
+
+  skel = udp_monitor_bpf__open_and_load();
+  if (!skel) {
+    err("%s, failed to open and load skeleton\n", __func__);
+    goto exit;
+  }
+  int udp_hdr_rb_fd = bpf_map__fd(skel->maps.udp_hdr_rb);
+  rb = ring_buffer__new(udp_hdr_rb_fd, udp_hdr_entry_handler, &ctx, NULL);
+  if (!rb) {
+    err("%s, create ring buffer fail\n", __func__);
+    goto exit;
+  }
+  ret = udp_monitor_bpf__attach(skel);
+  if (ret) {
+    err("%s, failed to attach skeleton\n", __func__);
+    goto exit;
+  }
+  info("%s, attach socket skeleton succ\n", __func__);
+
+  /* Attach BPF program to raw socket */
+  prog_fd = bpf_program__fd(skel->progs.bpf_socket_handler);
+  ret = setsockopt(sock_raw_fd, SOL_SOCKET, SO_ATTACH_BPF, &prog_fd, sizeof(prog_fd));
+  if (ret < 0) {
+    err("%s, failed attach to raw socket %d\n", __func__, ret);
+    goto exit;
+  }
+  info("%s, attach bpf skeleton to %s succ, sock_raw_fd %d\n", __func__, ctx.interface,
+       sock_raw_fd);
+  ret = enable_promisc(sock_fd, ctx.interface, 1);
+  if (ret < 0) {
+    err("%s, failed to enable promisc %d\n", __func__, ret);
+    goto exit;
+  }
+  info("%s, enable promisc for %s succ, sock_fd %d\n", __func__, ctx.interface, sock_fd);
+
+  signal(SIGINT, um_sig_handler);
+
+  info("%s, start to poll udp pkts for %s\n", __func__, ctx.interface);
+  while (!g_um_stop) {
+    ret = ring_buffer__poll(rb, 100);
+    if (ret == -EINTR) {
+      ret = 0;
+      break;
+    }
+    if (ret < 0) {
+      err("%s, polling fail\n", __func__);
+      break;
+    }
+  }
+
+  info("%s, stop now\n", __func__);
+  enable_promisc(sock_fd, ctx.interface, 0);
+
+exit:
+  if (rb) ring_buffer__free(rb);
+  if (skel) udp_monitor_bpf__destroy(skel);
+  if (sock_fd >= 0) close(sock_fd);
+  if (sock_raw_fd >= 0) close(sock_raw_fd);
+  return 0;
+}

--- a/tools/ebpf/udp_monitor.h
+++ b/tools/ebpf/udp_monitor.h
@@ -5,9 +5,21 @@
 #ifndef __UDP_MONITOR_HEAD_H
 #define __UDP_MONITOR_HEAD_H
 
-struct udp_pkt_entry {
+struct udp_pkt_tuple {
   __be32 src_ip;
   __be32 dst_ip;
+  union {
+    __be32 ports;
+    struct {
+      __be16 src_port;
+      __be16 dst_port;
+    };
+  };
+};
+
+struct udp_pkt_entry {
+  struct udp_pkt_tuple tuple;
+  __u32 len;
 };
 
 #endif

--- a/tools/ebpf/udp_monitor.h
+++ b/tools/ebpf/udp_monitor.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2024 Intel Corporation
+ */
+
+#ifndef __UDP_MONITOR_HEAD_H
+#define __UDP_MONITOR_HEAD_H
+
+struct udp_pkt_entry {
+  __be32 src_ip;
+  __be32 dst_ip;
+};
+
+#endif


### PR DESCRIPTION
promiscuous mode is enabled to detect all UDP on the network.

----- DUMP UDP STAT EVERY 2s -----
192.168.17.102:20076 -> 239.168.17.102:20000, 2611.027318 Mb/s pkts 493288
192.168.17.101:19955 -> 239.168.17.101:20000, 2610.995542 Mb/s pkts 493282
192.168.17.101:29892 -> 239.168.17.101:30000, 1.967996 Mb/s pkts 2000
192.168.17.102:29941 -> 239.168.17.102:30000, 1.967996 Mb/s pkts 2000
192.168.17.102:40070 -> 239.168.17.102:40000, 0.102720 Mb/s pkts 120
192.168.17.101:40054 -> 239.168.17.101:40000, 0.102720 Mb/s pkts 120
