### PR TITLE
Fix: forcing mtl to initialize on lcore 0

### DIFF
--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -666,7 +666,8 @@ struct mtl_init_params {
   /** Optional, all future port params should be placed into this struct */
   struct mtl_port_init_params port_params[MTL_PORT_MAX];
 
-  /* The Core ID that is used as DPDK main thread, leave to zero is good for most case */
+  /* The Core ID designated for the DPDK main thread. If set to 0, the DPDK default core
+   * is used. */
   uint32_t main_lcore;
 
   /**

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -417,12 +417,16 @@ static int dev_eal_init(struct mtl_init_params* p, struct mt_kport_info* kport_i
 
   /* --main-lcore */
   char main_lcore[64];
-  argv[argc] = "--main-lcore";
-  argc++;
-  info("%s, main_lcore: %u\n", __func__, p->main_lcore);
-  snprintf(main_lcore, sizeof(main_lcore), "%u", p->main_lcore);
-  argv[argc] = main_lcore;
-  argc++;
+
+  if (p->main_lcore) {
+    argv[argc] = "--main-lcore";
+    argc++;
+
+    info("%s, main_lcore: %u\n", __func__, p->main_lcore);
+    snprintf(main_lcore, sizeof(main_lcore), "%u", p->main_lcore);
+    argv[argc] = main_lcore;
+    argc++;
+  }
 
   char lcores[128];
   if (p->lcores) {


### PR DESCRIPTION
Mtl could not initialize when forced to use
0 as main_lcore in lcore restrained environments,
like docker containers.

Change this by making the dpdk initialize
automatically when the main_lcore is 0.