### PR TITLE
ufd: fix memleak detected by mt_asan_check

### DIFF
--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -389,6 +389,7 @@ struct mt_cni_impl {
   rte_atomic32_t stop_thread;
   bool lcore_tasklet;
   struct mt_sch_tasklet_impl* tasklet;
+  int thread_sleep_ms;
 
   struct mt_cni_entry entries[MTL_PORT_MAX];
 

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -71,6 +71,7 @@ static int ufd_free_mt_ctx(struct ufd_mt_ctx* ctx) {
     mt_rte_free(ctx->slots);
     ctx->slots = NULL;
   }
+  mt_pthread_mutex_destroy(&ctx->slots_lock);
   if (ctx->alloc_with_rte)
     mt_rte_free(ctx);
   else
@@ -81,7 +82,6 @@ static int ufd_free_mt_ctx(struct ufd_mt_ctx* ctx) {
     mtl_uninit(mt);
     mt = NULL;
   }
-  mt_pthread_mutex_destroy(&ctx->slots_lock);
 
   return 0;
 }

--- a/lib/src/udp/ufd_main.c
+++ b/lib/src/udp/ufd_main.c
@@ -59,6 +59,8 @@ static int ufd_free_slot(struct ufd_mt_ctx* ctx, struct ufd_slot* slot) {
 }
 
 static int ufd_free_mt_ctx(struct ufd_mt_ctx* ctx) {
+  struct mtl_main_impl* mt = ctx->mt;
+
   if (ctx->slots) {
     for (int i = 0; i < ufd_max_slot(ctx); i++) {
       /* check if any not free slot */
@@ -69,15 +71,18 @@ static int ufd_free_mt_ctx(struct ufd_mt_ctx* ctx) {
     mt_rte_free(ctx->slots);
     ctx->slots = NULL;
   }
-  if (ctx->mt) {
-    mtl_uninit(ctx->mt);
-    ctx->mt = NULL;
-  }
-  mt_pthread_mutex_destroy(&ctx->slots_lock);
   if (ctx->alloc_with_rte)
     mt_rte_free(ctx);
   else
     mt_free(ctx);
+
+  /* always mtl_uninit at the last */
+  if (mt) {
+    mtl_uninit(mt);
+    mt = NULL;
+  }
+  mt_pthread_mutex_destroy(&ctx->slots_lock);
+
   return 0;
 }
 


### PR DESCRIPTION
Fix below fail:

MTL: 2024-06-15 00:45:30, mt_asan_check, leak of 1624 byte(s) at 0x7fc17ff3b900
MTL: 2024-06-15 00:45:30, mt_asan_check, backtrace info:
MTL: 2024-06-15 00:45:30, mt_asan_check, /lib/x86_64-linux-gnu/libasan.so.5(+0x6cd40) [0x7fc9823fdd40]
MTL: 2024-06-15 00:45:30, mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(mt_rte_zmalloc_socket+0x18a) [0x7fc981d07c69]
MTL: 2024-06-15 00:45:30, mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(+0x6ecbfe) [0x7fc982200bfe]
MTL: 2024-06-15 00:45:30, mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(+0x6ed322) [0x7fc982201322]
MTL: 2024-06-15 00:45:30, mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(mufd_socket_port+0x132) [0x7fc982201b26]
MTL: 2024-06-15 00:45:30, mt_asan_check, /usr/local/lib/x86_64-linux-gnu/libmtl.so(mufd_socket+0x55) [0x7fc982202d20]
MTL: 2024-06-15 00:45:30, mt_asan_check, ./build/app/UfdServerSample(+0x81f0) [0x559cc2cc11f0]
MTL: 2024-06-15 00:45:30, mt_asan_check, /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fc981923083]
MTL: 2024-06-15 00:45:30, mt_asan_check, ./build/app/UfdServerSample(+0x588e) [0x559cc2cbe88e]
