### PR TITLE
Fix: build_dpdk.sh - git am command path

### DIFF
--- a/script/build_dpdk.sh
+++ b/script/build_dpdk.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+script_name=$(basename "$0")
+script_path=$(readlink -qe "$0")
+script_folder=${script_path/$script_name/}
+cd "${script_folder}"
+
 if [ -n "$1" ]; then
 	dpdk_ver=$1
 else

--- a/script/build_dpdk.sh
+++ b/script/build_dpdk.sh
@@ -24,7 +24,7 @@ git checkout v"$dpdk_ver"
 git switch -c v"$dpdk_ver"
 
 # apply the patches
-git am ../patches/dpdk/"$dpdk_ver"/*.patch
+git am ../../patches/dpdk/"$dpdk_ver"/*.patch
 
 # build and install dpdk now
 meson build


### PR DESCRIPTION
The `git am` command does use a path which drills down too little (does not hit the `patches` folder) and fails the script entirely.