### PR TITLE
mtl: add dedicated lcore options for sys tasks

### DIFF
--- a/app/src/args.c
+++ b/app/src/args.c
@@ -91,6 +91,7 @@ enum st_args_cmd {
   ST_ARG_DMA_DEV,
   ST_ARG_RX_SEPARATE_VIDEO_LCORE,
   ST_ARG_RX_MIX_VIDEO_LCORE,
+  ST_ARG_DEDICATE_SYS_LCORE,
   ST_ARG_TSC_PACING,
   ST_ARG_PCAPNG_DUMP,
   ST_ARG_RUNTIME_SESSION,
@@ -224,6 +225,7 @@ static struct option st_app_args_options[] = {
     {"rx_pool_data_size", required_argument, 0, ST_ARG_RX_POOL_DATA_SIZE},
     {"rx_separate_lcore", no_argument, 0, ST_ARG_RX_SEPARATE_VIDEO_LCORE},
     {"rx_mix_lcore", no_argument, 0, ST_ARG_RX_MIX_VIDEO_LCORE},
+    {"dedicated_sys_lcore", no_argument, 0, ST_ARG_DEDICATE_SYS_LCORE},
     {"nb_tx_desc", required_argument, 0, ST_ARG_NB_TX_DESC},
     {"nb_rx_desc", required_argument, 0, ST_ARG_NB_RX_DESC},
     {"dma_dev", required_argument, 0, ST_ARG_DMA_DEV},
@@ -629,6 +631,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_RX_MIX_VIDEO_LCORE:
         p->flags &= ~MTL_FLAG_RX_SEPARATE_VIDEO_LCORE;
+        break;
+      case ST_ARG_DEDICATE_SYS_LCORE:
+        p->flags |= MTL_FLAG_DEDICATED_SYS_LCORE;
         break;
       case ST_ARG_TSC_PACING:
         p->pacing = ST21_TX_PACING_WAY_TSC;

--- a/doc/run.md
+++ b/doc/run.md
@@ -367,15 +367,16 @@ If it failed to run the sample, please help to collect the system setup status b
 --ptp                                : Enable the built-in PTP implementation, default is disabled and system time is selected as PTP time source.
 --lcores <lcore list>                : the DPDK lcore list for this run, e.g. --lcores 28,29,30,31. If not assigned, lib will allocate lcore from system socket cores.
 --test_time <seconds>                : the run duration, unit: seconds
---rx_separate_lcore                  : If enabled, RX video session will run on dedicated lcores, it means TX video and RX video is not running on the same core.
 --dma_dev <DMA1,DMA2,DMA3...>        : DMA dev list to offload the packet memory copy for RX video frame session.
---runtime_session                    : start instance before create video/audio/anc sessions, similar to runtime tx/rx create.
 --log_level <level>                  : set log level. e.g. debug, info, notice, warning, error.
 --log_file <file path>               : set log file for mtl log. If you're initiating multiple RxTxApp processes simultaneously, please ensure each process has a unique filename path. Default the log is writing to stderr.
---arp_timeout_s <sec>                : set the arp timeout in seconds if using unicast address. Default timeout value is 60 seconds.
---allow_across_numa_core             : allow the usage of cores across NUMA nodes
---no_multicast                       : disable the multicast join message, usually for the SDN switch case.
 
+--arp_timeout_s <sec>                : debug option, set the arp timeout in seconds if using unicast address. Default timeout value is 60 seconds.
+--allow_across_numa_core             : debug option, allow the usage of cores across NUMA nodes
+--no_multicast                       : debug option, disable the multicast join message, usually for the SDN switch case.
+--rx_separate_lcore                  : debug option, if enabled, RX video session will run on dedicated lcores, it means TX video and RX video is not running on the same core.
+--rx_mix_lcore                       : debug option, if enabled, it means TX video and RX video are possible to run on the same core.
+--runtime_session                    : debug option, start instance before create video/audio/anc sessions, similar to runtime tx/rx create.
 --rx_timing_parser                   : debug option, enable timing check for video rx streams.
 --pcapng_dump <n>                    : debug option, dump n packets from rx video streams to pcapng files.
 --rx_video_file_frames <n>           : debug option, dump the received video frames to a yuv file, n is dump file size in frame unit.
@@ -413,6 +414,7 @@ packet egresses from the sender.
 --log_time_ms                        : debug option, enable a ms accuracy log printer by the api mtl_set_log_prefix_formatter.
 --rx_video_file_frames <count>       : debug option, dump the received video frames to one yuv file
 --rx_audio_dump_time_s <seconds>     : debug option, dump the received audio frames to one pcm file
+--dedicated_sys_lcore                : debug option, run MTL system tasks(CNI, PTP, etc...) in a dedicated lcore
 ```
 
 ## 6. Tests

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -395,6 +395,8 @@ enum mtl_init_flag {
    * directly
    */
   MTL_FLAG_NO_MULTICAST = (MTL_BIT64(19)),
+  /** Dedicated lcore for system CNI tasks. */
+  MTL_FLAG_DEDICATED_SYS_LCORE = (MTL_BIT64(20)),
   /**
    * dedicate thread for cni message
    */

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -1881,7 +1881,9 @@ int mt_dev_create(struct mtl_main_impl* impl) {
   }
 
   /* create system sch */
-  impl->main_sch = mt_sch_get(impl, 0, MT_SCH_TYPE_DEFAULT, MT_SCH_MASK_ALL);
+  enum mt_sch_type type =
+      mt_user_dedicated_sys_lcore(impl) ? MT_SCH_TYPE_SYSTEM : MT_SCH_TYPE_DEFAULT;
+  impl->main_sch = mt_sch_get(impl, 0, type, MT_SCH_MASK_ALL);
   if (!impl->main_sch) {
     err("%s, get sch fail\n", __func__);
     ret = -EIO;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -484,6 +484,8 @@ enum mt_sch_type {
   MT_SCH_TYPE_DEFAULT = 0,
   MT_SCH_TYPE_RX_VIDEO_ONLY,
   MT_SCH_TYPE_APP, /* created by user */
+  /* dedicated for system task */
+  MT_SCH_TYPE_SYSTEM,
   MT_SCH_TYPE_MAX,
 };
 
@@ -1488,6 +1490,14 @@ static inline bool mt_user_hw_timestamp(struct mtl_main_impl* impl) {
 /* if user enable separate sch for rx video session */
 static inline bool mt_user_rxv_separate_sch(struct mtl_main_impl* impl) {
   if (mt_get_user_params(impl)->flags & MTL_FLAG_RX_SEPARATE_VIDEO_LCORE)
+    return true;
+  else
+    return false;
+}
+
+/* if user enable dedicated lcore for system tasks(CNI, PTP, etc...) */
+static inline bool mt_user_dedicated_sys_lcore(struct mtl_main_impl* impl) {
+  if (mt_get_user_params(impl)->flags & MTL_FLAG_DEDICATED_SYS_LCORE)
     return true;
   else
     return false;

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -323,8 +323,8 @@ static struct mtl_sch_impl* sch_request(struct mtl_main_impl* impl, enum mt_sch_
       rte_atomic32_inc(&sch->active);
       rte_atomic32_inc(&mt_sch_get_mgr(impl)->sch_cnt);
       sch_unlock(sch);
-      info("%s(%d), name %s with %u tasklets\n", __func__, sch_idx, sch->name,
-           sch->nb_tasklets);
+      info("%s(%d), name %s with %u tasklets, type %d\n", __func__, sch_idx, sch->name,
+           sch->nb_tasklets, type);
       return sch;
     }
     sch_unlock(sch);


### PR DESCRIPTION
VF ptp may require a dedicated lcore for accuracy.