### PR TITLE
mcast: add MTL_FLAG_NO_MULTICAST option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * tools/ebpf: add lcore_monitor to monitor the lcore status for debug usage
 * tools/ebpf: add udp_monitor to sniff all UDP streaming on the network
 * usdt: add eBPF based User Statically-Defined Tracing (USDT) probes support, see doc/usdt.md
+* multicast: add MTL_FLAG_NO_MULTICAST option
 
 ## Changelog for 23.12
 

--- a/app/src/args.c
+++ b/app/src/args.c
@@ -133,6 +133,7 @@ enum st_args_cmd {
   ST_ARG_ARP_TIMEOUT_S,
   ST_ARG_RSS_SCH_NB,
   ST_ARG_ALLOW_ACROSS_NUMA_CORE,
+  ST_ARG_NO_MULTICAST,
   ST_ARG_MAX,
 };
 
@@ -262,6 +263,7 @@ static struct option st_app_args_options[] = {
     {"arp_timeout_s", required_argument, 0, ST_ARG_ARP_TIMEOUT_S},
     {"rss_sch_nb", required_argument, 0, ST_ARG_RSS_SCH_NB},
     {"allow_across_numa_core", no_argument, 0, ST_ARG_ALLOW_ACROSS_NUMA_CORE},
+    {"no_multicast", no_argument, 0, ST_ARG_NO_MULTICAST},
 
     {0, 0, 0, 0}};
 
@@ -824,6 +826,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_ALLOW_ACROSS_NUMA_CORE:
         p->flags |= MTL_FLAG_ALLOW_ACROSS_NUMA_CORE;
+        break;
+      case ST_ARG_NO_MULTICAST:
+        p->flags |= MTL_FLAG_NO_MULTICAST;
         break;
       case '?':
         break;

--- a/doc/run.md
+++ b/doc/run.md
@@ -368,6 +368,8 @@ If it failed to run the sample, please help to collect the system setup status b
 --log_level <level>                  : set log level. e.g. debug, info, notice, warning, error.
 --log_file <file path>               : set log file for mtl log. If you're initiating multiple RxTxApp processes simultaneously, please ensure each process has a unique filename path. Default the log is writing to stderr.
 --arp_timeout_s <sec>                : set the arp timeout in seconds if using unicast address. Default timeout value is 60 seconds.
