### PR TITLE
dpdk: add main_lcore support

### DIFF
--- a/app/sample/sample_util.c
+++ b/app/sample/sample_util.c
@@ -69,6 +69,7 @@ enum sample_args_cmd {
   SAMPLE_ARG_PERF_FRAMES,
   SAMPLE_ARG_PERF_FB_CNT,
   SAMPLE_ARG_MULTI_INC_ADDR,
+  SAMPLE_ARG_LCORES,
   /* audio */
   SAMPLE_ARG_AUDIO_FMT,
   SAMPLE_ARG_AUDIO_CHANNEL,
@@ -146,6 +147,7 @@ static struct option sample_args_options[] = {
     {"perf_frames", required_argument, 0, SAMPLE_ARG_PERF_FRAMES},
     {"perf_fb_cnt", required_argument, 0, SAMPLE_ARG_PERF_FB_CNT},
     {"multi_inc_addr", no_argument, 0, SAMPLE_ARG_MULTI_INC_ADDR},
+    {"lcores", required_argument, 0, SAMPLE_ARG_LCORES},
 
     {0, 0, 0, 0}};
 
@@ -459,6 +461,9 @@ static int _sample_parse_args(struct st_sample_context* ctx, int argc, char** ar
         break;
       case SAMPLE_ARG_MULTI_INC_ADDR:
         ctx->multi_inc_addr = true;
+        break;
+      case SAMPLE_ARG_LCORES:
+        p->lcores = optarg;
         break;
       case '?':
         break;

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -666,6 +666,9 @@ struct mtl_init_params {
   /** Optional, all future port params should be placed into this struct */
   struct mtl_port_init_params port_params[MTL_PORT_MAX];
 
+  /* The Core ID that is used as DPDK main thread, leave to zero is good for most case */
+  uint32_t main_lcore;
+
   /**
    * deprecated for MTL_TRANSPORT_ST2110.
    * max tx sessions(st20, st22, st30, st40) requested the lib to support,

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -409,11 +409,22 @@ static int dev_eal_init(struct mtl_init_params* p, struct mt_kport_info* kport_i
     argc++;
   }
 
+  /* --main-lcore */
+  char main_lcore[64];
+  argv[argc] = "--main-lcore";
+  argc++;
+  info("%s, main_lcore: %u\n", __func__, p->main_lcore);
+  snprintf(main_lcore, sizeof(main_lcore), "%u", p->main_lcore);
+  argv[argc] = main_lcore;
+  argc++;
+
+  char lcores[128];
   if (p->lcores) {
     argv[argc] = "-l";
     argc++;
     info("%s, lcores: %s\n", __func__, p->lcores);
-    argv[argc] = p->lcores;
+    snprintf(lcores, sizeof(lcores), "%u,%s", p->main_lcore, p->lcores);
+    argv[argc] = lcores;
     argc++;
   }
 

--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -642,6 +642,7 @@ int mt_sch_get_lcore(struct mtl_main_impl* impl, unsigned int* lcore,
   int ret;
   bool skip_numa_check = false;
   struct mt_sch_mgr* mgr = mt_sch_get_mgr(impl);
+  int tried = 0;
 
   if (mt_user_not_bind_numa(impl)) skip_numa_check = true;
 
@@ -664,6 +665,7 @@ again:
           return 0;
         }
       }
+      tried++;
     } while (cur_lcore < RTE_MAX_LCORE);
   } else {
     struct mt_user_info* info = &impl->u_info;
@@ -707,6 +709,7 @@ again:
           return 0;
         }
       }
+      tried++;
     } while (cur_lcore < RTE_MAX_LCORE);
 
     sch_filelock_unlock(mgr);
@@ -719,7 +722,8 @@ again:
     goto again;
   }
 
-  err("%s, no available lcore, type %s\n", __func__, lcore_type_name(type));
+  err("%s, no available lcore, type %s tried %d\n", __func__, lcore_type_name(type),
+      tried);
   return -EIO;
 }
 

--- a/rust/imtl-sys/examples/no_std.rs
+++ b/rust/imtl-sys/examples/no_std.rs
@@ -24,6 +24,7 @@ fn main() {
             tx_sessions_cnt_max: 1,
             rx_sessions_cnt_max: 1,
             lcores: null_mut(),
+            main_lcore: 0,
             dma_dev_port: [[0; 64]; 8],
             num_dma_dev_port: 0,
             log_level: mtl_log_level_MTL_LOG_LEVEL_INFO,


### PR DESCRIPTION
The Core ID that is used as DPDK main thread.