### PR TITLE
Fix: error handling in mt_af_xdp.c

### DIFF
--- a/lib/src/dev/mt_af_xdp.c
+++ b/lib/src/dev/mt_af_xdp.c
@@ -317,13 +317,13 @@ static int xdp_umem_init(struct mt_xdp_priv* xdp, struct mt_xdp_queue* xq) {
       umem_size);
   ret = xsk_umem__create(&xq->umem, aligned_base_addr, umem_size, &xq->rx_prod,
                          &xq->tx_cons, &cfg);
-  if (ret < 0) {
+  if (ret) {
     err("%s(%d,%u), umem create fail %d %s\n", __func__, port, q, ret, strerror(errno));
     if (ret == -EPERM)
       err("%s(%d,%u), please add capability for the app: sudo setcap 'cap_net_raw+ep' "
           "<app>\n",
           __func__, port, q);
-    return ret;
+    return -EINVAL;
   }
   xq->umem_buffer = aligned_base_addr;
 


### PR DESCRIPTION
xsk_umem__create can return positive and negative values as error codes