### PR TITLE
Fix: RxTxApp Meson configuration issue 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,4 @@ assets/
 mtl_system_status_*
 *.pyc
 *.mp4
+tests/tools/RxTxApp/build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Media Transport Library
 
+> [!TIP]
+> [Full Documentation](https://openvisualcloud.github.io/Media-Transport-Library/README.html) for [Media Transport Library](https://openvisualcloud.github.io/Media-Transport-Library/README.html).
+
 [![Ubuntu](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build.yml/badge.svg)](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build.yml)
 [![Windows](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/msys2_build.yml/badge.svg)](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/msys2_build.yml)
 [![Test](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build_with_gtest.yml/badge.svg)](https://github.com/OpenVisualCloud/Media-Transport-Library/actions/workflows/ubuntu_build_with_gtest.yml)

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -16,7 +16,6 @@ import sys
 project = "Media Transport Library"
 copyright = "2023-2025, Intel Corporation"
 author = "Intel Corporation"
-version = release = "24.09"
 
 extensions = [
     "myst_parser",

--- a/docker/README.md
+++ b/docker/README.md
@@ -124,5 +124,5 @@ docker-compose run imtl
 # Run below command to generate a fake yuv file or follow "#### 3.3 Prepare source files:" in [run guide](../doc/run.md)
 # dd if=/dev/urandom of=test.yuv count=2160 bs=4800
 # Edit and Run the loop JSON file.
-./app/RxTxApp --config_file tests/script/loop_json/1080p60_1v.json
+./RxTxApp --config_file scripts/loop_json/1080p60_1v.json
 ```

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -72,6 +72,8 @@ RUN groupadd -g 2110 vfio && \
 # Copy libraries and binaries
 COPY --chown=imtl --from=builder /install /
 COPY --chown=imtl --from=builder /Media-Transport-Library/build /home/imtl
+COPY --chown=imtl --from=builder /Media-Transport-Library/tests/tools/RxTxApp/build/RxTxApp /home/imtl/RxTxApp
+COPY --chown=imtl --from=builder /Media-Transport-Library/tests/tools/RxTxApp/script /home/imtl/scripts
 
 WORKDIR /home/imtl/
 


### PR DESCRIPTION
The image was not building correctly when
the bare metal directory was built before due
to the .dockerignore copying the build directory
of RxTxApp from a new location.

Fix by adding the necessary entries to
.dockerignore to prevent the build directory
from being copied to image.

Add copy of the RxTxApp to the final stage and
adjust the README to reflect the changes.

Fixes: 1580c7ff04a93664bf3751b5b533ccf23b940da1