### PR TITLE
rx/audio: add dump support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ assets/
 mtl_system_status_*
 *.pyc
 *.mp4
+*.pcm
+*.wav

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -290,6 +290,13 @@ struct st_app_rx_audio_session {
   uint8_t* st30_ref_cursor;
   int st30_ref_err;
 
+  int st30_dump_time_s;
+  int st30_dump_fd;
+  char st30_dump_url[ST_APP_URL_MAX_LEN];
+  uint8_t* st30_dump_begin;
+  uint8_t* st30_dump_end;
+  uint8_t* st30_dump_cursor;
+
   pthread_t st30_app_thread;
   pthread_cond_t st30_wake_cond;
   pthread_mutex_t st30_wake_mutex;
@@ -570,6 +577,7 @@ struct st_app_context {
   int rx_video_fb_cnt;
   int rx_video_rtp_ring_size; /* the ring size for rx video rtp type */
   bool has_sdl;               /* has SDL device or not*/
+  int rx_audio_dump_time_s;   /* the audio dump time */
 
   struct st_app_rx_audio_session* rx_audio_sessions;
   int rx_audio_session_cnt;

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -45,6 +45,7 @@ enum st_args_cmd {
   ST_ARG_RX_VIDEO_RTP_RING_SIZE,
   ST_ARG_RX_AUDIO_SESSIONS_CNT,
   ST_ARG_RX_AUDIO_RTP_RING_SIZE,
+  ST_ARG_RX_AUDIO_DUMP_TIME_S,
   ST_ARG_RX_ANC_SESSIONS_CNT,
   ST22_ARG_RX_SESSIONS_CNT,
   ST_ARG_HDR_SPLIT,
@@ -177,6 +178,7 @@ static struct option st_app_args_options[] = {
     {"rx_video_rtp_ring_size", required_argument, 0, ST_ARG_RX_VIDEO_RTP_RING_SIZE},
     {"rx_audio_sessions_count", required_argument, 0, ST_ARG_RX_AUDIO_SESSIONS_CNT},
     {"rx_audio_rtp_ring_size", required_argument, 0, ST_ARG_RX_AUDIO_RTP_RING_SIZE},
+    {"rx_audio_dump_time_s", required_argument, 0, ST_ARG_RX_AUDIO_DUMP_TIME_S},
     {"rx_anc_sessions_count", required_argument, 0, ST_ARG_RX_ANC_SESSIONS_CNT},
     {"rx_st22_sessions_count", required_argument, 0, ST22_ARG_RX_SESSIONS_CNT},
     {"hdr_split", no_argument, 0, ST_ARG_HDR_SPLIT},
@@ -498,6 +500,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_RX_AUDIO_RTP_RING_SIZE:
         ctx->rx_audio_rtp_ring_size = atoi(optarg);
+        break;
+      case ST_ARG_RX_AUDIO_DUMP_TIME_S:
+        ctx->rx_audio_dump_time_s = atoi(optarg);
         break;
       case ST_ARG_RX_ANC_SESSIONS_CNT:
         ctx->rx_anc_session_cnt = atoi(optarg);

--- a/app/src/rx_video_app.c
+++ b/app/src/rx_video_app.c
@@ -568,7 +568,7 @@ static int app_rx_video_init(struct st_app_context* ctx, st_json_video_session_t
   st_pthread_mutex_init(&s->st20_wake_mutex, NULL);
   st_pthread_cond_init(&s->st20_wake_cond, NULL);
 
-  if (mtl_pmd_by_port_name(ops.port[MTL_SESSION_PORT_P]) == MTL_PMD_DPDK_AF_XDP) {
+  if (mtl_pmd_by_port_name(ops.port[MTL_SESSION_PORT_P]) != MTL_PMD_DPDK_USER) {
     snprintf(s->st20_dst_url, ST_APP_URL_MAX_LEN, "st_app%d_%d_%d_%s.yuv", idx, ops.width,
              ops.height, ops.port[MTL_SESSION_PORT_P]);
   } else {

--- a/app/src/rxtx_app.c
+++ b/app/src/rxtx_app.c
@@ -171,7 +171,7 @@ static void st_app_ctx_init(struct st_app_context* ctx) {
   /* tx */
   snprintf(ctx->tx_video_url, sizeof(ctx->tx_video_url), "%s", "test.yuv");
   ctx->tx_video_session_cnt = 0;
-  snprintf(ctx->tx_audio_url, sizeof(ctx->tx_audio_url), "%s", "test.wav");
+  snprintf(ctx->tx_audio_url, sizeof(ctx->tx_audio_url), "%s", "test.pcm");
   ctx->tx_audio_session_cnt = 0;
   snprintf(ctx->tx_anc_url, sizeof(ctx->tx_anc_url), "%s", "test.txt");
   ctx->tx_anc_session_cnt = 0;

--- a/app/src/tx_audio_app.c
+++ b/app/src/tx_audio_app.c
@@ -332,7 +332,7 @@ static int app_tx_audio_start_source(struct st_app_tx_audio_session* s) {
 }
 
 static void app_tx_audio_stop_source(struct st_app_tx_audio_session* s) {
-  if (s->st30_source_fd >= 0) {
+  if (s->st30_source_fd >= 0 || s->st30_pcap) {
     s->st30_app_thread_stop = true;
     /* wake up the thread */
     st_pthread_mutex_lock(&s->st30_wake_mutex);
@@ -388,6 +388,9 @@ static int app_tx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   s->st30_source_fd = -1;
   st_pthread_mutex_init(&s->st30_wake_mutex, NULL);
   st_pthread_cond_init(&s->st30_wake_cond, NULL);
+
+  snprintf(s->st30_source_url, sizeof(s->st30_source_url), "%s",
+           audio ? audio->info.audio_url : ctx->tx_audio_url);
 
   snprintf(name, 32, "app_tx_audio%d", idx);
   ops.name = name;
@@ -480,8 +483,6 @@ static int app_tx_audio_init(struct st_app_context* ctx, st_json_audio_session_t
   }
 
   s->handle = handle;
-  snprintf(s->st30_source_url, sizeof(s->st30_source_url), "%s",
-           audio ? audio->info.audio_url : ctx->tx_audio_url);
 
   ret = app_tx_audio_open_source(s);
   if (ret < 0) {

--- a/config/test_rx_1port_1v_1a_1anc.json
+++ b/config/test_rx_1port_1v_1a_1anc.json
@@ -37,7 +37,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/config/test_rx_2port_1v_1a.json
+++ b/config/test_rx_2port_1v_1a.json
@@ -42,7 +42,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/config/test_rx_2port_1v_1a_1anc.json
+++ b/config/test_rx_2port_1v_1a_1anc.json
@@ -47,7 +47,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/config/test_tx_1port_1v_1a_1anc.json
+++ b/config/test_tx_1port_1v_1a_1anc.json
@@ -37,7 +37,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/config/test_tx_2port_1v_1a.json
+++ b/config/test_tx_2port_1v_1a.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/config/test_tx_2port_1v_1a_1anc.json
+++ b/config/test_tx_2port_1v_1a_1anc.json
@@ -44,7 +44,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/config/test_tx_2port_1v_1a_1anc_50fps.json
+++ b/config/test_tx_2port_1v_1a_1anc_50fps.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/config/test_tx_2port_1v_1a_1anc_rtp.json
+++ b/config/test_tx_2port_1v_1a_1anc_rtp.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/doc/configuration_guide.md
+++ b/doc/configuration_guide.md
@@ -43,7 +43,7 @@ Example `tx_multicast.json` file, find more example config file in [example conf
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/doc/run.md
+++ b/doc/run.md
@@ -404,6 +404,8 @@ packet egresses from the sender.
 --ptp_sync_sys                       : debug option, enabling the synchronization of PTP time from MTL to the system time in the application. On Linux, need to set capability for the app before running, `sudo setcap 'cap_sys_time+ep' ./build/app/RxTxApp`.
 --rss_sch_nb <number>                : debug option, set the schedulers(lcores) number for the RSS dispatch.
 --log_time_ms                        : debug option, enable a ms accuracy log printer by the api mtl_set_log_prefix_formatter.
+--rx_video_file_frames <count>       : debug option, dump the received video frames to one yuv file
+--rx_audio_dump_time_s <seconds>     : debug option, dump the received audio frames to one pcm file
 ```
 
 ## 6. Tests

--- a/tests/script/README.md
+++ b/tests/script/README.md
@@ -6,7 +6,7 @@
 * test_720p.yuv for 720p video
 * test_4k.yuv for 4k video
 * test_8k.yuv for 4k video
-* test.wav for audio
+* test.pcm for audio
 * test.txt for ancillary
 * test.pcap for rtp pcap models
 * test_st22.pcap for st22 pcap files

--- a/tests/script/audio_json/loop.json
+++ b/tests/script/audio_json/loop.json
@@ -27,7 +27,7 @@
                     "audio_channel": ["U02"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }
@@ -50,7 +50,7 @@
                     "audio_channel": ["U02"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/audio_json/loop_125us_u32_96k.json
+++ b/tests/script/audio_json/loop_125us_u32_96k.json
@@ -48,7 +48,7 @@
                     "audio_channel": ["U32"],
                     "audio_sampling": "96kHz",
                     "audio_ptime": "0.125",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }
@@ -71,7 +71,7 @@
                     "audio_channel": ["U32"],
                     "audio_sampling": "96kHz",
                     "audio_ptime": "0.125",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/audio_json/loop_redundant_125us_u32_96k.json
+++ b/tests/script/audio_json/loop_redundant_125us_u32_96k.json
@@ -50,7 +50,7 @@
                     "audio_channel": ["U32"],
                     "audio_sampling": "96kHz",
                     "audio_ptime": "0.125",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }
@@ -75,7 +75,7 @@
                     "audio_channel": ["U32"],
                     "audio_sampling": "96kHz",
                     "audio_ptime": "0.125",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/audio_json/rx_shared_queue_750v.json
+++ b/tests/script/audio_json/rx_shared_queue_750v.json
@@ -28,7 +28,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/audio_json/tx_shared_queue_750v.json
+++ b/tests/script/audio_json/tx_shared_queue_750v.json
@@ -28,7 +28,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/dhcp_loop_json/unicast_1v_1a_1anc.json
+++ b/tests/script/dhcp_loop_json/unicast_1v_1a_1anc.json
@@ -40,7 +40,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -87,7 +87,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/dpdk_af_packet_json/multicast_1v_1a_1anc.json
+++ b/tests/script/dpdk_af_packet_json/multicast_1v_1a_1anc.json
@@ -39,7 +39,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -86,7 +86,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/dpdk_af_xdp_json/multicast_1v_1a_1anc.json
+++ b/tests/script/dpdk_af_xdp_json/multicast_1v_1a_1anc.json
@@ -39,7 +39,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -86,7 +86,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/dpdk_af_xdp_json/multicast_redundant_1v_1a_1anc.json
+++ b/tests/script/dpdk_af_xdp_json/multicast_redundant_1v_1a_1anc.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -90,7 +90,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/dpdk_af_xdp_json/rtp_multicast_1v_1a_1anc.json
+++ b/tests/script/dpdk_af_xdp_json/rtp_multicast_1v_1a_1anc.json
@@ -39,7 +39,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -86,7 +86,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/dpdk_af_xdp_json/rtp_redundant_1v_1a_1anc.json
+++ b/tests/script/dpdk_af_xdp_json/rtp_redundant_1v_1a_1anc.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -90,7 +90,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/loop.json
+++ b/tests/script/kernel_socket_json/loop.json
@@ -36,7 +36,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -84,7 +84,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/loop_4k.json
+++ b/tests/script/kernel_socket_json/loop_4k.json
@@ -36,7 +36,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -84,7 +84,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/mix.json
+++ b/tests/script/kernel_socket_json/mix.json
@@ -40,7 +40,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -88,7 +88,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/rtp_loop.json
+++ b/tests/script/kernel_socket_json/rtp_loop.json
@@ -36,7 +36,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -84,7 +84,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/rx.json
+++ b/tests/script/kernel_socket_json/rx.json
@@ -36,7 +36,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/rx_mcast.json
+++ b/tests/script/kernel_socket_json/rx_mcast.json
@@ -36,7 +36,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/tx.json
+++ b/tests/script/kernel_socket_json/tx.json
@@ -36,7 +36,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/kernel_socket_json/tx_mcast.json
+++ b/tests/script/kernel_socket_json/tx_mcast.json
@@ -36,7 +36,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/audio_128v.json
+++ b/tests/script/loop_json/audio_128v.json
@@ -27,7 +27,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }
@@ -50,7 +50,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/loop_json/audio_shared_queue_400v.json
+++ b/tests/script/loop_json/audio_shared_queue_400v.json
@@ -35,7 +35,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }
@@ -58,7 +58,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/loop_json/multicast_1v_1a_1anc.json
+++ b/tests/script/loop_json/multicast_1v_1a_1anc.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -88,7 +88,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/multicast_redundant_1v_1a_1anc.json
+++ b/tests/script/loop_json/multicast_redundant_1v_1a_1anc.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/multicast_source_1v_1a_1anc.json
+++ b/tests/script/loop_json/multicast_source_1v_1a_1anc.json
@@ -43,7 +43,7 @@
                     ],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -95,7 +95,7 @@
                     ],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/multicast_source_redundant_1v_1a_1anc.json
+++ b/tests/script/loop_json/multicast_source_redundant_1v_1a_1anc.json
@@ -45,7 +45,7 @@
                     ],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -100,7 +100,7 @@
                     ],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/rtp_1v_1a_1anc.json
+++ b/tests/script/loop_json/rtp_1v_1a_1anc.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -88,7 +88,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/rtp_4v_4a_4anc.json
+++ b/tests/script/loop_json/rtp_4v_4a_4anc.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -88,7 +88,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/rtp_redundant_1v_1a_1anc.json
+++ b/tests/script/loop_json/rtp_redundant_1v_1a_1anc.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/rtp_redundant_4v_4a_4anc.json
+++ b/tests/script/loop_json/rtp_redundant_4v_4a_4anc.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/st20r_1v_1a_1anc.json
+++ b/tests/script/loop_json/st20r_1v_1a_1anc.json
@@ -42,7 +42,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/st20r_4v_4a_4anc.json
+++ b/tests/script/loop_json/st20r_4v_4a_4anc.json
@@ -42,7 +42,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_1a_1anc.json
+++ b/tests/script/loop_json/unicast_1a_1anc.json
@@ -27,7 +27,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -61,7 +61,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_1v_1a_1anc.json
+++ b/tests/script/loop_json/unicast_1v_1a_1anc.json
@@ -40,7 +40,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -87,7 +87,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_1v_1a_1anc_rif.json
+++ b/tests/script/loop_json/unicast_1v_1a_1anc_rif.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -88,7 +88,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_4a.json
+++ b/tests/script/loop_json/unicast_4a.json
@@ -27,7 +27,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
                 {
                     "replicas": 1,
@@ -38,7 +38,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "0.12",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
                 {
                     "replicas": 1,
@@ -49,7 +49,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "44.1kHz",
                     "audio_ptime": "0.09",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
                 {
                     "replicas": 1,
@@ -60,7 +60,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "4",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
             ],
         }
@@ -83,7 +83,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
                 {
                     "replicas": 1,
@@ -94,7 +94,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "0.12",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
                 {
                     "replicas": 1,
@@ -105,7 +105,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "44.1kHz",
                     "audio_ptime": "0.09",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
                 {
                     "replicas": 1,
@@ -116,7 +116,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "4",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 },
             ],
         }

--- a/tests/script/loop_json/unicast_4v_4a_4anc.json
+++ b/tests/script/loop_json/unicast_4v_4a_4anc.json
@@ -40,7 +40,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -87,7 +87,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_redundant_1v_1a_1anc.json
+++ b/tests/script/loop_json/unicast_redundant_1v_1a_1anc.json
@@ -42,7 +42,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -91,7 +91,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_redundant_1v_1a_1anc_rif.json
+++ b/tests/script/loop_json/unicast_redundant_1v_1a_1anc_rif.json
@@ -42,7 +42,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -91,7 +91,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_redundant_4v_4a_4anc.json
+++ b/tests/script/loop_json/unicast_redundant_4v_4a_4anc.json
@@ -42,7 +42,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -91,7 +91,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/loop_json/unicast_shared_queue.json
+++ b/tests/script/loop_json/unicast_shared_queue.json
@@ -47,7 +47,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -94,7 +94,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/multi_port_json/multicast_1v_1a_1anc_4port.json
+++ b/tests/script/multi_port_json/multicast_1v_1a_1anc_4port.json
@@ -49,7 +49,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -95,7 +95,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -142,7 +142,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -183,7 +183,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/multi_port_json/multicast_2v_2a_2anc_4port.json
+++ b/tests/script/multi_port_json/multicast_2v_2a_2anc_4port.json
@@ -49,7 +49,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -95,7 +95,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -142,7 +142,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -183,7 +183,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/multi_port_json/unicast_2v_2a_2anc_4port.json
+++ b/tests/script/multi_port_json/unicast_2v_2a_2anc_4port.json
@@ -49,7 +49,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -95,7 +95,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -142,7 +142,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -183,7 +183,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/multi_port_json/unicast_2v_2a_2anc_4port_redundant.json
+++ b/tests/script/multi_port_json/unicast_2v_2a_2anc_4port_redundant.json
@@ -51,7 +51,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -99,7 +99,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -148,7 +148,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -191,7 +191,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/native_af_xdp_json/loop.json
+++ b/tests/script/native_af_xdp_json/loop.json
@@ -39,7 +39,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -87,7 +87,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/native_af_xdp_json/loop_rtp.json
+++ b/tests/script/native_af_xdp_json/loop_rtp.json
@@ -39,7 +39,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -87,7 +87,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/native_af_xdp_json/loop_shared.json
+++ b/tests/script/native_af_xdp_json/loop_shared.json
@@ -45,7 +45,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/native_af_xdp_json/mcast.json
+++ b/tests/script/native_af_xdp_json/mcast.json
@@ -39,7 +39,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -87,7 +87,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/native_af_xdp_json/redundant.json
+++ b/tests/script/native_af_xdp_json/redundant.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -90,7 +90,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/native_af_xdp_json/redundant_rtp.json
+++ b/tests/script/native_af_xdp_json/redundant_rtp.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -90,7 +90,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/native_af_xdp_json/rss.json
+++ b/tests/script/native_af_xdp_json/rss.json
@@ -40,7 +40,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -87,7 +87,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/rss_json/audio_multi.json
+++ b/tests/script/rss_json/audio_multi.json
@@ -31,7 +31,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }
@@ -54,7 +54,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ]
         }

--- a/tests/script/rss_json/unicast_1v_1a_1anc.json
+++ b/tests/script/rss_json/unicast_1v_1a_1anc.json
@@ -41,7 +41,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -88,7 +88,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/rss_json/unicast_redundant_1v_1a_1anc.json
+++ b/tests/script/rss_json/unicast_redundant_1v_1a_1anc.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [

--- a/tests/script/rss_json/unicast_redundant_4v_4a_4anc.json
+++ b/tests/script/rss_json/unicast_redundant_4v_4a_4anc.json
@@ -43,7 +43,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [
@@ -92,7 +92,7 @@
                     "audio_channel": ["ST"],
                     "audio_sampling": "48kHz",
                     "audio_ptime": "1",
-                    "audio_url": "./test.wav"
+                    "audio_url": "./test.pcm"
                 }
             ],
             "ancillary": [


### PR DESCRIPTION
also fix pcap tx, test with:
./build/app/RxTxApp --config_file tests/script/audio_json/pcap_replay.json --rx_audio_dump_time_s 10

then convert the dumped pcm to wav 
ffmpeg -f s24be -ar 48000 -ac 2 -i st_audio_app0_48000_24_2.pcm output.wav