### PR TITLE
fix(build): fixing 'maybe-uninitialized' errors for 'debugoptimized' build

### DIFF
--- a/lib/src/st2110/st_video_transmitter.c
+++ b/lib/src/st2110/st_video_transmitter.c
@@ -584,7 +584,7 @@ static int video_trs_ptp_tasklet(struct mtl_main_impl* impl,
 
   /* check valid bulk */
   int valid_bulk = bulk;
-  uint32_t pkt_idx;
+  uint32_t pkt_idx = 0;
   for (int i = 0; i < bulk; i++) {
     pkt_idx = st_tx_mbuf_get_idx(pkts[i]);
     if (pkt_idx == ST_TX_DUMMY_PKT_IDX) {

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -1471,14 +1471,13 @@ ssize_t mudp_sendmsg(mudp_handle ut, const struct msghdr* msg, int flags) {
   size_t sz_per_pkt = s->gso_segment_sz;
   size_t total_len = udp_msg_len(msg);
   unsigned int pkts_nb = total_len / sz_per_pkt;
-
+  if (total_len % sz_per_pkt) pkts_nb++;
   /* Ensure pkts_nb is greater than 0 */
   if (pkts_nb == 0) {
     err("%s(%d): pkts_nb is 0\n", __func__, idx);
     return -EINVAL; /* Invalid argument */
   }
 
-  if (total_len % sz_per_pkt) pkts_nb++;
   struct rte_mbuf* pkts[pkts_nb];
   dbg("%s(%d), pkts_nb %u total_len %" PRId64 "\n", __func__, idx, pkts_nb, total_len);
   if (pkts_nb > 1) s->stat_tx_gso_count++;

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -1475,7 +1475,7 @@ ssize_t mudp_sendmsg(mudp_handle ut, const struct msghdr* msg, int flags) {
   /* Ensure pkts_nb is greater than 0 */
   if (pkts_nb == 0) {
     err("%s(%d): pkts_nb is 0\n", __func__, idx);
-    return -EINVAL;  /* Invalid argument */
+    return -EINVAL; /* Invalid argument */
   }
 
   if (total_len % sz_per_pkt) pkts_nb++;

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -246,12 +246,12 @@ static int udp_build_tx_msg_pkt(struct mtl_main_impl* impl, struct mudp_impl* s,
   int idx = s->idx;
   int ret;
 
-    // Ensure pkts_nb is greater than 0
+  // Ensure pkts_nb is greater than 0
   if (pkts_nb == 0) {
     err("%s(%d): pkts_nb is 0\n", __func__, idx);
     return -EINVAL;  // Invalid argument
   }
-  
+
   /* get the dst mac address */
   struct rte_ether_addr d_addr;
   uint8_t* dip = (uint8_t*)&addr_in->sin_addr;

--- a/lib/src/udp/udp_main.c
+++ b/lib/src/udp/udp_main.c
@@ -246,6 +246,12 @@ static int udp_build_tx_msg_pkt(struct mtl_main_impl* impl, struct mudp_impl* s,
   int idx = s->idx;
   int ret;
 
+    // Ensure pkts_nb is greater than 0
+  if (pkts_nb == 0) {
+    err("%s(%d): pkts_nb is 0\n", __func__, idx);
+    return -EINVAL;  // Invalid argument
+  }
+  
   /* get the dst mac address */
   struct rte_ether_addr d_addr;
   uint8_t* dip = (uint8_t*)&addr_in->sin_addr;


### PR DESCRIPTION
# Summary 
During the budling MTL with debugoptimized there are some errors with maybe-uninitialized variables
`./build.sh debugoptimized`

This PR should fix this issue 
