### PR TITLE
add support for ixgbe driver

### DIFF
--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -1274,7 +1274,9 @@ static int dev_if_init_rx_queues(struct mtl_main_impl* impl, struct mt_interface
           mbuf_pool = mt_mempool_create_common(impl, inf->port, pool_name, mbuf_elements);
         else {
           uint16_t data_room_sz = ST_PKT_MAX_ETHER_BYTES;
-          if (inf->drv_info.drv_type == MT_DRV_IGC || inf->drv_info.drv_type == MT_DRV_IXGBE)/* to avoid igc/igxbe nic split mbuf */
+          /* to avoid igc/igxbe nic split mbuf */
+          if (inf->drv_info.drv_type == MT_DRV_IGC ||
+              inf->drv_info.drv_type == MT_DRV_IXGBE)
             data_room_sz = MT_MBUF_DEFAULT_DATA_SIZE;
           if (impl->rx_pool_data_size) /* user suggested data room size */
             data_room_sz = impl->rx_pool_data_size;

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -22,6 +22,12 @@ static const struct mt_dev_driver_info dev_drvs[] = {
         .flow_type = MT_FLOW_ALL, /* or MT_FLOW_NONE? */
     },
     {
+        .name = "net_ixgbe", /* For ixgbe */
+        .port_type = MT_PORT_PF,
+        .drv_type = MT_DRV_IXGBE,
+        .flow_type = MT_FLOW_NONE,
+    },
+    {
         .name = "net_ice",
         .port_type = MT_PORT_PF,
         .drv_type = MT_DRV_ICE,
@@ -1268,7 +1274,7 @@ static int dev_if_init_rx_queues(struct mtl_main_impl* impl, struct mt_interface
           mbuf_pool = mt_mempool_create_common(impl, inf->port, pool_name, mbuf_elements);
         else {
           uint16_t data_room_sz = ST_PKT_MAX_ETHER_BYTES;
-          if (inf->drv_info.drv_type == MT_DRV_IGC) /* to avoid igc nic split mbuf */
+          if (inf->drv_info.drv_type == MT_DRV_IGC || inf->drv_info.drv_type == MT_DRV_IXGBE)/* to avoid igc/igxbe nic split mbuf */
             data_room_sz = MT_MBUF_DEFAULT_DATA_SIZE;
           if (impl->rx_pool_data_size) /* user suggested data room size */
             data_room_sz = impl->rx_pool_data_size;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -142,10 +142,10 @@ enum mt_rl_type {
 
 enum mt_driver_type {
   MT_DRV_DEFAULT = 0,
-  MT_DRV_ICE,  /* ice pf, net_ice */
-  MT_DRV_IXGBE,  /* ixgbe pf, net_ixgbe */
-  MT_DRV_I40E, /* flv pf, net_i40e */
-  MT_DRV_IAVF, /* IA vf, net_iavf */
+  MT_DRV_ICE,   /* ice pf, net_ice */
+  MT_DRV_IXGBE, /* ixgbe pf, net_ixgbe */
+  MT_DRV_I40E,  /* flv pf, net_i40e */
+  MT_DRV_IAVF,  /* IA vf, net_iavf */
   /* dpdk af xdp, net_af_xdp */
   MT_DRV_DPDK_AF_XDP,
   MT_DRV_E1000_IGB, /* e1000 igb, net_e1000_igb */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -143,6 +143,7 @@ enum mt_rl_type {
 enum mt_driver_type {
   MT_DRV_DEFAULT = 0,
   MT_DRV_ICE,  /* ice pf, net_ice */
+  MT_DRV_IXGBE,  /* ixgbe pf, net_ixgbe */
   MT_DRV_I40E, /* flv pf, net_i40e */
   MT_DRV_IAVF, /* IA vf, net_iavf */
   /* dpdk af xdp, net_af_xdp */


### PR DESCRIPTION
This PR adds support for the IXGBE driver, according #930 . 
Both the Intel 10-Gigabit X540-AT2 (1528) and Intel 10G X550T (1563) have been tested. In the test where PF was used to bind with the PMD, both RxTxApp and ffmpeg-plugin app transmit media successfully. 