### PR TITLE
usdt: add log_msg support

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -548,3 +548,9 @@ static void log_user_printer(enum mtl_log_level level, const char* format, ...) 
   va_end(args);
 }
 ```
+
+And in a production system, the `enum mtl_log_level` is set to the `MTL_LOG_LEVEL_ERR` usually, in this cast USDT probes can be used to fetching the logging, detail see [usdt](usdt.md) doc, `#### 2.1.1 log_msg USDT` part.
+
+### 7.2 USDT
+
+IMTL offer eBPF based User Statically-Defined Tracing (USDT) support to monitor status or issues tracking in a production system, detail see [usdt](usdt.md) doc.

--- a/doc/usdt.md
+++ b/doc/usdt.md
@@ -49,50 +49,77 @@ tplist-bpfcc -l /usr/local/lib/x86_64-linux-gnu/libmtl.so -v
 
 ## 2. Tracing
 
-### 2.1 PTP tracing
+All USDT probes is defined in [mt_usdt_provider.d](../lib/src/mt_usdt_provider.d)
 
-#### 2.1.1 ptp_msg USDT
+### 2.1 sys tracing
+
+#### 2.1.1 log_msg USDT
+
+Provider: sys, probe name: log_msg, parm1: level, parm2: char* msg
+
+The `log_msg` USDT is strategically positioned within the `MT_LOG` macro, enabling it to trace all log messages within IMTL. It operates independently from the IMTL Logging system, offering a means to monitor the system's status in production, where typically, the `enum mtl_log_level` is configured to `MTL_LOG_LEVEL_ERR`.
+
+usage:
+```bash
+# customize the application process name as your setup
+sudo BPFTRACE_STRLEN=128 bpftrace -e 'usdt::sys:log_msg { printf("%s l%d: %s\n", strftime("%H:%M:%S", nsecs), arg0, str(arg1)); }' -p $(pidof RxTxApp)
+```
+
+Example output like below:
+```bash
+10:58:51 l2: * *    M T    D E V   S T A T E   * *
+10:58:51 l2: DEV(0): Avr rate, tx: 2610.318120 Mb/s, rx: 0.009552 Mb/s, pkts, tx: 2465803, rx: 127
+10:58:51 l2: DEV(1): Avr rate, tx: 0.000000 Mb/s, rx: 2602.483541 Mb/s, pkts, tx: 0, rx: 2465819
+10:58:51 l2: SCH(0:sch_0): tasklets 3, lcore 29(t_pid: 171515), avg loop 106 ns
+10:58:51 l2: SCH(1:sch_1): tasklets 1, lcore 30(t_pid: 171516), avg loop 46 ns
+10:58:51 l2: CNI(0): eth_rx_rate 0.009552 Mb/s, eth_rx_cnt 127
+10:58:51 l2: CNI(1): eth_rx_rate 0.000552 Mb/s, eth_rx_cnt 2
+10:58:51 l2: PTP(0): time 1711077212656358421, 2024-03-22 11:12:55
+10:58:51 l2: PTP(0): delta avg 24799, min 24190, max 25343, cnt 40
+10:58:51 l2: PTP(0): correct_delta avg 304, min -236, max 904, cnt 40
+10:58:51 l2: PTP(0): path_delay avg 3011, min 2576, max 3586, cnt 40
+10:58:51 l2: PTP(0): mode l4, sync cnt 40, expect avg 49607:243@0.250441s t2_t1_delta -21844 t4_t3_delta 27763
+10:58:51 l2: PTP(0): t2_t1_delta_calibrate 1 t4_t3_delta_calibrate 1
+10:58:51 l2: TX_VIDEO_SESSION(0,0:app_tx_video_0): fps 59.899444, frame 599 pkts 2467464:2466867 inflight 148002:148112
+10:58:51 l2: TX_VIDEO_SESSION(0,0): throughput 2611.461089 Mb/s: 0.000000 Mb/s, cpu busy 0.687289
+10:58:51 l2: RX_VIDEO_SESSION(1,0:app_rx_video_0): fps 59.899436 frames 599 pkts 2466858
+10:58:51 l2: RX_VIDEO_SESSION(1,0:app_rx_video_0): throughput 2611.475818 Mb/s, cpu busy 0.393960
+10:58:51 l2: RX_VIDEO_SESSION(1,0): succ burst max 21, avg 1.036176
+10:58:51 l2: * *    E N D    S T A T E   * *
+```
+
+### 2.2 PTP tracing
+
+#### 2.2.1 ptp_msg USDT
 
 Provider: ptp, probe name: ptp_msg, parm1: port, parm2: stage, parm3: value
 
 usage:
 ```bash
 # customize the application process name as your setup
-sudo bpftrace -e 'usdt::ptp:ptp_msg { printf("p%u,t%u:%llu\n", arg0, arg1, arg2); }' -p $(pidof RxTxApp)
+sudo bpftrace -e 'usdt::ptp:ptp_msg { printf("%s p%u,t%u:%llu\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof RxTxApp)
 ```
 
 Example output like below:
 ```bash
-p0,t2:1711003484946427306
-p0,t1:1711003484946449452
-p0,t3:1711003484953729512
-p0,t4:1711003484953757844
+11:00:37 p0,t2:1711077318712839835
+11:00:37 p0,t1:1711077318712861878
+11:00:37 p0,t3:1711077318719139980
+11:00:37 p0,t4:1711077318719167902
 ```
 
