### PR TITLE
Fix: flow rules failing after verification on PF

### DIFF
--- a/lib/src/mt_flow.c
+++ b/lib/src/mt_flow.c
@@ -178,6 +178,25 @@ static struct rte_flow* rte_rx_flow_create(struct mt_interface* inf, uint16_t q,
   mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
   r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
   mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+
+  /* WA specific for e810 for PF interfaces */
+  if (!has_ip_flow && !r_flow) {
+    info("%s(%d), Flow creation failed on default group, retrying with group 2\n",
+         __func__, port);
+    attr.group = 2;
+
+    ret = rte_flow_validate(port_id, &attr, pattern, action, &error);
+    if (ret < 0) {
+      err("%s(%d), rte_flow_validate fail %d for queue %d, %s\n", __func__, port, ret, q,
+          mt_string_safe(error.message));
+      return NULL;
+    }
+
+    mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
+    r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
+    mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+  }
+
   if (!r_flow) {
     err("%s(%d), rte_flow_create fail for queue %d, %s\n", __func__, port, q,
         mt_string_safe(error.message));


### PR DESCRIPTION
DPDK backend flow rules are failing on the E810 PF when ETH rules are ignored on
the default attribute group 0.

Flow rules are used to filter the data coming from queues, and by default,
attribute group 0 should be used. Applying the filters should not fail when the
flow validation function passes. However, this does not happen when we use
filters with the ETH segment set to NULL on E810 physical cards (it works fine
on the virtual NICs hosted on the same NIC).

Fix this problem for now by reapplying the flow rules when the verification
fails in this specific scenario.

This code should be deleted when the E810 PF NIC stops failing to apply
flow rules in this specific scenario.