### PR TITLE
Fix: unify gstreamer arguments across plugins

### DIFF
--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -209,7 +209,8 @@ gboolean gst_mtl_common_parse_sampling(gint sampling, enum st30_sampling* st_sam
 void gst_mtl_common_init_general_argumetns(GObjectClass* gobject_class) {
   g_object_class_install_property(
       gobject_class, PROP_GENERAL_LOG_LEVEL,
-      g_param_spec_uint("log-level", "Log Level", "Set the log level.", 0, G_MAXUINT, 0,
+      g_param_spec_uint("log-level", "Log Level", "Set the log level (INFO 1 to CRIT 5).",
+                        1, MTL_LOG_LEVEL_MAX, 1,
                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
@@ -401,7 +402,6 @@ mtl_handle gst_mtl_common_mtl_init(struct mtl_init_params* p, StDevArgs* devArgs
     return NULL;
   }
 
-  memset(&mtl_init_params, 0, sizeof(mtl_init_params));
   mtl_init_params.num_ports = 0;
 
   if (gst_mtl_common_parse_dev_arguments(&mtl_init_params, devArgs) == FALSE) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -393,8 +393,8 @@ gboolean gst_mtl_common_parse_dev_arguments(struct mtl_init_params* mtl_init_par
   return ret;
 }
 
-mtl_handle gst_mtl_common_mtl_init(struct mtl_init_params* p, StDevArgs* devArgs,
-                                   guint* log_level) {
+mtl_handle gst_mtl_common_init_handle(struct mtl_init_params* p, StDevArgs* devArgs,
+                                      guint* log_level) {
   struct mtl_init_params mtl_init_params = {0};
 
   if (!p || !devArgs || !log_level) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -209,8 +209,8 @@ gboolean gst_mtl_common_parse_sampling(gint sampling, enum st30_sampling* st_sam
 void gst_mtl_common_init_general_argumetns(GObjectClass* gobject_class) {
   g_object_class_install_property(
       gobject_class, PROP_GENERAL_LOG_LEVEL,
-      g_param_spec_int("log-level", "Log Level", "Set the log level.", 0, G_MAXUINT, 0,
-                       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+      g_param_spec_uint("log-level", "Log Level", "Set the log level.", 0, G_MAXUINT, 0,
+                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
       gobject_class, PROP_GENERAL_DEV_ARGS_PORT,
@@ -390,4 +390,37 @@ gboolean gst_mtl_common_parse_dev_arguments(struct mtl_init_params* mtl_init_par
 
   gst_mtl_port_idx++;
   return ret;
+}
+
+mtl_handle gst_mtl_common_mtl_init(struct mtl_init_params* p, StDevArgs* devArgs,
+                                   guint* log_level) {
+  struct mtl_init_params mtl_init_params = {0};
+
+  if (!p || !devArgs || !log_level) {
+    GST_ERROR("Invalid input");
+    return NULL;
+  }
+
+  memset(&mtl_init_params, 0, sizeof(mtl_init_params));
+  mtl_init_params.num_ports = 0;
+
+  if (gst_mtl_common_parse_dev_arguments(&mtl_init_params, devArgs) == FALSE) {
+    GST_ERROR("Failed to parse dev arguments");
+    return NULL;
+  }
+  mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
+
+  /*
+   * Log levels range from 1 to LOG_LEVEL_MAX.
+   * We avoid using 0 (DEBUG) in normal scenarios,
+   * so it's acceptable to use 0 as a placeholder.
+   */
+  if (*log_level && *log_level < MTL_LOG_LEVEL_MAX) {
+    mtl_init_params.log_level = *log_level;
+  } else {
+    mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
+  }
+  *log_level = mtl_init_params.log_level;
+
+  return mtl_init(&mtl_init_params);
 }

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -209,8 +209,8 @@ gboolean gst_mtl_common_parse_sampling(gint sampling, enum st30_sampling* st_sam
 void gst_mtl_common_init_general_argumetns(GObjectClass* gobject_class) {
   g_object_class_install_property(
       gobject_class, PROP_GENERAL_LOG_LEVEL,
-      g_param_spec_boolean("silent", "Silent", "Turn on silent mode.", FALSE,
-                           G_PARAM_READWRITE));
+      g_param_spec_int("log-level", "Log Level", "Set the log level.", 0, G_MAXUINT, 0,
+                       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
       gobject_class, PROP_GENERAL_DEV_ARGS_PORT,

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -19,7 +19,13 @@
 #define PAYLOAD_TYPE_VIDEO (112)
 #define PAYLOAD_TYPE_ANCILLARY (113)
 
+#ifndef NS_PER_MS
 #define NS_PER_MS (1000 * 1000)
+#endif
+
+#ifndef NS_PER_S
+#define NS_PER_S (1000 * NS_PER_MS)
+#endif
 
 enum {
   PROP_GENERAL_0,

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -101,4 +101,7 @@ void gst_mtl_common_get_general_argumetns(GObject* object, guint prop_id,
                                           StDevArgs* devArgs, SessionPortArgs* portArgs,
                                           guint* log_level);
 
+mtl_handle gst_mtl_common_mtl_init(struct mtl_init_params* p, StDevArgs* devArgs,
+                                   guint* log_level);
+
 #endif /* __GST_MTL_COMMON_H__ */

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -101,7 +101,7 @@ void gst_mtl_common_get_general_argumetns(GObject* object, guint prop_id,
                                           StDevArgs* devArgs, SessionPortArgs* portArgs,
                                           guint* log_level);
 
-mtl_handle gst_mtl_common_mtl_init(struct mtl_init_params* p, StDevArgs* devArgs,
-                                   guint* log_level);
+mtl_handle gst_mtl_common_init_handle(struct mtl_init_params* p, StDevArgs* devArgs,
+                                      guint* log_level);
 
 #endif /* __GST_MTL_COMMON_H__ */

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
@@ -200,26 +200,12 @@ static gboolean gst_mtl_st20p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG_OBJECT(src, "start");
   GST_DEBUG("Media Transport Initialization start");
 
-  /* Check for future support of multiple plugins initialized from the same handle.
-   * TODO: Add support for initializing multiple pipelines from a single handle. */
+  src->mtl_lib_handle =
+      gst_mtl_common_mtl_init(&mtl_init_params, &(src->devArgs), &(src->log_level));
+
   if (!src->mtl_lib_handle) {
-    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(src->devArgs))) {
-      GST_ERROR("Failed to parse dev arguments");
-      return FALSE;
-    }
-
-    if (src->log_level && src->log_level < MTL_LOG_LEVEL_MAX) {
-      mtl_init_params.log_level = src->log_level;
-    } else {
-      mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
-    }
-
-    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-    src->mtl_lib_handle = mtl_init(&mtl_init_params);
-    if (!src->mtl_lib_handle) {
-      GST_ERROR("Could not initialize MTL");
-      return FALSE;
-    }
+    GST_ERROR("Could not initialize MTL");
+    return FALSE;
   }
 
   if (src->width == 0 || src->height == 0) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
@@ -90,22 +90,12 @@ GST_DEBUG_CATEGORY_STATIC(gst_mtl_st20p_rx_debug);
 #endif
 
 enum {
-  PROP_0,
-  PROP_SILENT,
-  PROP_RX_DEV_ARGS_PORT,
-  PROP_RX_DEV_ARGS_SIP,
-  PROP_RX_DEV_ARGS_DMA_DEV,
-  PROP_RX_PORT_PORT,
-  PROP_RX_PORT_IP,
-  PROP_RX_PORT_UDP_PORT,
-  PROP_RX_PORT_PAYLOAD_TYPE,
-  PROP_RX_PORT_RX_QUEUES,
-  PROP_RX_FRAMERATE,
-  PROP_RX_FRAMEBUFF_NUM,
-  PROP_RX_WIDTH,
-  PROP_RX_HEIGHT,
-  PROP_RX_INTERLACED,
-  PROP_RX_PIXEL_FORMAT,
+  PROP_ST20P_RX_FRAMERATE = PROP_GENERAL_MAX,
+  PROP_ST20P_RX_FRAMEBUFF_NUM,
+  PROP_ST20P_RX_WIDTH,
+  PROP_ST20P_RX_HEIGHT,
+  PROP_ST20P_RX_INTERLACED,
+  PROP_ST20P_RX_PIXEL_FORMAT,
   PROP_MAX
 };
 
@@ -164,89 +154,37 @@ static void gst_mtl_st20p_rx_class_init(Gst_Mtl_St20p_RxClass* klass) {
   gstbasesrc_class->negotiate = GST_DEBUG_FUNCPTR(gst_mtl_st20p_rx_negotiate);
   gstbasesrc_class->create = GST_DEBUG_FUNCPTR(gst_mtl_st20p_rx_create);
 
-  g_object_class_install_property(
-      gobject_class, PROP_SILENT,
-      g_param_spec_boolean("silent", "Silent", "Turn on silent mode.", FALSE,
-                           G_PARAM_READWRITE));
+  gst_mtl_common_init_general_argumetns(gobject_class);
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_DEV_ARGS_PORT,
-      g_param_spec_string("dev-port", "DPDK device port",
-                          "DPDK port for synchronous ST 2110-20 uncompressed"
-                          "video transmission, bound to the VFIO DPDK driver. ",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_DEV_ARGS_SIP,
-      g_param_spec_string("dev-ip", "Local device IP",
-                          "Local IP address that the port will be "
-                          "identified by. This is the address from which ARP "
-                          "responses will be sent.",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_DEV_ARGS_DMA_DEV,
-      g_param_spec_string("dma-dev", "DPDK DMA port",
-                          "DPDK port for the MTL direct memory functionality.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_PORT,
-      g_param_spec_string("rx-port", "Transmission Device Port",
-                          "DPDK device port initialized for the transmission.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_IP,
-      g_param_spec_string("rx-ip", "Sender node's IP", "Receiving MTL node IP address.",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_UDP_PORT,
-      g_param_spec_uint("rx-udp-port", "Sender UDP port", "Receiving MTL node UDP port.",
-                        0, G_MAXUINT, 20000, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_PAYLOAD_TYPE,
-      g_param_spec_uint("rx-payload-type", "ST 2110 payload type",
-                        "SMPTE ST 2110 payload type.", 0, G_MAXUINT, 112,
-                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_RX_QUEUES,
-      g_param_spec_uint("rx-queues", "Number of RX queues",
-                        "Number of RX queues to initialize in DPDK backend.", 0,
-                        G_MAXUINT, 16, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_FRAMERATE,
+      gobject_class, PROP_ST20P_RX_FRAMERATE,
       g_param_spec_uint("rx-fps", "Video framerate", "Framerate of the video.", 0,
                         G_MAXUINT, 0, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_FRAMEBUFF_NUM,
+      gobject_class, PROP_ST20P_RX_FRAMEBUFF_NUM,
       g_param_spec_uint("rx-framebuff-num", "Number of framebuffers",
                         "Number of framebuffers to be used for transmission.", 0,
                         G_MAXUINT, 3, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_WIDTH,
+      gobject_class, PROP_ST20P_RX_WIDTH,
       g_param_spec_uint("rx-width", "Video width", "Width of the video.", 0, G_MAXUINT,
                         1920, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_HEIGHT,
+      gobject_class, PROP_ST20P_RX_HEIGHT,
       g_param_spec_uint("rx-height", "Video height", "Height of the video.", 0, G_MAXUINT,
                         1080, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_INTERLACED,
+      gobject_class, PROP_ST20P_RX_INTERLACED,
       g_param_spec_boolean("rx-interlaced", "Interlaced video",
                            "Whether the video is interlaced.", FALSE,
                            G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_PIXEL_FORMAT,
+      gobject_class, PROP_ST20P_RX_PIXEL_FORMAT,
       g_param_spec_string("rx-pixel-format", "Pixel format", "Pixel format of the video.",
                           "v210", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
@@ -262,54 +200,21 @@ static gboolean gst_mtl_st20p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG_OBJECT(src, "start");
   GST_DEBUG("Media Transport Initialization start");
 
-  /* mtl is already initialzied */
-  if (src->mtl_lib_handle) {
-    GST_INFO("Mtl already initialized");
-    if (mtl_start(src->mtl_lib_handle)) {
-      GST_ERROR("Failed to start MTL");
-      return FALSE;
-    }
-    return TRUE;
-  } else {
-    strncpy(mtl_init_params.port[MTL_PORT_P], src->devArgs.port, MTL_PORT_MAX_LEN);
-
-    ret = inet_pton(AF_INET, src->devArgs.local_ip_string,
-                    mtl_init_params.sip_addr[MTL_PORT_P]);
-    if (ret != 1) {
-      GST_ERROR("%s, sip %s is not valid ip address\n", __func__,
-                src->devArgs.local_ip_string);
+  /* Check for future support of multiple plugins initialized from the same handle.
+   * TODO: Add support for initializing multiple pipelines from a single handle. */
+  if (!src->mtl_lib_handle) {
+    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(src->devArgs))) {
+      GST_ERROR("Failed to parse dev arguments");
       return FALSE;
     }
 
-    if (src->devArgs.rx_queues_cnt[MTL_PORT_P]) {
-      mtl_init_params.rx_queues_cnt[MTL_PORT_P] = src->devArgs.rx_queues_cnt[MTL_PORT_P];
-    } else {
-      mtl_init_params.rx_queues_cnt[MTL_PORT_P] = 16;
-      mtl_init_params.tx_queues_cnt[MTL_PORT_P] = 16;
-    }
-
-    mtl_init_params.num_ports++;
-
-    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-    if (src->silent) {
-      mtl_init_params.log_level = MTL_LOG_LEVEL_ERROR;
+    if (src->log_level && src->log_level < MTL_LOG_LEVEL_MAX) {
+      mtl_init_params.log_level = src->log_level;
     } else {
       mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
     }
 
-    src->retry_frame = 10;
-
     mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-
-    if (src->devArgs.dma_dev) {
-      strncpy(mtl_init_params.dma_dev_port[0], src->devArgs.dma_dev, MTL_PORT_MAX_LEN);
-    }
-
-    if (src->mtl_lib_handle) {
-      GST_ERROR("MTL already initialized");
-      return FALSE;
-    }
-
     src->mtl_lib_handle = mtl_init(&mtl_init_params);
     if (!src->mtl_lib_handle) {
       GST_ERROR("Could not initialize MTL");
@@ -407,51 +312,29 @@ static void gst_mtl_st20p_rx_set_property(GObject* object, guint prop_id,
                                           const GValue* value, GParamSpec* pspec) {
   Gst_Mtl_St20p_Rx* self = GST_MTL_ST20P_RX(object);
 
+  if (prop_id < PROP_GENERAL_MAX) {
+    gst_mtl_common_set_general_argumetns(object, prop_id, value, pspec, &(self->devArgs),
+                                         &(self->portArgs), &self->log_level);
+    return;
+  }
+
   switch (prop_id) {
-    case PROP_SILENT:
-      self->silent = g_value_get_boolean(value);
-      break;
-    case PROP_RX_DEV_ARGS_PORT:
-      strncpy(self->devArgs.port, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_DEV_ARGS_SIP:
-      strncpy(self->devArgs.local_ip_string, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_DEV_ARGS_DMA_DEV:
-      strncpy(self->devArgs.dma_dev, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_PORT_PORT:
-      strncpy(self->portArgs.port, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_PORT_IP:
-      strncpy(self->portArgs.session_ip_string, g_value_get_string(value),
-              MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_PORT_UDP_PORT:
-      self->portArgs.udp_port = g_value_get_uint(value);
-      break;
-    case PROP_RX_PORT_PAYLOAD_TYPE:
-      self->portArgs.payload_type = g_value_get_uint(value);
-      break;
-    case PROP_RX_PORT_RX_QUEUES:
-      self->devArgs.rx_queues_cnt[MTL_PORT_P] = g_value_get_uint(value);
-      break;
-    case PROP_RX_FRAMERATE:
+    case PROP_ST20P_RX_FRAMERATE:
       self->framerate = g_value_get_uint(value);
       break;
-    case PROP_RX_FRAMEBUFF_NUM:
+    case PROP_ST20P_RX_FRAMEBUFF_NUM:
       self->framebuffer_num = g_value_get_uint(value);
       break;
-    case PROP_RX_WIDTH:
+    case PROP_ST20P_RX_WIDTH:
       self->width = g_value_get_uint(value);
       break;
-    case PROP_RX_HEIGHT:
+    case PROP_ST20P_RX_HEIGHT:
       self->height = g_value_get_uint(value);
       break;
-    case PROP_RX_INTERLACED:
+    case PROP_ST20P_RX_INTERLACED:
       self->interlaced = g_value_get_boolean(value);
       break;
-    case PROP_RX_PIXEL_FORMAT:
+    case PROP_ST20P_RX_PIXEL_FORMAT:
       strncpy(self->pixel_format, g_value_get_string(value), MTL_PORT_MAX_LEN);
       break;
     default:
@@ -464,50 +347,29 @@ static void gst_mtl_st20p_rx_get_property(GObject* object, guint prop_id, GValue
                                           GParamSpec* pspec) {
   Gst_Mtl_St20p_Rx* src = GST_MTL_ST20P_RX(object);
 
+  if (prop_id < PROP_GENERAL_MAX) {
+    gst_mtl_common_get_general_argumetns(object, prop_id, value, pspec, &(src->devArgs),
+                                         &(src->portArgs), &src->log_level);
+    return;
+  }
+
   switch (prop_id) {
-    case PROP_SILENT:
-      g_value_set_boolean(value, src->silent);
-      break;
-    case PROP_RX_DEV_ARGS_PORT:
-      g_value_set_string(value, src->devArgs.port);
-      break;
-    case PROP_RX_DEV_ARGS_SIP:
-      g_value_set_string(value, src->devArgs.local_ip_string);
-      break;
-    case PROP_RX_DEV_ARGS_DMA_DEV:
-      g_value_set_string(value, src->devArgs.dma_dev);
-      break;
-    case PROP_RX_PORT_PORT:
-      g_value_set_string(value, src->portArgs.port);
-      break;
-    case PROP_RX_PORT_IP:
-      g_value_set_string(value, src->portArgs.session_ip_string);
-      break;
-    case PROP_RX_PORT_UDP_PORT:
-      g_value_set_uint(value, src->portArgs.udp_port);
-      break;
-    case PROP_RX_PORT_PAYLOAD_TYPE:
-      g_value_set_uint(value, src->portArgs.payload_type);
-      break;
-    case PROP_RX_PORT_RX_QUEUES:
-      g_value_set_uint(value, src->devArgs.rx_queues_cnt[MTL_PORT_P]);
-      break;
-    case PROP_RX_FRAMERATE:
+    case PROP_ST20P_RX_FRAMERATE:
       g_value_set_uint(value, src->framerate);
       break;
-    case PROP_RX_FRAMEBUFF_NUM:
+    case PROP_ST20P_RX_FRAMEBUFF_NUM:
       g_value_set_uint(value, src->framebuffer_num);
       break;
-    case PROP_RX_WIDTH:
+    case PROP_ST20P_RX_WIDTH:
       g_value_set_uint(value, src->width);
       break;
-    case PROP_RX_HEIGHT:
+    case PROP_ST20P_RX_HEIGHT:
       g_value_set_uint(value, src->height);
       break;
-    case PROP_RX_INTERLACED:
+    case PROP_ST20P_RX_INTERLACED:
       g_value_set_boolean(value, src->interlaced);
       break;
-    case PROP_RX_PIXEL_FORMAT:
+    case PROP_ST20P_RX_PIXEL_FORMAT:
       g_value_set_string(value, src->pixel_format);
       break;
     default:

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.h
@@ -61,19 +61,15 @@ struct _Gst_Mtl_St20p_Rx {
   GstBuffer* buffer;
 
   /*< private >*/
-  struct st20p_rx_ops ops_rx;
-  gboolean silent;
+  struct st20p_rx_ops ops_rx; /* needed for caps negotiation */
+  guint log_level;
   mtl_handle mtl_lib_handle;
   st20p_rx_handle rx_handle;
-
-  /* arguments for incomplete frame buffers */
   guint retry_frame;
   guint frame_size;
 
-  /* arguments for imtl initialization device */
-  StDevArgs devArgs;
-  /* arguments for imtl rx session */
-  SessionPortArgs portArgs;
+  StDevArgs devArgs;        /* imtl initialization device */
+  SessionPortArgs portArgs; /* imtl session device */
 
   /* arguments for session */
   guint width;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -179,7 +179,7 @@ static gboolean gst_mtl_st20p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_mtl_init(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");
@@ -224,6 +224,9 @@ static void gst_mtl_st20p_tx_set_property(GObject* object, guint prop_id,
   }
 
   switch (prop_id) {
+    case PROP_ST20P_TX_RETRY:
+      self->retry_frame = g_value_get_uint(value);
+      break;
     case PROP_ST20P_TX_FRAMERATE:
       self->framerate = g_value_get_uint(value);
       break;
@@ -247,6 +250,9 @@ static void gst_mtl_st20p_tx_get_property(GObject* object, guint prop_id, GValue
   }
 
   switch (prop_id) {
+    case PROP_ST20P_TX_RETRY:
+      g_value_set_uint(value, sink->retry_frame);
+      break;
     case PROP_ST20P_TX_FRAMERATE:
       g_value_set_uint(value, sink->framerate);
       break;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -178,26 +178,12 @@ static gboolean gst_mtl_st20p_tx_start(GstBaseSink* bsink) {
   GST_DEBUG("Media Transport Initialization start");
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
-  /* Check for future support of multiple plugins initialized from the same handle.
-   * TODO: Add support for initializing multiple pipelines from a single handle. */
+  sink->mtl_lib_handle =
+      gst_mtl_common_mtl_init(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
+
   if (!sink->mtl_lib_handle) {
-    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(sink->devArgs))) {
-      GST_ERROR("Failed to parse dev arguments");
-      return FALSE;
-    }
-
-    if (sink->log_level && sink->log_level < MTL_LOG_LEVEL_MAX) {
-      mtl_init_params.log_level = sink->log_level;
-    } else {
-      mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
-    }
-
-    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-    sink->mtl_lib_handle = mtl_init(&mtl_init_params);
-    if (!sink->mtl_lib_handle) {
-      GST_ERROR("Could not initialize MTL");
-      return FALSE;
-    }
+    GST_ERROR("Could not initialize MTL");
+    return FALSE;
   }
 
   if (sink->retry_frame == 0)

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
@@ -56,21 +56,15 @@ G_DECLARE_FINAL_TYPE(Gst_Mtl_St20p_Tx, gst_mtl_st20p_tx, GST, MTL_ST20P_TX, GstV
 
 struct _Gst_Mtl_St20p_Tx {
   GstVideoSink element;
-  GstElement* child;
-  gboolean silent;
   mtl_handle mtl_lib_handle;
   st20p_tx_handle tx_handle;
-
-  /* arguments for incomplete frame buffers */
-  guint retry_frame;
   guint frame_size;
 
-  /* arguments for imtl initialization device */
-  StDevArgs devArgs;
-  /* arguments for imtl tx session */
-  SessionPortArgs portArgs;
-
-  /* arguments for session */
+  /* arguments */
+  guint log_level;
+  guint retry_frame;
+  StDevArgs devArgs;        /* imtl initialization device */
+  SessionPortArgs portArgs; /* imtl session device */
   guint framebuffer_num;
   guint framerate;
 
@@ -79,7 +73,7 @@ struct _Gst_Mtl_St20p_Tx {
   gboolean gpu_direct_enabled;
   gint gpu_driver_index;
   gint gpu_device_index;
-  gboolean* gpu_context;
+  guint8* gpu_context;
 #endif /* MTL_GPU_DIRECT_ENABLED */
 };
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
@@ -90,21 +90,11 @@ GST_DEBUG_CATEGORY_STATIC(gst_mtl_st30p_rx_debug);
 #endif
 
 enum {
-  PROP_0,
-  PROP_SILENT,
-  PROP_RX_DEV_ARGS_PORT,
-  PROP_RX_DEV_ARGS_SIP,
-  PROP_RX_DEV_ARGS_DMA_DEV,
-  PROP_RX_PORT_PORT,
-  PROP_RX_PORT_IP,
-  PROP_RX_PORT_UDP_PORT,
-  PROP_RX_PORT_PAYLOAD_TYPE,
-  PROP_RX_PORT_RX_QUEUES,
-  PROP_RX_FRAMERATE,
-  PROP_RX_FRAMEBUFF_NUM,
-  PROP_RX_CHANNEL,
-  PROP_RX_SAMPLING,
-  PROP_RX_AUDIO_FORMAT,
+  PROP_ST30P_RX_FRAMERATE = PROP_GENERAL_MAX,
+  PROP_ST30P_RX_FRAMEBUFF_NUM,
+  PROP_ST30P_RX_CHANNEL,
+  PROP_ST30P_RX_SAMPLING,
+  PROP_ST30P_RX_AUDIO_FORMAT,
   PROP_MAX
 };
 
@@ -162,83 +152,31 @@ static void gst_mtl_st30p_rx_class_init(Gst_Mtl_St30p_RxClass* klass) {
   gstbasesrc_class->negotiate = GST_DEBUG_FUNCPTR(gst_mtl_st30p_rx_negotiate);
   gstbasesrc_class->create = GST_DEBUG_FUNCPTR(gst_mtl_st30p_rx_create);
 
-  g_object_class_install_property(
-      gobject_class, PROP_SILENT,
-      g_param_spec_boolean("silent", "Silent", "Turn on silent mode.", FALSE,
-                           G_PARAM_READWRITE));
+  gst_mtl_common_init_general_argumetns(gobject_class);
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_DEV_ARGS_PORT,
-      g_param_spec_string("dev-port", "DPDK device port",
-                          "DPDK port for synchronous ST 2110-30 uncompressed"
-                          "audio transmission, bound to the VFIO DPDK driver. ",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_DEV_ARGS_SIP,
-      g_param_spec_string("dev-ip", "Local device IP",
-                          "Local IP address that the port will be "
-                          "identified by. This is the address from which ARP "
-                          "responses will be sent.",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_DEV_ARGS_DMA_DEV,
-      g_param_spec_string("dma-dev", "DPDK DMA port",
-                          "DPDK port for the MTL direct memory functionality.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_PORT,
-      g_param_spec_string("rx-port", "Transmission Device Port",
-                          "DPDK device port initialized for the transmission.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_IP,
-      g_param_spec_string("rx-ip", "Sender node's IP", "Receiving MTL node IP address.",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_UDP_PORT,
-      g_param_spec_uint("rx-udp-port", "Sender UDP port", "Receiving MTL node UDP port.",
-                        0, G_MAXUINT, 20000, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_PAYLOAD_TYPE,
-      g_param_spec_uint("rx-payload-type", "ST 2110 payload type",
-                        "SMPTE ST 2110 payload type.", 0, G_MAXUINT, 112,
-                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_PORT_RX_QUEUES,
-      g_param_spec_uint("rx-queues", "Number of RX queues",
-                        "Number of RX queues to initialize in DPDK backend.", 0,
-                        G_MAXUINT, 16, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_RX_FRAMERATE,
+      gobject_class, PROP_ST30P_RX_FRAMERATE,
       g_param_spec_uint("rx-fps", "Audio framerate", "Framerate of the audio.", 0,
                         G_MAXUINT, 0, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_FRAMEBUFF_NUM,
+      gobject_class, PROP_ST30P_RX_FRAMEBUFF_NUM,
       g_param_spec_uint("rx-framebuff-num", "Number of framebuffers",
                         "Number of framebuffers to be used for transmission.", 0,
                         G_MAXUINT, 3, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_CHANNEL,
+      gobject_class, PROP_ST30P_RX_CHANNEL,
       g_param_spec_uint("rx-channel", "Audio channel", "Audio channel number.", 0,
                         G_MAXUINT, 2, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_SAMPLING,
+      gobject_class, PROP_ST30P_RX_SAMPLING,
       g_param_spec_uint("rx-sampling", "Audio sampling rate", "Audio sampling rate.", 0,
                         G_MAXUINT, 48000, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_RX_AUDIO_FORMAT,
+      gobject_class, PROP_ST30P_RX_AUDIO_FORMAT,
       g_param_spec_string("rx-audio-format", "Audio format", "Audio format type.", NULL,
                           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
@@ -254,47 +192,21 @@ static gboolean gst_mtl_st30p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG_OBJECT(src, "start");
   GST_DEBUG("Media Transport Initialization start");
 
-  /* mtl is already initialzied
-  TODO: add support for initialization of multiple pipelines from one handle */
+  /* Check for future support of multiple plugins initialized from the same handle.
+   * TODO: Add support for initializing multiple pipelines from a single handle. */
   if (!src->mtl_lib_handle) {
-    strncpy(mtl_init_params.port[MTL_PORT_P], src->devArgs.port, MTL_PORT_MAX_LEN);
-    ret = inet_pton(AF_INET, src->devArgs.local_ip_string,
-                    mtl_init_params.sip_addr[MTL_PORT_P]);
-    if (ret != 1) {
-      GST_ERROR("%s, sip %s is not valid ip address\n", __func__,
-                src->devArgs.local_ip_string);
+    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(src->devArgs))) {
+      GST_ERROR("Failed to parse dev arguments");
       return FALSE;
     }
 
-    if (src->devArgs.rx_queues_cnt[MTL_PORT_P]) {
-      mtl_init_params.rx_queues_cnt[MTL_PORT_P] = src->devArgs.rx_queues_cnt[MTL_PORT_P];
-    } else {
-      mtl_init_params.rx_queues_cnt[MTL_PORT_P] = 16;
-    }
-    mtl_init_params.tx_queues_cnt[MTL_PORT_P] = 16;
-
-    mtl_init_params.num_ports = 1;
-
-    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-    if (src->silent) {
-      mtl_init_params.log_level = MTL_LOG_LEVEL_ERROR;
+    if (src->log_level && src->log_level < MTL_LOG_LEVEL_MAX) {
+      mtl_init_params.log_level = src->log_level;
     } else {
       mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
     }
 
-    src->retry_frame = 10;
-
     mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-
-    if (src->devArgs.dma_dev) {
-      strncpy(mtl_init_params.dma_dev_port[0], src->devArgs.dma_dev, MTL_PORT_MAX_LEN);
-    }
-
-    if (src->mtl_lib_handle) {
-      GST_ERROR("MTL already initialized");
-      return FALSE;
-    }
-
     src->mtl_lib_handle = mtl_init(&mtl_init_params);
     if (!src->mtl_lib_handle) {
       GST_ERROR("Could not initialize MTL");
@@ -393,45 +305,23 @@ static void gst_mtl_st30p_rx_set_property(GObject* object, guint prop_id,
                                           const GValue* value, GParamSpec* pspec) {
   Gst_Mtl_St30p_Rx* self = GST_MTL_ST30P_RX(object);
 
+  if (prop_id < PROP_GENERAL_MAX) {
+    gst_mtl_common_set_general_argumetns(object, prop_id, value, pspec, &(self->devArgs),
+                                         &(self->portArgs), &self->log_level);
+    return;
+  }
+
   switch (prop_id) {
-    case PROP_SILENT:
-      self->silent = g_value_get_boolean(value);
-      break;
-    case PROP_RX_DEV_ARGS_PORT:
-      strncpy(self->devArgs.port, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_DEV_ARGS_SIP:
-      strncpy(self->devArgs.local_ip_string, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_DEV_ARGS_DMA_DEV:
-      strncpy(self->devArgs.dma_dev, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_PORT_PORT:
-      strncpy(self->portArgs.port, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_PORT_IP:
-      strncpy(self->portArgs.session_ip_string, g_value_get_string(value),
-              MTL_PORT_MAX_LEN);
-      break;
-    case PROP_RX_PORT_UDP_PORT:
-      self->portArgs.udp_port = g_value_get_uint(value);
-      break;
-    case PROP_RX_PORT_PAYLOAD_TYPE:
-      self->portArgs.payload_type = g_value_get_uint(value);
-      break;
-    case PROP_RX_PORT_RX_QUEUES:
-      self->devArgs.rx_queues_cnt[MTL_PORT_P] = g_value_get_uint(value);
-      break;
-    case PROP_RX_FRAMEBUFF_NUM:
+    case PROP_ST30P_RX_FRAMEBUFF_NUM:
       self->framebuffer_num = g_value_get_uint(value);
       break;
-    case PROP_RX_CHANNEL:
+    case PROP_ST30P_RX_CHANNEL:
       self->channel = g_value_get_uint(value);
       break;
-    case PROP_RX_SAMPLING:
+    case PROP_ST30P_RX_SAMPLING:
       self->sampling = g_value_get_uint(value);
       break;
-    case PROP_RX_AUDIO_FORMAT:
+    case PROP_ST30P_RX_AUDIO_FORMAT:
       strncpy(self->audio_format, g_value_get_string(value), MTL_PORT_MAX_LEN);
       break;
     default:
@@ -444,44 +334,23 @@ static void gst_mtl_st30p_rx_get_property(GObject* object, guint prop_id, GValue
                                           GParamSpec* pspec) {
   Gst_Mtl_St30p_Rx* src = GST_MTL_ST30P_RX(object);
 
+  if (prop_id < PROP_GENERAL_MAX) {
+    gst_mtl_common_get_general_argumetns(object, prop_id, value, pspec, &(src->devArgs),
+                                         &(src->portArgs), &src->log_level);
+    return;
+  }
+
   switch (prop_id) {
-    case PROP_SILENT:
-      g_value_set_boolean(value, src->silent);
-      break;
-    case PROP_RX_DEV_ARGS_PORT:
-      g_value_set_string(value, src->devArgs.port);
-      break;
-    case PROP_RX_DEV_ARGS_SIP:
-      g_value_set_string(value, src->devArgs.local_ip_string);
-      break;
-    case PROP_RX_DEV_ARGS_DMA_DEV:
-      g_value_set_string(value, src->devArgs.dma_dev);
-      break;
-    case PROP_RX_PORT_PORT:
-      g_value_set_string(value, src->portArgs.port);
-      break;
-    case PROP_RX_PORT_IP:
-      g_value_set_string(value, src->portArgs.session_ip_string);
-      break;
-    case PROP_RX_PORT_UDP_PORT:
-      g_value_set_uint(value, src->portArgs.udp_port);
-      break;
-    case PROP_RX_PORT_PAYLOAD_TYPE:
-      g_value_set_uint(value, src->portArgs.payload_type);
-      break;
-    case PROP_RX_PORT_RX_QUEUES:
-      g_value_set_uint(value, src->devArgs.rx_queues_cnt[MTL_PORT_P]);
-      break;
-    case PROP_RX_FRAMEBUFF_NUM:
+    case PROP_ST30P_RX_FRAMEBUFF_NUM:
       g_value_set_uint(value, src->framebuffer_num);
       break;
-    case PROP_RX_CHANNEL:
+    case PROP_ST30P_RX_CHANNEL:
       g_value_set_uint(value, src->channel);
       break;
-    case PROP_RX_SAMPLING:
+    case PROP_ST30P_RX_SAMPLING:
       g_value_set_uint(value, src->sampling);
       break;
-    case PROP_RX_AUDIO_FORMAT:
+    case PROP_ST30P_RX_AUDIO_FORMAT:
       g_value_set_string(value, src->audio_format);
       break;
     default:

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
@@ -192,26 +192,12 @@ static gboolean gst_mtl_st30p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG_OBJECT(src, "start");
   GST_DEBUG("Media Transport Initialization start");
 
-  /* Check for future support of multiple plugins initialized from the same handle.
-   * TODO: Add support for initializing multiple pipelines from a single handle. */
+  src->mtl_lib_handle =
+      gst_mtl_common_mtl_init(&mtl_init_params, &(src->devArgs), &(src->log_level));
+
   if (!src->mtl_lib_handle) {
-    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(src->devArgs))) {
-      GST_ERROR("Failed to parse dev arguments");
-      return FALSE;
-    }
-
-    if (src->log_level && src->log_level < MTL_LOG_LEVEL_MAX) {
-      mtl_init_params.log_level = src->log_level;
-    } else {
-      mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
-    }
-
-    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-    src->mtl_lib_handle = mtl_init(&mtl_init_params);
-    if (!src->mtl_lib_handle) {
-      GST_ERROR("Could not initialize MTL");
-      return FALSE;
-    }
+    GST_ERROR("Could not initialize MTL");
+    return FALSE;
   }
 
   ops_rx->name = "st30src";

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
@@ -90,7 +90,8 @@ GST_DEBUG_CATEGORY_STATIC(gst_mtl_st30p_rx_debug);
 #endif
 
 enum {
-  PROP_ST30P_RX_FRAMERATE = PROP_GENERAL_MAX,
+  PROP_ST30P_RX_RETRY = PROP_GENERAL_MAX,
+  PROP_ST30P_RX_FRAMERATE,
   PROP_ST30P_RX_FRAMEBUFF_NUM,
   PROP_ST30P_RX_CHANNEL,
   PROP_ST30P_RX_SAMPLING,
@@ -193,12 +194,14 @@ static gboolean gst_mtl_st30p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_mtl_init(&mtl_init_params, &(src->devArgs), &(src->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level));
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");
     return FALSE;
   }
+
+  src->retry_frame = 10; /* TODO add support for parameter */
 
   ops_rx->name = "st30src";
   ops_rx->channel = src->channel;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.h
@@ -62,25 +62,22 @@ struct _Gst_Mtl_St30p_Rx {
 
   /*< private >*/
   struct st30p_rx_ops ops_rx;
-  gboolean silent;
   mtl_handle mtl_lib_handle;
   st30p_rx_handle rx_handle;
-
-  /* arguments for mtl frame buffers */
-  guint retry_frame;
   guint frame_size;
 
-  /* arguments for imtl initialization device */
-  StDevArgs devArgs;
-  /* arguments for imtl rx session */
-  SessionPortArgs portArgs;
+  /* arguments */
+  guint log_level;
+  guint retry_frame;
+  StDevArgs devArgs;        /* imtl initialization device */
+  SessionPortArgs portArgs; /* imtl session device */
+  gint framebuffer_num;
 
-  /* arguments for session */
+  /* audio (st30p) specific arguments */
   guint channel;
   guint sampling;
   gboolean ptime;
   gchar audio_format[MTL_PORT_MAX_LEN];
-  gint framebuffer_num;
 };
 
 G_END_DECLS

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -90,7 +90,12 @@ GST_DEBUG_CATEGORY_STATIC(gst_mtl_st30p_tx_debug);
 #define PACKAGE_VERSION "1.0"
 #endif
 
-enum { PROP_TX_FRAMERATE = PROP_GENERAL_MAX, PROP_TX_FRAMEBUFF_NUM, PROP_MAX };
+enum {
+  PROP_ST30P_TX_RETRY = PROP_GENERAL_MAX,
+  PROP_ST30P_TX_FRAMERATE,
+  PROP_ST30P_TX_FRAMEBUFF_NUM,
+  PROP_MAX
+};
 
 /* pad template */
 static GstStaticPadTemplate gst_mtl_st30p_tx_sink_pad_template =
@@ -169,7 +174,7 @@ static void gst_mtl_st30p_tx_class_init(Gst_Mtl_St30p_TxClass* klass) {
   gst_mtl_common_init_general_argumetns(gobject_class);
 
   g_object_class_install_property(
-      gobject_class, PROP_TX_FRAMEBUFF_NUM,
+      gobject_class, PROP_ST30P_TX_FRAMEBUFF_NUM,
       g_param_spec_uint("tx-framebuff-num", "Number of framebuffers",
                         "Number of framebuffers to be used for transmission.", 0,
                         G_MAXUINT, 3, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
@@ -185,7 +190,7 @@ static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_mtl_init(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");
@@ -224,10 +229,13 @@ static void gst_mtl_st30p_tx_set_property(GObject* object, guint prop_id,
   }
 
   switch (prop_id) {
-    case PROP_TX_FRAMERATE:
+    case PROP_ST30P_TX_RETRY:
+      self->retry_frame = g_value_get_uint(value);
+      break;
+    case PROP_ST30P_TX_FRAMERATE:
       self->framerate = g_value_get_uint(value);
       break;
-    case PROP_TX_FRAMEBUFF_NUM:
+    case PROP_ST30P_TX_FRAMEBUFF_NUM:
       self->framebuffer_num = g_value_get_uint(value);
       break;
     default:
@@ -247,10 +255,13 @@ static void gst_mtl_st30p_tx_get_property(GObject* object, guint prop_id, GValue
   }
 
   switch (prop_id) {
-    case PROP_TX_FRAMERATE:
+    case PROP_ST30P_TX_RETRY:
+      g_value_set_uint(value, sink->retry_frame);
+      break;
+    case PROP_ST30P_TX_FRAMERATE:
       g_value_set_uint(value, sink->framerate);
       break;
-    case PROP_TX_FRAMEBUFF_NUM:
+    case PROP_ST30P_TX_FRAMEBUFF_NUM:
       g_value_set_uint(value, sink->framebuffer_num);
       break;
     default:

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -90,21 +90,7 @@ GST_DEBUG_CATEGORY_STATIC(gst_mtl_st30p_tx_debug);
 #define PACKAGE_VERSION "1.0"
 #endif
 
-enum {
-  PROP_0,
-  PROP_SILENT,
-  PROP_TX_DEV_ARGS_PORT,
-  PROP_TX_DEV_ARGS_SIP,
-  PROP_TX_DEV_ARGS_DMA_DEV,
-  PROP_TX_PORT_PORT,
-  PROP_TX_PORT_IP,
-  PROP_TX_PORT_UDP_PORT,
-  PROP_TX_PORT_PAYLOAD_TYPE,
-  PROP_TX_PORT_TX_QUEUES,
-  PROP_TX_FRAMERATE,
-  PROP_TX_FRAMEBUFF_NUM,
-  PROP_MAX
-};
+enum { PROP_TX_FRAMERATE = PROP_GENERAL_MAX, PROP_TX_FRAMEBUFF_NUM, PROP_MAX };
 
 /* pad template */
 static GstStaticPadTemplate gst_mtl_st30p_tx_sink_pad_template =
@@ -180,61 +166,7 @@ static void gst_mtl_st30p_tx_class_init(Gst_Mtl_St30p_TxClass* klass) {
   gobject_class->finalize = GST_DEBUG_FUNCPTR(gst_mtl_st30p_tx_finalize);
   gstbasesink_class->start = GST_DEBUG_FUNCPTR(gst_mtl_st30p_tx_start);
 
-  g_object_class_install_property(
-      gobject_class, PROP_SILENT,
-      g_param_spec_boolean("silent", "Silent", "Turn on silent mode.", FALSE,
-                           G_PARAM_READWRITE));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_DEV_ARGS_PORT,
-      g_param_spec_string("dev-port", "DPDK device port",
-                          "DPDK port for synchronous ST 2110-30 uncompressed"
-                          "audio transmission, bound to the VFIO DPDK driver. ",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_DEV_ARGS_SIP,
-      g_param_spec_string("dev-ip", "Local device IP",
-                          "Local IP address that the port will be "
-                          "identified by. This is the address from which ARP "
-                          "responses will be sent.",
-                          NULL, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_DEV_ARGS_DMA_DEV,
-      g_param_spec_string("dma-dev", "DPDK DMA port",
-                          "DPDK port for the MTL direct memory functionality.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_PORT_PORT,
-      g_param_spec_string("tx-port", "Transmission Device Port",
-                          "DPDK device port initialized for the transmission.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_PORT_IP,
-      g_param_spec_string("tx-ip", "Receiving node's IP",
-                          "Receiving MTL node IP address.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_PORT_UDP_PORT,
-      g_param_spec_uint("tx-udp-port", "Receiver's UDP port",
-                        "Receiving MTL node UDP port.", 0, G_MAXUINT, 20000,
-                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_PORT_PAYLOAD_TYPE,
-      g_param_spec_uint("tx-payload-type", "ST 2110 payload type",
-                        "SMPTE ST 2110 payload type.", 0, G_MAXUINT, 111,
-                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property(
-      gobject_class, PROP_TX_PORT_TX_QUEUES,
-      g_param_spec_uint("tx-queues", "Number of TX queues",
-                        "Number of TX queues to initialize in DPDK backend.", 0,
-                        G_MAXUINT, 16, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  gst_mtl_common_init_general_argumetns(gobject_class);
 
   g_object_class_install_property(
       gobject_class, PROP_TX_FRAMEBUFF_NUM,
@@ -245,7 +177,6 @@ static void gst_mtl_st30p_tx_class_init(Gst_Mtl_St30p_TxClass* klass) {
 
 static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
   struct mtl_init_params mtl_init_params = {0};
-  gint ret;
 
   Gst_Mtl_St30p_Tx* sink = GST_MTL_ST30P_TX(bsink);
 
@@ -253,61 +184,29 @@ static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
   GST_DEBUG("Media Transport Initialization start");
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
-  /* mtl is already initialzied */
-  if (sink->mtl_lib_handle) {
-    GST_INFO("Mtl already initialized");
-    if (mtl_start(sink->mtl_lib_handle)) {
-      GST_ERROR("Failed to start MTL");
+  /* Check for future support of multiple plugins initialized from the same handle.
+   * TODO: Add support for initializing multiple pipelines from a single handle. */
+  if (!sink->mtl_lib_handle) {
+    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(sink->devArgs))) {
+      GST_ERROR("Failed to parse dev arguments");
       return FALSE;
     }
-    return TRUE;
-  }
 
-  strncpy(mtl_init_params.port[MTL_PORT_P], sink->devArgs.port, MTL_PORT_MAX_LEN);
+    if (sink->log_level && sink->log_level < MTL_LOG_LEVEL_MAX) {
+      mtl_init_params.log_level = sink->log_level;
+    } else {
+      mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
+    }
 
-  ret = inet_pton(AF_INET, sink->devArgs.local_ip_string,
-                  mtl_init_params.sip_addr[MTL_PORT_P]);
-  if (ret != 1) {
-    GST_ERROR("%s, sip %s is not valid ip address\n", __func__,
-              sink->devArgs.local_ip_string);
-    return false;
-  }
-
-  if (sink->devArgs.tx_queues_cnt[MTL_PORT_P]) {
-    mtl_init_params.tx_queues_cnt[MTL_PORT_P] = sink->devArgs.tx_queues_cnt[MTL_PORT_P];
-  } else {
-    mtl_init_params.tx_queues_cnt[MTL_PORT_P] = 16;
-  }
-
-  mtl_init_params.rx_queues_cnt[MTL_PORT_P] = 0;
-  mtl_init_params.num_ports++;
-
-  mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-  if (sink->silent) {
-    mtl_init_params.log_level = MTL_LOG_LEVEL_ERROR;
-  } else {
-    mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
+    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
+    sink->mtl_lib_handle = mtl_init(&mtl_init_params);
+    if (!sink->mtl_lib_handle) {
+      GST_ERROR("Could not initialize MTL");
+      return FALSE;
+    }
   }
 
   sink->retry_frame = 10;
-
-  mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-
-  if (sink->devArgs.dma_dev) {
-    strncpy(mtl_init_params.dma_dev_port[0], sink->devArgs.dma_dev, MTL_PORT_MAX_LEN);
-  }
-
-  if (sink->mtl_lib_handle) {
-    GST_ERROR("MTL already initialized");
-    return false;
-  }
-
-  sink->mtl_lib_handle = mtl_init(&mtl_init_params);
-  if (!sink->mtl_lib_handle) {
-    GST_ERROR("Could not initialize MTL");
-    return false;
-  }
-
   gst_element_set_state(GST_ELEMENT(sink), GST_STATE_PLAYING);
 
   return true;
@@ -332,34 +231,13 @@ static void gst_mtl_st30p_tx_set_property(GObject* object, guint prop_id,
                                           const GValue* value, GParamSpec* pspec) {
   Gst_Mtl_St30p_Tx* self = GST_MTL_ST30P_TX(object);
 
+  if (prop_id < PROP_GENERAL_MAX) {
+    gst_mtl_common_set_general_argumetns(object, prop_id, value, pspec, &(self->devArgs),
+                                         &(self->portArgs), &self->log_level);
+    return;
+  }
+
   switch (prop_id) {
-    case PROP_SILENT:
-      self->silent = g_value_get_boolean(value);
-      break;
-    case PROP_TX_DEV_ARGS_PORT:
-      strncpy(self->devArgs.port, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_TX_DEV_ARGS_SIP:
-      strncpy(self->devArgs.local_ip_string, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_TX_DEV_ARGS_DMA_DEV:
-      strncpy(self->devArgs.dma_dev, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_TX_PORT_PORT:
-      strncpy(self->portArgs.port, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_TX_PORT_IP:
-      strncpy(self->portArgs.tx_ip_string, g_value_get_string(value), MTL_PORT_MAX_LEN);
-      break;
-    case PROP_TX_PORT_UDP_PORT:
-      self->portArgs.udp_port = g_value_get_uint(value);
-      break;
-    case PROP_TX_PORT_PAYLOAD_TYPE:
-      self->portArgs.payload_type = g_value_get_uint(value);
-      break;
-    case PROP_TX_PORT_TX_QUEUES:
-      self->devArgs.tx_queues_cnt[MTL_PORT_P] = g_value_get_uint(value);
-      break;
     case PROP_TX_FRAMERATE:
       self->framerate = g_value_get_uint(value);
       break;
@@ -376,34 +254,13 @@ static void gst_mtl_st30p_tx_get_property(GObject* object, guint prop_id, GValue
                                           GParamSpec* pspec) {
   Gst_Mtl_St30p_Tx* sink = GST_MTL_ST30P_TX(object);
 
+  if (prop_id < PROP_GENERAL_MAX) {
+    gst_mtl_common_get_general_argumetns(object, prop_id, value, pspec, &(sink->devArgs),
+                                         &(sink->portArgs), &sink->log_level);
+    return;
+  }
+
   switch (prop_id) {
-    case PROP_SILENT:
-      g_value_set_boolean(value, sink->silent);
-      break;
-    case PROP_TX_DEV_ARGS_PORT:
-      g_value_set_string(value, sink->devArgs.port);
-      break;
-    case PROP_TX_DEV_ARGS_SIP:
-      g_value_set_string(value, sink->devArgs.local_ip_string);
-      break;
-    case PROP_TX_DEV_ARGS_DMA_DEV:
-      g_value_set_string(value, sink->devArgs.dma_dev);
-      break;
-    case PROP_TX_PORT_PORT:
-      g_value_set_string(value, sink->portArgs.port);
-      break;
-    case PROP_TX_PORT_IP:
-      g_value_set_string(value, sink->portArgs.tx_ip_string);
-      break;
-    case PROP_TX_PORT_UDP_PORT:
-      g_value_set_uint(value, sink->portArgs.udp_port);
-      break;
-    case PROP_TX_PORT_PAYLOAD_TYPE:
-      g_value_set_uint(value, sink->portArgs.payload_type);
-      break;
-    case PROP_TX_PORT_TX_QUEUES:
-      g_value_set_uint(value, sink->devArgs.tx_queues_cnt[MTL_PORT_P]);
-      break;
     case PROP_TX_FRAMERATE:
       g_value_set_uint(value, sink->framerate);
       break;
@@ -482,9 +339,9 @@ static gboolean gst_mtl_st30p_tx_session_create(Gst_Mtl_St30p_Tx* sink, GstCaps*
     ops_tx.framebuff_cnt = 3;
   }
 
-  if (inet_pton(AF_INET, sink->portArgs.tx_ip_string, ops_tx.port.dip_addr[MTL_PORT_P]) !=
+  if (inet_pton(AF_INET, sink->portArgs.session_ip_string, ops_tx.port.dip_addr[MTL_PORT_P]) !=
       1) {
-    GST_ERROR("Invalid destination IP address: %s", sink->portArgs.tx_ip_string);
+    GST_ERROR("Invalid destination IP address: %s", sink->portArgs.session_ip_string);
     return FALSE;
   }
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -184,26 +184,12 @@ static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
   GST_DEBUG("Media Transport Initialization start");
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
-  /* Check for future support of multiple plugins initialized from the same handle.
-   * TODO: Add support for initializing multiple pipelines from a single handle. */
+  sink->mtl_lib_handle =
+      gst_mtl_common_mtl_init(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
+
   if (!sink->mtl_lib_handle) {
-    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(sink->devArgs))) {
-      GST_ERROR("Failed to parse dev arguments");
-      return FALSE;
-    }
-
-    if (sink->log_level && sink->log_level < MTL_LOG_LEVEL_MAX) {
-      mtl_init_params.log_level = sink->log_level;
-    } else {
-      mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
-    }
-
-    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-    sink->mtl_lib_handle = mtl_init(&mtl_init_params);
-    if (!sink->mtl_lib_handle) {
-      GST_ERROR("Could not initialize MTL");
-      return FALSE;
-    }
+    GST_ERROR("Could not initialize MTL");
+    return FALSE;
   }
 
   sink->retry_frame = 10;
@@ -339,8 +325,8 @@ static gboolean gst_mtl_st30p_tx_session_create(Gst_Mtl_St30p_Tx* sink, GstCaps*
     ops_tx.framebuff_cnt = 3;
   }
 
-  if (inet_pton(AF_INET, sink->portArgs.session_ip_string, ops_tx.port.dip_addr[MTL_PORT_P]) !=
-      1) {
+  if (inet_pton(AF_INET, sink->portArgs.session_ip_string,
+                ops_tx.port.dip_addr[MTL_PORT_P]) != 1) {
     GST_ERROR("Invalid destination IP address: %s", sink->portArgs.session_ip_string);
     return FALSE;
   }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
@@ -47,67 +47,32 @@
 #ifndef __GST_MTL_ST30P_TX_H__
 #define __GST_MTL_ST30P_TX_H__
 
-#include <arpa/inet.h>
-#include <gst/audio/audio.h>
-#include <gst/gst.h>
-#include <mtl/mtl_api.h>
-#include <mtl/st30_pipeline_api.h>
+#include "gst_mtl_common.h"
 
 G_BEGIN_DECLS
-
-#ifndef NS_PER_MS
-#define NS_PER_MS (1000 * 1000)
-#endif
-
-#ifndef NS_PER_S
-#define NS_PER_S (1000 * NS_PER_MS)
-#endif
 
 #define GST_TYPE_MTL_ST30P_TX (gst_mtl_st30p_tx_get_type())
 G_DECLARE_FINAL_TYPE(Gst_Mtl_St30p_Tx, gst_mtl_st30p_tx, GST, MTL_ST30P_TX, GstAudioSink)
 
-typedef struct StDevArgs {
-  gchar port[MTL_PORT_MAX_LEN];
-  gchar local_ip_string[MTL_PORT_MAX_LEN];
-  gint tx_queues_cnt[MTL_PORT_MAX];
-  gint rx_queues_cnt[MTL_PORT_MAX];
-  gchar dma_dev[MTL_PORT_MAX_LEN];
-} StDevArgs;
-
-typedef struct StTxSessionPortArgs {
-  gchar tx_ip_string[MTL_PORT_MAX_LEN];
-  gchar port[MTL_PORT_MAX_LEN];
-  gint udp_port;
-  gint payload_type;
-} StTxSessionPortArgs;
-
 struct _Gst_Mtl_St30p_Tx {
   GstAudioSink element;
-  gboolean silent;
   mtl_handle mtl_lib_handle;
   st30p_tx_handle tx_handle;
+  guint frame_size;
 
+  /*
+   * Handles incomplete frame buffers when their size does not match the expected size.
+   */
   struct st30_frame* cur_frame;
   guint cur_frame_available_size;
 
-  /* arguments for incomplete frame buffers */
+  /* arguments */
   guint retry_frame;
-  guint frame_size;
-
-  /* arguments for imtl initialization device */
-  StDevArgs devArgs;
-  /* arguments for imtl tx session */
-  StTxSessionPortArgs portArgs;
-
-  /* arguments for session */
+  guint log_level;
+  StDevArgs devArgs;            /* imtl initialization device */
+  SessionPortArgs portArgs; /* imtl tx session */
   guint framebuffer_num;
   guint framerate;
-};
-
-enum gst_mtl_supported_audio_sampling {
-  GST_MTL_SUPPORTED_AUDIO_SAMPLING_44_1K = 44100,
-  GST_MTL_SUPPORTED_AUDIO_SAMPLING_48K = 48000,
-  GST_MTL_SUPPORTED_AUDIO_SAMPLING_96K = 96000
 };
 
 G_END_DECLS

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
@@ -69,7 +69,7 @@ struct _Gst_Mtl_St30p_Tx {
   /* arguments */
   guint retry_frame;
   guint log_level;
-  StDevArgs devArgs;            /* imtl initialization device */
+  StDevArgs devArgs;        /* imtl initialization device */
   SessionPortArgs portArgs; /* imtl tx session */
   guint framebuffer_num;
   guint framerate;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -191,26 +191,12 @@ static gboolean gst_mtl_st40_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG_OBJECT(src, "start");
   GST_DEBUG("Media Transport Initialization start");
 
-  /* Check for future support of multiple plugins initialized from the same handle.
-   * TODO: Add support for initializing multiple pipelines from a single handle. */
+  src->mtl_lib_handle =
+      gst_mtl_common_mtl_init(&mtl_init_params, &(src->devArgs), &(src->log_level));
+
   if (!src->mtl_lib_handle) {
-    if (!gst_mtl_common_parse_dev_arguments(&mtl_init_params, &(src->devArgs))) {
-      GST_ERROR("Failed to parse dev arguments");
-      return FALSE;
-    }
-
-    if (src->log_level && src->log_level < MTL_LOG_LEVEL_MAX) {
-      mtl_init_params.log_level = src->log_level;
-    } else {
-      mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
-    }
-
-    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
-    src->mtl_lib_handle = mtl_init(&mtl_init_params);
-    if (!src->mtl_lib_handle) {
-      GST_ERROR("Could not initialize MTL");
-      return FALSE;
-    }
+    GST_ERROR("Could not initialize MTL");
+    return FALSE;
   }
 
   if (src->timeout_mbuf_get_seconds <= 0) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -205,6 +205,7 @@ static gboolean gst_mtl_st40_rx_start(GstBaseSrc* basesrc) {
       mtl_init_params.log_level = MTL_LOG_LEVEL_INFO;
     }
 
+    mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
     src->mtl_lib_handle = mtl_init(&mtl_init_params);
     if (!src->mtl_lib_handle) {
       GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -192,7 +192,7 @@ static gboolean gst_mtl_st40_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_mtl_init(&mtl_init_params, &(src->devArgs), &(src->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level));
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.h
@@ -58,25 +58,21 @@ G_DECLARE_FINAL_TYPE(Gst_Mtl_St40_Rx, gst_mtl_st40_rx, GST, MTL_ST40_RX, GstBase
 
 struct _Gst_Mtl_St40_Rx {
   GstBaseSrc element;
-  GstBuffer* buffer;
 
+  /*< private >*/
   pthread_mutex_t mbuff_mutex;
   pthread_cond_t mbuff_cond;
-  /*< private >*/
-  guint log_level;
   mtl_handle mtl_lib_handle;
   st40_rx_handle rx_handle;
 
-  /* arguments for mtl mbuf buffers */
+  /* arguments */
+  StDevArgs devArgs;        /* imtl initialization device */
+  SessionPortArgs portArgs; /* imtl session device */
+  guint log_level;
   guint timeout_mbuf_get_seconds;
   guint16 mbuff_size;
   guint16 udw_size;
   char* anc_data;
-
-  /* arguments for imtl initialization device */
-  StDevArgs devArgs;
-  /* arguments for imtl rx session */
-  SessionPortArgs portArgs;
 };
 
 G_END_DECLS

--- a/ecosystem/gstreamer_plugin/meson.build
+++ b/ecosystem/gstreamer_plugin/meson.build
@@ -91,7 +91,7 @@ gstmtl_st30p_tx_sources = [
 ]
 
 gstmtl_st30p_tx = library('gstmtl_st30p_tx',
-    gstmtl_st30p_tx_sources,
+    gst_mtl_common_sources + gstmtl_st30p_tx_sources,
     dependencies : [gst_dep, gstbase_dep, gstreamer_audio_dep, mtl_dep],
     install : true,
     install_dir : plugins_install_dir,


### PR DESCRIPTION
Using functions from gst_mtl_common to make all
arguments in gstreamer plugins cross compatible,
order the arguments in the header files.