### PR TITLE
correct the use of header in sample tx rtp app

### DIFF
--- a/app/sample/low_level/tx_rtp_video_sample.c
+++ b/app/sample/low_level/tx_rtp_video_sample.c
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
     ops_tx.notify_rtp_done = notify_rtp_done;
     // 4320 for ex. it is for 1080p, each line, we have 4 packet.
     ops_tx.rtp_frame_total_pkts = 4320;
-    ops_tx.rtp_pkt_size = 1200 + sizeof(struct st_rfc3550_rtp_hdr);
+    ops_tx.rtp_pkt_size = 1200 + sizeof(struct st20_rfc4175_rtp_hdr);
     // rtp_frame_total_pkts x rtp_pkt_size will be used for Rate limit in the lib.
 
     tx_handle[i] = st20_tx_create(ctx.st, &ops_tx);


### PR DESCRIPTION
`struct st20_rfc4175_rtp_hdr` is the correct one to use because:
In function `app_tx_build_rtp_packet`, payload is filled using `memset(payload, 0, s->packet_size - sizeof(*rtp))`, where rtp is of type `struct st20_rfc4175_rtp_hdr*`, so in `main`, the packet size `ops_tx.rtp_pkt_size` should be `1200 + sizeof(struct st20_rfc4175_rtp_hdr)`