### PR TITLE
Docs: removed release from Sphinx docs title and link to main docs added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Media Transport Library
 
+> [!TIP]
+> [Full Documentation](https://openvisualcloud.github.io/Media-Transport-Library/README.html) for [Media Transport Library](https://openvisualcloud.github.io/Media-Transport-Library/README.html).
+
 [![Ubuntu](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build.yml/badge.svg)](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build.yml)
 [![Windows](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/msys2_build.yml/badge.svg)](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/msys2_build.yml)
 [![Test](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build_with_gtest.yml/badge.svg)](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build_with_gtest.yml)

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -16,7 +16,6 @@ import sys
 project = "Media Transport Library"
 copyright = "2023-2025, Intel Corporation"
 author = "Intel Corporation"
-version = release = "24.09"
 
 extensions = [
     "myst_parser",


### PR DESCRIPTION
Docs:
- removed release from Sphinx docs title 
- link to main webpage of docs added at the beginning of main README.md file -> [- https://github.com/OpenVisualCloud/Intel-Tiber-Broadcast-Suite/pull/58](https://openvisualcloud.github.io/Media-Transport-Library/)