### PR TITLE
Fix: FMD Adjust the Space Memory Check

### DIFF
--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -430,7 +430,7 @@ static void tx_fastmetadata_session_build_packet(
   uint16_t data_item_length =
       (data_item_length_bytes + 3) / 4; /* expressed in number of 4-byte words */
 
-  if (rte_pktmbuf_data_len(pkt) < sizeof(*hdr) + data_item_length) {
+  if (rte_pktmbuf_data_len(pkt) < sizeof(*hdr) + data_item_length_bytes ) {
     err("%s: packet doesn't contain RTP payload", __func__);
     return;
   }


### PR DESCRIPTION
In the FMD build packet, we were checking
the space using a value that represented 4-byte
chunks. This has been fixed by multiplying the
value by 4.

Fixes: 664344a8

Co-authored-by: Kolelis, Szymon <szymon.kolelis@intel.com>