### PR TITLE
rdma/ud: reduce l2/l3/l4 headers in data path

### DIFF
--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -2208,6 +2208,9 @@ int mt_dev_if_init(struct mtl_main_impl* impl) {
       inf->feature |= MT_IF_FEATURE_TX_OFFLOAD_IPV4_CKSUM;
 #endif
 
+    /* Disable checksum calculation for RDMA UD backend */
+    if (mt_pmd_is_rdma_ud(impl, i)) inf->feature |= MT_IF_FEATURE_TX_OFFLOAD_IPV4_CKSUM;
+
 #if RTE_VERSION >= RTE_VERSION_NUM(23, 3, 0, 0)
     /* Detect LaunchTime capability */
     if (dev_info->tx_offload_capa & RTE_ETH_TX_OFFLOAD_SEND_ON_TIMESTAMP &&

--- a/lib/src/dev/mt_rdma.c
+++ b/lib/src/dev/mt_rdma.c
@@ -308,7 +308,7 @@ static uint16_t rdma_tx(struct mtl_main_impl* impl, struct mt_rdma_tx_queue* txq
 
     txq->outstanding_wr++;
 
-    tx_bytes += m->pkt_len;
+    tx_bytes += m->pkt_len - sizeof(struct mt_udp_hdr);
     tx++;
   }
 
@@ -359,7 +359,7 @@ static uint16_t rdma_rx(struct mt_rx_rdma_entry* entry, struct rte_mbuf** rx_pkt
     rte_pktmbuf_pkt_len(pkt) = len;
     rte_pktmbuf_data_len(pkt) = len;
     rx_pkts[i] = pkt;
-    rx_bytes += len;
+    rx_bytes += len - sizeof(struct mt_udp_hdr);
   }
 
   /* post recv */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -87,6 +87,14 @@
 #define MT_TIMEOUT_INFINITE (INT_MAX)
 #define MT_TIMEOUT_ZERO (0)
 
+#define MT_SAFE_FREE(obj, free_fn) \
+  do {                             \
+    if (obj) {                     \
+      free_fn(obj);                \
+      obj = NULL;                  \
+    }                              \
+  } while (0)
+
 struct mtl_main_impl; /* forward declare */
 
 /* dynamic fields are implemented after rte_mbuf */


### PR DESCRIPTION
These headers are redundant in RDMA UD datapath.