-Or by trace-bpfcc:
-```bash
-#customize the so path and application process name as your setup
-sudo trace-bpfcc 'u:/usr/local/lib/x86_64-linux-gnu/libmtl.so:ptp_msg "p%u,t%u:%llu", arg1,arg2,arg3' -T -p $(pidof RxTxApp)
-```
-
-#### 2.1.2 ptp_result USDT
+#### 2.2.2 ptp_result USDT
 
 Provider: ptp, Name: ptp_result, parm1: port, parm2: raw delta, parm3: correct delta of PI.
 
 usage:
 ```bash
 # customize the application process name as your setup
-sudo bpftrace -e 'usdt::ptp:ptp_result { printf("p%d,delta:%d,correct_delta:%d\n", arg0, arg1, arg2); }' -p $(pidof RxTxApp)
+sudo bpftrace -e 'usdt::ptp:ptp_result { printf("%s p%d,delta:%d,correct_delta:%d\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof RxTxApp)
 ```
 
 Example output like below:
 ```bash
-p0,delta:25122,correct_delta:67
-p0,delta:25216,correct_delta:353
-```
-
-Or by trace-bpfcc:
-```bash
-# customize the so path and application process name as your setup
-sudo trace-bpfcc 'u:/usr/local/lib/x86_64-linux-gnu/libmtl.so:ptp_result "p%u,delta:%d,correct_delta:%d", arg1,arg2,arg3' -T -p $(pidof RxTxApp)
+11:00:45 p0,delta:24622,correct_delta:470
+11:00:45 p0,delta:25426,correct_delta:633
 ```

--- a/doc/usdt.md
+++ b/doc/usdt.md
@@ -23,9 +23,11 @@ rm build
 ./build.sh
 ```
 
-Check the build log and below build message indicate the USDT support is enabled successfully.
+Check the build log and below build messages indicate the USDT support is enabled successfully.
 ```bash
-Message: sys/sdt.h found, build with USDT support
+Program dtrace found: YES (/usr/bin/dtrace)
+Has header "sys/sdt.h" : YES
+Message: usdt tools check ok, build with USDT support
 ```
 
 Then please find all USDT probes available in IMTL by the `bpftrace` tool, the `bpftrace` installation please follow <https://github.com/bpftrace/bpftrace/blob/master/INSTALL.md>.
@@ -41,9 +43,8 @@ usdt:/usr/local/lib/x86_64-linux-gnu/libmtl.so:ptp:ptp_msg
 usdt:/usr/local/lib/x86_64-linux-gnu/libmtl.so:ptp:ptp_result
 ```
 
