### PR TITLE
Fix: error handling in parsing sample freq in FFmpeg audio plugins

### DIFF
--- a/ecosystem/ffmpeg_plugin/mtl_st30p_rx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st30p_rx.c
@@ -119,7 +119,7 @@ static int mtl_st30p_read_header(AVFormatContext* ctx) {
   ops_rx.ptime = s->ptime;
   ops_rx.channel = s->channels;
   ret = mtl_parse_st30_sample_rate(&ops_rx.sampling, s->sample_rate);
-  if (!ret) {
+  if (ret) {
     err(ctx, "%s, invalid sample_rate: %d\n", __func__, s->sample_rate);
     return ret;
   }

--- a/ecosystem/ffmpeg_plugin/mtl_st30p_tx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st30p_tx.c
@@ -111,7 +111,7 @@ static int mtl_st30p_write_header(AVFormatContext* ctx) {
   ops_tx.channel = codecpar->ch_layout.nb_channels;
 #endif
   ret = mtl_parse_st30_sample_rate(&ops_tx.sampling, codecpar->sample_rate);
-  if (!ret) {
+  if (ret) {
     err(ctx, "%s, unknown sample_rate %d\n", __func__, codecpar->sample_rate);
     return ret;
   }


### PR DESCRIPTION
Commit 065923f3f768 ("Refactor FFmpeg audio plugin sample rate parsing") added a helper function for parsing the sample frequency. However, the error returned from the function was checked incorrectly (inverted). This led to a segmentation fault when starting FFmpeg with MTL audio plugins.

This commit fixes the error handling by checking if the return value is non zero.

Fixes: 065923f3f768 ("Refactor FFmpeg audio plugin sample rate parsing")

Change-type: DefectResolution