### PR TITLE
Fix FFmpeg audio plugin sample rate to be 44100

### DIFF
--- a/ecosystem/ffmpeg_plugin/mtl_st30p_rx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st30p_rx.c
@@ -122,7 +122,7 @@ static int mtl_st30p_read_header(AVFormatContext* ctx) {
     ops_rx.sampling = ST30_SAMPLING_48K;
   else if (s->sample_rate == 96000)
     ops_rx.sampling = ST30_SAMPLING_96K;
-  else if (s->sample_rate == 44000)
+  else if (s->sample_rate == 44100)
     ops_rx.sampling = ST31_SAMPLING_44K;
   else {
     err(ctx, "%s, invalid sample_rate: %d\n", __func__, s->sample_rate);

--- a/ecosystem/ffmpeg_plugin/mtl_st30p_tx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st30p_tx.c
@@ -114,7 +114,7 @@ static int mtl_st30p_write_header(AVFormatContext* ctx) {
     ops_tx.sampling = ST30_SAMPLING_48K;
   } else if (codecpar->sample_rate == 96000) {
     ops_tx.sampling = ST30_SAMPLING_96K;
-  } else if (codecpar->sample_rate == 44000) {
+  } else if (codecpar->sample_rate == 44100) {
     ops_tx.sampling = ST31_SAMPLING_44K;
   } else {
     err(ctx, "%s, unknown sample_rate %d\n", __func__, codecpar->sample_rate);


### PR DESCRIPTION
This commit changes the audio sample rate in the FFmpeg plugin from 44000 to a correct value of 44100 kHz.