-Or by trace-bpfcc:
+Or by trace-bpfcc: customize the so path as your setup
 ```bash
-# customize the so path as your setup
 tplist-bpfcc -l /usr/local/lib/x86_64-linux-gnu/libmtl.so -v
 ```
 
@@ -59,10 +60,9 @@ Provider: sys, probe name: log_msg, parm1: level, parm2: char* msg
 
 The `log_msg` USDT is strategically positioned within the `MT_LOG` macro, enabling it to trace all log messages within IMTL. It operates independently from the IMTL Logging system, offering a means to monitor the system's status in production, where typically, the `enum mtl_log_level` is configured to `MTL_LOG_LEVEL_ERR`.
 
-usage:
+usage: customize the application process name as your setup
 ```bash
-# customize the application process name as your setup
-sudo BPFTRACE_STRLEN=128 bpftrace -e 'usdt::sys:log_msg { printf("%s l%d: %s\n", strftime("%H:%M:%S", nsecs), arg0, str(arg1)); }' -p $(pidof RxTxApp)
+sudo BPFTRACE_STRLEN=128 bpftrace -e 'usdt::sys:log_msg { printf("%s l%d: %s", strftime("%H:%M:%S", nsecs), arg0, str(arg1)); }' -p $(pidof RxTxApp)
 ```
 
 Example output like below:
@@ -94,9 +94,8 @@ Example output like below:
 
 Provider: ptp, probe name: ptp_msg, parm1: port, parm2: stage, parm3: value
 
-usage:
+usage: customize the application process name as your setup
 ```bash
-# customize the application process name as your setup
 sudo bpftrace -e 'usdt::ptp:ptp_msg { printf("%s p%u,t%u:%llu\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof RxTxApp)
 ```
 
@@ -112,9 +111,8 @@ Example output like below:
 
 Provider: ptp, Name: ptp_result, parm1: port, parm2: raw delta, parm3: correct delta of PI.
 
-usage:
+usage: customize the application process name as your setup
 ```bash
-# customize the application process name as your setup
 sudo bpftrace -e 'usdt::ptp:ptp_result { printf("%s p%d,delta:%d,correct_delta:%d\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof RxTxApp)
 ```
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -49,6 +49,7 @@ else
   message('sys/sdt.h or dtrace not found, no USDT support')
 endif
 
+usdt_provider_header = []
 if mtl_has_usdt
   message('usdt tools check ok, build with USDT support')
   add_global_arguments('-DMTL_HAS_USDT', language : 'c')
@@ -67,6 +68,10 @@ if mtl_has_usdt
     depends: usdt_provider_header,
   )
 endif
+
+usdt_provider_header_dep = declare_dependency(
+  sources : usdt_provider_header,
+)
 
 # add source file
 subdir('src')
@@ -140,6 +145,7 @@ mtl_lib += shared_library(meson.project_name(), sources,
   link_args : mtl_link_c_args,
   # asan should be always the first dep
   dependencies: [asan_dep, dpdk_dep, libm_dep, libnuma_dep, libpthread_dep, libdl_dep,
-                 jsonc_dep, ws2_32_dep, libxdp_dep, libbpf_dep, libibvers_dep, librdmacm_dep],
+                 jsonc_dep, ws2_32_dep, libxdp_dep, libbpf_dep, libibvers_dep, librdmacm_dep,
+                 usdt_provider_header_dep,],
   install: true
 )

