### PR TITLE
Fix: deinitialization of the shared plugin crash

### DIFF
--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -67,9 +67,9 @@ typedef struct GeneralArgs {
 } GeneralArgs;
 
 typedef struct SessionPortArgs {
-  gchar session_ip_string[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
-  gchar port[MTL_PORT_MAX][MTL_PORT_MAX_LEN];
-  gint udp_port[MTL_PORT_MAX];
+  gchar session_ip_string[2][MTL_PORT_MAX_LEN];
+  gchar port[2][MTL_PORT_MAX_LEN];
+  gint udp_port[2];
   gint payload_type;
 } SessionPortArgs;
 
@@ -108,5 +108,5 @@ void gst_mtl_common_get_general_arguments(GObject* object, guint prop_id,
 mtl_handle gst_mtl_common_init_handle(GeneralArgs* generalArgs,
                                       gboolean force_to_initialize_new_instance);
 
-gint gst_mtl_common_deinit_handle(mtl_handle handle);
+gint gst_mtl_common_deinit_handle(mtl_handle* handle);
 #endif /* __GST_MTL_COMMON_H__ */

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_rx.c
@@ -495,7 +495,7 @@ static void gst_mtl_st20p_rx_finalize(GObject* object) {
   }
 
   if (src->mtl_lib_handle) {
-    if (gst_mtl_common_deinit_handle(src->mtl_lib_handle)) {
+    if (gst_mtl_common_deinit_handle(&src->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -482,7 +482,7 @@ static void gst_mtl_st20p_tx_finalize(GObject* object) {
   }
 
   if (sink->mtl_lib_handle) {
-    if (gst_mtl_common_deinit_handle(sink->mtl_lib_handle))
+    if (gst_mtl_common_deinit_handle(&sink->mtl_lib_handle))
       GST_ERROR("Failed to uninitialize MTL library");
   }
 }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_rx.c
@@ -464,7 +464,7 @@ static void gst_mtl_st30p_rx_finalize(GObject* object) {
   }
 
   if (src->mtl_lib_handle) {
-    if (gst_mtl_common_deinit_handle(src->mtl_lib_handle)) {
+    if (gst_mtl_common_deinit_handle(&src->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -535,7 +535,7 @@ static void gst_mtl_st30p_tx_finalize(GObject* object) {
   }
 
   if (sink->mtl_lib_handle) {
-    if (gst_mtl_common_deinit_handle(sink->mtl_lib_handle))
+    if (gst_mtl_common_deinit_handle(&sink->mtl_lib_handle))
       GST_ERROR("Failed to uninitialize MTL library");
   }
 }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -485,7 +485,7 @@ static void gst_mtl_st40_rx_finalize(GObject* object) {
   pthread_cond_destroy(&src->mbuff_cond);
 
   if (src->mtl_lib_handle) {
-    if (gst_mtl_common_deinit_handle(src->mtl_lib_handle)) {
+    if (gst_mtl_common_deinit_handle(&src->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
     }
   }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -460,7 +460,7 @@ static void gst_mtl_st40p_tx_finalize(GObject* object) {
   }
 
   if (sink->mtl_lib_handle) {
-    if (gst_mtl_common_deinit_handle(sink->mtl_lib_handle)) {
+    if (gst_mtl_common_deinit_handle(&sink->mtl_lib_handle)) {
       GST_ERROR("Failed to uninitialize MTL library");
       return;
     }


### PR DESCRIPTION
Fix gst mtl shared plugin deinitialization
function naive approach to the plugins in the
shared pipline space, making sure the
plugins cannot abuse the shared counter by
reseting their handle to NULL>