+--allow_across_numa_core             : allow the usage of cores across NUMA nodes
+--no_multicast                       : disable the multicast join message, usually for the SDN switch case.
 
 --rx_timing_parser                   : debug option, enable timing check for video rx streams.
 --pcapng_dump <n>                    : debug option, dump n packets from rx video streams to pcapng files.

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -391,6 +391,10 @@ enum mtl_init_flag {
    * NUMA node as the NIC are used due to the high cost of cross-NUMA communication.
    */
   MTL_FLAG_ALLOW_ACROSS_NUMA_CORE = (MTL_BIT64(18)),
+  /** not send multicast join message, for the SDN switch case which deliver the stream
+   * directly
+   */
+  MTL_FLAG_NO_MULTICAST = (MTL_BIT64(19)),
   /**
    * dedicate thread for cni message
    */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1438,6 +1438,14 @@ static inline bool mt_user_across_numa_core(struct mtl_main_impl* impl) {
     return false;
 }
 
+/* if user enable the MTL_FLAG_NO_MULTICAST */
+static inline bool mt_user_no_multicast(struct mtl_main_impl* impl) {
+  if (mt_get_user_params(impl)->flags & MTL_FLAG_NO_MULTICAST)
+    return true;
+  else
+    return false;
+}
+
 /* if user disable the af xdp zc */
 static inline bool mt_user_af_xdp_zc(struct mtl_main_impl* impl) {
   if (mt_get_user_params(impl)->flags & MTL_FLAG_AF_XDP_ZC_DISABLE)

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -566,6 +566,7 @@ struct st_rx_video_session_impl {
   enum mtl_port port_maps[MTL_SESSION_PORT_MAX];
   struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
   uint16_t st20_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  bool mcast_joined[MTL_SESSION_PORT_MAX];
 
   struct st_rx_video_session_handle_impl* st20_handle;
   struct st22_rx_video_session_handle_impl* st22_handle;
@@ -967,6 +968,7 @@ struct st_rx_audio_session_impl {
   struct mt_rxq_entry* rxq[MTL_SESSION_PORT_MAX];
 
   uint16_t st30_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  bool mcast_joined[MTL_SESSION_PORT_MAX];
 
   struct st_frame_trans* st30_frames;
   int st30_frames_cnt; /* numbers of frames requested */
@@ -1137,6 +1139,7 @@ struct st_rx_ancillary_session_impl {
   struct rte_ring* packet_ring;
 
   uint16_t st40_dst_port[MTL_SESSION_PORT_MAX]; /* udp port */
+  bool mcast_joined[MTL_SESSION_PORT_MAX];
 
   int latest_seq_id; /* latest seq id */
 

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -298,9 +298,8 @@ static int rx_ancillary_session_uinit_mcast(struct mtl_main_impl* impl,
   enum mtl_port port;
 
   for (int i = 0; i < ops->num_port; i++) {
-    if (!mt_is_multicast_ip(ops->ip_addr[i])) continue;
+    if (!s->mcast_joined[i]) continue;
     port = mt_port_logic2phy(s->port_maps, i);
-    if (mt_drv_mcast_in_dp(impl, port)) continue;
     mt_mcast_leave(impl, mt_ip_to_u32(ops->ip_addr[i]),
                    mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
   }
@@ -325,6 +324,7 @@ static int rx_ancillary_session_init_mcast(struct mtl_main_impl* impl,
     ret = mt_mcast_join(impl, mt_ip_to_u32(ops->ip_addr[i]),
                         mt_ip_to_u32(ops->mcast_sip_addr[i]), port);
     if (ret < 0) return ret;
+    s->mcast_joined[i] = true;
   }
 
   return 0;
@@ -366,6 +366,14 @@ static int rx_ancillary_session_uinit_sw(struct st_rx_ancillary_session_impl* s)
   return 0;
 }
 
+static int rx_ancillary_session_uinit(struct mtl_main_impl* impl,
+                                      struct st_rx_ancillary_session_impl* s) {
+  rx_ancillary_session_uinit_mcast(impl, s);
+  rx_ancillary_session_uinit_sw(s);
+  rx_ancillary_session_uinit_hw(s);
+  return 0;
+}
+
 static int rx_ancillary_session_attach(struct mtl_main_impl* impl,
                                        struct st_rx_ancillary_sessions_mgr* mgr,
                                        struct st_rx_ancillary_session_impl* s,
@@ -399,21 +407,21 @@ static int rx_ancillary_session_attach(struct mtl_main_impl* impl,
   ret = rx_ancillary_session_init_hw(impl, s);
   if (ret < 0) {
     err("%s(%d), rx_audio_session_init_hw fail %d\n", __func__, idx, ret);
-    return -EIO;
+    rx_ancillary_session_uinit(impl, s);
+    return ret;
   }
 
   ret = rx_ancillary_session_init_sw(impl, mgr, s);
   if (ret < 0) {
     err("%s(%d), rx_ancillary_session_init_rtps fail %d\n", __func__, idx, ret);
-    rx_ancillary_session_uinit_hw(s);
-    return -EIO;
+    rx_ancillary_session_uinit(impl, s);
+    return ret;
   }
 
   ret = rx_ancillary_session_init_mcast(impl, s);
   if (ret < 0) {
     err("%s(%d), rx_ancillary_session_init_mcast fail %d\n", __func__, idx, ret);
-    rx_ancillary_session_uinit_sw(s);
-    rx_ancillary_session_uinit_hw(s);
+    rx_ancillary_session_uinit(impl, s);
     return -EIO;
   }
 
@@ -486,9 +494,7 @@ static int rx_ancillary_session_detach(struct mtl_main_impl* impl,
                                        struct st_rx_ancillary_session_impl* s) {
   s->attached = false;
   rx_ancillary_session_stat(s);
-  rx_ancillary_session_uinit_mcast(impl, s);
-  rx_ancillary_session_uinit_sw(s);
-  rx_ancillary_session_uinit_hw(s);
+  rx_ancillary_session_uinit(impl, s);
   return 0;
 }
 

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -1388,6 +1388,12 @@ static int tx_ancillary_session_init_sw(struct mtl_main_impl* impl,
   return 0;
 }
 
+static int tx_ancillary_session_uinit(struct st_tx_ancillary_sessions_mgr* mgr,
+                                      struct st_tx_ancillary_session_impl* s) {
+  tx_ancillary_session_uinit_sw(mgr, s);
+  return 0;
+}
+
 static int tx_ancillary_session_attach(struct mtl_main_impl* impl,
                                        struct st_tx_ancillary_sessions_mgr* mgr,
                                        struct st_tx_ancillary_session_impl* s,
@@ -1421,7 +1427,7 @@ static int tx_ancillary_session_attach(struct mtl_main_impl* impl,
     ret = tx_ancillary_sessions_mgr_init_hw(impl, mgr, port);
     if (ret < 0) {
       err("%s(%d), mgr init hw fail for port %d\n", __func__, idx, port);
-      return -EIO;
+      return ret;
     }
   }
   s->tx_mono_pool = mt_user_tx_mono_pool(impl);
@@ -1465,6 +1471,7 @@ static int tx_ancillary_session_attach(struct mtl_main_impl* impl,
   ret = tx_ancillary_session_init_sw(impl, mgr, s);
   if (ret < 0) {
     err("%s(%d), init sw fail %d\n", __func__, idx, ret);
+    tx_ancillary_session_uinit(mgr, s);
     return ret;
   }
 
@@ -1539,7 +1546,7 @@ static void tx_ancillary_session_stat(struct st_tx_ancillary_session_impl* s) {
 static int tx_ancillary_session_detach(struct st_tx_ancillary_sessions_mgr* mgr,
                                        struct st_tx_ancillary_session_impl* s) {
   tx_ancillary_session_stat(s);
-  tx_ancillary_session_uinit_sw(mgr, s);
+  tx_ancillary_session_uinit(mgr, s);
   return 0;
 }
 

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -1892,6 +1892,13 @@ static int tx_audio_session_init_sw(struct mtl_main_impl* impl,
   return 0;
 }
 
+static int tx_audio_session_uinit(struct st_tx_audio_sessions_mgr* mgr,
+                                  struct st_tx_audio_session_impl* s) {
+  tx_audio_session_uinit_rl(mgr->parent, s);
+  tx_audio_session_uinit_sw(mgr, s);
+  return 0;
+}
+
 static int tx_audio_session_attach(struct mtl_main_impl* impl,
                                    struct st_tx_audio_sessions_mgr* mgr,
                                    struct st_tx_audio_session_impl* s,
@@ -2036,6 +2043,7 @@ static int tx_audio_session_attach(struct mtl_main_impl* impl,
   ret = tx_audio_session_init_sw(impl, mgr, s);
   if (ret < 0) {
     err("%s(%d), init sw fail %d\n", __func__, idx, ret);
+    tx_audio_session_uinit(mgr, s);
     return ret;
   }
 
@@ -2043,7 +2051,7 @@ static int tx_audio_session_attach(struct mtl_main_impl* impl,
     ret = tx_audio_session_init_rl(impl, s);
     if (ret < 0) {
       err("%s(%d), init rl fail %d\n", __func__, idx, ret);
-      tx_audio_session_uinit_sw(mgr, s);
+      tx_audio_session_uinit(mgr, s);
       return ret;
     }
   } else {
@@ -2222,8 +2230,7 @@ static void tx_audio_session_stat(struct st_tx_audio_sessions_mgr* mgr,
 static int tx_audio_session_detach(struct st_tx_audio_sessions_mgr* mgr,
                                    struct st_tx_audio_session_impl* s) {
   tx_audio_session_stat(mgr, s);
-  tx_audio_session_uinit_rl(mgr->parent, s);
-  tx_audio_session_uinit_sw(mgr, s);
+  tx_audio_session_uinit(mgr, s);
   if (s->tx_pacing_way != ST30_TX_PACING_WAY_RL) {
     rte_atomic32_dec(&mgr->transmitter_clients);
   }


### PR DESCRIPTION
For the SDN switch case which dispatch the stream directly.
Also refine the uinit routine for error handling in the attach.