### PR TITLE
Fix ST22P session creation socket ID

### DIFF
--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -706,6 +706,7 @@ st22p_rx_handle st22p_rx_create(mtl_handle mt, struct st22p_rx_ops* ops) {
   }
 
   ctx->idx = idx;
+  ctx->socket_id = socket;
   ctx->ready = false;
   ctx->ext_frame = (ops->flags & ST22P_RX_FLAG_EXT_FRAME) ? true : false;
   ctx->codestream_fmt = codestream_fmt;

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -808,7 +808,6 @@ st22p_tx_handle st22p_tx_create(mtl_handle mt, struct st22p_tx_ops* ops) {
     err("%s(%d), ctx malloc fail on socket %d\n", __func__, idx, socket);
     return NULL;
   }
-  ctx->socket_id = socket;
 
   if (codestream_fmt == ops->input_fmt) {
     ctx->derive = true;
@@ -831,6 +830,7 @@ st22p_tx_handle st22p_tx_create(mtl_handle mt, struct st22p_tx_ops* ops) {
   }
 
   ctx->idx = idx;
+  ctx->socket_id = socket;
   ctx->codestream_fmt = codestream_fmt;
   ctx->ready = false;
   ctx->ext_frame = (ops->flags & ST22P_TX_FLAG_EXT_FRAME) ? true : false;


### PR DESCRIPTION
Fix ST22P create session functions ignoring
socket_id values, which causes the sessions to
allocate memory on socket 0 regardless of the
session NUMA range.

- Ensure socket_id is correctly handled during session creation.
- Prevent memory allocation on incorrect sockets.