### PR TITLE
Add: MTL common handle support in GStreamer

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -101,13 +101,16 @@ In MTL GStreamer plugins there are general arguments that apply to every plugin.
 | udp-port      | uint   | Receiving MTL node UDP port.                                                                      | 0 to G_MAXUINT           |
 | tx-queues     | uint   | Number of TX queues to initialize in DPDK backend.                                                | 0 to G_MAXUINT           |
 | rx-queues     | uint   | Number of RX queues to initialize in DPDK backend.                                                | 0 to G_MAXUINT           |
-| payload-type  | uint   | SMPTE ST 2110 payload type.                                                                  | 0 to G_MAXUINT           |
+| payload-type  | uint   | SMPTE ST 2110 payload type.                                                                       | 0 to G_MAXUINT           |
 
 These are also general parameters accepted by plugins, but the functionality they provide to the user is not yet supported in plugins.
 | Property Name | Type   | Description                                                                                       | Range                    |
 |---------------|--------|---------------------------------------------------------------------------------------------------|--------------------------|
 | dma-dev       | string | **RESERVED FOR FUTURE USE** port for the MTL direct memory functionality.                         | N/A                      |
 | port          | string | **RESERVED FOR FUTURE USE** DPDK device port. Utilized when multiple ports are passed to the MTL library to select the port for the session. | N/A |
+
+> **Warning:**
+> Generally, the `log-level`, `dev-port`, `dev-ip`, `tx-queues`, and `rx-queues` are used to initialize the MTL library. As the MTL library handle is shared between MTL GStreamer plugins of the same pipeline, you only need to pass them once when specifying the arguments for the first pipeline. Nothing happens when you specify them elsewhere; they will just be ignored after the initialization of MTL has already happened.
 
 ### 2.3. General capabilities
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -111,7 +111,7 @@ These are also general parameters accepted by plugins, but the functionality the
 
 > **Warning:**
 > Generally, the `log-level`, `dev-port`, `dev-ip`, `tx-queues`, and `rx-queues` are used to initialize the MTLlibrary. As the MTL library handle is shared between MTL
-> GStreamer plugins of the same pipeline, you only need to pass them once when specifying the arguments for thefirst pipeline. Nothing happens when you specify them elsewhere;
+> GStreamer plugins of the same pipeline, you only need to pass them once when specifying the arguments for the firstly initialized pipeline. Nothing happens when you specify them elsewhere;
 > they will just be ignored after the initialization of MTL has already happened.
 
 ### 2.3. General capabilities

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -110,7 +110,9 @@ These are also general parameters accepted by plugins, but the functionality the
 | port          | string | **RESERVED FOR FUTURE USE** DPDK device port. Utilized when multiple ports are passed to the MTL library to select the port for the session. | N/A |
 
 > **Warning:**
-> Generally, the `log-level`, `dev-port`, `dev-ip`, `tx-queues`, and `rx-queues` are used to initialize the MTL library. As the MTL library handle is shared between MTL GStreamer plugins of the same pipeline, you only need to pass them once when specifying the arguments for the first pipeline. Nothing happens when you specify them elsewhere; they will just be ignored after the initialization of MTL has already happened.
+> Generally, the `log-level`, `dev-port`, `dev-ip`, `tx-queues`, and `rx-queues` are used to initialize the MTLlibrary. As the MTL library handle is shared between MTL
+> GStreamer plugins of the same pipeline, you only need to pass them once when specifying the arguments for thefirst pipeline. Nothing happens when you specify them elsewhere;
+> they will just be ignored after the initialization of MTL has already happened.
 
 ### 2.3. General capabilities
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -9,6 +9,8 @@
 #include "gst_mtl_common.h"
 
 guint gst_mtl_port_idx = MTL_PORT_P;
