### PR TITLE
mtl: add force numa option

### DIFF
--- a/app/src/args.c
+++ b/app/src/args.c
@@ -64,6 +64,7 @@ enum st_args_cmd {
   ST_ARG_DISABLE_MIGRATE,
   ST_ARG_BIND_NUMA,
   ST_ARG_NOT_BIND_NUMA,
+  ST_ARG_FORCE_NUMA,
 
   ST_ARG_CONFIG_FILE = 0x300,
   ST_ARG_TEST_TIME,
@@ -204,6 +205,7 @@ static struct option st_app_args_options[] = {
     {"disable_migrate", no_argument, 0, ST_ARG_DISABLE_MIGRATE},
     {"bind_numa", no_argument, 0, ST_ARG_BIND_NUMA},
     {"not_bind_numa", no_argument, 0, ST_ARG_NOT_BIND_NUMA},
+    {"force_numa", required_argument, 0, ST_ARG_FORCE_NUMA},
 
     {"config_file", required_argument, 0, ST_ARG_CONFIG_FILE},
     {"test_time", required_argument, 0, ST_ARG_TEST_TIME},
@@ -593,7 +595,13 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         p->flags |= MTL_FLAG_BIND_NUMA;
         break;
       case ST_ARG_NOT_BIND_NUMA:
-        p->flags &= ~MTL_FLAG_BIND_NUMA;
+        p->flags |= MTL_FLAG_NOT_BIND_NUMA;
+        break;
+      case ST_ARG_FORCE_NUMA:
+        for (int port = 0; port < MTL_PORT_MAX; port++) {
+          p->port_params[port].flags |= MTL_PORT_FLAG_FORCE_NUMA;
+          p->port_params[port].socket_id = atoi(optarg);
+        }
         break;
       case ST_ARG_SHAPING:
         if (!strcmp(optarg, "narrow"))

--- a/doc/run.md
+++ b/doc/run.md
@@ -417,6 +417,7 @@ packet egresses from the sender.
 --dedicated_sys_lcore                : debug option, run MTL system tasks(CNI, PTP, etc...) in a dedicated lcore
 --bind_numa                          : debug option, all MTL threads bind to same numa of NIC
 --not_bind_numa                      : debug option, MTL threads runs without NIC numa aware
+--force_numa <id>                    : debug option, force the NIC port numa id instead of reading from PCIE topology
 ```
 
 ## 6. Tests

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1431,9 +1431,9 @@ static inline bool mt_user_ptp_service(struct mtl_main_impl* impl) {
     return false;
 }
 
-/* if user enable the numa bind for lcore thread and memory */
-static inline bool mt_user_bind_numa(struct mtl_main_impl* impl) {
-  if (mt_get_user_params(impl)->flags & MTL_FLAG_BIND_NUMA)
+/* if user enable the not numa bind for lcore thread */
+static inline bool mt_user_not_bind_numa(struct mtl_main_impl* impl) {
+  if (mt_get_user_params(impl)->flags & MTL_FLAG_NOT_BIND_NUMA)
     return true;
   else
     return false;

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -640,7 +640,7 @@ int mt_sch_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore,
   bool skip_numa_check = false;
   struct mt_sch_mgr* mgr = mt_sch_get_mgr(impl);
 
-  if (!mt_user_bind_numa(impl)) skip_numa_check = true;
+  if (mt_user_not_bind_numa(impl)) skip_numa_check = true;
 
 again:
   cur_lcore = 0;

--- a/rust/imtl-sys/examples/no_std.rs
+++ b/rust/imtl-sys/examples/no_std.rs
@@ -10,6 +10,10 @@ fn main() {
         for i in 0..12 {
             port_p[i] = *port_str.add(i);
         }
+        let mut port_param = mtl_port_init_params {
+            flags: 0,
+            socket_id: 0,
+        };
         let mut param = mtl_init_params {
             port: [port_p; 8],
             num_ports: 1,
@@ -49,6 +53,7 @@ fn main() {
             ptp_sync_notify: None,
             rss_sch_nb: [0; 8],
             memzone_max: 0,
+            port_params: [port_param; 8],
         };
 
         /* initialize dev handle */


### PR DESCRIPTION
MTL_PORT_FLAG_FORCE_NUMA is introduced to force the numa id for each port.

test with:
./build/app/RxTxApp --config_file tests/script/loop_json/4kp59_1v.json --force_numa 0