### PR TITLE
Fix: Remove unsupported 720p resolution from tests

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -159,10 +159,13 @@ Video plugins for MTL that are able to send, receive synchronous video via the M
 The `mtl_st20p_tx` plugin supports the following pad capabilities:
 
 - **Formats**: `v210`, `I422_10LE`
-- **Width Range**: 64 to 16384
+- **Width Range**: 64 to 16384*
 - **Height Range**: 64 to 8704
 - **Framerate Range**: `2398/100`, `24`, `25`, `2997/100`, `30`, `50`, `5994/100`, `60`, `100`,
 `11988/100`, `120`
+
+\* Resolution width for v210 format has to be divisible by 3, so the plugin does not support 720p and 1440p.
+To be fixed in the future.
 
 [More information about GStreamer capabilities (GstCaps)](https://gstreamer.freedesktop.org/documentation/gstreamer/gstcaps.html)
 

--- a/tests/validation/tests/single/gstreamer/video_resolution/test_video_resolution.py
+++ b/tests/validation/tests/single/gstreamer/video_resolution/test_video_resolution.py
@@ -7,6 +7,7 @@ import pytest
 import tests.Engine.GstreamerApp as gstreamerapp
 import tests.Engine.media_creator as media_create
 from tests.Engine.media_files import yuv_files
+from tests.xfail import SDBQ1971_conversion_v210_720p_error
 
 
 @pytest.mark.parametrize("file", yuv_files.keys())
@@ -15,9 +16,16 @@ def test_video_resolutions(
     media,
     nic_port_list,
     file,
+    request,
 ):
     video_file = yuv_files[file]
     video_file["format"] = "v210"
+
+    SDBQ1971_conversion_v210_720p_error(
+        video_format=video_file["format"],
+        resolution_width=video_file["height"],
+        request=request,
+    )
 
     input_file_path = media_create.create_video_file(
         width=video_file["width"],

--- a/tests/validation/tests/xfail.py
+++ b/tests/validation/tests/xfail.py
@@ -26,3 +26,14 @@ def SDBQ1002_pg_format_error_check(video_format: str, pg_format: str, request):
             "XFAIL: SDBQ-1002 - Video, i720p50fps with V210 pg_format Error: tv_frame_free_cb",
             request,
         )
+
+
+def SDBQ1971_conversion_v210_720p_error(
+    video_format: str, resolution_width: int, request
+):
+    if video_format == "v210" and resolution_width == 720:
+        add_issue(
+            "XFAIL: SDBQ-1971 - Conversion from v210 format does not work on 720p",
+            request,
+        )
+        assert False


### PR DESCRIPTION
- Add disclaimer about 720p in docs.
- The 720p resolution is not supported by MTL for v210 at the moment. This is a MTL bug, but the GStreamer plugin does not need to support it.