### PR TITLE
Fix: Update audio channel tests.

### DIFF
--- a/doc/configuration_guide.md
+++ b/doc/configuration_guide.md
@@ -238,6 +238,9 @@ Items in each element of the "audio" array
 ​ **audio_sampling (string):** `"48kHz", "96kHz"` audio sample rate
 
 ​ **audio_ptime (string):** `"1", "0.12", "0.25", "0.33", "4"` audio packet time, AES67(st30) supported: 1ms, 4ms, 125us(0.12), 250us(0.25) and 333us(0.33), AM824(st31) supported: 1ms
+> The maximum frame size that can be sent in the Media Transport Library (MTL) is
+> 1440 bytes. This means that the combination of channel size, packet time (ptime),
+> and audio channel should not exceed this limit.
 
 ​ **audio_url (string):** audio reference file
 

--- a/tests/validation/tests/single/audio/audio_channel/test_audio_channel.py
+++ b/tests/validation/tests/single/audio/audio_channel/test_audio_channel.py
@@ -15,6 +15,15 @@ from tests.xfail import SDBQ1001_audio_channel_check
 def test_audio_channel(
     build, media, nic_port_list, test_time, audio_format, audio_channel, request
 ):
+    # The max frame size that could be sent in MTL is:
+    # ST_PKT_MAX_ETHER_BYTES - sizeof(struct st_rfc3550_audio_hdr) = 1440 bytes
+    # "222" represents "22.2" which requires 24 channels
+    # with 24 channel size, 1ms ptime and audio_format PCM16 or PCM24 the packet size is too big (~2100 - ~2800 bytes)
+    # to send the packet with this size ptime should be changed to the lower value (0.33 ms)
+    audio_ptime = "1"  # 1ms
+    if audio_channel == "222" and (audio_format == "PCM16" or audio_format == "PCM24"):
+        audio_ptime = "0.33"  # 333 us
+
     SDBQ1001_audio_channel_check(audio_channel, audio_format, request)
 
     audio_file = audio_files[audio_format]
@@ -27,7 +36,7 @@ def test_audio_channel(
         audio_format=audio_format,
         audio_channel=[audio_channel],
         audio_sampling="48kHz",
-        audio_ptime="1",
+        audio_ptime=audio_ptime,
         audio_url=os.path.join(media, audio_file["filename"]),
     )
 


### PR DESCRIPTION
Adjust ptime to 0.33 ms for "222" audio channel with PCM16 or PCM24 formats to accommodate the packet size.