+/* handles for the mtl libs */
+mtl_handle gst_mtl_common_shared_handle;
 
 gboolean gst_mtl_common_parse_input_finfo(const GstVideoFormatInfo* finfo,
                                           enum st_frame_fmt* fmt) {
@@ -394,12 +396,17 @@ gboolean gst_mtl_common_parse_dev_arguments(struct mtl_init_params* mtl_init_par
 }
 
 mtl_handle gst_mtl_common_init_handle(struct mtl_init_params* p, StDevArgs* devArgs,
-                                      guint* log_level) {
+                                      guint* log_level, gboolean force_to_initialize_new) {
   struct mtl_init_params mtl_init_params = {0};
 
   if (!p || !devArgs || !log_level) {
     GST_ERROR("Invalid input");
     return NULL;
+  }
+
+  if (gst_mtl_common_shared_handle) {
+    GST_INFO("Mtl is already initialized with shared handle %p", gst_mtl_common_shared_handle);
+    return gst_mtl_common_shared_handle;
   }
 
   mtl_init_params.num_ports = 0;

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -420,6 +420,7 @@ gboolean gst_mtl_common_parse_dev_arguments(struct mtl_init_params* mtl_init_par
 mtl_handle gst_mtl_common_init_handle(StDevArgs* devArgs, guint* log_level,
                                       gboolean force_to_initialize_new_instance) {
   struct mtl_init_params mtl_init_params = {0};
+  mtl_handle ret;
   pthread_mutex_lock(&common_handle.mutex);
 
   if (!force_to_initialize_new_instance && common_handle.mtl_handle) {
@@ -460,9 +461,11 @@ mtl_handle gst_mtl_common_init_handle(StDevArgs* devArgs, guint* log_level,
 
   if (force_to_initialize_new_instance) {
     GST_INFO("MTL shared handle ignored");
+
+    ret = mtl_init(&mtl_init_params);
     pthread_mutex_unlock(&common_handle.mutex);
 
-    return mtl_init(&mtl_init_params);
+    return ret;
   }
 
   common_handle.mtl_handle = mtl_init(&mtl_init_params);
@@ -482,7 +485,7 @@ mtl_handle gst_mtl_common_init_handle(StDevArgs* devArgs, guint* log_level,
  * shared value will be used).
  */
 gint gst_mtl_common_deinit_handle(mtl_handle handle) {
-  int ret;
+  gint ret;
 
   pthread_mutex_lock(&common_handle.mutex);
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -433,6 +433,7 @@ mtl_handle gst_mtl_common_init_handle(StDevArgs* devArgs, guint* log_level,
 
   if (!devArgs || !log_level) {
     GST_ERROR("Invalid input");
+    pthread_mutex_unlock(&common_handle.mutex);
     return NULL;
   }
 
@@ -440,6 +441,7 @@ mtl_handle gst_mtl_common_init_handle(StDevArgs* devArgs, guint* log_level,
 
   if (gst_mtl_common_parse_dev_arguments(&mtl_init_params, devArgs) == FALSE) {
     GST_ERROR("Failed to parse dev arguments");
+    pthread_mutex_unlock(&common_handle.mutex);
     return NULL;
   }
   mtl_init_params.flags |= MTL_FLAG_BIND_NUMA;
@@ -485,8 +487,9 @@ gint gst_mtl_common_deinit_handle(mtl_handle handle) {
   pthread_mutex_lock(&common_handle.mutex);
 
   if (handle && handle != common_handle.mtl_handle) {
+    ret = mtl_uninit(handle);
     pthread_mutex_unlock(&common_handle.mutex);
-    return mtl_uninit(handle);
+    return ret;
   }
 
   common_handle.mtl_handle_reference_count--;

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -104,4 +104,5 @@ void gst_mtl_common_get_general_arguments(GObject* object, guint prop_id,
 mtl_handle gst_mtl_common_init_handle(StDevArgs* devArgs, guint* log_level,
                                       gboolean force_to_initialize_new_instance);
 
+gint gst_mtl_common_deinit_handle(mtl_handle handle);
 #endif /* __GST_MTL_COMMON_H__ */

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -101,7 +101,7 @@ void gst_mtl_common_get_general_arguments(GObject* object, guint prop_id,
                                           StDevArgs* devArgs, SessionPortArgs* portArgs,
                                           guint* log_level);
 
-mtl_handle gst_mtl_common_init_handle(struct mtl_init_params* p, StDevArgs* devArgs,
-                                      guint* log_level, gboolean force_to_initialize_new);
+mtl_handle gst_mtl_common_init_handle(StDevArgs* devArgs, guint* log_level,
+                                      gboolean force_to_initialize_new_instance);
 
 #endif /* __GST_MTL_COMMON_H__ */

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -102,6 +102,6 @@ void gst_mtl_common_get_general_arguments(GObject* object, guint prop_id,
                                           guint* log_level);
 
 mtl_handle gst_mtl_common_init_handle(struct mtl_init_params* p, StDevArgs* devArgs,
-                                      guint* log_level);
+                                      guint* log_level, gboolean force_to_initialize_new);
 
 #endif /* __GST_MTL_COMMON_H__ */

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
@@ -208,7 +208,7 @@ static gboolean gst_mtl_st20p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level), FALSE);
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
@@ -509,7 +509,8 @@ static void gst_mtl_st20p_rx_finalize(GObject* object) {
   }
 
   if (src->mtl_lib_handle) {
-    if (mtl_stop(src->mtl_lib_handle) || mtl_uninit(src->mtl_lib_handle)) {
+    if (mtl_stop(src->mtl_lib_handle) ||
+        gst_mtl_common_deinit_handle(src->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
@@ -197,7 +197,6 @@ static void gst_mtl_st20p_rx_class_init(Gst_Mtl_St20p_RxClass* klass) {
 }
 
 static gboolean gst_mtl_st20p_rx_start(GstBaseSrc* basesrc) {
-  struct mtl_init_params mtl_init_params = {0};
   struct st20p_rx_ops* ops_rx;
   gint ret;
 
@@ -208,7 +207,7 @@ static gboolean gst_mtl_st20p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level), FALSE);
+      gst_mtl_common_init_handle(&(src->devArgs), &(src->log_level), FALSE);
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -457,7 +457,8 @@ static void gst_mtl_st20p_tx_finalize(GObject* object) {
   }
 
   if (sink->mtl_lib_handle) {
-    if (mtl_stop(sink->mtl_lib_handle) || mtl_uninit(sink->mtl_lib_handle)) {
+    if (mtl_stop(sink->mtl_lib_handle) ||
+        gst_mtl_common_deinit_handle(sink->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -179,7 +179,7 @@ static gboolean gst_mtl_st20p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level), FALSE);
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -170,8 +170,6 @@ static void gst_mtl_st20p_tx_class_init(Gst_Mtl_St20p_TxClass* klass) {
 }
 
 static gboolean gst_mtl_st20p_tx_start(GstBaseSink* bsink) {
-  struct mtl_init_params mtl_init_params = {0};
-
   Gst_Mtl_St20p_Tx* sink = GST_MTL_ST20P_TX(bsink);
 
   GST_DEBUG_OBJECT(sink, "start");
@@ -179,7 +177,7 @@ static gboolean gst_mtl_st20p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level), FALSE);
+      gst_mtl_common_init_handle(&(sink->devArgs), &(sink->log_level), FALSE);
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
@@ -468,7 +468,8 @@ static void gst_mtl_st30p_rx_finalize(GObject* object) {
   }
 
   if (src->mtl_lib_handle) {
-    if (mtl_stop(src->mtl_lib_handle) || mtl_uninit(src->mtl_lib_handle)) {
+    if (mtl_stop(src->mtl_lib_handle) ||
+        gst_mtl_common_deinit_handle(src->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
@@ -183,7 +183,6 @@ static void gst_mtl_st30p_rx_class_init(Gst_Mtl_St30p_RxClass* klass) {
 }
 
 static gboolean gst_mtl_st30p_rx_start(GstBaseSrc* basesrc) {
-  struct mtl_init_params mtl_init_params = {0};
   struct st30p_rx_ops* ops_rx;
   gint ret;
 
@@ -194,7 +193,7 @@ static gboolean gst_mtl_st30p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level), FALSE);
+      gst_mtl_common_init_handle(&(src->devArgs), &(src->log_level), FALSE);
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
@@ -194,7 +194,7 @@ static gboolean gst_mtl_st30p_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level), FALSE);
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -497,7 +497,8 @@ static void gst_mtl_st30p_tx_finalize(GObject* object) {
   }
 
   if (sink->mtl_lib_handle) {
-    if (mtl_stop(sink->mtl_lib_handle) || mtl_uninit(sink->mtl_lib_handle)) {
+    if (mtl_stop(sink->mtl_lib_handle) ||
+        gst_mtl_common_deinit_handle(sink->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -181,8 +181,6 @@ static void gst_mtl_st30p_tx_class_init(Gst_Mtl_St30p_TxClass* klass) {
 }
 
 static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
-  struct mtl_init_params mtl_init_params = {0};
-
   Gst_Mtl_St30p_Tx* sink = GST_MTL_ST30P_TX(bsink);
 
   GST_DEBUG_OBJECT(sink, "start");
@@ -190,7 +188,7 @@ static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level), FALSE);
+      gst_mtl_common_init_handle(&(sink->devArgs), &(sink->log_level), FALSE);
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -190,7 +190,7 @@ static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level), FALSE);
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -192,7 +192,7 @@ static gboolean gst_mtl_st40_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level), FALSE);
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -182,7 +182,6 @@ static void gst_mtl_st40_rx_class_init(Gst_Mtl_St40_RxClass* klass) {
 }
 
 static gboolean gst_mtl_st40_rx_start(GstBaseSrc* basesrc) {
-  struct mtl_init_params mtl_init_params = {0};
   struct st40_rx_ops ops_rx = {0};
   gint ret;
 
@@ -192,7 +191,7 @@ static gboolean gst_mtl_st40_rx_start(GstBaseSrc* basesrc) {
   GST_DEBUG("Media Transport Initialization start");
 
   src->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(src->devArgs), &(src->log_level), FALSE);
+      gst_mtl_common_init_handle(&(src->devArgs), &(src->log_level), FALSE);
 
   if (!src->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -463,7 +463,8 @@ static void gst_mtl_st40_rx_finalize(GObject* object) {
   pthread_cond_destroy(&src->mbuff_cond);
 
   if (src->mtl_lib_handle) {
-    if (mtl_stop(src->mtl_lib_handle) || mtl_uninit(src->mtl_lib_handle)) {
+    if (mtl_stop(src->mtl_lib_handle) ||
+        gst_mtl_common_deinit_handle(src->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
     }
   }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -481,7 +481,8 @@ static void gst_mtl_st40p_tx_finalize(GObject* object) {
   }
 
   if (sink->mtl_lib_handle) {
-    if (mtl_stop(sink->mtl_lib_handle) || mtl_uninit(sink->mtl_lib_handle)) {
+    if (mtl_stop(sink->mtl_lib_handle) ||
+        gst_mtl_common_deinit_handle(sink->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -177,8 +177,6 @@ static void gst_mtl_st40p_tx_class_init(Gst_Mtl_St40p_TxClass* klass) {
 }
 
 static gboolean gst_mtl_st40p_tx_start(GstBaseSink* bsink) {
-  struct mtl_init_params mtl_init_params = {0};
-
   Gst_Mtl_St40p_Tx* sink = GST_MTL_ST40P_TX(bsink);
 
   GST_DEBUG_OBJECT(sink, "start");
@@ -186,7 +184,7 @@ static gboolean gst_mtl_st40p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level), FALSE);
+      gst_mtl_common_init_handle(&(sink->devArgs), &(sink->log_level), FALSE);
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -186,7 +186,7 @@ static gboolean gst_mtl_st40p_tx_start(GstBaseSink* bsink) {
   gst_base_sink_set_async_enabled(bsink, FALSE);
 
   sink->mtl_lib_handle =
-      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level));
+      gst_mtl_common_init_handle(&mtl_init_params, &(sink->devArgs), &(sink->log_level), FALSE);
 
   if (!sink->mtl_lib_handle) {
     GST_ERROR("Could not initialize MTL");

--- a/ecosystem/gstreamer_plugin/meson.build
+++ b/ecosystem/gstreamer_plugin/meson.build
@@ -39,9 +39,26 @@ gstreamer_video_dep = dependency('gstreamer-video-1.0')
 gstreamer_audio_dep = dependency('gstreamer-audio-1.0')
 mtl_dep             = dependency('mtl')
 
+# mtl_common_library
 gst_mtl_common_sources = [
   'gst_mtl_common.c'
 ]
+
+gst_mtl_common = library('gstmtl_common',
+  gst_mtl_common_sources,
+  dependencies : [gst_dep, gstbase_dep, mtl_dep],
+  install : true,
+  install_dir : plugins_install_dir,
+  include_directories: inc_dirs,
+  c_args: plugin_c_args
+)
+
+gst_mtl_common_dep = declare_dependency(
+  include_directories: inc_dirs,
+  dependencies : [gst_dep, gstbase_dep, mtl_dep],
+  link_with : gst_mtl_common,
+  link_args : ['-Wl,--no-as-needed']
+)
 
 # mtl_st20p_tx Plugin
 gst_mtl_st20p_tx_sources = [
@@ -49,8 +66,8 @@ gst_mtl_st20p_tx_sources = [
 ]
 
 gst_mtl_st20p_tx = library('gstmtl_st20p_tx',
-  gst_mtl_common_sources + gst_mtl_st20p_tx_sources,
-  dependencies : [gst_dep, gstbase_dep, gstreamer_video_dep, mtl_dep],
+  gst_mtl_st20p_tx_sources,
+  dependencies : [gst_dep, gstbase_dep, gstreamer_video_dep, mtl_dep, gst_mtl_common_dep],
   install : true,
   install_dir : plugins_install_dir,
   include_directories: inc_dirs,
@@ -63,8 +80,8 @@ gst_mtl_st20p_rx_sources = [
 ]
 
 gst_mtl_st20p_rx = library('gstmtl_st20p_rx',
-  gst_mtl_common_sources + gst_mtl_st20p_rx_sources,
-  dependencies : [gst_dep, gstbase_dep, gstreamer_video_dep, mtl_dep],
+  gst_mtl_st20p_rx_sources,
+  dependencies : [gst_dep, gstbase_dep, gstreamer_video_dep, mtl_dep, gst_mtl_common_dep],
   install : true,
   install_dir : plugins_install_dir,
   include_directories: inc_dirs,
@@ -77,8 +94,8 @@ gst_mtl_st30p_rx_sources = [
 ]
 
 gst_mtl_st30p_rx = library('gstmtl_st30p_rx',
-  gst_mtl_common_sources + gst_mtl_st30p_rx_sources,
-  dependencies : [gst_dep, gstbase_dep, gstreamer_audio_dep, mtl_dep],
+  gst_mtl_st30p_rx_sources,
+  dependencies : [gst_dep, gstbase_dep, gstreamer_audio_dep, mtl_dep, gst_mtl_common_dep],
   install : true,
   install_dir : plugins_install_dir,
   include_directories: inc_dirs,
@@ -91,8 +108,8 @@ gstmtl_st30p_tx_sources = [
 ]
 
 gstmtl_st30p_tx = library('gstmtl_st30p_tx',
-    gst_mtl_common_sources + gstmtl_st30p_tx_sources,
-    dependencies : [gst_dep, gstbase_dep, gstreamer_audio_dep, mtl_dep],
+    gstmtl_st30p_tx_sources,
+    dependencies : [gst_dep, gstbase_dep, gstreamer_audio_dep, mtl_dep, gst_mtl_common_dep],
     install : true,
     install_dir : plugins_install_dir,
     include_directories: inc_dirs,
@@ -105,8 +122,8 @@ gst_mtl_st40_rx_sources = [
 ]
 
 gst_mtl_st40_rx = library('gstmtl_st40_rx',
-  gst_mtl_common_sources + gst_mtl_st40_rx_sources,
-  dependencies : [gst_dep, gstbase_dep, gstreamer_audio_dep, mtl_dep],
+  gst_mtl_st40_rx_sources,
+  dependencies : [gst_dep, gstbase_dep, gstreamer_audio_dep, mtl_dep, gst_mtl_common_dep],
   install : true,
   install_dir : plugins_install_dir,
   include_directories: inc_dirs,
@@ -119,8 +136,8 @@ gst_mtl_st40p_tx_sources = [
 ]
 
 gst_mtl_st40p_tx = library('gstmtl_st40p_tx',
-  gst_mtl_common_sources + gst_mtl_st40p_tx_sources,
-  dependencies : [gst_dep, gstbase_dep, mtl_dep],
+  gst_mtl_st40p_tx_sources,
+  dependencies : [gst_dep, gstbase_dep, mtl_dep, gst_mtl_common_dep],
   install : true,
   install_dir : plugins_install_dir,
   include_directories: inc_dirs,


### PR DESCRIPTION
MTL common handle support in GStreamer
- Add ability to use the same MTL instance for
  multiple GStreamer plugin instances in the same
  pipeline.
- Change the default behavior of the MTL GStreamer
  plugins to make all subsequent plugins ignore
  dev arguments after the first one.
  After this change only one MTL library process
  is spawned per pipeline.
- Add a new module called gst_common to hold
  the address of the MTL instance.
- Update documentation to include a warning about
  the behavior change.