### PR TITLE
Docs: GStreamer documentation

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -2,12 +2,33 @@
 
 ## Building the gstreamer plugins
 
+Before you begin, ensure you have the following installed on your system:  
+``` Meson ```
+
+
 ```shell
 cd Media-Transport-Library/ecosystem/gstreamer_plugin
 ./build.sh
 ```
 
 ## Running the pipeline
+
+### General argumetns
+In gstreamer plugins there are general arguments that apply to every plugin
+
+| Property Name | Type   | Description                                                                                       | Default Value | Range                    |
+|---------------|--------|---------------------------------------------------------------------------------------------------|---------------|--------------------------|
+| log-level     | uint   | Set the log level (INFO 1 to CRIT 5).                                                             | 1             | 1 (INFO) TO 5 (CRITICAL) |
+| dev-port      | string | DPDK port for synchronous ST 2110 data video transmission, bound to the VFIO DPDK driver.         | NULL          | N/A                      |
+| dev-ip        | string | Local IP address that the port will be identified by. This is the address from which ARP responses will be sent. | NULL | N/A                |
+| dma-dev       | string | DPDK port for the MTL direct memory functionality.                                                | NULL          | N/A                      |
+| port          | string | DPDK device port initialized for the transmission.                                                | NULL          | N/A                      |
+| ip            | string | Receiving MTL node IP address.                                                                    | NULL          | N/A                      |
+| udp-port      | uint   | Receiving MTL node UDP port.                                                                      | 20000         | 0 to G_MAXUINT           |
+| tx-queues     | uint   | Number of TX queues to initialize in DPDK backend.                                                | 16            | 0 to G_MAXUINT           |
+| rx-queues     | uint   | Number of RX queues to initialize in DPDK backend.                                                | 16            | 0 to G_MAXUINT           |
+| payload-type  | uint   | SMPTE ST 2110 payload type.                                                                       | 112           | 0 to G_MAXUINT           |
+
 
 ### St20 rawvideo plugin
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -151,6 +151,7 @@ Video plugins for MTL that are able to send, receive synchronous video via the M
 > Raw video plugins require that the buffers passed to them match the size of the video frame.
 > Ensure that the buffer size corresponds to the frame size of the video being processed.
 
+
 > **Warning:**
 > Keep in mind that raw video files are very large and saving / using them is I/O and memory space intensive.
 > Oftentimes pipeline choking point is the drive I/O speed limitation.

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -15,7 +15,7 @@ Before you begin, ensure you have the following installed on your system:
 
 To install the required GStreamer packages on Ubuntu or Debian, run the following commands:
 
-```shell
+```bash
 sudo apt update
 
 sudo apt install -y gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-tools gstreamer1.0-libav libgstreamer1.0-dev
@@ -27,7 +27,7 @@ sudo apt install -y gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreame
 
 To build the GStreamer plugins using the provided script, run the following commands:
 
-```shell
+```bash
 cd Media-Transport-Library/ecosystem/gstreamer_plugin
 ./build.sh
 ```
@@ -38,25 +38,25 @@ If you prefer to build the GStreamer plugins manually, follow these steps:
 
 1. Navigate to the GStreamer plugin directory:
 
-    ```shell
+    ```bash
     cd Media-Transport-Library/ecosystem/gstreamer_plugin
     ```
 
 2. Set up the build directory with debug build type:
 
-    ```shell
+    ```bash
     meson setup --buildtype=debug "$BUILD_DIR"
     ```
 
 3. Set up the build directory (if not already done):
 
-    ```shell
+    ```bash
     meson setup "$BUILD_DIR"
     ```
 
 4. Compile the project:
 
-    ```shell
+    ```bash
     meson compile -C "$BUILD_DIR"
     ```
 
@@ -71,7 +71,7 @@ To run GStreamer plugins, you need an application capable of using the GStreamer
 For first-time users, to use `gst-launch-1.0` with our plugins, you need to install the following packages from the package manager. For Ubuntu,
 this can be done by running the following command:
 
-```sh
+```bash
 sudo apt-get update
 sudo apt-get install gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly
 ```
