### PR TITLE
PoC of video frames encryption using AES-CTR

### DIFF
--- a/config/tx-rx-encryption.json
+++ b/config/tx-rx-encryption.json
@@ -1,0 +1,84 @@
+{
+    "tx_no_chain": false,
+    "interfaces": [
+        {
+            "name": "0000:4b:01.0",
+            "ip": "192.168.17.101"
+        },
+        {
+            "name": "0000:4b:01.1",
+            "ip": "192.168.17.102"
+        }
+    ],
+    "tx_sessions": [
+        {
+            "dip": [
+                "192.168.17.102"
+            ],
+            "interface": [
+                0
+            ],
+            "video": [],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p25",
+                    "interlaced": false,
+                    "device": "AUTO",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "input_format": "YUV422RFC4175PG2BE10",
+                    "transport_format": "YUV_422_10bit",
+                    "st20p_url": "/tmp/yuv422p10be.yuv",
+                    "display": false,
+                    "enable_rtcp": false
+                }
+            ],
+            "st22p": [],
+            "st30p": [],
+            "audio": [],
+            "ancillary": [],
+            "fastmetadata": []
+        }
+    ],
+    "rx_sessions": [
+        {
+            "ip": [
+                "192.168.17.101"
+            ],
+            "interface": [
+                1
+            ],
+            "video": [],
+            "st20p": [
+                {
+                    "replicas": 1,
+                    "start_port": 20000,
+                    "payload_type": 112,
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": "p25",
+                    "interlaced": false,
+                    "device": "AUTO",
+                    "pacing": "gap",
+                    "packing": "BPM",
+                    "output_format": "YUV422RFC4175PG2BE10",
+                    "transport_format": "YUV_422_10bit",
+                    "measure_latency": false,
+                    "display": false,
+                    "enable_rtcp": false,
+                    "st20p_url": "/tmp/out.yuv"
+                }
+            ],
+            "st22p": [],
+            "st30p": [],
+            "audio": [],
+            "ancillary": [],
+            "fastmetadata": []
+        }
+    ]
+}

--- a/tests/tools/RxTxApp/meson.build
+++ b/tests/tools/RxTxApp/meson.build
@@ -24,6 +24,8 @@ libm = cc.find_library('m', required : true)
 libpthread = cc.find_library('pthread', required : true)
 libjson_c = dependency('json-c', required : true)
 libpcap = dependency('pcap', required: true)
+libIPSec_MB = cc.find_library('IPSec_MB', required: true)
+
 
 libsdl2 = dependency('sdl2', required: false)
 if libsdl2.found()
@@ -90,5 +92,5 @@ executable('RxTxApp', sources,
   c_args : app_c_args,
   link_args: app_ld_args,
   # asan should be always the first dep
-  dependencies: [asan_dep, mtl, libjson_c, libpcap, libsdl2, libsdl2_ttf, libm, libpthread, ws2_32_dep, mman_dep, libopenssl]
+  dependencies: [asan_dep, mtl, libjson_c, libpcap, libsdl2, libsdl2_ttf, libm, libpthread, ws2_32_dep, mman_dep, libopenssl, libIPSec_MB]
 )

--- a/tests/tools/RxTxApp/src/app_base.h
+++ b/tests/tools/RxTxApp/src/app_base.h
@@ -558,6 +558,8 @@ struct st_app_rx_st20p_session {
 
   bool measure_latency;
   uint64_t stat_latency_us_sum;
+
+  void* tmp_framebuff;
 };
 
 struct st_app_tx_st30p_session {


### PR DESCRIPTION
This PoC demonstrates the use of AES-CTR encryption of video frames transmitted between the Tx and Rx sessions. It shows that video frames can be treated as binary blobs that could be encrypted. The PoC uses https://github.com/intel/intel-ipsec-mb for the AES-CTR encryption.

Sample file can be generated with:
```
ffmpeg -an -y -f lavfi -i \
testsrc=d=5:s=1920x1080:r=25,format=yuv422p10be -f rawvideo \
/tmp/yuv422p10be.yuv
```

To run PoC:
```
./tests/tools/RxTxApp/build/RxTxApp --config_file \
config/tx-rx-encryption.json  --test_time=10
```

RxTxApp sends the input file (`/tmp/yuv422p10be.yuv` is used by tx-rx-encryption.json)   in a loop,
the output file (`/tmp/out.yuv`) can have data from the input file written to in multiple times.

known issues:
- There is no key exchange mechanism implemented in this PoC, the key
  is hardcoded in the code.
- Transport format has to be the same as the input format. Mismatch
  causes corruption of the data
- It works only for uncompressed video formats. (not for SMPTE 2110-22)
- Everything is done in an application instead of in the library