--- a/lib/src/mt_log.c
+++ b/lib/src/mt_log.c
@@ -43,6 +43,20 @@ int mtl_set_log_printer(mtl_log_printer_t f) {
 
 mtl_log_printer_t mt_get_log_printer(void) { return g_mt_log_printer; }
 
+static void log_usdt_printer(enum mtl_log_level level, const char* format, ...) {
+  char msg[256];
+  va_list args;
+  MTL_MAY_UNUSED(level);
+
+  va_start(args, format);
+  vsnprintf(msg, sizeof(msg), format, args);
+  va_end(args);
+
+  MT_USDT_SYS_LOG_MSG(level, msg);
+}
+
+mtl_log_printer_t mt_get_usdt_log_printer(void) { return log_usdt_printer; }
+
 static enum mtl_log_level g_mt_log_level = MTL_LOG_LEVEL_INFO;
 
 int mt_set_log_global_level(enum mtl_log_level level) {

--- a/lib/src/mt_log.h
+++ b/lib/src/mt_log.h
@@ -7,6 +7,7 @@
 
 #include <rte_log.h>
 
+#include "mt_usdt.h"
 #include "mtl_api.h"
 
 /* log define */
@@ -17,6 +18,8 @@ enum mtl_log_level mt_get_log_global_level(void);
 
 mtl_log_prefix_formatter_t mt_get_log_prefix_formatter(void);
 mtl_log_printer_t mt_get_log_printer(void);
+
+mtl_log_printer_t mt_get_usdt_log_printer(void);
 
 #define MT_LOG(l, t, format, ...)                                              \
   do {                                                                         \
@@ -29,6 +32,10 @@ mtl_log_printer_t mt_get_log_printer(void);
         printer(MTL_LOG_LEVEL_##l, "MTL: %s" format, __prefix, ##__VA_ARGS__); \
       else                                                                     \
         RTE_LOG(l, t, "%s" format, __prefix, ##__VA_ARGS__);                   \
+    }                                                                          \
+    if (MT_USDT_SYS_LOG_MSG_ENABLED()) {                                       \
+      mtl_log_printer_t usdt_printer = mt_get_usdt_log_printer();              \
+      usdt_printer(MTL_LOG_LEVEL_##l, format, ##__VA_ARGS__);                  \
     }                                                                          \
   } while (0)
 

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -404,7 +404,11 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
     err("%s, mt_dev_eal_init fail %d\n", __func__, ret);
     return NULL;
   }
-  info("MTL version: %s, dpdk version: %s\n", mtl_version(), rte_version());
+  notice("%s, MTL version: %s, dpdk version: %s\n", __func__, mtl_version(),
+         rte_version());
+#ifdef MTL_HAS_USDT
+  notice("%s, MTL_HAS_USDT is defined for this build\n", __func__);
+#endif
 
   for (int i = 0; i < num_ports; i++) {
     pmd = p->pmd[i];

--- a/lib/src/mt_ptp.c
+++ b/lib/src/mt_ptp.c
@@ -11,7 +11,6 @@
 #include "mt_mcast.h"
 #include "mt_sch.h"
 #include "mt_stat.h"
-#include "mt_usdt.h"
 #include "mt_util.h"
 
 #define MT_PTP_USE_TX_TIME_STAMP (1)
@@ -759,7 +758,7 @@ static int ptp_parse_result(struct mt_ptp_impl* ptp) {
   }
 
   ptp_adjust_delta(ptp, delta, false);
-  MT_PTP_RESULT_PROBE(ptp->port, delta, correct_delta);
+  MT_USDT_PTP_RESULT(ptp->port, delta, correct_delta);
   ptp_t_result_clear(ptp);
   ptp->connected = true;
 
@@ -933,7 +932,7 @@ static void ptp_delay_req_task(struct mt_ptp_impl* ptp) {
 #endif
     dbg("%s(%d), t3 %" PRIu64 ", seq %d, max_retry %d, ptp %" PRIu64 "\n", __func__, port,
         ptp->t3, ptp->t3_sequence_id, max_retry, ptp_get_raw_time(ptp));
-    MT_PTP_MSG_PROBE(ptp->port, 3, ptp->t3);
+    MT_USDT_PTP_MSG(ptp->port, 3, ptp->t3);
 
     /* all time get */
     if (ptp->t4 && ptp->t2 && ptp->t1) {
@@ -997,7 +996,7 @@ static int ptp_parse_sync(struct mt_ptp_impl* ptp, struct mt_ptp_sync_msg* msg, 
   ptp->t2_mode = mode;
   dbg("%s(%d), t2 %" PRIu64 ", seq %d, ptp %" PRIu64 "\n", __func__, ptp->port, ptp->t2,
       ptp->t2_sequence_id, ptp_get_raw_time(ptp));
-  MT_PTP_MSG_PROBE(ptp->port, 2, ptp->t2);
+  MT_USDT_PTP_MSG(ptp->port, 2, ptp->t2);
 
   return 0;
 }
@@ -1014,7 +1013,7 @@ static int ptp_parse_follow_up(struct mt_ptp_impl* ptp,
   ptp->t1_domain_number = msg->hdr.domain_number;
   dbg("%s(%d), t1 %" PRIu64 ", ptp %" PRIu64 "\n", __func__, ptp->port, ptp->t1,
       ptp_get_raw_time(ptp));
-  MT_PTP_MSG_PROBE(ptp->port, 1, ptp->t1);
+  MT_USDT_PTP_MSG(ptp->port, 1, ptp->t1);
 
 #if MT_PTP_USE_TX_TIMER
   rte_eal_alarm_set(MT_PTP_DELAY_REQ_US + (ptp->port * MT_PTP_DELAY_STEP_US),
@@ -1089,7 +1088,7 @@ static int ptp_parse_delay_resp(struct mt_ptp_impl* ptp,
             (be64toh(msg->hdr.correction_field) >> 16);
   dbg("%s(%d), t4 %" PRIu64 ", seq %d, ptp %" PRIu64 "\n", __func__, ptp->port, ptp->t4,
       ptp->t3_sequence_id, ptp_get_raw_time(ptp));
-  MT_PTP_MSG_PROBE(ptp->port, 4, ptp->t4);
+  MT_USDT_PTP_MSG(ptp->port, 4, ptp->t4);
 
   /* all time get */
   if (ptp->t3 && ptp->t2 && ptp->t1) {

--- a/lib/src/mt_usdt.h
+++ b/lib/src/mt_usdt.h
@@ -31,11 +31,17 @@
   do {                                                         \
   } while (0)
 
+#define SYS_LOG_MSG_ENABLED() (0)
+
 #endif
 
-#define MT_PTP_MSG_PROBE(port, stage, value) \
+#define MT_USDT_PTP_MSG(port, stage, value) \
   MT_DTRACE_PROBE3(ptp, ptp_msg, port, stage, value)
-#define MT_PTP_RESULT_PROBE(port, delta, correct) \
+#define MT_USDT_PTP_RESULT(port, delta, correct) \
   MT_DTRACE_PROBE3(ptp, ptp_result, port, delta, correct)
+
+#define MT_USDT_SYS_LOG_MSG(level, msg) MT_DTRACE_PROBE2(sys, log_msg, level, msg)
+
+#define MT_USDT_SYS_LOG_MSG_ENABLED() SYS_LOG_MSG_ENABLED()
 
 #endif

--- a/lib/src/mt_usdt_provider.d
+++ b/lib/src/mt_usdt_provider.d
@@ -4,6 +4,10 @@
  * The USDT provider and probe define.
  */
 
+provider sys {
+  probe log_msg(int level, char* msg);
+}
+
 provider ptp {
   probe ptp_msg(int port, int stage, uint64_t value);
   probe ptp_result(int port, int64_t delta, int64_t correct);


### PR DESCRIPTION
It can be used to track the system in a production system where the log level is set to error only.