@@ -88,7 +88,7 @@ To run plugins, you need to pass the path to the plugins to your GStreamer appli
 In the case of `gst-launch-1.0`, the argument for this is `--gst-plugin-path`.
 You can also move the plugins to the default plugin directory `$GSTREAMER_PLUGINS_PATH` instead (see [gstreamer-launch documentation](https://gstreamer.freedesktop.org/documentation/tools/gst-launch.html)).
 
-```sh
+```bash
 export GSTREAMER_PLUGINS_PATH=/path/to/your/compiled/plugins
 gst-inspect-1.0 --gst-plugin-path $GSTREAMER_PLUGINS_PATH mtl_st20p_rx
 ```
@@ -182,7 +182,7 @@ Here is how to generate an input video with `y210` format using GStreamer.
 
 In our pipelines, we will use the `$INPUT` variable to hold the path to the input video.
 
-```shell
+```bash
 export INPUT="path_to_the_input_v210_file"
 
 gst-launch-1.0 -v videotestsrc pattern=ball ! video/x-raw,width=1920,height=1080,format=v210,framerate=60/1 ! filesink location=$INPUT
@@ -195,7 +195,7 @@ To ensure the correct size of the buffer, we will use the `rawvideoparse` elemen
 
 
 The rest of rawvideo metadata will be passed via pad capabilities of the buffer.
-```shell
+```bash
 # If you don't know how to find VFIO PCI address of your device
 # refer to Media-Transport-Library/doc/run.md
 export VFIO_PORT_T="pci_address_of_the_device"
@@ -239,7 +239,7 @@ The `mtl_st20p_rx` plugin supports the following pad capabilities:
 
 In our pipelines, we will use the `$OUTPUT` variable to hold the path to the video.
 
-```shell
+```bash
 export OUTPUT="path_to_the_file_we_want_to_save"
 ```
 
@@ -249,7 +249,7 @@ To run the `mtl_st20p_rx` plugin, use the following command to specify the input
 
 > **Warning**: To receive data, ensure that a transmission is running with the same parameters on the `239.168.75.30` address.
 
-```shell
+```bash
 # If you don't know how to find the VFIO PCI address of your device
 # refer to Media-Transport-Library/doc/run.md
 export VFIO_PORT_R="pci_address_of_the_device"
@@ -287,7 +287,7 @@ The `mtl_st30p_tx` plugin supports the following pad capabilities:
 To run the `mtl_st30p_tx` plugin, you need to setup metadata (Here we are using pipeline capabilities).
 Instead of using input video we opted for build-in GStreamer audio files generator.
 
-```shell
+```bash
 # If you don't know how to find the VFIO PCI address of your device
 # refer to Media-Transport-Library/doc/run.md
 export VFIO_PORT_T="pci_address_of_the_device"
@@ -321,7 +321,7 @@ The `mtl_st30p_rx` plugin supports the following pad capabilities:
 
 In our pipelines, we will use the `$OUTPUT` variable to hold the path to the audio file.
 
-```shell
+```bash
 export OUTPUT="path_to_the_file_we_want_to_save"
 ```
 
@@ -331,7 +331,7 @@ To run the `mtl_st30p_rx` audio plugin use the command below:
 
 > **Warning**: To receive data, ensure that a transmission is running with the same parameters on the `239.168.75.30` address.
 
-```shell
+```bash
 # If you don't know how to find the VFIO PCI address of your device
 # refer to Media-Transport-Library/doc/run.md
 export VFIO_PORT_R="pci_address_of_the_device"
@@ -366,7 +366,7 @@ The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked
 
 To run the `mtl_st40p_tx` plugin, use the following command:
 
-```shell
+```bash
 # If you don't know how to find the VFIO PCI address of your device
 # refer to Media-Transport-Library/doc/run.md
 export VFIO_PORT_T="pci_address_of_the_device"
@@ -398,7 +398,7 @@ The `mtl_st40p_rx` plugin supports all pad capabilities (the data is not checked
 To run the `mtl_st40p_rx` plugin, use the following command:
 > **Warning**: To receive ancillary data, ensure that a transmission is running on the `239.168.75.30` address.
 
-```shell
+```bash
 # If you don't know how to find the VFIO PCI address of your device
 # refer to Media-Transport-Library/doc/run.md
 export VFIO_PORT_R="pci_address_of_the_device"

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -71,7 +71,7 @@ this can be done by running the following command:
 
 ```bash
 sudo apt-get update
-sudo apt-get install gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly
+sudo apt-get install gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 ```
 
 These packages include:
@@ -90,7 +90,7 @@ gst-inspect-1.0 --gst-plugin-path $GSTREAMER_PLUGINS_PATH mtl_st20p_rx
 ```
 
 ### 2.2. General arguments
-In GStreamer plugins there are general arguments that apply to every plugin.
+In MTL GStreamer plugins there are general arguments that apply to every plugin.
 
 | Property Name | Type   | Description                                                                                       | Range                    |
 |---------------|--------|---------------------------------------------------------------------------------------------------|--------------------------|
@@ -176,7 +176,7 @@ The `mtl_st20p_tx` plugin supports the following pad capabilities:
 To send the video, you need to have an input video ready.
 Here is how to generate an input video with `y210` format using GStreamer.
 
-In our pipelines, we will use the `$INPUT` variable to hold the path to the input video.
+In the following examples, we will use the `$INPUT` variable to hold the path to the input video.
 
 ```bash
 export INPUT="path_to_the_input_v210_file"
@@ -198,12 +198,6 @@ export VFIO_PORT_T="pci_address_of_the_device"
 
 # video pipeline y210 FHD 60fps on port 20000
 gst-launch-1.0 filesrc location=$INPUT ! \
-rawvideoparse format=v210 height=1080 width=1920 framerate=60/1 ! \
-mtl_st20p_tx tx-queues=4 rx-queues=0 udp-port=20000 payload-type=112 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T \
---gst-plugin-path $GSTREAMER_PLUGINS_PATH
-
-# video pipeline y210 FHD 60fps on port 20000
-gst-launch-1.0 multifilesrc location=$INPUT loop=true ! \
 rawvideoparse format=v210 height=1080 width=1920 framerate=60/1 ! \
 mtl_st20p_tx tx-queues=4 rx-queues=0 udp-port=20000 payload-type=112 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T \
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
@@ -274,7 +268,6 @@ The `mtl_st30p_tx` plugin supports the following pad capabilities:
 **Arguments**
 | Property Name       | Type   | Description                                           | Range                   | Default Value |
 |---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
-| retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
 | tx-samplerate       | uint   | Sample rate of the audio.                             | [gst_mtl_supported_audio_sampling](#232-supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 0 |
 | tx-channels         | uint   | Number of audio channels.                             | 1 to 8                  | 2             |
 
@@ -353,10 +346,12 @@ The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked
 - **Capabilities**: Any (GST_STATIC_CAPS_ANY)
 
 **Arguments**
-| Property Name       | Type   | Description                                           | Range                   | Default Value |
-|---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
-| retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
-| tx-framebuff-cnt    | uint   | Number of framebuffers to be used for transmission.   | 0 to G_MAXUINT          | 3             |
+| Property Name     | Type | Description                                                        | Range         | Default Value |
+|-------------------|------|--------------------------------------------------------------------|---------------|---------------|
+| tx-framebuff-cnt  | uint | Number of framebuffers to be used for transmission.                | 0 to G_MAXUINT| 3             |
+| tx-fps            | uint | Framerate of the video to which the ancillary data is synchronized.| 0 to G_MAXUINT| 60            |
+| tx-did            | uint | Data ID for the ancillary data.                                    | 0 to 255      | 0             |
+| tx-sdid           | uint | Secondary Data ID for the ancillary data.                          | 0 to 255      | 0             |
 
 #### 5.1.2. Example GStreamer Pipeline for Transmission
 
@@ -368,10 +363,8 @@ To run the `mtl_st40p_tx` plugin, use the following command:
 export VFIO_PORT_T="pci_address_of_the_device"
 
 # Ancillary data pipeline on port 40000
-gst-launch-1.0 -v mtl_st40p_tx tx-queues=4 rx-queues=0 udp-port=40000 payload-type=113 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T retry=10 tx-framebuff-cnt=3 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
+gst-launch-1.0 -v mtl_st40p_tx tx-queues=4 udp-port=40000 payload-type=113 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T  tx-framebuff-cnt=3 tx-fps=60 tx-did=67 tx-sdid=2 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
-
-> **Warning**: To transmit ancillary data, ensure that a receiver is running with the same parameters on the `239.168.75.30` address.
 
 This command sets up the transmission pipeline with the specified parameters and sends the ancillary data using the `mtl_st40p_tx` plugin.
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -1,8 +1,8 @@
 # Gstreamer plugin for MTL
 
-## Building the gstreamer plugins
+## Building the GStreamer plugins
 
-### Prerequisits
+### Prerequisites
 Before you begin, ensure you have the following installed on your system:
 - `MTL`
 - `Meson`
@@ -21,7 +21,7 @@ sudo apt update
 sudo apt install -y gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-tools gstreamer1.0-libav libgstreamer1.0-dev
 ```
 
-For mtl installation instruction please look at [Build Documentation](../../doc/build.md)
+> For MTL installation instructions please refer to  [Build Documentation](../../doc/build.md).
 
 ### Automated Build
 
@@ -64,7 +64,7 @@ By following these steps, you can manually build the GStreamer plugins.
 
 ## Running the pipeline
 
-### Prerequisits
+### Prerequisites
 
 To run GStreamer plugins, you need an application capable of using the GStreamer plugin API. In the examples provided, we are using `gst-launch-1.0`.
 
@@ -84,18 +84,17 @@ These packages include:
 - **gstreamer1.0-plugins-ugly**: Includes plugins that might have licensing issues or are not considered to be of the highest quality.
 By installing these packages, you will have all the necessary tools and plugins to run GStreamer applications and use the `gst-launch-1.0` tool with our plugins.
 
-To run plugins you need to pass the path to the plugin to your gstreamer aplication / load the plugins to your gstreamer aplication.
-In case of gstreamer-launch-1.0 argument for those is `--gst-plugin-path`. In the pipeline examples below we will be using the `$GSTREAMER_PLUGINS_PATH` wchich
-should contain the path to the compiled mtl gstreamer plugins.
-You can also move the plugins to the deafult plugin directory instead (see [gstreamer-launch documentation] ).
+To run plugins, you need to pass the path to the plugins to your GStreamer application or load them directly.
+In the case of `gst-launch-1.0`, the argument for this is `--gst-plugin-path`.
+You can also move the plugins to the default plugin directory `$GSTREAMER_PLUGINS_PATH` instead (see [gstreamer-launch documentation](https://gstreamer.freedesktop.org/documentation/tools/gst-launch.html)).
 
 ```sh
 export GSTREAMER_PLUGINS_PATH=/path/to/your/compiled/plugins
 gst-inspect-1.0 --gst-plugin-path $GSTREAMER_PLUGINS_PATH mtl_st20p_rx
 ```
 
-### General argumetns
-In gstreamer plugins there are general arguments that apply to every plugin
+### General arguments
+In GStreamer plugins there are general arguments that apply to every plugin.
 
 | Property Name | Type   | Description                                                                                       | Range                    |
 |---------------|--------|---------------------------------------------------------------------------------------------------|--------------------------|
@@ -108,15 +107,15 @@ In gstreamer plugins there are general arguments that apply to every plugin
 | rx-queues     | uint   | Number of RX queues to initialize in DPDK backend.                                                | 0 to G_MAXUINT           |
 | payload-type  | uint   | SMPTE ST 2110 payload type.                                                                  | 0 to G_MAXUINT           |
 
-Those are also general parameters akcepted by plugins but the functionality they "give" to the user is not yet supported in plugins.
+These are also general parameters accepted by plugins, but the functionality they provide to the user is not yet supported in plugins.
 | Property Name | Type   | Description                                                                                       | Range                    |
 |---------------|--------|---------------------------------------------------------------------------------------------------|--------------------------|
 | dma-dev       | string | **RESERVED FOR FUTURE USE** port for the MTL direct memory functionality.                         | N/A                      |
 | port          | string | **RESERVED FOR FUTURE USE** DPDK device port. Utilized when multiple ports are passed to the MTL library to select the port for the session. | N/A |
 
-### General capabilites
+### General capabilities
 
-Some structures describe the capabilites generally
+Some structures describe the capabilities generally
 
 #### Supported video fps codes gst_mtl_supported_fps
 ```c
@@ -146,7 +145,7 @@ enum gst_mtl_supported_audio_sampling {
 
 ### SMPTE ST 2110-20 Rawvideo plugins
 
-Video plugins for MTL that are able to send, recieve synchronous video via the MTL pipeline API.
+Video plugins for MTL that are able to send, receive synchronous video via the MTL pipeline API.
 
 > **Warning:**
 > Raw video plugins require that the buffers passed to them match the size of the video frame.
@@ -154,11 +153,11 @@ Video plugins for MTL that are able to send, recieve synchronous video via the M
 
 > **Warning:**
 > Keep in mind that raw video files are very large and saving / using them is I/O and memory space intensive.
-> Oftentimes pipeline chocking point is the drive I/O speed limitation.
+> Oftentimes pipeline choking point is the drive I/O speed limitation.
 
 ### Running the SMPTE ST 2110-20 transmission plugin mtl_st20p_tx
 
-#### Supported parmeters and pad capabilites
+#### Supported parameters and pad capabilities
 
 The `mtl_st20p_tx` plugin supports the following pad capabilities:
 
@@ -181,7 +180,7 @@ The `mtl_st20p_tx` plugin supports the following pad capabilities:
 To send the video, you need to have an input video ready.
 Here is how to generate an input video with `y210` format using GStreamer.
 
-In our pipelines, we will use the `$INPUT` variable to hold the path to the video.
+In our pipelines, we will use the `$INPUT` variable to hold the path to the input video.
 
 ```shell
 export INPUT="path_to_the_input_v210_file"
@@ -191,12 +190,11 @@ gst-launch-1.0 -v videotestsrc pattern=ball ! video/x-raw,width=1920,height=1080
 
 #### Pipline example for multicast `y210`
 
-To run the raw video transmission plugin we need to pass the mtl parameters
-responsible for initializing mtl library, to ensure the correct size of the buffer
-we will use rawvideo prarser in case of `y210`.
+To run the raw video transmission plugin, we need to pass the MTL parameters responsible for initializing the MTL library.
+To ensure the correct size of the buffer, we will use the `rawvideoparse` element in the case of `y210`.
 
 
-The rest of rawvideo metadata will be passed via pad capabilites of the buffer.
+The rest of rawvideo metadata will be passed via pad capabilities of the buffer.
 ```shell
 # If you don't know how to find VFIO PCI address of your device
 # refer to Media-Transport-Library/doc/run.md
@@ -215,7 +213,7 @@ mtl_st20p_tx tx-queues=4 rx-queues=0 udp-port=20000 payload-type=112 dev-ip="192
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
-### Running the SMPTE ST 2110-20 reciever plugin mtl_st20p_rx
+### Running the SMPTE ST 2110-20 receiver plugin mtl_st20p_rx
 
 #### Supported Parameters and Pad Capabilities
 
@@ -265,7 +263,7 @@ This command sets up the receiver pipeline with the specified parameters and sav
 
 ### SMPTE ST 2110-30 Raw audio plugins
 
-Audio plugins for MTL that are able to send, recieve synchronous raw audio via the MTL pipeline API.
+Audio plugins for MTL that are able to send, receive synchronous raw audio via the MTL pipeline API.
 
 ### Running the SMPTE ST 2110-30 transmission plugin mtl_st30p_tx
 
@@ -287,7 +285,7 @@ The `mtl_st30p_tx` plugin supports the following pad capabilities:
 #### Example GStreamer Pipeline for Transmission with s16LE format
 
 To run the `mtl_st30p_tx` plugin, you need to setup metadata (Here we are using pipeline capabilities).
-Instead of using input video we opted for buildin gstreamer audio files generator.
+Instead of using input video we opted for build-in GStreamer audio files generator.
 
 ```shell
 # If you don't know how to find the VFIO PCI address of your device
@@ -348,7 +346,7 @@ filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 
 ### SMPT SMPTE ST 2110-40 Ancillary Data Plugins
 
-Ancillary data plugins for MTL that are able to send and receive synchronous ancillary data via the MTL pipeline API.
+Ancillary data plugins for MTL that are able to send and receive synchronous ancillary data via the MTL API.
 
 ### Running the SMPTE ST 2110-40 Transmission Plugin `mtl_st40p_tx`
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -172,7 +172,7 @@ The `mtl_st20p_tx` plugin supports the following pad capabilities:
 | Property Name       | Type   | Description                                           | Range                   | Default Value |
 |---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
 | retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
-| tx-fps              | uint   | Framerate of the video.                               | [gst_mtl_supported_fps](#video-formats-gst_mtl_supported_fps) | 0 |
+| tx-fps              | uint   | Framerate of the video.                               | [gst_mtl_supported_fps](#231-supported-video-fps-codes-gst_mtl_supported_fps) | 0 |
 | tx-framebuff-num    | uint   | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
 
 #### 3.1.2. Preparing Input Video
@@ -228,7 +228,7 @@ The `mtl_st20p_rx` plugin supports the following pad capabilities:
 | Property Name       | Type    | Description                                         | Range                      | Default Value |
 |---------------------|---------|-----------------------------------------------------|----------------------------|---------------|
 | retry               | uint    | Number of times the MTL will try to get a frame.    | 0 to G_MAXUINT             | 10            |
-| rx-fps              | uint    | Framerate of the video.                             | [gst_mtl_supported_fps](#video-formats-gst_mtl_supported_fps) | 0 |
+| rx-fps              | uint    | Framerate of the video.                             | [gst_mtl_supported_fps](#231-supported-video-fps-codes-gst_mtl_supported_fps) | 0 |
 | rx-framebuff-num    | uint    | Number of framebuffers to be used for transmission. | 0 to 8                     | 3             |
 | rx-width            | uint    | Width of the video.                                 | 0 to G_MAXUINT             | 1920          |
 | rx-height           | uint    | Height of the video.                                | 0 to G_MAXUINT             | 1080          |
@@ -279,7 +279,7 @@ The `mtl_st30p_tx` plugin supports the following pad capabilities:
 | Property Name       | Type   | Description                                           | Range                   | Default Value |
 |---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
 | retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
-| tx-samplerate       | uint   | Sample rate of the audio.                             | [gst_mtl_supported_audio_sampling](#supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 0 |
+| tx-samplerate       | uint   | Sample rate of the audio.                             | [gst_mtl_supported_audio_sampling](#232-supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 0 |
 | tx-channels         | uint   | Number of audio channels.                             | 1 to 8                  | 2             |
 
 #### 4.1.2. Example GStreamer Pipeline for Transmission with s16LE format
@@ -314,7 +314,7 @@ The `mtl_st30p_rx` plugin supports the following pad capabilities:
 |---------------------|---------|-------------------------------------------------------|-------------------------|---------------|
 | rx-framebuff-num    | uint    | Number of framebuffers to be used for transmission.   | 0 to G_MAXUINT          | 3             |
 | rx-channel          | uint    | Audio channel number.                                 | 0 to G_MAXUINT          | 2             |
-| rx-sampling         | uint    | Audio sampling rate.                                  | [gst_mtl_supported_audio_sampling](#supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 48000         |
+| rx-sampling         | uint    | Audio sampling rate.                                  | [gst_mtl_supported_audio_sampling](#232-supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 48000         |
 | rx-audio-format     | string  | Audio format type.                                    | `S8`, `S16LE`, `S24LE`  | `S16LE`       |
 
 #### 4.2.2. Preparing Output Path

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -1,8 +1,8 @@
 # Gstreamer plugin for MTL
 
-## Building the GStreamer plugins
+## 1. Building the GStreamer plugins
 
-### Prerequisites
+### 1.1. Prerequisites
 Before you begin, ensure you have the following installed on your system:
 - `MTL`
 - `Meson`
@@ -23,7 +23,7 @@ sudo apt install -y gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreame
 
 > For MTL installation instructions please refer to  [Build Documentation](../../doc/build.md).
 
-### Automated Build
+### 1.2. Automated Build
 
 To build the GStreamer plugins using the provided script, run the following commands:
 
@@ -32,7 +32,7 @@ cd Media-Transport-Library/ecosystem/gstreamer_plugin
 ./build.sh
 ```
 
-### Manual Build Instructions
+### 1.3. Manual Build Instructions
 
 If you prefer to build the GStreamer plugins manually, follow these steps:
 
@@ -62,9 +62,9 @@ If you prefer to build the GStreamer plugins manually, follow these steps:
 
 By following these steps, you can manually build the GStreamer plugins.
 
-## Running the pipeline
+## 2. Running the pipeline
 
-### Prerequisites
+### 2.1. Prerequisites
 
 To run GStreamer plugins, you need an application capable of using the GStreamer plugin API. In the examples provided, we are using `gst-launch-1.0`.
 
@@ -93,7 +93,7 @@ export GSTREAMER_PLUGINS_PATH=/path/to/your/compiled/plugins
 gst-inspect-1.0 --gst-plugin-path $GSTREAMER_PLUGINS_PATH mtl_st20p_rx
 ```
 
-### General arguments
+### 2.2. General arguments
 In GStreamer plugins there are general arguments that apply to every plugin.
 
 | Property Name | Type   | Description                                                                                       | Range                    |
@@ -113,11 +113,11 @@ These are also general parameters accepted by plugins, but the functionality the
 | dma-dev       | string | **RESERVED FOR FUTURE USE** port for the MTL direct memory functionality.                         | N/A                      |
 | port          | string | **RESERVED FOR FUTURE USE** DPDK device port. Utilized when multiple ports are passed to the MTL library to select the port for the session. | N/A |
 
-### General capabilities
+### 2.3. General capabilities
 
 Some structures describe the capabilities generally
 
-#### Supported video fps codes gst_mtl_supported_fps
+#### 2.3.1. Supported video fps codes gst_mtl_supported_fps
 ```c
 enum gst_mtl_supported_fps {
   GST_MTL_SUPPORTED_FPS_23_98 = 2398,   // 23.98 fps
@@ -134,7 +134,7 @@ enum gst_mtl_supported_fps {
 };
 ```
 
-#### Supported Audio Sampling Rates gst_mtl_supported_audio_sampling
+#### 2.3.2. Supported Audio Sampling Rates gst_mtl_supported_audio_sampling
 ```c
 enum gst_mtl_supported_audio_sampling {
   GST_MTL_SUPPORTED_AUDIO_SAMPLING_44_1K = 44100,  // 44.1 kHz
@@ -143,7 +143,7 @@ enum gst_mtl_supported_audio_sampling {
 };
 ```
 
-### SMPTE ST 2110-20 Rawvideo plugins
+## 3. SMPTE ST 2110-20 Rawvideo plugins
 
 Video plugins for MTL that are able to send, receive synchronous video via the MTL pipeline API.
 
@@ -155,9 +155,9 @@ Video plugins for MTL that are able to send, receive synchronous video via the M
 > Keep in mind that raw video files are very large and saving / using them is I/O and memory space intensive.
 > Oftentimes pipeline choking point is the drive I/O speed limitation.
 
-### Running the SMPTE ST 2110-20 transmission plugin mtl_st20p_tx
+### 3.1. Running the SMPTE ST 2110-20 transmission plugin mtl_st20p_tx
 
-#### Supported parameters and pad capabilities
+#### 3.1.1. Supported parameters and pad capabilities
 
 The `mtl_st20p_tx` plugin supports the following pad capabilities:
 
@@ -175,7 +175,7 @@ The `mtl_st20p_tx` plugin supports the following pad capabilities:
 | tx-fps              | uint   | Framerate of the video.                               | [gst_mtl_supported_fps](#video-formats-gst_mtl_supported_fps) | 0 |
 | tx-framebuff-num    | uint   | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
 
-#### Preparing Input Video
+#### 3.1.2. Preparing Input Video
 
 To send the video, you need to have an input video ready.
 Here is how to generate an input video with `y210` format using GStreamer.
@@ -188,7 +188,7 @@ export INPUT="path_to_the_input_v210_file"
 gst-launch-1.0 -v videotestsrc pattern=ball ! video/x-raw,width=1920,height=1080,format=v210,framerate=60/1 ! filesink location=$INPUT
 ```
 
-#### Pipline example for multicast `y210`
+#### 3.1.3. Pipline example for multicast `y210`
 
 To run the raw video transmission plugin, we need to pass the MTL parameters responsible for initializing the MTL library.
 To ensure the correct size of the buffer, we will use the `rawvideoparse` element in the case of `y210`.
@@ -213,9 +213,9 @@ mtl_st20p_tx tx-queues=4 rx-queues=0 udp-port=20000 payload-type=112 dev-ip="192
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
-### Running the SMPTE ST 2110-20 receiver plugin mtl_st20p_rx
+### 3.2. Running the SMPTE ST 2110-20 receiver plugin mtl_st20p_rx
 
-#### Supported Parameters and Pad Capabilities
+#### 3.2.1. Supported Parameters and Pad Capabilities
 
 The `mtl_st20p_rx` plugin supports the following pad capabilities:
 
@@ -235,7 +235,7 @@ The `mtl_st20p_rx` plugin supports the following pad capabilities:
 | rx-interlaced       | boolean | Whether the video is interlaced.                    | TRUE/FALSE                 | FALSE         |
 | rx-pixel-format     | string  | Pixel format of the video.                          | `v210`, `YUV444PLANAR10LE` | `v210`        |
 
-#### Preparing output path
+#### 3.2.2. Preparing output path
 
 In our pipelines, we will use the `$OUTPUT` variable to hold the path to the video.
 
@@ -243,7 +243,7 @@ In our pipelines, we will use the `$OUTPUT` variable to hold the path to the vid
 export OUTPUT="path_to_the_file_we_want_to_save"
 ```
 
-#### Pipline example for multicast with `y210` format
+#### 3.2.3. Pipline example for multicast with `y210` format
 
 To run the `mtl_st20p_rx` plugin, use the following command to specify the input parameters of the incoming stream.
 
@@ -261,13 +261,13 @@ filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 
 This command sets up the receiver pipeline with the specified parameters and saves the received video to the specified output path.
 
-### SMPTE ST 2110-30 Raw audio plugins
+## 4. SMPTE ST 2110-30 Raw audio plugins
 
 Audio plugins for MTL that are able to send, receive synchronous raw audio via the MTL pipeline API.
 
-### Running the SMPTE ST 2110-30 transmission plugin mtl_st30p_tx
+### 4.1. Running the SMPTE ST 2110-30 transmission plugin mtl_st30p_tx
 
-#### Supported Parameters and Pad Capabilities
+#### 4.1.1. Supported Parameters and Pad Capabilities
 
 The `mtl_st30p_tx` plugin supports the following pad capabilities:
 
@@ -282,7 +282,7 @@ The `mtl_st30p_tx` plugin supports the following pad capabilities:
 | tx-samplerate       | uint   | Sample rate of the audio.                             | [gst_mtl_supported_audio_sampling](#supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 0 |
 | tx-channels         | uint   | Number of audio channels.                             | 1 to 8                  | 2             |
 
-#### Example GStreamer Pipeline for Transmission with s16LE format
+#### 4.1.2. Example GStreamer Pipeline for Transmission with s16LE format
 
 To run the `mtl_st30p_tx` plugin, you need to setup metadata (Here we are using pipeline capabilities).
 Instead of using input video we opted for build-in GStreamer audio files generator.
@@ -299,9 +299,9 @@ mtl_st30p_tx tx-queues=4 rx-queues=0 udp-port=30000 payload-type=113 dev-ip="192
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
-### Running the SMPTE ST 2110-30 Receiver Plugin `mtl_st30p_rx`
+### 4.2. Running the SMPTE ST 2110-30 Receiver Plugin `mtl_st30p_rx`
 
-#### Supported Parameters and Pad Capabilities
+#### 4.2.1. Supported Parameters and Pad Capabilities
 
 The `mtl_st30p_rx` plugin supports the following pad capabilities:
 
@@ -317,7 +317,7 @@ The `mtl_st30p_rx` plugin supports the following pad capabilities:
 | rx-sampling         | uint    | Audio sampling rate.                                  | [gst_mtl_supported_audio_sampling](#supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 48000         |
 | rx-audio-format     | string  | Audio format type.                                    | `S8`, `S16LE`, `S24LE`  | `S16LE`       |
 
-#### Preparing Output Path
+#### 4.2.2. Preparing Output Path
 
 In our pipelines, we will use the `$OUTPUT` variable to hold the path to the audio file.
 
@@ -325,7 +325,7 @@ In our pipelines, we will use the `$OUTPUT` variable to hold the path to the aud
 export OUTPUT="path_to_the_file_we_want_to_save"
 ```
 
-#### Example GStreamer pipeline for reception
+#### 4.2.3. Example GStreamer pipeline for reception
 
 To run the `mtl_st30p_rx` audio plugin use the command below:
 
@@ -344,13 +344,13 @@ gst-launch-1.0 -v mtl_st30p_rx rx-queues=4 udp-port=30000 payload-type=111 dev-i
 filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
-### SMPT SMPTE ST 2110-40 Ancillary Data Plugins
+## 5. SMPT SMPTE ST 2110-40 Ancillary Data Plugins
 
 Ancillary data plugins for MTL that are able to send and receive synchronous ancillary data via the MTL API.
 
-### Running the SMPTE ST 2110-40 Transmission Plugin `mtl_st40p_tx`
+### 5.1. Running the SMPTE ST 2110-40 Transmission Plugin `mtl_st40p_tx`
 
-#### Supported Parameters and Pad Capabilities
+#### 5.1.1. Supported Parameters and Pad Capabilities
 
 The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked):
 
@@ -362,7 +362,7 @@ The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked
 | retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
 | tx-framebuff-cnt    | uint   | Number of framebuffers to be used for transmission.   | 0 to G_MAXUINT          | 3             |
 
-#### Example GStreamer Pipeline for Transmission
+#### 5.1.2. Example GStreamer Pipeline for Transmission
 
 To run the `mtl_st40p_tx` plugin, use the following command:
 
@@ -379,14 +379,9 @@ gst-launch-1.0 -v mtl_st40p_tx tx-queues=4 rx-queues=0 udp-port=40000 payload-ty
 
 This command sets up the transmission pipeline with the specified parameters and sends the ancillary data using the `mtl_st40p_tx` plugin.
 
+### 5.2. Running the SMPTE ST 2110-40 Receiver Plugin `mtl_st40p_rx`
 
-### SMPTE ST 2110-40 Ancillary Data Plugins
-
-Ancillary data plugins for MTL that are able to send and receive synchronous ancillary data via the MTL pipeline API.
-
-### Running the SMPTE ST 2110-40 Receiver Plugin `mtl_st40p_rx`
-
-#### Supported Parameters and Pad Capabilities
+#### 5.2.1. Supported Parameters and Pad Capabilities
 
 The `mtl_st40p_rx` plugin supports all pad capabilities (the data is not checked):
 
@@ -398,7 +393,7 @@ The `mtl_st40p_rx` plugin supports all pad capabilities (the data is not checked
 | buffer-size         | uint   | Size of the buffer used for receiving data            | 0 to G_MAXUINT (power of 2) | 1024          |
 | timeout             | uint   | Timeout in seconds for getting mbuf                   | 0 to G_MAXUINT              | 10            |
 
-#### Example GStreamer Pipeline for Reception
+#### 5.2.2. Example GStreamer Pipeline for Reception
 
 To run the `mtl_st40p_rx` plugin, use the following command:
 > **Warning**: To receive ancillary data, ensure that a transmission is running on the `239.168.75.30` address.

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -1,0 +1,66 @@
+# Gstreamer plugin for MTL
+
+## Building the gstreamer plugins
+
+```shell
+cd Media-Transport-Library/ecosystem/gstreamer_plugin
+./build.sh
+```
+
+## Running the pipeline
+
+### St20 rawvideo plugin
+
+To run the st20 rawvideo plugin you need to pass the path to the plugin to your
+gstreamer aplication.
+
+you need to also prepare v210 video
+
+```shell
+export INPUT="path_to_the_input_v210_file"
+
+# you can produce it with gst-launch-1.0
+gst-launch-1.0 -v videotestsrc pattern=ball ! video/x-raw,width=1920,height=1080,format=v210,framerate=60/1 ! filesink location=$INPUT
+```
+
+```shell
+# DPDK PCI address bound (see doc/build.md)
+export VFIO_PORT_T="pci address of the device"
+
+# Path to the built GStreamer plugin
+export GSTREAMER_PLUGINS_PATH="path to the folder with builded plugins"
+
+# video pipeline
+gst-launch-1.0 filesrc location=$INPUT ! \
+rawvideoparse format=v210 height=1080 width=1920 framerate=60/1 ! \
+mtltxsink tx-queues=4 tx-udp-port=20000 tx-payload-type=112 dev-ip="192.168.96.3" tx-ip="239.168.75.30" dev-port=$VFIO_PORT_T \
+--gst-plugin-path $GSTREAMER_PLUGINS_PATH
+
+
+# looping video pipeline
+gst-launch-1.0 multifilesrc location=$INPUT loop=true ! \
+rawvideoparse format=v210 height=1080 width=1920 framerate=60/1 ! \
+mtltxsink tx-queues=4 tx-udp-port=20000 tx-payload-type=112 dev-ip="192.168.96.3" tx-ip="239.168.75.30" dev-port=$VFIO_PORT_T \
+--gst-plugin-path $GSTREAMER_PLUGINS_PATH
+```
+
+## Supported formats
+The mtltxsink element supports the following pad capabilities:
+
+Format:
+v210
+I422_10LE
+
+Width:
+Range: 64 to 16384 pixels
+
+Height:
+Range: 64 to 8704 pixels
+
+Framerate:
+Supported values: 24, 25, 30, 50, 60, 120
+If you use the `fps` property to overwrite the caps, you can use the following framerates:
+120 119.88 100 60 59.94 50 30 29.97 25 24 23.98
+
+
+Framebuffers passed need to be the size of the frame

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -2,137 +2,346 @@
 
 ## Building the gstreamer plugins
 
-Before you begin, ensure you have the following installed on your system:  
-``` Meson ```
+### Prerequisits
+Before you begin, ensure you have the following installed on your system:
+- `MTL`
+- `Meson`
+- `gst-plugins-base`
+- `gst-plugins-good`
+- `gst-plugins-bad`
+- `gst-plugins-ugly`
+- `gstreamer`
+- `gstreamer-devel`
 
+To install the required GStreamer packages on Ubuntu or Debian, run the following commands:
+
+```shell
+sudo apt update
+
+sudo apt install -y gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-tools gstreamer1.0-libav libgstreamer1.0-dev
+```
+
+For mtl installation instruction please look at [Build Documentation](../../doc/build.md)
+
+### Automated Build
+
+To build the GStreamer plugins using the provided script, run the following commands:
 
 ```shell
 cd Media-Transport-Library/ecosystem/gstreamer_plugin
 ./build.sh
 ```
 
+### Manual Build Instructions
+
+If you prefer to build the GStreamer plugins manually, follow these steps:
+
+1. Navigate to the GStreamer plugin directory:
+
+    ```shell
+    cd Media-Transport-Library/ecosystem/gstreamer_plugin
+    ```
+
+2. Set up the build directory with debug build type:
+
+    ```shell
+    meson setup --buildtype=debug "$BUILD_DIR"
+    ```
+
+3. Set up the build directory (if not already done):
+
+    ```shell
+    meson setup "$BUILD_DIR"
+    ```
+
+4. Compile the project:
+
+    ```shell
+    meson compile -C "$BUILD_DIR"
+    ```
+
+By following these steps, you can manually build the GStreamer plugins.
+
 ## Running the pipeline
+
+### Prerequisits
+
+To run GStreamer plugins, you need an application capable of using the GStreamer plugin API. In the examples provided, we are using `gst-launch-1.0`.
+
+For first-time users, to use `gst-launch-1.0` with our plugins, you need to install the following packages from the package manager. For Ubuntu,
+this can be done by running the following command:
+
+```sh
+sudo apt-get update
+sudo apt-get install gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly
+```
+
+These packages include:
+- **gstreamer1.0-tools**: Provides the `gst-launch-1.0` tool and other GStreamer utilities.
+- **gstreamer1.0-plugins-base**: Contains the base set of plugins, which are essential for most GStreamer applications.
+- **gstreamer1.0-plugins-good**: Includes a set of well-supported plugins that are generally considered to be of good quality.
+- **gstreamer1.0-plugins-bad**: Contains a set of plugins that are still under development or testing.
+- **gstreamer1.0-plugins-ugly**: Includes plugins that might have licensing issues or are not considered to be of the highest quality.
+By installing these packages, you will have all the necessary tools and plugins to run GStreamer applications and use the `gst-launch-1.0` tool with our plugins.
+
+To run plugins you need to pass the path to the plugin to your gstreamer aplication / load the plugins to your gstreamer aplication.
+In case of gstreamer-launch-1.0 argument for those is `--gst-plugin-path`. In the pipeline examples below we will be using the `$GSTREAMER_PLUGINS_PATH` wchich
+should contain the path to the compiled mtl gstreamer plugins.
+You can also move the plugins to the deafult plugin directory instead (see [gstreamer-launch documentation] ).
+
+```sh
+export GSTREAMER_PLUGINS_PATH=/path/to/your/compiled/plugins
+gst-inspect-1.0 --gst-plugin-path $GSTREAMER_PLUGINS_PATH mtl_st20p_rx
+```
 
 ### General argumetns
 In gstreamer plugins there are general arguments that apply to every plugin
 
-| Property Name | Type   | Description                                                                                       | Default Value | Range                    |
-|---------------|--------|---------------------------------------------------------------------------------------------------|---------------|--------------------------|
-| log-level     | uint   | Set the log level (INFO 1 to CRIT 5).                                                             | 1             | 1 (INFO) TO 5 (CRITICAL) |
-| dev-port      | string | DPDK port for synchronous ST 2110 data video transmission, bound to the VFIO DPDK driver.         | NULL          | N/A                      |
-| dev-ip        | string | Local IP address that the port will be identified by. This is the address from which ARP responses will be sent. | NULL | N/A                |
-| dma-dev       | string | DPDK port for the MTL direct memory functionality.                                                | NULL          | N/A                      |
-| port          | string | DPDK device port initialized for the transmission.                                                | NULL          | N/A                      |
-| ip            | string | Receiving MTL node IP address.                                                                    | NULL          | N/A                      |
-| udp-port      | uint   | Receiving MTL node UDP port.                                                                      | 20000         | 0 to G_MAXUINT           |
-| tx-queues     | uint   | Number of TX queues to initialize in DPDK backend.                                                | 16            | 0 to G_MAXUINT           |
-| rx-queues     | uint   | Number of RX queues to initialize in DPDK backend.                                                | 16            | 0 to G_MAXUINT           |
-| payload-type  | uint   | SMPTE ST 2110 payload type.                                                                       | 112           | 0 to G_MAXUINT           |
+| Property Name | Type   | Description                                                                                       | Range                    |
+|---------------|--------|---------------------------------------------------------------------------------------------------|--------------------------|
+| log-level     | uint   | Set the log level (INFO 1 to CRIT 5).                                                             | 1 (INFO) TO 5 (CRITICAL) |
+| dev-port      | string | DPDK port for synchronous transmission and reception, bound to the VFIO DPDK driver.              | N/A                      |
+| dev-ip        | string | Local IP address that the port will be identified by. This is the address from which ARP responses will be sent. | N/A       |
+| ip            | string | Receiving MTL node IP address.                                                                    | N/A                      |
+| udp-port      | uint   | Receiving MTL node UDP port.                                                                      | 0 to G_MAXUINT           |
+| tx-queues     | uint   | Number of TX queues to initialize in DPDK backend.                                                | 0 to G_MAXUINT           |
+| rx-queues     | uint   | Number of RX queues to initialize in DPDK backend.                                                | 0 to G_MAXUINT           |
+| payload-type  | uint   | SMPTE ST 2110 payload type.                                                                       | 0 to G_MAXUINT           |
+
+Those are also general parameters akcepted by plugins but the functionality they "give" to the user is not yet supported in plugins.
+| Property Name | Type   | Description                                                                                       | Range                    |
+|---------------|--------|---------------------------------------------------------------------------------------------------|--------------------------|
+| dma-dev       | string | **RESERVED FOR FUTURE USE** port for the MTL direct memory functionality.                         | N/A                      |
+| port          | string | **RESERVED FOR FUTURE USE** DPDK device port. Utilized when multiple ports are passed to the MTL library to select the port for the session. | N/A |
+
+### General capabilites
+
+Some structures describe the capabilites generally
+
+#### Supported video fps codes gst_mtl_supported_fps
+```c
+enum gst_mtl_supported_fps {
+  GST_MTL_SUPPORTED_FPS_23_98 = 2398,   // 23.98 fps
+  GST_MTL_SUPPORTED_FPS_24 = 24,        // 24 fps
+  GST_MTL_SUPPORTED_FPS_25 = 25,        // 25 fps
+  GST_MTL_SUPPORTED_FPS_29_97 = 2997,   // 29.97 fps
+  GST_MTL_SUPPORTED_FPS_30 = 30,        // 30 fps
+  GST_MTL_SUPPORTED_FPS_50 = 50,        // 50 fps
+  GST_MTL_SUPPORTED_FPS_59_94 = 5994,   // 59.94 fps
+  GST_MTL_SUPPORTED_FPS_60 = 60,        // 60 fps
+  GST_MTL_SUPPORTED_FPS_100 = 100,      // 100 fps
+  GST_MTL_SUPPORTED_FPS_119_88 = 11988, // 119.88 fps
+  GST_MTL_SUPPORTED_FPS_120 = 120       // 120 fps
+};
+```
+
+#### Supported Audio Sampling Rates gst_mtl_supported_audio_sampling
+```c
+enum gst_mtl_supported_audio_sampling {
+  GST_MTL_SUPPORTED_AUDIO_SAMPLING_44_1K = 44100,  // 44.1 kHz
+  GST_MTL_SUPPORTED_AUDIO_SAMPLING_48K = 48000,    // 48 kHz
+  GST_MTL_SUPPORTED_AUDIO_SAMPLING_96K = 96000     // 96 kHz
+};
+```
+
+### ST 2110-20 Rawvideo plugins
+
+Video plugins for MTL that are able to send, recieve synchronous video via the MTL pipeline API.
+
+> **Warning:**
+> Raw video plugins require that the buffers passed to them match the size of the video frame.
+> Ensure that the buffer size corresponds to the frame size of the video being processed.
+
+> **Warning:**
+> Keep in mind that raw video files are very large and saving / using them is I/O and memory space intensive.
+> Oftentimes pipeline chocking point is the drive I/O speed limitation.
+
+### Running the ST 2110-20 transmission plugin mtl_st20p_tx
+
+#### Supported parmeters and pad capabilites
+
+The `mtl_st20p_tx` plugin supports the following pad capabilities:
+
+- **Formats**: `v210`, `I422_10LE`
+- **Width Range**: 64 to 16384
+- **Height Range**: 64 to 8704
+- **Framerate Range**: 24, 25, 30, 50, 60, 100, 120
+
+[More information about GStreamer capabilities (GstCaps)](https://gstreamer.freedesktop.org/documentation/gstreamer/gstcaps.html)
 
 
-### St20 rawvideo plugin
+| Property Name       | Type   | Description                                           | Range                   | Default Value |
+|---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
+| retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
+| tx-fps              | uint   | Framerate of the video.                               | [gst_mtl_supported_fps](#video-formats-gst_mtl_supported_fps) | 0 |
+| tx-framebuff-num    | uint   | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
 
-To run the st20 rawvideo plugin you need to pass the path to the plugin to your
-gstreamer aplication.
+#### Preparing Input Video
 
-you need to also prepare v210 video
+To send the video, you need to have an input video ready.
+Here is how to generate an input video with `y210` format using GStreamer.
+
+In our pipelines, we will use the `$INPUT` variable to hold the path to the video.
 
 ```shell
 export INPUT="path_to_the_input_v210_file"
 
-# you can produce it with gst-launch-1.0
 gst-launch-1.0 -v videotestsrc pattern=ball ! video/x-raw,width=1920,height=1080,format=v210,framerate=60/1 ! filesink location=$INPUT
 ```
 
+#### Pipline example for multicast `y210`
+
+To run the raw video transmission plugin we need to pass the mtl parameters
+responsible for initializing mtl library, to ensure the correct size of the buffer
+we will use rawvideo prarser in case of `y210`.
+
+
+The rest of rawvideo metadata will be passed via pad capabilites of the buffer.
 ```shell
-# DPDK PCI address bound (see doc/build.md)
-export VFIO_PORT_T="pci address of the device"
+# If you don't know how to find VFIO PCI address of your device
+# refer to Media-Transport-Library/doc/run.md
+export VFIO_PORT_T="pci_address_of_the_device"
 
-# Path to the built GStreamer plugin
-export GSTREAMER_PLUGINS_PATH="path to the folder with builded plugins"
-
-# video pipeline
+# video pipeline y210 FHD 60fps on port 20000
 gst-launch-1.0 filesrc location=$INPUT ! \
 rawvideoparse format=v210 height=1080 width=1920 framerate=60/1 ! \
-mtltxsink tx-queues=4 tx-udp-port=20000 tx-payload-type=112 dev-ip="192.168.96.3" tx-ip="239.168.75.30" dev-port=$VFIO_PORT_T \
+mtl_st20p_tx tx-queues=4 rx-queues=0 udp-port=20000 payload-type=112 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T \
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 
-
-# looping video pipeline
+# video pipeline y210 FHD 60fps on port 20000
 gst-launch-1.0 multifilesrc location=$INPUT loop=true ! \
 rawvideoparse format=v210 height=1080 width=1920 framerate=60/1 ! \
-mtltxsink tx-queues=4 tx-udp-port=20000 tx-payload-type=112 dev-ip="192.168.96.3" tx-ip="239.168.75.30" dev-port=$VFIO_PORT_T \
+mtl_st20p_tx tx-queues=4 rx-queues=0 udp-port=20000 payload-type=112 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T \
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
-## Supported formats
-The mtltxsink element supports the following pad capabilities:
+### Running the ST 2110-20 reciever plugin mtl_st20p_rx
 
-Format:
-v210
-I422_10LE
+#### Supported Parameters and Pad Capabilities
 
-Width:
-Range: 64 to 16384 pixels
+The `mtl_st20p_rx` plugin supports the following pad capabilities:
 
-Height:
-Range: 64 to 8704 pixels
+- **Formats**: `v210`, `I422_10LE`
+- **Width Range**: 64 to 16384
+- **Height Range**: 64 to 8704
+- **Framerate Range**: 0 to MAX
 
-Framerate:
-Supported values: 24, 25, 30, 50, 60, 120
-If you use the `fps` property to overwrite the caps, you can use the following framerates:
-120 119.88 100 60 59.94 50 30 29.97 25 24 23.98
+[More information about GStreamer capabilities (GstCaps)](https://gstreamer.freedesktop.org/documentation/gstreamer/gstcaps.html)
 
-Framebuffers passed need to be the size of the frame
+| Property Name       | Type    | Description                                         | Range                      | Default Value |
+|---------------------|---------|-----------------------------------------------------|----------------------------|---------------|
+| retry               | uint    | Number of times the MTL will try to get a frame.    | 0 to G_MAXUINT             | 10            |
+| rx-fps              | uint    | Framerate of the video.                             | [gst_mtl_supported_fps](#video-formats-gst_mtl_supported_fps) | 0 |
+| rx-framebuff-num    | uint    | Number of framebuffers to be used for transmission. | 0 to 8                     | 3             |
+| rx-width            | uint    | Width of the video.                                 | 0 to G_MAXUINT             | 1920          |
+| rx-height           | uint    | Height of the video.                                | 0 to G_MAXUINT             | 1080          |
+| rx-interlaced       | boolean | Whether the video is interlaced.                    | TRUE/FALSE                 | FALSE         |
+| rx-pixel-format     | string  | Pixel format of the video.                          | `v210`, `YUV444PLANAR10LE` | `v210`        |
 
-## Supported parameters for the plugin 
+#### Preparing output path
 
-- **dev-port** (Required)
-  - **Type:** String
-  - **Description:** DPDK device port for synchronous ST 2110-20 uncompressed video transmission, bound to the VFIO DPDK driver.
-  - **Default Value:** NULL
+In our pipelines, we will use the `$OUTPUT` variable to hold the path to the video.
 
-- **dev-ip** (Required)
-  - **Type:** String
-  - **Description:** Local IP address that the port will be identified by. This is the address from which ARP responses will be sent.
-  - **Default Value:** NULL
+```shell
+export OUTPUT="path_to_the_file_we_want_to_save"
+```
 
-- **tx-ip** (Required)
-  - **Type:** String
-  - **Description:** Receiving MTL node IP address.
-  - **Default Value:** NULL
+#### Pipline example for multicast with `y210` format
 
-- **tx-udp-port** (Required)
-  - **Type:** Unsigned Integer
-  - **Description:** Receiving MTL node UDP port.
-  - **Default Value:** 20000
-  - **Range:** 0 to G_MAXUINT
+To run the `mtl_st20p_rx` plugin, use the following command to specify the input parameters of the incoming stream.
 
-- **tx-payload-type** (Required)
-  - **Type:** Unsigned Integer
-  - **Description:** SMPTE ST 2110 payload type.
-  - **Default Value:** 112
-  - **Range:** 0 to G_MAXUINT
+> **Warning**: To receive data, ensure that a transmission is running with the same parameters on the `239.168.75.30` address.
 
-- **silent**
-  - **Type:** Boolean
-  - **Description:** Turn on silent mode.
-  - **Default Value:** FALSE
+```shell
+# If you don't know how to find the VFIO PCI address of your device
+# refer to Media-Transport-Library/doc/run.md
+export VFIO_PORT_R="pci_address_of_the_device"
 
-- **tx-queues**
-  - **Type:** Unsigned Integer
-  - **Description:** Number of TX queues to initialize in DPDK backend.
-  - **Default Value:** 16
-  - **Range:** 0 to G_MAXUINT
+# Run the receiver pipeline y210 FHD 60fps on port 20000
+gst-launch-1.0 mtl_st20p_rx rx-queues=4 udp-port=20000 payload-type=112 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_R rx-pixel-format=v210 rx-height=1080 rx-width=1920 rx-fps=25 ! \
+filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
+```
 
-- **tx-fps**
-  - **Type:** Unsigned Integer
-  - **Description:** Framerate of the video.
-  - **Default Value:** 0
-  - **Range:** 0 to G_MAXUINT
+This command sets up the receiver pipeline with the specified parameters and saves the received video to the specified output path.
 
-- **tx-framebuff-num**
-  - **Type:** Unsigned Integer
-  - **Description:** Number of framebuffers to be used for transmission.
-  - **Default Value:** 3
-  - **Range:** 0 to G_MAXUINT
+### ST 2110-30 Raw audio plugins
+
+Audio plugins for MTL that are able to send, recieve synchronous raw audio via the MTL pipeline API.
+
+### Running the ST 2110-30 transmission plugin mtl_st30p_tx
+
+#### Supported Parameters and Pad Capabilities
+
+The `mtl_st30p_tx` plugin supports the following pad capabilities:
+
+- **Formats**: `S16LE`, `S24LE`, `S32LE`
+- **Sample Rate Range**: 44100, 48000, 96000
+- **Channels Range**: 1 to 8
+
+| Property Name       | Type   | Description                                           | Range                   | Default Value |
+|---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
+| retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
+| tx-samplerate       | uint   | Sample rate of the audio.                             | [gst_mtl_supported_audio_sampling](#supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 0 |
+| tx-channels         | uint   | Number of audio channels.                             | 1 to 8                  | 2             |
+
+#### Example GStreamer Pipeline for Transmission with s16LE format
+
+To run the `mtl_st30p_tx` plugin, you need to setup metadata (Here we are using pipeline capabilities).
+Instead of using input video we opted for buildin gstreamer audio files generator.
+
+```shell
+# If you don't know how to find the VFIO PCI address of your device
+# refer to Media-Transport-Library/doc/run.md
+export VFIO_PORT_T="pci_address_of_the_device"
+
+# Audio pipeline with 48kHz sample rate on port 30000
+gst-launch-1.0 audiotestsrc ! \
+audio/x-raw,format=S16LE,rate=48000,channels=2 ! \
+mtl_st30p_tx tx-queues=4 rx-queues=0 udp-port=30000 payload-type=113 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T \
+--gst-plugin-path $GSTREAMER_PLUGINS_PATH
+```
+
+### Running the ST 2110-30 Receiver Plugin `mtl_st30p_rx`
+
+#### Supported Parameters and Pad Capabilities
+
+The `mtl_st30p_rx` plugin supports the following pad capabilities:
+
+- **Formats**: `S8`, `S16LE`, `S24LE`
+- **Channels Range**: 1 to 2
+- **Sample Rate Range**: 44100, 48000, 96000
+
+| Property Name       | Type    | Description                                           | Range                   | Default Value |
+|---------------------|---------|-------------------------------------------------------|-------------------------|---------------|
+| rx-framebuff-num    | uint    | Number of framebuffers to be used for transmission.   | 0 to G_MAXUINT          | 3             |
+| rx-channel          | uint    | Audio channel number.                                 | 0 to G_MAXUINT          | 2             |
+| rx-sampling         | uint    | Audio sampling rate.                                  | [gst_mtl_supported_audio_sampling](#supported-audio-sampling-rates-gst_mtl_supported_audio_sampling) | 48000         |
+| rx-audio-format     | string  | Audio format type.                                    | `S8`, `S16LE`, `S24LE`  | `S16LE`       |
+
+#### Preparing Output Path
+
+In our pipelines, we will use the `$OUTPUT` variable to hold the path to the audio file.
+
+```shell
+export OUTPUT="path_to_the_file_we_want_to_save"
+```
+
+#### Example GStreamer pipeline for reception
+
+To run the `mtl_st30p_rx` audio plugin use the command below:
+
+> **Warning**: To receive data, ensure that a transmission is running with the same parameters on the `239.168.75.30` address.
+
+```shell
+# If you don't know how to find the VFIO PCI address of your device
+# refer to Media-Transport-Library/doc/run.md
+export VFIO_PORT_R="pci_address_of_the_device"
+
+# Set the output path
+export OUTPUT="path_to_the_file_we_want_to_save"
+
+# Run the receiver pipeline
+gst-launch-1.0 -v mtl_st30p_rx rx-queues=4 udp-port=30000 payload-type=111 dev-ip="192.168.96.2" ip="239.168.75.30" dev-port=$VFIO_PORT_R rx-audio-format=PCM24 rx-channel=2 rx-sampling=48000 ! \
+filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
+```
+

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -62,5 +62,56 @@ Supported values: 24, 25, 30, 50, 60, 120
 If you use the `fps` property to overwrite the caps, you can use the following framerates:
 120 119.88 100 60 59.94 50 30 29.97 25 24 23.98
 
-
 Framebuffers passed need to be the size of the frame
+
+## Supported parameters for the plugin 
+
+- **dev-port** (Required)
+  - **Type:** String
+  - **Description:** DPDK device port for synchronous ST 2110-20 uncompressed video transmission, bound to the VFIO DPDK driver.
+  - **Default Value:** NULL
+
+- **dev-ip** (Required)
+  - **Type:** String
+  - **Description:** Local IP address that the port will be identified by. This is the address from which ARP responses will be sent.
+  - **Default Value:** NULL
+
+- **tx-ip** (Required)
+  - **Type:** String
+  - **Description:** Receiving MTL node IP address.
+  - **Default Value:** NULL
+
+- **tx-udp-port** (Required)
+  - **Type:** Unsigned Integer
+  - **Description:** Receiving MTL node UDP port.
+  - **Default Value:** 20000
+  - **Range:** 0 to G_MAXUINT
+
+- **tx-payload-type** (Required)
+  - **Type:** Unsigned Integer
+  - **Description:** SMPTE ST 2110 payload type.
+  - **Default Value:** 112
+  - **Range:** 0 to G_MAXUINT
+
+- **silent**
+  - **Type:** Boolean
+  - **Description:** Turn on silent mode.
+  - **Default Value:** FALSE
+
+- **tx-queues**
+  - **Type:** Unsigned Integer
+  - **Description:** Number of TX queues to initialize in DPDK backend.
+  - **Default Value:** 16
+  - **Range:** 0 to G_MAXUINT
+
+- **tx-fps**
+  - **Type:** Unsigned Integer
+  - **Description:** Framerate of the video.
+  - **Default Value:** 0
+  - **Range:** 0 to G_MAXUINT
+
+- **tx-framebuff-num**
+  - **Type:** Unsigned Integer
+  - **Description:** Number of framebuffers to be used for transmission.
+  - **Default Value:** 3
+  - **Range:** 0 to G_MAXUINT

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -106,7 +106,7 @@ In gstreamer plugins there are general arguments that apply to every plugin
 | udp-port      | uint   | Receiving MTL node UDP port.                                                                      | 0 to G_MAXUINT           |
 | tx-queues     | uint   | Number of TX queues to initialize in DPDK backend.                                                | 0 to G_MAXUINT           |
 | rx-queues     | uint   | Number of RX queues to initialize in DPDK backend.                                                | 0 to G_MAXUINT           |
-| payload-type  | uint   | SMPTE ST 2110 payload type.                                                                       | 0 to G_MAXUINT           |
+| payload-type  | uint   | SMPTE ST 2110 payload type.                                                                  | 0 to G_MAXUINT           |
 
 Those are also general parameters akcepted by plugins but the functionality they "give" to the user is not yet supported in plugins.
 | Property Name | Type   | Description                                                                                       | Range                    |
@@ -144,7 +144,7 @@ enum gst_mtl_supported_audio_sampling {
 };
 ```
 
-### ST 2110-20 Rawvideo plugins
+### SMPTE ST 2110-20 Rawvideo plugins
 
 Video plugins for MTL that are able to send, recieve synchronous video via the MTL pipeline API.
 
@@ -156,7 +156,7 @@ Video plugins for MTL that are able to send, recieve synchronous video via the M
 > Keep in mind that raw video files are very large and saving / using them is I/O and memory space intensive.
 > Oftentimes pipeline chocking point is the drive I/O speed limitation.
 
-### Running the ST 2110-20 transmission plugin mtl_st20p_tx
+### Running the SMPTE ST 2110-20 transmission plugin mtl_st20p_tx
 
 #### Supported parmeters and pad capabilites
 
@@ -169,7 +169,7 @@ The `mtl_st20p_tx` plugin supports the following pad capabilities:
 
 [More information about GStreamer capabilities (GstCaps)](https://gstreamer.freedesktop.org/documentation/gstreamer/gstcaps.html)
 
-
+**Arguments**
 | Property Name       | Type   | Description                                           | Range                   | Default Value |
 |---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
 | retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
@@ -215,7 +215,7 @@ mtl_st20p_tx tx-queues=4 rx-queues=0 udp-port=20000 payload-type=112 dev-ip="192
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
-### Running the ST 2110-20 reciever plugin mtl_st20p_rx
+### Running the SMPTE ST 2110-20 reciever plugin mtl_st20p_rx
 
 #### Supported Parameters and Pad Capabilities
 
@@ -226,8 +226,7 @@ The `mtl_st20p_rx` plugin supports the following pad capabilities:
 - **Height Range**: 64 to 8704
 - **Framerate Range**: 0 to MAX
 
-[More information about GStreamer capabilities (GstCaps)](https://gstreamer.freedesktop.org/documentation/gstreamer/gstcaps.html)
-
+**Arguments**
 | Property Name       | Type    | Description                                         | Range                      | Default Value |
 |---------------------|---------|-----------------------------------------------------|----------------------------|---------------|
 | retry               | uint    | Number of times the MTL will try to get a frame.    | 0 to G_MAXUINT             | 10            |
@@ -264,11 +263,11 @@ filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 
 This command sets up the receiver pipeline with the specified parameters and saves the received video to the specified output path.
 
-### ST 2110-30 Raw audio plugins
+### SMPTE ST 2110-30 Raw audio plugins
 
 Audio plugins for MTL that are able to send, recieve synchronous raw audio via the MTL pipeline API.
 
-### Running the ST 2110-30 transmission plugin mtl_st30p_tx
+### Running the SMPTE ST 2110-30 transmission plugin mtl_st30p_tx
 
 #### Supported Parameters and Pad Capabilities
 
@@ -278,6 +277,7 @@ The `mtl_st30p_tx` plugin supports the following pad capabilities:
 - **Sample Rate Range**: 44100, 48000, 96000
 - **Channels Range**: 1 to 8
 
+**Arguments**
 | Property Name       | Type   | Description                                           | Range                   | Default Value |
 |---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
 | retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
@@ -301,7 +301,7 @@ mtl_st30p_tx tx-queues=4 rx-queues=0 udp-port=30000 payload-type=113 dev-ip="192
 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
-### Running the ST 2110-30 Receiver Plugin `mtl_st30p_rx`
+### Running the SMPTE ST 2110-30 Receiver Plugin `mtl_st30p_rx`
 
 #### Supported Parameters and Pad Capabilities
 
@@ -311,6 +311,7 @@ The `mtl_st30p_rx` plugin supports the following pad capabilities:
 - **Channels Range**: 1 to 2
 - **Sample Rate Range**: 44100, 48000, 96000
 
+**Arguments**
 | Property Name       | Type    | Description                                           | Range                   | Default Value |
 |---------------------|---------|-------------------------------------------------------|-------------------------|---------------|
 | rx-framebuff-num    | uint    | Number of framebuffers to be used for transmission.   | 0 to G_MAXUINT          | 3             |
@@ -343,5 +344,76 @@ export OUTPUT="path_to_the_file_we_want_to_save"
 # Run the receiver pipeline
 gst-launch-1.0 -v mtl_st30p_rx rx-queues=4 udp-port=30000 payload-type=111 dev-ip="192.168.96.2" ip="239.168.75.30" dev-port=$VFIO_PORT_R rx-audio-format=PCM24 rx-channel=2 rx-sampling=48000 ! \
 filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
+```
+
+### SMPT SMPTE ST 2110-40 Ancillary Data Plugins
+
+Ancillary data plugins for MTL that are able to send and receive synchronous ancillary data via the MTL pipeline API.
+
+### Running the SMPTE ST 2110-40 Transmission Plugin `mtl_st40p_tx`
+
+#### Supported Parameters and Pad Capabilities
+
+The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked):
+
+- **Capabilities**: Any (GST_STATIC_CAPS_ANY)
+
+**Arguments**
+| Property Name       | Type   | Description                                           | Range                   | Default Value |
+|---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
+| retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
+| tx-framebuff-cnt    | uint   | Number of framebuffers to be used for transmission.   | 0 to G_MAXUINT          | 3             |
+
+#### Example GStreamer Pipeline for Transmission
+
+To run the `mtl_st40p_tx` plugin, use the following command:
+
+```shell
+# If you don't know how to find the VFIO PCI address of your device
+# refer to Media-Transport-Library/doc/run.md
+export VFIO_PORT_T="pci_address_of_the_device"
+
+# Ancillary data pipeline on port 40000
+gst-launch-1.0 -v mtl_st40p_tx tx-queues=4 rx-queues=0 udp-port=40000 payload-type=113 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T retry=10 tx-framebuff-cnt=3 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
+```
+
+> **Warning**: To transmit ancillary data, ensure that a receiver is running with the same parameters on the `239.168.75.30` address.
+
+This command sets up the transmission pipeline with the specified parameters and sends the ancillary data using the `mtl_st40p_tx` plugin.
+
+
+### SMPTE ST 2110-40 Ancillary Data Plugins
+
+Ancillary data plugins for MTL that are able to send and receive synchronous ancillary data via the MTL pipeline API.
+
+### Running the SMPTE ST 2110-40 Receiver Plugin `mtl_st40p_rx`
+
+#### Supported Parameters and Pad Capabilities
+
+The `mtl_st40p_rx` plugin supports all pad capabilities (the data is not checked):
+
+- **Capabilities**: Any (GST_STATIC_CAPS_ANY)
+
+**Arguments**
+| Property Name       | Type   | Description                                           | Range                       | Default Value |
+|---------------------|--------|-------------------------------------------------------|-----------------------------|---------------|
+| buffer-size         | uint   | Size of the buffer used for receiving data            | 0 to G_MAXUINT (power of 2) | 1024          |
+| timeout             | uint   | Timeout in seconds for getting mbuf                   | 0 to G_MAXUINT              | 10            |
+
+#### Example GStreamer Pipeline for Reception
+
+To run the `mtl_st40p_rx` plugin, use the following command:
+> **Warning**: To receive ancillary data, ensure that a transmission is running on the `239.168.75.30` address.
+
+```shell
+# If you don't know how to find the VFIO PCI address of your device
+# refer to Media-Transport-Library/doc/run.md
+export VFIO_PORT_R="pci_address_of_the_device"
+
+# Set the output path
+export OUTPUT="path_to_the_file_we_want_to_save"
+
+# Run the receiver pipeline
+gst-launch-1.0 -v mtl_st40p_rx rx-queues=4 udp-port=40000 payload-type=113 dev-ip="$IP_PORT_R" ip="$IP_PORT_T" timeout=61 dev-port=$VFIO_PORT_R ! filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -363,7 +363,7 @@ To run the `mtl_st40p_tx` plugin, use the following command:
 export VFIO_PORT_T="pci_address_of_the_device"
 
 # Ancillary data pipeline on port 40000
-gst-launch-1.0 -v mtl_st40p_tx tx-queues=4 udp-port=40000 payload-type=113 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T  tx-framebuff-cnt=3 tx-fps=60 tx-did=67 tx-sdid=2 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
+gst-launch-1.0 filesrc location=$INPUT ! mtl_st40p_tx tx-queues=4 udp-port=40000 payload-type=113 dev-ip="192.168.96.3" ip="239.168.75.30" dev-port=$VFIO_PORT_T  tx-framebuff-cnt=3 tx-fps=60 tx-did=67 tx-sdid=2 --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 
 This command sets up the transmission pipeline with the specified parameters and sends the ancillary data using the `mtl_st40p_tx` plugin.
@@ -396,6 +396,6 @@ export VFIO_PORT_R="pci_address_of_the_device"
 export OUTPUT="path_to_the_file_we_want_to_save"
 
 # Run the receiver pipeline
-gst-launch-1.0 -v mtl_st40p_rx rx-queues=4 udp-port=40000 payload-type=113 dev-ip="$IP_PORT_R" ip="$IP_PORT_T" timeout=61 dev-port=$VFIO_PORT_R ! filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
+gst-launch-1.0 -v mtl_st40_rx rx-queues=4 udp-port=40000 payload-type=113 dev-ip="$IP_PORT_R" ip="$IP_PORT_T" timeout=61 dev-port=$VFIO_PORT_R ! filesink location=$OUTPUT --gst-plugin-path $GSTREAMER_PLUGINS_PATH
 ```
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -8,8 +8,6 @@ Before you begin, ensure you have the following installed on your system:
 - `Meson`
 - `gst-plugins-base`
 - `gst-plugins-good`
-- `gst-plugins-bad`
-- `gst-plugins-ugly`
 - `gstreamer`
 - `gstreamer-devel`
 
@@ -18,7 +16,7 @@ To install the required GStreamer packages on Ubuntu or Debian, run the followin
 ```bash
 sudo apt update
 
-sudo apt install -y gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-tools gstreamer1.0-libav libgstreamer1.0-dev
+sudo apt install -y gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-tools gstreamer1.0-libav libgstreamer1.0-dev
 ```
 
 > For MTL installation instructions please refer to  [Build Documentation](../../doc/build.md).
@@ -73,15 +71,13 @@ this can be done by running the following command:
 
 ```bash
 sudo apt-get update
-sudo apt-get install gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly
+sudo apt-get install gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly
 ```
 
 These packages include:
 - **gstreamer1.0-tools**: Provides the `gst-launch-1.0` tool and other GStreamer utilities.
 - **gstreamer1.0-plugins-base**: Contains the base set of plugins, which are essential for most GStreamer applications.
 - **gstreamer1.0-plugins-good**: Includes a set of well-supported plugins that are generally considered to be of good quality.
-- **gstreamer1.0-plugins-bad**: Contains a set of plugins that are still under development or testing.
-- **gstreamer1.0-plugins-ugly**: Includes plugins that might have licensing issues or are not considered to be of the highest quality.
 By installing these packages, you will have all the necessary tools and plugins to run GStreamer applications and use the `gst-launch-1.0` tool with our plugins.
 
 To run plugins, you need to pass the path to the plugins to your GStreamer application or load them directly.

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -150,8 +150,7 @@ Video plugins for MTL that are able to send, receive synchronous video via the M
 > **Warning:**
 > Raw video plugins require that the buffers passed to them match the size of the video frame.
 > Ensure that the buffer size corresponds to the frame size of the video being processed.
-
-
+>
 > **Warning:**
 > Keep in mind that raw video files are very large and saving / using them is I/O and memory space intensive.
 > Oftentimes pipeline choking point is the drive I/O speed limitation.


### PR DESCRIPTION
Add GStreamer plugins documentation

- Detailed instructions for building the plugins.
- Example usage of the plugins.
- Run instructions for various scenarios.