### PR TITLE
Fix: Correct wrong license headers in /tests/validation/

### DIFF
--- a/tests/validation/tests/Engine/RxTxApp.py
+++ b/tests/validation/tests/Engine/RxTxApp.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import copy
 import json
 import os

--- a/tests/validation/tests/Engine/const.py
+++ b/tests/validation/tests/Engine/const.py
@@ -1,11 +1,3 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 LOG_FOLDER = "logs"

--- a/tests/validation/tests/Engine/csv_report.py
+++ b/tests/validation/tests/Engine/csv_report.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import csv
 
 report = []

--- a/tests/validation/tests/Engine/execute.py
+++ b/tests/validation/tests/Engine/execute.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import logging
 import os
 import subprocess

--- a/tests/validation/tests/Engine/ffmpeg_app.py
+++ b/tests/validation/tests/Engine/ffmpeg_app.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import copy
 import os

--- a/tests/validation/tests/Engine/fixtures.py
+++ b/tests/validation/tests/Engine/fixtures.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 from typing import Dict
 

--- a/tests/validation/tests/Engine/logging.py
+++ b/tests/validation/tests/Engine/logging.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import datetime
 import logging
 import os

--- a/tests/validation/tests/Engine/media_files.py
+++ b/tests/validation/tests/Engine/media_files.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 yuv_files = dict(
     i720p23={

--- a/tests/validation/tests/Engine/rxtxapp_config.py
+++ b/tests/validation/tests/Engine/rxtxapp_config.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 config_empty = {
     "tx_no_chain": False,

--- a/tests/validation/tests/Engine/stash.py
+++ b/tests/validation/tests/Engine/stash.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 from typing import List
 

--- a/tests/validation/tests/Engine/udp_app.py
+++ b/tests/validation/tests/Engine/udp_app.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import copy
 import json

--- a/tests/validation/tests/Engine/udp_app_config.py
+++ b/tests/validation/tests/Engine/udp_app_config.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 config_client = {
     "interfaces": [

--- a/tests/validation/tests/conftest.py
+++ b/tests/validation/tests/conftest.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 pytest_plugins = ["tests.Engine.fixtures", "tests.Engine.logging"]
 
 

--- a/tests/validation/tests/single/ancillary/anc_format/test_anc_format.py
+++ b/tests/validation/tests/single/ancillary/anc_format/test_anc_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/ancillary/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/ancillary/test_mode/test_multicast.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/ancillary/type_mode/test_type_mode.py
+++ b/tests/validation/tests/single/ancillary/type_mode/test_type_mode.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/audio/audio_channel/test_audio_channel.py
+++ b/tests/validation/tests/single/audio/audio_channel/test_audio_channel.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/audio/audio_format/test_audio_format.py
+++ b/tests/validation/tests/single/audio/audio_format/test_audio_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/audio/audio_ptime/test_audio_ptime.py
+++ b/tests/validation/tests/single/audio/audio_ptime/test_audio_ptime.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/audio/audio_sampling/test_audio_sampling.py
+++ b/tests/validation/tests/single/audio/audio_sampling/test_audio_sampling.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/audio/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/audio/test_mode/test_multicast.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/audio/type_mode/test_type_mode.py
+++ b/tests/validation/tests/single/audio/type_mode/test_type_mode.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg.py
@@ -1,14 +1,5 @@
-# INTEL CONFIDENTIAL
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24.py
@@ -1,14 +1,5 @@
-# INTEL CONFIDENTIAL
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple.py
@@ -1,14 +1,5 @@
-# INTEL CONFIDENTIAL
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_rxtxapp.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_rxtxapp.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/performance/test_1tx_1nic.py
+++ b/tests/validation/tests/single/performance/test_1tx_1nic.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/performance/test_1tx_1rx_2nics.py
+++ b/tests/validation/tests/single/performance/test_1tx_1rx_2nics.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/performance/test_2tx_2nics.py
+++ b/tests/validation/tests/single/performance/test_2tx_2nics.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/performance/test_2tx_2rx_4nics.py
+++ b/tests/validation/tests/single/performance/test_2tx_2rx_4nics.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/performance/test_4tx_4nics.py
+++ b/tests/validation/tests/single/performance/test_4tx_4nics.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/performance/test_4tx_4rx_8nics.py
+++ b/tests/validation/tests/single/performance/test_4tx_4rx_8nics.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
+++ b/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/rss_mode/video/test_performance.py
+++ b/tests/validation/tests/single/rss_mode/video/test_performance.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
+++ b/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/rx_timing/mixed/test_mode.py
+++ b/tests/validation/tests/single/rx_timing/mixed/test_mode.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/rx_timing/video/test_replicas.py
+++ b/tests/validation/tests/single/rx_timing/video/test_replicas.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import tests.Engine.RxTxApp as rxtxapp

--- a/tests/validation/tests/single/rx_timing/video/test_video_format.py
+++ b/tests/validation/tests/single/rx_timing/video/test_video_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st20p/format/test_format.py
+++ b/tests/validation/tests/single/st20p/format/test_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 import re
 

--- a/tests/validation/tests/single/st20p/fps/test_fps.py
+++ b/tests/validation/tests/single/st20p/fps/test_fps.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st20p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st20p/interlace/test_interlace.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st20p/pacing/test_pacing.py
+++ b/tests/validation/tests/single/st20p/pacing/test_pacing.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st20p/packing/test_packing.py
+++ b/tests/validation/tests/single/st20p/packing/test_packing.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
+++ b/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st20p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st20p/test_mode/test_multicast.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st22p/codec/test_codec.py
+++ b/tests/validation/tests/single/st22p/codec/test_codec.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/st22p/format/test_format.py
+++ b/tests/validation/tests/single/st22p/format/test_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/st22p/fps/test_fps.py
+++ b/tests/validation/tests/single/st22p/fps/test_fps.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/st22p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st22p/interlace/test_interlace.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/st22p/quality/test_quality.py
+++ b/tests/validation/tests/single/st22p/quality/test_quality.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import os
 

--- a/tests/validation/tests/single/st22p/test_mode/test_unicast.py
+++ b/tests/validation/tests/single/st22p/test_mode/test_unicast.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import tests.Engine.RxTxApp as rxtxapp

--- a/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
+++ b/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
+++ b/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
+++ b/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
+++ b/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st30p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st30p/test_mode/test_multicast.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st41/dit/test_dit.py
+++ b/tests/validation/tests/single/st41/dit/test_dit.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st41/fps/test_fps.py
+++ b/tests/validation/tests/single/st41/fps/test_fps.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st41/k_bit/test_k_bit.py
+++ b/tests/validation/tests/single/st41/k_bit/test_k_bit.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st41/no_chain/test_no_chain.py
+++ b/tests/validation/tests/single/st41/no_chain/test_no_chain.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st41/payload_type/test_payload_type.py
+++ b/tests/validation/tests/single/st41/payload_type/test_payload_type.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/st41/type_mode/test_type_mode.py
+++ b/tests/validation/tests/single/st41/type_mode/test_type_mode.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/udp/librist/test_sessions_cnt.py
+++ b/tests/validation/tests/single/udp/librist/test_sessions_cnt.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import pytest
 from tests.Engine import udp_app

--- a/tests/validation/tests/single/udp/sample/test_sessions_cnt.py
+++ b/tests/validation/tests/single/udp/sample/test_sessions_cnt.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 
 import pytest
 from tests.Engine import udp_app

--- a/tests/validation/tests/single/video/pacing/test_pacing.py
+++ b/tests/validation/tests/single/video/pacing/test_pacing.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/video/packing/test_packing.py
+++ b/tests/validation/tests/single/video/packing/test_packing.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/video/pg_format/test_pg_format.py
+++ b/tests/validation/tests/single/video/pg_format/test_pg_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/video/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/video/test_mode/test_multicast.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/video/tr_offset/test_tr_offset.py
+++ b/tests/validation/tests/single/video/tr_offset/test_tr_offset.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/video/type_mode/test_type_mode.py
+++ b/tests/validation/tests/single/video/type_mode/test_type_mode.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/video/video_format/test_video_format.py
+++ b/tests/validation/tests/single/video/video_format/test_video_format.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/virtio_user/test_virtio_user.py
+++ b/tests/validation/tests/single/virtio_user/test_virtio_user.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/xdp/test_mode/test_xdp_mode.py
+++ b/tests/validation/tests/single/xdp/test_mode/test_xdp_mode.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/single/xdp/test_standard/test_standard.py
+++ b/tests/validation/tests/single/xdp/test_standard/test_standard.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import os
 
 import pytest

--- a/tests/validation/tests/xfail.py
+++ b/tests/validation/tests/xfail.py
@@ -1,13 +1,5 @@
-# INTEL CONFIDENTIAL
-# Copyright 2024-2024 Intel Corporation.
-#
-# This software and the related documents are Intel copyrighted materials, and your use of them is governed
-# by the express license under which they were provided to you ("License"). Unless the License provides otherwise,
-# you may not use, modify, copy, publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is, with no express or implied warranties,
-# other than those that are expressly stated in the License.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2025 Intel Corporation
 import logging
 
 import pytest


### PR DESCRIPTION
Headers in the tests/validation/ folder contain "INTEL CONFIDENTIAL".
Fix by exchanging with SPDX-based BSD-3-Clause identifier:

> SPDX-License-Identifier: BSD-3-Clause
> Copyright(c) 2024-2025 Intel Corporation

fixes: 1580c7ff04a93664bf3751b5b533ccf23b940da1