### PR TITLE
Add: Option to launch a session in the background

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -170,10 +170,11 @@ To be fixed in the future.
 [More information about GStreamer capabilities (GstCaps)](https://gstreamer.freedesktop.org/documentation/gstreamer/gstcaps.html)
 
 **Arguments**
-| Property Name       | Type   | Description                                           | Range                   | Default Value |
-|---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
-| retry               | uint   | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
-| tx-framebuff-num    | uint   | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
+| Property Name       | Type     | Description                                           | Range                   | Default Value |
+|---------------------|----------|-------------------------------------------------------|-------------------------|---------------|
+| retry               | uint     | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
+| tx-framebuff-num    | uint     | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
+| async-session-create | boolean | Improve initialization time by creating a session in a separate thread. All buffers that arrive before the session is ready will be dropped | TRUE/FALSE              | FALSE         |
 
 #### 3.1.2. Preparing Input Video
 
@@ -271,11 +272,12 @@ The `mtl_st30p_tx` plugin supports the following pad capabilities:
 - **Channels Range**: 1 to 8
 
 **Arguments**
-| Property Name       | Type   | Description                                           | Range                   | Default Value |
-|---------------------|--------|-------------------------------------------------------|-------------------------|---------------|
-| tx-samplerate       | uint   | Sample rate of the audio.                             | [Supported Audio Sampling Rates](#232-supported-audio-sampling-rates) | 0 |
-| tx-channels         | uint   | Number of audio channels.                             | 1 to 8                  | 2             |
-| tx-ptime            | string | Packetization time for the audio stream.              | `1ms`, `125us`, `250us`, `333us`, `4ms`, `80us`, `1.09ms`, `0.14ms`, `0.09ms` | `1.09ms` for 44.1kHz, `1ms` for others |
+| Property Name        | Type    | Description                                           | Range                   | Default Value |
+|----------------------|---------|-------------------------------------------------------|-------------------------|---------------|
+| tx-samplerate        | uint    | Sample rate of the audio.                             | [Supported Audio Sampling Rates](#232-supported-audio-sampling-rates) | 0 |
+| tx-channels          | uint    | Number of audio channels.                             | 1 to 8                  | 2             |
+| tx-ptime             | string  | Packetization time for the audio stream.              | `1ms`, `125us`, `250us`, `333us`, `4ms`, `80us`, `1.09ms`, `0.14ms`, `0.09ms` | `1.09ms` for 44.1kHz, `1ms` for others |
+| async-session-create | boolean | Improve initialization time by creating a session in a separate thread. All buffers that arrive before the session is ready will be dropped | TRUE/FALSE              | FALSE         |
 
 #### 4.1.2. Example GStreamer Pipeline for Transmission with s16LE format
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -170,10 +170,10 @@ To be fixed in the future.
 [More information about GStreamer capabilities (GstCaps)](https://gstreamer.freedesktop.org/documentation/gstreamer/gstcaps.html)
 
 **Arguments**
-| Property Name       | Type     | Description                                           | Range                   | Default Value |
-|---------------------|----------|-------------------------------------------------------|-------------------------|---------------|
-| retry               | uint     | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
-| tx-framebuff-num    | uint     | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
+| Property Name        | Type     | Description                                           | Range                   | Default Value |
+|----------------------|----------|-------------------------------------------------------|-------------------------|---------------|
+| retry                | uint     | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
+| tx-framebuff-num     | uint     | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
 | async-session-create | boolean | Improve initialization time by creating a session in a separate thread. All buffers that arrive before the session is ready will be dropped | TRUE/FALSE              | FALSE         |
 
 #### 3.1.2. Preparing Input Video

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -194,11 +194,16 @@ static gboolean gst_mtl_st20p_tx_start(GstBaseSink* bsink) {
     return FALSE;
   }
 
-  if (sink->retry_frame == 0)
+  if (sink->retry_frame == 0) {
     sink->retry_frame = 10;
-  else if (sink->retry_frame < 3) {
+  } else if (sink->retry_frame < 3) {
     GST_WARNING("Retry count is too low, setting to 3");
     sink->retry_frame = 3;
+  }
+
+  if (sink->async_session_create) {
+    pthread_mutex_init(&sink->session_mutex, NULL);
+    sink->session_ready = FALSE;
   }
 
   gst_element_set_state(GST_ELEMENT(sink), GST_STATE_PLAYING);
@@ -219,9 +224,6 @@ static void gst_mtl_st20p_tx_init(Gst_Mtl_St20p_Tx* sink) {
   gst_pad_set_event_function(sinkpad, GST_DEBUG_FUNCPTR(gst_mtl_st20p_tx_sink_event));
 
   gst_pad_set_chain_function(sinkpad, GST_DEBUG_FUNCPTR(gst_mtl_st20p_tx_chain));
-
-  pthread_mutex_init(&sink->session_mutex, NULL);
-  sink->session_ready = FALSE;
 }
 
 static void gst_mtl_st20p_tx_set_property(GObject* object, guint prop_id,
@@ -360,9 +362,11 @@ static gboolean gst_mtl_st20p_tx_session_create(Gst_Mtl_St20p_Tx* sink, GstCaps*
     return FALSE;
   }
 
-  pthread_mutex_lock(&sink->session_mutex);
-  sink->session_ready = TRUE;
-  pthread_mutex_unlock(&sink->session_mutex);
+  if (sink->async_session_create) {
+    pthread_mutex_lock(&sink->session_mutex);
+    sink->session_ready = TRUE;
+    pthread_mutex_unlock(&sink->session_mutex);
+  }
 
   sink->frame_size = st20p_tx_frame_size(sink->tx_handle);
   return TRUE;
@@ -382,6 +386,7 @@ static void* gst_mtl_st20p_tx_session_create_thread(void* data) {
 
 static gboolean gst_mtl_st20p_tx_sink_event(GstPad* pad, GstObject* parent,
                                             GstEvent* event) {
+  GstMtlSt20pTxThreadData* thread_data;
   Gst_Mtl_St20p_Tx* sink;
   GstCaps* caps;
   gint ret;
@@ -397,7 +402,7 @@ static gboolean gst_mtl_st20p_tx_sink_event(GstPad* pad, GstObject* parent,
     case GST_EVENT_CAPS:
       gst_event_parse_caps(event, &caps);
       if (sink->async_session_create) {
-        GstMtlSt20pTxThreadData* thread_data = malloc(sizeof(GstMtlSt20pTxThreadData));
+        thread_data = malloc(sizeof(GstMtlSt20pTxThreadData));
         thread_data->sink = sink;
         thread_data->caps = gst_caps_ref(caps);
         pthread_create(&sink->session_thread, NULL,
@@ -438,14 +443,16 @@ static GstFlowReturn gst_mtl_st20p_tx_chain(GstPad* pad, GstObject* parent,
   GstMemory* gst_buffer_memory;
   GstMapInfo map_info;
 
-  pthread_mutex_lock(&sink->session_mutex);
-  gboolean session_ready = sink->session_ready;
-  pthread_mutex_unlock(&sink->session_mutex);
+  if (sink->async_session_create) {
+    pthread_mutex_lock(&sink->session_mutex);
+    gboolean session_ready = sink->session_ready;
+    pthread_mutex_unlock(&sink->session_mutex);
 
-  if (!session_ready) {
-    GST_WARNING("Session not ready, dropping buffer");
-    gst_buffer_unref(buf);
-    return GST_FLOW_OK;
+    if (!session_ready) {
+      GST_WARNING("Session not ready, dropping buffer");
+      gst_buffer_unref(buf);
+      return GST_FLOW_OK;
+    }
   }
 
   if (!sink->tx_handle) {
@@ -483,10 +490,10 @@ static GstFlowReturn gst_mtl_st20p_tx_chain(GstPad* pad, GstObject* parent,
 static void gst_mtl_st20p_tx_finalize(GObject* object) {
   Gst_Mtl_St20p_Tx* sink = GST_MTL_ST20P_TX(object);
 
-  if (sink->async_session_create && sink->session_thread) {
-    pthread_join(sink->session_thread, NULL);
+  if (sink->async_session_create) {
+    if (sink->session_thread) pthread_join(sink->session_thread, NULL);
+    pthread_mutex_destroy(&sink->session_mutex);
   }
-  pthread_mutex_destroy(&sink->session_mutex);
 
   if (sink->tx_handle) {
     if (st20p_tx_free(sink->tx_handle)) GST_ERROR("Failed to free tx handle");

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
@@ -60,6 +60,11 @@ struct _Gst_Mtl_St20p_Tx {
   st20p_tx_handle tx_handle;
   guint frame_size;
 
+  bool async_session_create;
+  bool session_ready;
+  pthread_mutex_t session_mutex;
+  pthread_t session_thread;
+
   /* arguments */
   guint log_level;
   guint retry_frame;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
@@ -60,8 +60,7 @@ struct _Gst_Mtl_St20p_Tx {
   st20p_tx_handle tx_handle;
   guint frame_size;
 
-  bool async_session_create;
-  bool session_ready;
+  gboolean session_ready;
   pthread_mutex_t session_mutex;
   pthread_t session_thread;
 
@@ -71,6 +70,7 @@ struct _Gst_Mtl_St20p_Tx {
   StDevArgs devArgs;        /* imtl initialization device */
   SessionPortArgs portArgs; /* imtl session device */
   guint framebuffer_num;
+  gboolean async_session_create;
 
   /* TODO add support for gpu direct */
 #ifdef MTL_GPU_DIRECT_ENABLED

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -65,6 +65,7 @@
 #endif
 
 #include <gst/gst.h>
+#include <pthread.h>
 #include <unistd.h>
 
 #include "gst_mtl_st30p_tx.h"
@@ -94,8 +95,15 @@ enum {
   PROP_ST30P_TX_RETRY = PROP_GENERAL_MAX,
   PROP_ST30P_TX_FRAMEBUFF_NUM,
   PROP_ST30P_TX_PTIME,
+  PROP_ST30P_TX_ASYNC_SESSION_CREATE,
   PROP_MAX
 };
+
+/* Structure to pass arguments to the thread function */
+typedef struct {
+  Gst_Mtl_St30p_Tx* sink;
+  GstCaps* caps;
+} GstMtlSt30pTxThreadData;
 
 /* pad template */
 static GstStaticPadTemplate gst_mtl_st30p_tx_sink_pad_template =
@@ -163,6 +171,12 @@ static void gst_mtl_st30p_tx_class_init(Gst_Mtl_St30p_TxClass* klass) {
       g_param_spec_string("tx-ptime", "Packetization time",
                           "Packetization time for the audio stream", NULL,
                           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property(
+      gobject_class, PROP_ST30P_TX_ASYNC_SESSION_CREATE,
+      g_param_spec_boolean("async-session-create", "Async Session Create",
+                           "Create TX session in a separate thread.", FALSE,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
 
 static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
@@ -199,6 +213,9 @@ static void gst_mtl_st30p_tx_init(Gst_Mtl_St30p_Tx* sink) {
   gst_pad_set_event_function(sinkpad, GST_DEBUG_FUNCPTR(gst_mtl_st30p_tx_sink_event));
 
   gst_pad_set_chain_function(sinkpad, GST_DEBUG_FUNCPTR(gst_mtl_st30p_tx_chain));
+
+  pthread_mutex_init(&sink->session_mutex, NULL);
+  sink->session_ready = FALSE;
 }
 
 static void gst_mtl_st30p_tx_set_property(GObject* object, guint prop_id,
@@ -220,6 +237,9 @@ static void gst_mtl_st30p_tx_set_property(GObject* object, guint prop_id,
       break;
     case PROP_ST30P_TX_PTIME:
       g_strlcpy(self->ptime, g_value_get_string(value), MTL_PORT_MAX_LEN);
+      break;
+    case PROP_ST30P_TX_ASYNC_SESSION_CREATE:
+      self->async_session_create = g_value_get_boolean(value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -246,6 +266,9 @@ static void gst_mtl_st30p_tx_get_property(GObject* object, guint prop_id, GValue
       break;
     case PROP_ST30P_TX_PTIME:
       g_value_set_string(value, sink->ptime);
+      break;
+    case PROP_ST30P_TX_ASYNC_SESSION_CREATE:
+      g_value_set_boolean(value, sink->async_session_create);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -362,7 +385,25 @@ static gboolean gst_mtl_st30p_tx_session_create(Gst_Mtl_St30p_Tx* sink, GstCaps*
   }
 
   sink->frame_size = st30p_tx_frame_size(sink->tx_handle);
+
+  pthread_mutex_lock(&sink->session_mutex);
+  sink->session_ready = TRUE;
+  pthread_mutex_unlock(&sink->session_mutex);
+
   return TRUE;
+}
+
+static void* gst_mtl_st30p_tx_session_create_thread(void* data) {
+  GstMtlSt30pTxThreadData* thread_data = (GstMtlSt30pTxThreadData*)data;
+
+  gboolean result = gst_mtl_st30p_tx_session_create(thread_data->sink, thread_data->caps);
+  if (!result) {
+    GST_ELEMENT_ERROR(thread_data->sink, RESOURCE, FAILED, (NULL),
+                      ("Failed to create TX session in worker thread"));
+  }
+  gst_caps_unref(thread_data->caps);
+  free(thread_data);
+  return NULL;
 }
 
 static gboolean gst_mtl_st30p_tx_sink_event(GstPad* pad, GstObject* parent,
@@ -379,20 +420,22 @@ static gboolean gst_mtl_st30p_tx_sink_event(GstPad* pad, GstObject* parent,
   ret = GST_EVENT_TYPE(event);
 
   switch (GST_EVENT_TYPE(event)) {
-    case GST_EVENT_SEGMENT:
-      if (!sink->tx_handle) {
-        GST_ERROR("Tx handle not initialized");
-        return FALSE;
-      }
-      ret = gst_pad_event_default(pad, parent, event);
-      break;
     case GST_EVENT_CAPS:
       gst_event_parse_caps(event, &caps);
-      ret = gst_mtl_st30p_tx_session_create(sink, caps);
-      if (!ret) {
-        GST_ERROR("Failed to create TX session");
-        return FALSE;
+      if (sink->async_session_create) {
+        GstMtlSt30pTxThreadData* thread_data = malloc(sizeof(GstMtlSt30pTxThreadData));
+        thread_data->sink = sink;
+        thread_data->caps = gst_caps_ref(caps);
+        pthread_create(&sink->session_thread, NULL,
+                       gst_mtl_st30p_tx_session_create_thread, thread_data);
+      } else {
+        ret = gst_mtl_st30p_tx_session_create(sink, caps);
+        if (!ret) {
+          GST_ERROR("Failed to create TX session");
+          return FALSE;
+        }
       }
+
       ret = gst_pad_event_default(pad, parent, event);
       break;
     case GST_EVENT_EOS:
@@ -437,6 +480,16 @@ static GstFlowReturn gst_mtl_st30p_tx_chain(GstPad* pad, GstObject* parent,
     return GST_FLOW_ERROR;
   }
 
+  pthread_mutex_lock(&sink->session_mutex);
+  gboolean session_ready = sink->session_ready;
+  pthread_mutex_unlock(&sink->session_mutex);
+
+  if (!session_ready) {
+    GST_WARNING("Session not ready, dropping buffer");
+    gst_buffer_unref(buf);
+    return GST_FLOW_OK;
+  }
+
   for (int i = 0; i < buffer_n; i++) {
     bytes_to_write = gst_buffer_get_size(buf);
     gst_buffer_memory = gst_buffer_peek_memory(buf, i);
@@ -477,18 +530,18 @@ static GstFlowReturn gst_mtl_st30p_tx_chain(GstPad* pad, GstObject* parent,
 static void gst_mtl_st30p_tx_finalize(GObject* object) {
   Gst_Mtl_St30p_Tx* sink = GST_MTL_ST30P_TX(object);
 
+  if (sink->async_session_create && sink->session_thread) {
+    pthread_join(sink->session_thread, NULL);
+  }
+  pthread_mutex_destroy(&sink->session_mutex);
+
   if (sink->tx_handle) {
-    if (st30p_tx_free(sink->tx_handle)) {
-      GST_ERROR("Failed to free tx handle");
-      return;
-    }
+    if (st30p_tx_free(sink->tx_handle)) GST_ERROR("Failed to free tx handle");
   }
 
   if (sink->mtl_lib_handle) {
-    if (gst_mtl_common_deinit_handle(sink->mtl_lib_handle)) {
+    if (gst_mtl_common_deinit_handle(sink->mtl_lib_handle))
       GST_ERROR("Failed to uninitialize MTL library");
-      return;
-    }
   }
 }
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
@@ -60,8 +60,7 @@ struct _Gst_Mtl_St30p_Tx {
   st30p_tx_handle tx_handle;
   guint frame_size;
 
-  bool async_session_create;
-  bool session_ready;
+  gboolean session_ready;
   pthread_mutex_t session_mutex;
   pthread_t session_thread;
 
@@ -78,6 +77,7 @@ struct _Gst_Mtl_St30p_Tx {
   SessionPortArgs portArgs; /* imtl tx session */
   guint framebuffer_num;
   gchar ptime[MTL_PORT_MAX_LEN];
+  gboolean async_session_create;
 };
 
 G_END_DECLS

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.h
@@ -60,6 +60,11 @@ struct _Gst_Mtl_St30p_Tx {
   st30p_tx_handle tx_handle;
   guint frame_size;
 
+  bool async_session_create;
+  bool session_ready;
+  pthread_mutex_t session_mutex;
+  pthread_t session_thread;
+
   /*
    * Handles incomplete frame buffers when their size does not match the expected size.
    */


### PR DESCRIPTION
If session startup time is critical, it is possible to launch a session in the background.
This will allow the GST pipeline to be running while the session is being created.
All buffers will be dropped until the session is ready.