### PR TITLE
Fix incorrect upper bound of RTP payload validity check (#946)

### DIFF
--- a/app/src/parse_json.c
+++ b/app/src/parse_json.c
@@ -464,7 +464,7 @@ static const struct st_video_fmt_desc st_video_fmt_descs[] = {
 
 /* 7 bits payload type define in RFC3550 */
 static inline bool st_json_is_valid_payload_type(int payload_type) {
-  if (payload_type > 0 && payload_type < 0x7F)
+  if (payload_type > 0 && payload_type <= 0x7F)
     return true;
   else
     return false;

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -89,7 +89,7 @@ void mt_eth_link_dump(uint16_t port_id);
 /* 7 bits payload type define in RFC3550 */
 static inline bool st_is_valid_payload_type(int payload_type) {
   /* Zero means disable the payload_type check */
-  if (payload_type >= 0 && payload_type < 0x7F)
+  if (payload_type >= 0 && payload_type <= 0x7F)
     return true;
   else
     return false;


### PR DESCRIPTION
This PR fixes #946 by fixing the upper limits of the conditional in [`lib/src/mt_util.h:92`](https://github.com/OpenVisualCloud/Media-Transport-Library/blob/ddcc0413559274f7ba83e8cf1141aa0b2bfba137/lib/src/mt_util.h#L92) and [`app/src/parse_json.c:467`](https://github.com/OpenVisualCloud/Media-Transport-Library/blob/ddcc0413559274f7ba83e8cf1141aa0b2bfba137/app/src/parse_json.c#L467).