### PR TITLE
Add: tests for pipeline mode API parameters check

### DIFF
--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -441,6 +441,12 @@ st40p_tx_handle st40p_tx_create(mtl_handle mt, struct st40p_tx_ops* ops) {
 
   notice("%s, start for %s\n", __func__, mt_string_safe(ops->name));
 
+  /* validate the input parameters */
+  // if (!mt || !ops) {
+  //   err("%s(%d), NULL input parameters \n", __func__, idx);
+  //   return NULL;
+  // }
+
   if (MT_HANDLE_MAIN != impl->type) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return NULL;

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -938,6 +938,12 @@ st20p_rx_handle st20p_rx_create(mtl_handle mt, struct st20p_rx_ops* ops) {
 
   notice("%s, start for %s\n", __func__, mt_string_safe(ops->name));
 
+  /* validate the input parameters */
+  // if (!mt || !ops) {
+  //   err("%s(%d), NULL input parameters \n", __func__, idx);
+  //   return NULL;
+  // }
+
   if (impl->type != MT_HANDLE_MAIN) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return NULL;

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -783,6 +783,12 @@ st20p_tx_handle st20p_tx_create(mtl_handle mt, struct st20p_tx_ops* ops) {
 
   notice("%s, start for %s\n", __func__, mt_string_safe(ops->name));
 
+  /* validate the input parameters */
+  // if (!mt || !ops) {
+  //   err("%s(%d), NULL input parameters \n", __func__, idx);
+  //   return NULL;
+  // }
+
   if (impl->type != MT_HANDLE_MAIN) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return NULL;

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -657,6 +657,12 @@ st22p_rx_handle st22p_rx_create(mtl_handle mt, struct st22p_rx_ops* ops) {
 
   notice("%s, start for %s\n", __func__, mt_string_safe(ops->name));
 
+  /* validate the input parameters */
+  // if (!mt || !ops) {
+  //   err("%s(%d), NULL input parameters \n", __func__, idx);
+  //   return NULL;
+  // }
+
   if (impl->type != MT_HANDLE_MAIN) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return NULL;

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -783,6 +783,12 @@ st22p_tx_handle st22p_tx_create(mtl_handle mt, struct st22p_tx_ops* ops) {
 
   notice("%s, start for %s\n", __func__, mt_string_safe(ops->name));
 
+  /* validate the input parameters */
+  // if (!mt || !ops) {
+  //   err("%s(%d), NULL input parameters \n", __func__, idx);
+  //   return NULL;
+  // }
+
   if (impl->type != MT_HANDLE_MAIN) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return NULL;

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.c
@@ -393,6 +393,12 @@ st30p_rx_handle st30p_rx_create(mtl_handle mt, struct st30p_rx_ops* ops) {
 
   notice("%s, start for %s\n", __func__, mt_string_safe(ops->name));
 
+  /* validate the input parameters */
+  // if (!mt || !ops) {
+  //   err("%s(%d), NULL input parameters \n", __func__, idx);
+  //   return NULL;
+  // }
+
   if (impl->type != MT_HANDLE_MAIN) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return NULL;

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.c
@@ -470,6 +470,12 @@ st30p_tx_handle st30p_tx_create(mtl_handle mt, struct st30p_tx_ops* ops) {
 
   notice("%s, start for %s\n", __func__, mt_string_safe(ops->name));
 
+  /* validate the input parameters */
+  // if (!mt || !ops) {
+  //   err("%s(%d), NULL input parameters \n", __func__, idx);
+  //   return NULL;
+  // }
+
   if (impl->type != MT_HANDLE_MAIN) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return NULL;

--- a/tests/unittest/st20p_test.cpp
+++ b/tests/unittest/st20p_test.cpp
@@ -803,6 +803,15 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
         st_frame_size(tx_fmt[i], width[i], height[i], ops_tx.interlaced) +
         para->line_padding_size * height[i] * planes;
 
+    tx_handle[i] = st20p_tx_create(NULL, &ops_tx);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    tx_handle[i] = st20p_tx_create(st, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    tx_handle[i] = st20p_tx_create(NULL, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
     tx_handle[i] = st20p_tx_create(st, &ops_tx);
     ASSERT_TRUE(tx_handle[i] != NULL);
 
@@ -1037,6 +1046,15 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
       ops_rx.rtcp.burst_loss_max = 1;
       ops_rx.rtcp.sim_loss_rate = 0.1;
     }
+
+    rx_handle[i] = st20p_rx_create(NULL, &ops_rx);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    rx_handle[i] = st20p_rx_create(st, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    rx_handle[i] = st20p_rx_create(NULL, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
 
     rx_handle[i] = st20p_rx_create(st, &ops_rx);
     ASSERT_TRUE(rx_handle[i] != NULL);

--- a/tests/unittest/st22p_test.cpp
+++ b/tests/unittest/st22p_test.cpp
@@ -925,6 +925,15 @@ static void st22p_rx_digest_test(enum st_fps fps[], int width[], int height[],
       ops_tx.codestream_size = test_ctx_tx[i]->frame_size / compress_ratio[i];
     }
 
+    tx_handle[i] = st22p_tx_create(NULL, &ops_tx);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    tx_handle[i] = st22p_tx_create(st, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    tx_handle[i] = st22p_tx_create(NULL, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
     tx_handle[i] = st22p_tx_create(st, &ops_tx);
     ASSERT_TRUE(tx_handle[i] != NULL);
 
@@ -1113,6 +1122,15 @@ static void st22p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     else
       test_ctx_rx[i]->frame_size = st_frame_size(ops_rx.output_fmt, ops_rx.width,
                                                  ops_rx.height, ops_rx.interlaced);
+
+    rx_handle[i] = st22p_rx_create(NULL, &ops_rx);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    rx_handle[i] = st22p_rx_create(st, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    rx_handle[i] = st22p_rx_create(NULL, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
 
     rx_handle[i] = st22p_rx_create(st, &ops_rx);
     ASSERT_TRUE(rx_handle[i] != NULL);

--- a/tests/unittest/st30p_test.cpp
+++ b/tests/unittest/st30p_test.cpp
@@ -357,6 +357,15 @@ static void st30p_rx_digest_test(enum st30_fmt fmt[], uint16_t channel[],
 
     test_ctx_tx[i]->frame_size = ops_tx.framebuff_size;
 
+    tx_handle[i] = st30p_tx_create(NULL, &ops_tx);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    tx_handle[i] = st30p_tx_create(st, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    tx_handle[i] = st30p_tx_create(NULL, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
     tx_handle[i] = st30p_tx_create(st, &ops_tx);
     ASSERT_TRUE(tx_handle[i] != NULL);
 
@@ -428,6 +437,15 @@ static void st30p_rx_digest_test(enum st30_fmt fmt[], uint16_t channel[],
       ops_rx.flags |= ST30P_RX_FLAG_BLOCK_GET;
     else
       ops_rx.notify_frame_available = test_st30p_rx_frame_available;
+
+    rx_handle[i] = st30p_rx_create(NULL, &ops_rx);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    rx_handle[i] = st30p_rx_create(st, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
+
+    rx_handle[i] = st30p_rx_create(NULL, NULL);
+    ASSERT_TRUE(tx_handle[i] == NULL);
 
     rx_handle[i] = st30p_rx_create(st, &ops_rx);
     ASSERT_TRUE(rx_handle[i] != NULL);


### PR DESCRIPTION
Pipeline API for st20, st22, and st30 TX was
segfaulting when NULL parameters were passed to
them. Add tests to cover these scenarios.

Tests: e1b7aa43092e4317a8f903337737be499c727d40