### PR TITLE
Fix: V210 pg format

### DIFF
--- a/app/src/legacy/tx_video_app.c
+++ b/app/src/legacy/tx_video_app.c
@@ -350,9 +350,10 @@ static int app_tx_video_init_rtp(struct st_app_tx_video_session* s,
   struct st20_rfc4175_rtp_hdr* rtp = &s->st20_rtp_base;
 
   /* 4800 if 1080p yuv422 */
+  /* Calculate bytes per line, rounding up if there's a remainder */
   size_t raw_bytes_size = (size_t)ops->width * s->st20_pg.size;
-  s->st20_bytes_in_line = (raw_bytes_size / s->st20_pg.coverage) +
-                          ((raw_bytes_size % s->st20_pg.coverage != 0) ? 1 : 0);
+  s->st20_bytes_in_line =
+      (raw_bytes_size + s->st20_pg.coverage - 1) / s->st20_pg.coverage;
   s->st20_pkt_idx = 0;
   s->st20_seq_id = 1;
   int height = ops->height;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2624,9 +2624,10 @@ static int rv_handle_detect_pkt(struct st_rx_video_session_impl* s, struct rte_m
         s->st20_frame_size =
             ops->width * ops->height * s->st20_pg.size / s->st20_pg.coverage;
         if (ops->interlaced) s->st20_frame_size = s->st20_frame_size >> 1;
+        /* Calculate bytes per line, rounding up if there's a remainder */
         size_t raw_bytes_size = (size_t)ops->width * s->st20_pg.size;
-        s->st20_bytes_in_line = (raw_bytes_size / s->st20_pg.coverage) +
-                                ((raw_bytes_size % s->st20_pg.coverage != 0) ? 1 : 0);
+        s->st20_bytes_in_line =
+            (raw_bytes_size + s->st20_pg.coverage - 1) / s->st20_pg.coverage;
         s->st20_linesize = s->st20_bytes_in_line;
         if (ops->linesize > s->st20_linesize)
           s->st20_linesize = ops->linesize;
@@ -3056,9 +3057,10 @@ static int rv_attach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
   s->impl = impl;
   s->frame_time = (double)1000000000.0 * fps_tm.den / fps_tm.mul;
   s->frame_time_sampling = (double)(fps_tm.sampling_clock_rate) * fps_tm.den / fps_tm.mul;
+  /* Calculate bytes per line, rounding up if there's a remainder */
   size_t raw_bytes_size = (size_t)ops->width * s->st20_pg.size;
-  s->st20_bytes_in_line = (raw_bytes_size / s->st20_pg.coverage) +
-                          ((raw_bytes_size % s->st20_pg.coverage != 0) ? 1 : 0);
+  s->st20_bytes_in_line =
+      (raw_bytes_size + s->st20_pg.coverage - 1) / s->st20_pg.coverage;
   s->st20_linesize = s->st20_bytes_in_line;
   if (ops->linesize > s->st20_linesize)
     s->st20_linesize = ops->linesize;

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -2903,9 +2903,10 @@ static int tv_init_pkt(struct mtl_main_impl* impl, struct st_tx_video_session_im
          sizeof(struct st20_packet_group_info) * ST20_PKT_TYPE_MAX);
 
   /* 4800 if 1080p yuv422 */
+  /* Calculate bytes per line, rounding up if there's a remainder */
   size_t raw_bytes_size = (size_t)ops->width * s->st20_pg.size;
-  s->st20_bytes_in_line = (raw_bytes_size / s->st20_pg.coverage) +
-                          ((raw_bytes_size % s->st20_pg.coverage != 0) ? 1 : 0);
+  s->st20_bytes_in_line =
+      (raw_bytes_size + s->st20_pg.coverage - 1) / s->st20_pg.coverage;
   /* rtp mode only  */
   s->rtp_pkt_max_size = ops->rtp_pkt_size;
 
@@ -3067,9 +3068,9 @@ static int tv_attach(struct mtl_main_impl* impl, struct st_tx_video_sessions_mgr
   else
     s->tx_hang_detect_time_thresh = NS_PER_S;
 
+  /* Calculate bytes per line, rounding up if there's a remainder */
   size_t raw_bytes_size = (size_t)ops->width * s->st20_pg.size;
-  s->st20_linesize = (raw_bytes_size / s->st20_pg.coverage) +
-                     ((raw_bytes_size % s->st20_pg.coverage != 0) ? 1 : 0);
+  s->st20_linesize = (raw_bytes_size + s->st20_pg.coverage - 1) / s->st20_pg.coverage;
   if (ops->linesize > s->st20_linesize)
     s->st20_linesize = ops->linesize;
   else if (ops->linesize) {


### PR DESCRIPTION
PR fixes correct `st20_fb_size` and `st20_bytes_in_line` assign during the frame initialization caused by integer truncation.
This will fix the 'V210' format.

Tests are passing now:
![image](https://github.com/user-attachments/assets/ab003802-1927-40c4-9375-9651f9e82de3)
