### PR TITLE
Fix: fix the enforced (hardcoded) payload types in RTP mode for ST41 and ST40

### DIFF
--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -248,6 +248,7 @@ struct st_app_tx_fmd_session {
   int st41_source_fd;
   pcap_t* st41_pcap;
   bool st41_pcap_input;
+  uint8_t st41_payload_type;
   uint32_t st41_dit;
   uint32_t st41_k_bit;
   bool st41_rtp_input;

--- a/app/src/app_base.h
+++ b/app/src/app_base.h
@@ -220,6 +220,7 @@ struct st_app_tx_anc_session {
   pcap_t* st40_pcap;
   bool st40_pcap_input;
   bool st40_rtp_input;
+  uint8_t st40_payload_type;
   uint8_t* st40_source_begin;
   uint8_t* st40_source_end;
   uint8_t* st40_frame_cursor; /* cursor to current frame */
@@ -248,10 +249,10 @@ struct st_app_tx_fmd_session {
   int st41_source_fd;
   pcap_t* st41_pcap;
   bool st41_pcap_input;
+  bool st41_rtp_input;
   uint8_t st41_payload_type;
   uint32_t st41_dit;
   uint32_t st41_k_bit;
-  bool st41_rtp_input;
   uint8_t* st41_source_begin;
   uint8_t* st41_source_end;
   uint8_t* st41_frame_cursor; /* cursor to current frame */

--- a/app/src/tx_ancillary_app.c
+++ b/app/src/tx_ancillary_app.c
@@ -204,7 +204,7 @@ static void app_tx_anc_build_rtp(struct st_app_tx_anc_session* s, void* usrptr,
   uint16_t check_sum, total_size, payload_len;
   hdr->base.marker = 1;
   hdr->anc_count = 1;
-  hdr->base.payload_type = ST_APP_PAYLOAD_TYPE_ANCILLARY;
+  hdr->base.payload_type = s->st40_payload_type;
   hdr->base.version = 2;
   hdr->base.extension = 0;
   hdr->base.padding = 0;
@@ -461,6 +461,7 @@ static int app_tx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
   ops.type = anc ? anc->info.type : ST40_TYPE_FRAME_LEVEL;
   ops.interlaced = anc ? anc->info.interlaced : false;
   ops.payload_type = anc ? anc->base.payload_type : ST_APP_PAYLOAD_TYPE_ANCILLARY;
+  s->st40_payload_type = ops.payload_type;
   /* select rtp type for pcap file or tx_video_rtp_ring_size */
   if (strstr(s->st40_source_url, ".pcap")) {
     ops.type = ST40_TYPE_RTP_LEVEL;

--- a/app/src/tx_fastmetadata_app.c
+++ b/app/src/tx_fastmetadata_app.c
@@ -205,7 +205,6 @@ static void app_tx_fmd_build_rtp(struct st_app_tx_fmd_session* s, void* usrptr,
   uint16_t data_item_length;
   data_item_length =
       (data_item_length_bytes + 3) / 4; /* expressed in number of 4-byte words */
-
   hdr->base.marker = 1;
   hdr->base.payload_type = s->st41_payload_type;
   hdr->base.version = 2;

--- a/app/src/tx_fastmetadata_app.c
+++ b/app/src/tx_fastmetadata_app.c
@@ -206,10 +206,8 @@ static void app_tx_fmd_build_rtp(struct st_app_tx_fmd_session* s, void* usrptr,
   data_item_length =
       (data_item_length_bytes + 3) / 4; /* expressed in number of 4-byte words */
 
-
-err("skolelis: file: %s, %s(), line: %d.\n", __FILE__, __func__, __LINE__); // skolelis tbd: remove    
   hdr->base.marker = 1;
-  hdr->base.payload_type = 117; //ST_APP_PAYLOAD_TYPE_FASTMETADATA; // skolelis
+  hdr->base.payload_type = s->st41_payload_type;
   hdr->base.version = 2;
   hdr->base.extension = 0;
   hdr->base.padding = 0;

--- a/app/src/tx_fastmetadata_app.c
+++ b/app/src/tx_fastmetadata_app.c
@@ -205,8 +205,11 @@ static void app_tx_fmd_build_rtp(struct st_app_tx_fmd_session* s, void* usrptr,
   uint16_t data_item_length;
   data_item_length =
       (data_item_length_bytes + 3) / 4; /* expressed in number of 4-byte words */
+
+
+err("skolelis: file: %s, %s(), line: %d.\n", __FILE__, __func__, __LINE__); // skolelis tbd: remove    
   hdr->base.marker = 1;
-  hdr->base.payload_type = ST_APP_PAYLOAD_TYPE_FASTMETADATA;
+  hdr->base.payload_type = 117; //ST_APP_PAYLOAD_TYPE_FASTMETADATA; // skolelis
   hdr->base.version = 2;
   hdr->base.extension = 0;
   hdr->base.padding = 0;
@@ -482,6 +485,7 @@ static int app_tx_fmd_init(struct st_app_context* ctx,
   /* copying frame fields for RTP mode to function*/
   s->st41_dit = ops.fmd_dit;
   s->st41_k_bit = ops.fmd_k_bit;
+  s->st41_payload_type = ops.payload_type;
 
   s->handle = handle;
   snprintf(s->st41_source_url, sizeof(s->st41_source_url), "%s",


### PR DESCRIPTION
Fix hardcoded payload type in RTP mode in the RxTxApp for st40 and st41 cases.

fixes: c43152d
fixes: 19f3e16