### PR TITLE
Add: Add to GStreamer lcore mask support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ mtl_system_status_*
 *.mp4
 *.pcm
 *.wav
+logs_*
 
 #Generated documentation
 doc/_build

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -108,6 +108,7 @@ In MTL GStreamer plugins there are general arguments that apply to every plugin.
 | payload-type  | uint   | SMPTE ST 2110 payload type.                                                                       | 0 to G_MAXUINT           |
 | port          | string | Session DPDK device port. If not specified it will be taken from the dev-port argument.           | N/A                      |
 | port-red      | string | Redundant session DPDK device port if left open taken from dev-port-red argument if specified.    | N/A                      |
+| lcore-list     | string | Map lcore set to physical cpu set. The argument format is: <lcores[@cpus]>[<,lcores[@cpus]>...]   | N/A                      |
 
 These are also general parameters accepted by plugins, but the functionality they provide to the user is not yet supported in plugins.
 | Property Name | Type   | Description                                                                                       | Range                    |

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -289,10 +289,11 @@ void gst_mtl_common_init_general_arguments(GObjectClass* gobject_class) {
                            G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
-      gobject_class, PROP_GENERAL_LCORE_MASK,
-      g_param_spec_string("lcore-mask", "dpdk core mask",
-                          "List of cores to run on for dpdk.", NULL,
-                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+      gobject_class, PROP_GENERAL_LCORE_LIST,
+      g_param_spec_string(
+          "lcore-list", "dpdk core list",
+          "List or range of cores to run on for DPDK (e.g., '1,2,3' or '1-3').", NULL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
 
 void gst_mtl_common_set_general_arguments(GObject* object, guint prop_id,
@@ -356,8 +357,8 @@ void gst_mtl_common_set_general_arguments(GObject* object, guint prop_id,
     case PROP_GENERAL_ENABLE_ONBOARD_PTP:
       general_args->enable_onboard_ptp = g_value_get_boolean(value);
       break;
-    case PROP_GENERAL_LCORE_MASK:
-      strncpy(general_args->lcore_mask, g_value_get_string(value), MTL_PORT_MAX_LEN);
+    case PROP_GENERAL_LCORE_LIST:
+      strncpy(general_args->lcore_map, g_value_get_string(value), MTL_PORT_MAX_LEN);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -415,8 +416,8 @@ void gst_mtl_common_get_general_arguments(GObject* object, guint prop_id,
     case PROP_GENERAL_ENABLE_ONBOARD_PTP:
       g_value_set_boolean(value, general_args->enable_onboard_ptp);
       break;
-    case PROP_GENERAL_LCORE_MASK:
-      g_value_set_string(value, general_args->lcore_mask);
+    case PROP_GENERAL_LCORE_LIST:
+      g_value_set_string(value, general_args->lcore_map);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -574,8 +575,8 @@ gboolean gst_mtl_common_parse_general_arguments(struct mtl_init_params* mtl_init
     GST_INFO("Using MTL library's onboard PTP");
   }
 
-  if (strlen(general_args->lcore_mask)) {
-    mtl_init_params->lcores = general_args->lcore_mask;
+  if (strlen(general_args->lcore_map)) {
+    mtl_init_params->lcores = general_args->lcore_map;
   }
 
   while (mtl_port_idx <= MTL_PORT_R && strlen(general_args->port[mtl_port_idx]) != 0) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.c
@@ -579,6 +579,8 @@ gboolean gst_mtl_common_parse_general_arguments(struct mtl_init_params* mtl_init
     mtl_init_params->lcores = general_args->lcore_map;
   }
 
+  strncpy(mtl_init_params->lcores, "1,3,5,7", MTL_PORT_MAX_LEN);
+
   while (mtl_port_idx <= MTL_PORT_R && strlen(general_args->port[mtl_port_idx]) != 0) {
     strncpy(mtl_init_params->port[mtl_port_idx], general_args->port[mtl_port_idx],
             MTL_PORT_MAX_LEN);

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -47,6 +47,7 @@ enum {
   PROP_GENERAL_PORT_RX_QUEUES,
   PROP_GENERAL_PORT_TX_QUEUES,
   PROP_GENERAL_ENABLE_ONBOARD_PTP,
+  PROP_GENERAL_LCORE_MASK,
   PROP_GENERAL_MAX
 };
 
@@ -64,6 +65,7 @@ typedef struct GeneralArgs {
   gchar dma_dev[MTL_PORT_MAX_LEN];
   gint log_level;
   gboolean enable_onboard_ptp;
+  gchar lcore_mask[MTL_PORT_MAX_LEN];
 } GeneralArgs;
 
 typedef struct SessionPortArgs {

--- a/ecosystem/gstreamer_plugin/gst_mtl_common.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_common.h
@@ -47,7 +47,7 @@ enum {
   PROP_GENERAL_PORT_RX_QUEUES,
   PROP_GENERAL_PORT_TX_QUEUES,
   PROP_GENERAL_ENABLE_ONBOARD_PTP,
-  PROP_GENERAL_LCORE_MASK,
+  PROP_GENERAL_LCORE_LIST,
   PROP_GENERAL_MAX
 };
 
@@ -65,7 +65,7 @@ typedef struct GeneralArgs {
   gchar dma_dev[MTL_PORT_MAX_LEN];
   gint log_level;
   gboolean enable_onboard_ptp;
-  gchar lcore_mask[MTL_PORT_MAX_LEN];
+  gchar lcore_map[MTL_CORE_LIST_MAX_SIZE];
 } GeneralArgs;
 
 typedef struct SessionPortArgs {

--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -93,6 +93,11 @@ extern "C" {
  */
 #define MTL_DMA_DEV_MAX (8)
 
+/** 
+ * Max core list size
+ */
+#define MTL_CORE_LIST_MAX_SIZE (128)
+
 /**
  * Max length of a pcap dump filename
  */

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -417,20 +417,25 @@ static int dev_eal_init(struct mtl_init_params* p, struct mt_kport_info* kport_i
 
   /* --main-lcore */
   char main_lcore[64];
-  argv[argc] = "--main-lcore";
-  argc++;
-  info("%s, main_lcore: %u\n", __func__, p->main_lcore);
-  snprintf(main_lcore, sizeof(main_lcore), "%u", p->main_lcore);
-  argv[argc] = main_lcore;
-  argc++;
+  char lcores[MTL_CORE_LIST_MAX_SIZE];
 
-  char lcores[128];
+  if (p->main_lcore) {
+    argv[argc] = "--main-lcore";
+    argc++;
+    snprintf(main_lcore, sizeof(main_lcore), "%u", p->main_lcore);
+    argv[argc] = main_lcore;
+
+    info("%s, main_lcore: %s\n", __func__, argv[argc]);
+    argc++;
+  }
+
   if (p->lcores) {
     argv[argc] = "-l";
     argc++;
-    info("%s, lcores: %s\n", __func__, p->lcores);
-    snprintf(lcores, sizeof(lcores), "%u,%s", p->main_lcore, p->lcores);
+    snprintf(lcores, sizeof(lcores), "%s", p->lcores);
     argv[argc] = lcores;
+
+    info("%s, lcores: %s\n", __func__, argv[argc]);
     argc++;
   }
 


### PR DESCRIPTION
- Add lcore masking support to allow users to specify the lcores  the MTL plugin can use. This is useful for scenarios with isolated lcores.

- Fix missing port and PTP arguments in gst common get arguments.