### PR TITLE
Update gtest jobs for a better naming convention.

### DIFF
--- a/.github/workflows/ubuntu_build_with_gtest.yml
+++ b/.github/workflows/ubuntu_build_with_gtest.yml
@@ -47,7 +47,7 @@ jobs:
 
   gtest-build-mtl:
     needs: gtest-check-for-changes
-    if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.changes.outputs.changed == 'true' }}
+    if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.gtest-check-for-changes.outputs.changed == 'true' }}
     runs-on: [Linux, self-hosted, DPDK]
     timeout-minutes: 60
 
@@ -91,7 +91,7 @@ jobs:
 
   gtest-perform-tests:
     needs: [gtest-check-for-changes, gtest-build-mtl]
-    if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.changes.outputs.changed == 'true' }}
+    if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.gtest-check-for-changes.outputs.changed == 'true' }}
     runs-on: [Linux, self-hosted, DPDK]
     steps:
       - name: Harden Runner

--- a/.github/workflows/ubuntu_build_with_gtest.yml
+++ b/.github/workflows/ubuntu_build_with_gtest.yml
@@ -1,4 +1,4 @@
-name: gtest
+name: gtest-bare-metal
 
 on:
   # allow manually trigger
@@ -31,8 +31,8 @@ permissions:
   contents: read
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
+  gtest-check-for-changes:
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: read
     outputs:
@@ -45,8 +45,8 @@ jobs:
         with:
           filters: .github/path_filters.yml
 
-  Build:
-    needs: changes
+  gtest-build-mtl:
+    needs: gtest-check-for-changes
     if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.changes.outputs.changed == 'true' }}
     runs-on: [Linux, self-hosted, DPDK]
     timeout-minutes: 60
@@ -89,8 +89,8 @@ jobs:
           ./build.sh
           sudo ldconfig
 
-  Test:
-    needs: [changes, Build]
+  gtest-perform-tests:
+    needs: [gtest-check-for-changes, gtest-build-mtl]
     if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.changes.outputs.changed == 'true' }}
     runs-on: [Linux, self-hosted, DPDK]
     steps:


### PR DESCRIPTION
Update `ubuntu_build_with_gtest.yml` (gtest) for a better naming convention.