### PR TITLE
Add: support for DPDK 25.03

### DIFF
--- a/.github/workflows/afxdp_build.yml
+++ b/.github/workflows/afxdp_build.yml
@@ -15,6 +15,7 @@ on:
 env:
   # Customize the env if
   PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+  DPDK_VERSION: 25.03
 
 permissions:
   contents: read
@@ -58,14 +59,27 @@ jobs:
           source: '.'
           extensions: 'hpp,h,cpp,c,cc'
 
+      - name: checkout dpdk repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: 'DPDK/dpdk'
+          ref: v${{  env.DPDK_VERSION  }}
+          path: dpdk
       - name: Install the build dependency
         run: |
           apt-get update -y
           apt-get install -y sudo git gcc meson python3 python3-pyelftools pkg-config libnuma-dev libjson-c-dev libpcap-dev libgtest-dev libsdl2-dev libsdl2-ttf-dev libssl-dev
           apt-get install -y make m4 clang llvm zlib1g-dev libelf-dev libcap-ng-dev gcc-multilib
-          apt-get install -y dpdk-dev
           apt-get install -y systemtap-sdt-dev
-        
+
+      - name: Build DPDK from source
+        working-directory: dpdk
+        run: |
+          meson build
+          ninja -C build
+          cd build
+          sudo ninja install
+
       - name: Checkout xdp-tools
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -74,16 +88,19 @@ jobs:
           submodules: recursive
 
       - name: Build and install xdp-tools
+        working-directory: xdp-tools
         run: |
-          cd xdp-tools && ./configure
+          ./configure
           make && sudo make install
           cd lib/libbpf/src && sudo make install
          
       - name: Build
+        working-directory: "${{ github.workspace }}"
         run: |
           ./build.sh
 
       - name: Build with debug
+        working-directory: "${{ github.workspace }}"
         run: |
           rm build -rf
           ./build.sh debug

--- a/.github/workflows/afxdp_build_with_gtest.yml
+++ b/.github/workflows/afxdp_build_with_gtest.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   # Customize the env if
   BUILD_TYPE: Release
-  DPDK_VERSION: 23.11
+  DPDK_VERSION: 25.03
   MTL_BUILD_DISABLE_USDT: true
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,10 @@ on:
 
 permissions:
   contents: read
+env:
+  # Customize the env if
+  PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+  DPDK_VERSION: 25.03
 
 jobs:
   analyze:
@@ -62,14 +66,27 @@ jobs:
         run: |
           sudo apt-get update --fix-missing -y
           sudo apt-get install --no-install-recommends -y sudo git gcc meson python3 python3-pyelftools pkg-config libnuma-dev libjson-c-dev libpcap-dev libgtest-dev libsdl2-dev libsdl2-ttf-dev libssl-dev llvm clang
-          sudo apt-get install --no-install-recommends -y dpdk-dev systemtap-sdt-dev software-properties-common
+          sudo apt-get install --no-install-recommends -y systemtap-sdt-dev software-properties-common
 
+      - name: checkout dpdk repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: 'DPDK/dpdk'
+          ref: v${{  env.DPDK_VERSION  }}
+          path: dpdk
       - name: Git config
         run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
-
+      - name: Build DPDK from source
+        working-directory: dpdk
+        run: |
+          meson build
+          ninja -C build
+          cd build
+          sudo ninja install
       - name: Build
+        working-directory: "${{ github.workspace }}"
         run: |
           ./build.sh
 

--- a/.github/workflows/dpdk_patches_build.yml
+++ b/.github/workflows/dpdk_patches_build.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Customize the env if
-  DPDK_VERSION: 23.11
+  DPDK_VERSION: 25.03
 
 permissions:
   contents: read

--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # Customize the env if
   BUILD_TYPE: 'Release'
-  DPDK_VERSION: '23.11'
+  DPDK_VERSION: '25.03'
   # Bellow ENV variables are required to be defined on runner side:
   # TEST_PF_PORT_P: '0000:49:00.0'
   # TEST_PF_PORT_R: '0000:49:00.1'

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -38,7 +38,7 @@ jobs:
         sys:
           - mingw64
           - ucrt64
-        dpdk: [23.11, 23.07]
+        dpdk: [25.03, 23.11]
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/msys2_ffmpeg.yml
+++ b/.github/workflows/msys2_ffmpeg.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         sys:
           - mingw64
-        dpdk: [23.11]
+        dpdk: [25.03]
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -14,7 +14,8 @@ on:
 
 permissions:
   contents: read
-
+env: 
+    DPDK_VERSION: 25.03
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -54,20 +55,35 @@ jobs:
           source: '.'
           extensions: 'hpp,h,cpp,c,cc'
 
+      - name: checkout dpdk repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: 'DPDK/dpdk'
+          ref: v${{  env.DPDK_VERSION  }}
+          path: dpdk
+
       - name: Install the build dependency
         run: |
           apt-get update -y
           apt-get install -y sudo git gcc meson python3 python3-pyelftools pkg-config libnuma-dev libjson-c-dev libpcap-dev libgtest-dev libsdl2-dev libsdl2-ttf-dev libssl-dev systemtap-sdt-dev llvm clang
-          apt-get install -y dpdk-dev
           apt-get install -y doxygen
           apt-get install -y make m4 clang llvm zlib1g-dev libelf-dev libcap-ng-dev libcap2-bin gcc-multilib
 
+      - name: Build DPDK from source
+        working-directory: dpdk
+        run: |
+            meson build
+            ninja -C build
+            cd build
+            sudo ninja install
       - name: Git config
+        working-directory: "${{ github.workspace }}"
         run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
 
       - name: Build
+        working-directory: "${{ github.workspace }}"
         run: |
           ./build.sh
 

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -106,7 +106,7 @@ on:
 
 env:
   BUILD_TYPE: 'Release'
-  DPDK_VERSION: '23.11'
+  DPDK_VERSION: '25.03'
   DPDK_REBUILD: 'false'
 
 permissions:

--- a/.github/workflows/windows_build_with_gtest.yml
+++ b/.github/workflows/windows_build_with_gtest.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   # Customize the env if
   BUILD_TYPE: Release
-  DPDK_VERSION: 23.11
+  DPDK_VERSION: 25.03
   TEST_PORT_P: 0000:af:00.0
   TEST_PORT_R: 0000:af:00.1
   MSYSTEM: UCRT64

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   dpdk:
     description: DPDK support version on Media Transport
     required: true
-    default: 23.11
+    default: 25.03
   tap:
     description: Enable TAP device
     required: true

--- a/doc/build.md
+++ b/doc/build.md
@@ -64,7 +64,7 @@ sudo pacman -Syu --needed  sdl2 sdl2_ttf
 
 ### 1.2. Build dependency from source code
 
-It's true that not all operating systems, including RHEL 9, come with all the libraries required for every software package. If you're trying to install a software that has dependencies not provided by default on your OS, you might need to install these dependencies manually. Skip these part if your setup has all dependencies resolved.
+It's true that not all operating systems, including RHEL 9, come with all the libraries required for every software package. If you're trying to install a software that has dependencies not provided by default by your package manager, you might need to install these dependencies manually. Skip these step if your setup has all dependencies resolved.
 
 Refer to below commands for how to build from code.
 
@@ -107,7 +107,7 @@ cd ../../
 
 ### 1.3. secure_path for root user
 
-The build steps use `sudo ninja install` to install the built to system. Some operating systems, including CentOS stream and RHEL 9, not has `/usr/local/bin/` into secure_path defaults.
+The build steps use `sudo ninja install` to install the build to the system. Some operating systems, including CentOS Stream and RHEL 9, do not have `/usr/local/bin/` in the secure_path defaults.
 
 Edit the file `/etc/sudoers`, find `secure_path` and append `/usr/local/bin`
 
@@ -128,13 +128,13 @@ export mtl_source_code=${PWD}/Media-Transport-Library
 
 ## 2. DPDK build and install
 
-### 2.1. Get DPDK 23.11 source code
+### 2.1. Get DPDK 25.03 source code
 
 ```bash
 git clone https://github.com/DPDK/dpdk.git
 cd dpdk
-git checkout v23.11
-git switch -c v23.11
+git checkout v25.03
+git switch -c v25.03
 cd ..
 ```
 
@@ -144,7 +144,7 @@ Note: $mtl_source_code should be pointed to top source code tree of Media Transp
 
 ```bash
 cd dpdk
-git am $mtl_source_code/patches/dpdk/23.11/*.patch
+git am $mtl_source_code/patches/dpdk/25.03/*.patch
 ```
 
 ### 2.3. Build and install DPDK library

--- a/doc/build_WIN.md
+++ b/doc/build_WIN.md
@@ -60,7 +60,7 @@ export mtl_source_code=${PWD}/Media-Transport-Library
 * Convert symlink patch files to real file:
 
 ```bash
-cd $mtl_source_code/patches/dpdk/23.11
+cd $mtl_source_code/patches/dpdk/25.03
 ls *.patch | xargs -I{} bash -c 'if [[ $(sed -n '1p' "{}") =~ ^../.*\.patch$ ]]; then cp "$(cat "{}")" "{}"; fi'
 cd windows
 ls *.patch | xargs -I{} bash -c 'if [[ $(sed -n '1p' "{}") =~ ^../.*\.patch$ ]]; then cp "$(cat "{}")" "{}"; fi'
@@ -72,13 +72,13 @@ ls *.patch | xargs -I{} bash -c 'if [[ $(sed -n '1p' "{}") =~ ^../.*\.patch$ ]];
 cd $mtl_source_code
 git clone https://github.com/DPDK/dpdk.git
 cd dpdk
-git checkout v23.11
-git switch -c v23.11
+git checkout v25.03
+git switch -c v25.03
 
 git config user.name "Your Name"        # config if not
 git config user.email "you@example.com" # config if not
-git am $mtl_source_code/patches/dpdk/23.11/*.patch
-git am $mtl_source_code/patches/dpdk/23.11/windows/*.patch
+git am $mtl_source_code/patches/dpdk/25.03/*.patch
+git am $mtl_source_code/patches/dpdk/25.03/windows/*.patch
 ```
 
 * Build and install DPDK:

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 ENV MTL_REPO=Media-Transport-Library
-ENV DPDK_VER=23.11
+ENV DPDK_VER=25.03
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
 
 COPY . $MTL_REPO

--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -795,6 +795,7 @@ static int dev_detect_link(struct mt_interface* inf) {
   struct rte_eth_link eth_link;
   uint16_t port_id = inf->port_id;
   enum mtl_port port = inf->port;
+  int err;
 
   if (inf->drv_info.flags & MT_DRV_F_NOT_DPDK_PMD) {
     dbg("%s(%d), not dpdk based\n", __func__, port);
@@ -804,7 +805,12 @@ static int dev_detect_link(struct mt_interface* inf) {
   memset(&eth_link, 0, sizeof(eth_link));
 
   for (int i = 0; i < 100; i++) {
-    rte_eth_link_get_nowait(port_id, &eth_link);
+    err = rte_eth_link_get_nowait(port_id, &eth_link);
+    if (err < 0) {
+      err("%s, failed to get link status for port %d, ret %d\n", __func__, port_id, err);
+      return err;
+    }
+
     if (eth_link.link_status) {
       inf->link_speed = eth_link.link_speed;
       mt_eth_link_dump(port_id);

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -119,7 +119,7 @@ struct mt_ptp_port_id {
 struct mt_ipv4_udp {
   struct rte_ipv4_hdr ip;
   struct rte_udp_hdr udp;
-} __attribute__((__packed__));
+} __attribute__((__packed__)) __attribute__((__aligned__(2)));
 
 enum mt_port_type {
   MT_PORT_ERR = 0,

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -386,8 +386,13 @@ void mt_lcore_dump() {
 
 void mt_eth_link_dump(uint16_t port_id) {
   struct rte_eth_link eth_link;
+  int err;
 
-  rte_eth_link_get_nowait(port_id, &eth_link);
+  err = rte_eth_link_get_nowait(port_id, &eth_link);
+  if (err < 0) {
+    err("%s, failed to get link status for port %d, ret %d\n", __func__, port_id, err);
+    return;
+  }
 
   critical("%s(%d), link_speed %dg link_status %d link_duplex %d link_autoneg %d\n",
            __func__, port_id, eth_link.link_speed / 1000, eth_link.link_status,

--- a/patches/dpdk/25.03/0001-e810-set-max-ring-desc-to-max-allowed-by-hardware.patch
+++ b/patches/dpdk/25.03/0001-e810-set-max-ring-desc-to-max-allowed-by-hardware.patch
@@ -1,0 +1,26 @@
+From 338b53c69db2462897efed66a97109e9ef3866c5 Mon Sep 17 00:00:00 2001
+From: "Kasiewicz, Marek" <marek.kasiewicz@intel.com>
+Date: Mon, 31 Mar 2025 11:42:58 +0000
+Subject: [PATCH 1/6] e810: set max ring desc to max allowed by hardware
+
+Signed-off-by: Kasiewicz, Marek <marek.kasiewicz@intel.com>
+---
+ drivers/net/intel/iavf/iavf_rxtx.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/intel/iavf/iavf_rxtx.h b/drivers/net/intel/iavf/iavf_rxtx.h
+index 823a6efa9a..c1a62a9a5f 100644
+--- a/drivers/net/intel/iavf/iavf_rxtx.h
++++ b/drivers/net/intel/iavf/iavf_rxtx.h
+@@ -11,7 +11,7 @@
+ /* In QLEN must be whole number of 32 descriptors. */
+ #define IAVF_ALIGN_RING_DESC      32
+ #define IAVF_MIN_RING_DESC        64
+-#define IAVF_MAX_RING_DESC        4096
++#define IAVF_MAX_RING_DESC        (8192 - 32)
+ #define IAVF_DMA_MEM_ALIGN        4096
+ /* Base address of the HW descriptor ring should be 128B aligned. */
+ #define IAVF_RING_BASE_ALIGN      128
+-- 
+2.34.1
+

--- a/patches/dpdk/25.03/0002-net-iavf-refine-queue-rate-limit-configure.patch
+++ b/patches/dpdk/25.03/0002-net-iavf-refine-queue-rate-limit-configure.patch
@@ -1,0 +1,56 @@
+From b9a0b92a6b38b6845934b2cc0668d0d1c48ce3cf Mon Sep 17 00:00:00 2001
+From: Ting Xu <ting.xu@intel.com>
+Date: Tue, 19 Apr 2022 02:09:28 +0000
+Subject: [PATCH 2/6] net/iavf: refine queue rate limit configure
+
+Refine two operations when configuring queue rate limit:
+1. no need to stop port first, now can configure queue rate limit at
+runtime
+2. users can delete part of the queues and set new rate limit for them,
+but they must assign correct queue id. Otherwise, the result will be not
+correct.
+
+Signed-off-by: Ting Xu <ting.xu@intel.com>
+---
+ drivers/net/intel/iavf/iavf_tm.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/intel/iavf/iavf_tm.c b/drivers/net/intel/iavf/iavf_tm.c
+index 1d12196ba6..67186dff67 100644
+--- a/drivers/net/intel/iavf/iavf_tm.c
++++ b/drivers/net/intel/iavf/iavf_tm.c
+@@ -810,8 +810,10 @@ static int iavf_hierarchy_commit(struct rte_eth_dev *dev,
+ 	int index = 0, node_committed = 0;
+ 	int i, ret_val = IAVF_SUCCESS;
+ 
+-	/* check if port is stopped */
+-	if (adapter->stopped != 1) {
++	/* check if port is stopped, except for setting queue bandwidth */
++	if (vf->tm_conf.nb_tc_node != 1 &&
++	    vf->qos_cap->num_elem != 1 &&
++	    adapter->stopped != 1) {
+ 		PMD_DRV_LOG(ERR, "Please stop port first");
+ 		ret_val = IAVF_ERR_NOT_READY;
+ 		goto err;
+@@ -862,7 +864,7 @@ static int iavf_hierarchy_commit(struct rte_eth_dev *dev,
+ 		q_tc_mapping->tc[tm_node->tc].req.queue_count++;
+ 
+ 		if (tm_node->shaper_profile) {
+-			q_bw->cfg[node_committed].queue_id = node_committed;
++			q_bw->cfg[node_committed].queue_id = tm_node->id;
+ 			q_bw->cfg[node_committed].shaper.peak =
+ 			tm_node->shaper_profile->profile.peak.rate /
+ 			1000 * IAVF_BITS_PER_BYTE;
+@@ -906,7 +908,8 @@ static int iavf_hierarchy_commit(struct rte_eth_dev *dev,
+ 		goto fail_clear;
+ 
+ 	vf->qtc_map = qtc_map;
+-	vf->tm_conf.committed = true;
++	if (adapter->stopped == 1)
++		vf->tm_conf.committed = true;
+ 	return ret_val;
+ 
+ fail_clear:
+-- 
+2.34.1
+

--- a/patches/dpdk/25.03/0003-ice-set-ICE_SCHED_DFLT_BURST_SIZE-to-2048.patch
+++ b/patches/dpdk/25.03/0003-ice-set-ICE_SCHED_DFLT_BURST_SIZE-to-2048.patch
@@ -1,0 +1,28 @@
+From 8317f81fcf086a539001fea497e51a307f55da82 Mon Sep 17 00:00:00 2001
+From: Frank Du <frank.du@intel.com>
+Date: Tue, 21 Feb 2023 09:26:05 +0800
+Subject: [PATCH 3/6] ice: set ICE_SCHED_DFLT_BURST_SIZE to 2048
+
+For st2110 rl burst optimization
+
+Signed-off-by: Frank Du <frank.du@intel.com>
+---
+ drivers/net/intel/ice/base/ice_type.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/intel/ice/base/ice_type.h b/drivers/net/intel/ice/base/ice_type.h
+index 35f832eb9f..20b73c9ab2 100644
+--- a/drivers/net/intel/ice/base/ice_type.h
++++ b/drivers/net/intel/ice/base/ice_type.h
+@@ -1087,7 +1087,7 @@ enum ice_rl_type {
+ #define ICE_SCHED_NO_SHARED_RL_PROF_ID	0xFFFF
+ #define ICE_SCHED_DFLT_BW_WT		4
+ #define ICE_SCHED_INVAL_PROF_ID		0xFFFF
+-#define ICE_SCHED_DFLT_BURST_SIZE	(15 * 1024)	/* in bytes (15k) */
++#define ICE_SCHED_DFLT_BURST_SIZE	(2 * 1024)	/* in bytes (2k) */
+ 
+ /* Access Macros for Tx Sched RL Profile data */
+ #define ICE_TXSCHED_GET_RL_PROF_ID(p) LE16_TO_CPU((p)->info.profile_id)
+-- 
+2.34.1
+

--- a/patches/dpdk/25.03/0004-Change-to-enable-PTP.patch
+++ b/patches/dpdk/25.03/0004-Change-to-enable-PTP.patch
@@ -1,0 +1,47 @@
+From 5bafac2314550708f5f015f535aeff35b2888884 Mon Sep 17 00:00:00 2001
+From: "Kasiewicz, Marek" <marek.kasiewicz@intel.com>
+Date: Mon, 31 Mar 2025 12:37:40 +0000
+Subject: [PATCH 4/6] Change to enable PTP
+
+Signed-off-by: Kasiewicz, Marek <marek.kasiewicz@intel.com>
+---
+ drivers/net/intel/ice/ice_rxtx.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/intel/ice/ice_rxtx.c b/drivers/net/intel/ice/ice_rxtx.c
+index 40ac01e782..807dbdc9e0 100644
+--- a/drivers/net/intel/ice/ice_rxtx.c
++++ b/drivers/net/intel/ice/ice_rxtx.c
+@@ -1809,8 +1809,7 @@ ice_rx_scan_hw_ring(struct ice_rx_queue *rxq)
+ 				pkt_flags |= ice_timestamp_dynflag;
+ 			}
+ 
+-			if (ad->ptp_ena && ((mb->packet_type &
+-			    RTE_PTYPE_L2_MASK) == RTE_PTYPE_L2_ETHER_TIMESYNC)) {
++			if (ad->ptp_ena) {
+ 				rxq->time_high =
+ 				   rte_le_to_cpu_32(rxdp[j].wb.flex_ts.ts_high);
+ 				mb->timesync = rxq->queue_id;
+@@ -2176,8 +2175,7 @@ ice_recv_scattered_pkts(void *rx_queue,
+ 			pkt_flags |= ice_timestamp_dynflag;
+ 		}
+ 
+-		if (ad->ptp_ena && ((first_seg->packet_type & RTE_PTYPE_L2_MASK)
+-		    == RTE_PTYPE_L2_ETHER_TIMESYNC)) {
++		if (ad->ptp_ena) {
+ 			rxq->time_high =
+ 			   rte_le_to_cpu_32(rxd.wb.flex_ts.ts_high);
+ 			first_seg->timesync = rxq->queue_id;
+@@ -2674,8 +2672,7 @@ ice_recv_pkts(void *rx_queue,
+ 			pkt_flags |= ice_timestamp_dynflag;
+ 		}
+ 
+-		if (ad->ptp_ena && ((rxm->packet_type & RTE_PTYPE_L2_MASK) ==
+-		    RTE_PTYPE_L2_ETHER_TIMESYNC)) {
++		if (ad->ptp_ena) {
+ 			rxq->time_high =
+ 			   rte_le_to_cpu_32(rxd.wb.flex_ts.ts_high);
+ 			rxm->timesync = rxq->queue_id;
+-- 
+2.34.1
+

--- a/patches/dpdk/25.03/0005-iavf-disable-runtime-queue.patch
+++ b/patches/dpdk/25.03/0005-iavf-disable-runtime-queue.patch
@@ -1,0 +1,28 @@
+From 3b227b2ae49fefbdd8c906634c038f9178aee36a Mon Sep 17 00:00:00 2001
+From: Ric Li <ming3.li@intel.com>
+Date: Fri, 1 Dec 2023 18:52:34 +0800
+Subject: [PATCH 5/6] iavf: disable runtime queue
+
+Signed-off-by: Ric Li <ming3.li@intel.com>
+---
+ drivers/net/intel/iavf/iavf_ethdev.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/drivers/net/intel/iavf/iavf_ethdev.c b/drivers/net/intel/iavf/iavf_ethdev.c
+index 2335746f04..032b71b2de 100644
+--- a/drivers/net/intel/iavf/iavf_ethdev.c
++++ b/drivers/net/intel/iavf/iavf_ethdev.c
+@@ -1139,9 +1139,7 @@ iavf_dev_info_get(struct rte_eth_dev *dev, struct rte_eth_dev_info *dev_info)
+ 	dev_info->reta_size = vf->vf_res->rss_lut_size;
+ 	dev_info->flow_type_rss_offloads = IAVF_RSS_OFFLOAD_ALL;
+ 	dev_info->max_mac_addrs = IAVF_NUM_MACADDR_MAX;
+-	dev_info->dev_capa =
+-		RTE_ETH_DEV_CAPA_RUNTIME_RX_QUEUE_SETUP |
+-		RTE_ETH_DEV_CAPA_RUNTIME_TX_QUEUE_SETUP;
++	dev_info->dev_capa &= ~RTE_ETH_DEV_CAPA_FLOW_RULE_KEEP;
+ 	dev_info->rx_offload_capa =
+ 		RTE_ETH_RX_OFFLOAD_VLAN_STRIP |
+ 		RTE_ETH_RX_OFFLOAD_QINQ_STRIP |
+-- 
+2.34.1
+

--- a/patches/dpdk/25.03/0006-pcapng-add-user-timestamp-support.patch
+++ b/patches/dpdk/25.03/0006-pcapng-add-user-timestamp-support.patch
@@ -1,0 +1,149 @@
+From d6a0057ffd73a379735d679523b7972a45b6d395 Mon Sep 17 00:00:00 2001
+From: "Kasiewicz, Marek" <marek.kasiewicz@intel.com>
+Date: Mon, 31 Mar 2025 12:48:41 +0000
+Subject: [PATCH 6/6] pcapng: add user timestamp support
+
+Signed-off-by: Kasiewicz, Marek <marek.kasiewicz@intel.com>
+---
+ lib/pcapng/rte_pcapng.c | 10 ++++++----
+ lib/pcapng/rte_pcapng.h | 43 ++++++++++++++++++++++++++++++++++++++---
+ lib/pcapng/version.map  |  1 +
+ 3 files changed, 47 insertions(+), 7 deletions(-)
+
+diff --git a/lib/pcapng/rte_pcapng.c b/lib/pcapng/rte_pcapng.c
+index 16485b27cb..0d2700a6be 100644
+--- a/lib/pcapng/rte_pcapng.c
++++ b/lib/pcapng/rte_pcapng.c
+@@ -467,12 +467,12 @@ pcapng_vlan_insert(struct rte_mbuf *m, uint16_t ether_type, uint16_t tci)
+ 
+ /* Make a copy of original mbuf with pcapng header and options */
+ struct rte_mbuf *
+-rte_pcapng_copy(uint16_t port_id, uint32_t queue,
++rte_pcapng_copy_ts(uint16_t port_id, uint32_t queue,
+ 		const struct rte_mbuf *md,
+ 		struct rte_mempool *mp,
+ 		uint32_t length,
+ 		enum rte_pcapng_direction direction,
+-		const char *comment)
++		const char *comment, uint64_t ts)
+ {
+ 	struct pcapng_enhance_packet_block *epb;
+ 	uint32_t orig_len, pkt_len, padding, flags;
+@@ -590,7 +590,7 @@ rte_pcapng_copy(uint16_t port_id, uint32_t queue,
+ 	mc->port = port_id;
+ 
+ 	/* Put timestamp in cycles here - adjust in packet write */
+-	timestamp = rte_get_tsc_cycles();
++	timestamp = ts ? ts : rte_get_tsc_cycles();
+ 	epb->timestamp_hi = timestamp >> 32;
+ 	epb->timestamp_lo = (uint32_t)timestamp;
+ 	epb->capture_length = pkt_len;
+@@ -618,7 +618,7 @@ rte_pcapng_write_packets(rte_pcapng_t *self,
+ 	for (i = 0; i < nb_pkts; i++) {
+ 		struct rte_mbuf *m = pkts[i];
+ 		struct pcapng_enhance_packet_block *epb;
+-		uint64_t cycles, timestamp;
++		//uint64_t cycles, timestamp;
+ 
+ 		/* sanity check that is really a pcapng mbuf */
+ 		epb = rte_pktmbuf_mtod(m, struct pcapng_enhance_packet_block *);
+@@ -635,12 +635,14 @@ rte_pcapng_write_packets(rte_pcapng_t *self,
+ 			return -1;
+ 		}
+ 
++#if 0
+ 		/* adjust timestamp recorded in packet */
+ 		cycles = (uint64_t)epb->timestamp_hi << 32;
+ 		cycles += epb->timestamp_lo;
+ 		timestamp = pcapng_timestamp(self, cycles);
+ 		epb->timestamp_hi = timestamp >> 32;
+ 		epb->timestamp_lo = (uint32_t)timestamp;
++#endif
+ 
+ 		/*
+ 		 * Handle case of highly fragmented and large burst size
+diff --git a/lib/pcapng/rte_pcapng.h b/lib/pcapng/rte_pcapng.h
+index 48f2b57564..52a066b8fc 100644
+--- a/lib/pcapng/rte_pcapng.h
++++ b/lib/pcapng/rte_pcapng.h
+@@ -99,7 +99,7 @@ enum rte_pcapng_direction {
+ };
+ 
+ /**
+- * Format an mbuf for writing to file.
++ * Format an mbuf with time stamp for writing to file.
+  *
+  * @param port_id
+  *   The Ethernet port on which packet was received
+@@ -118,17 +118,54 @@ enum rte_pcapng_direction {
+  *   The direction of the packer: receive, transmit or unknown.
+  * @param comment
+  *   Packet comment.
++ * @param ts
++ *   time stamp.
+  *
+  * @return
+  *   - The pointer to the new mbuf formatted for pcapng_write
+  *   - NULL if allocation fails.
+  */
+ struct rte_mbuf *
+-rte_pcapng_copy(uint16_t port_id, uint32_t queue,
++rte_pcapng_copy_ts(uint16_t port_id, uint32_t queue,
+ 		const struct rte_mbuf *m, struct rte_mempool *mp,
+ 		uint32_t length,
+-		enum rte_pcapng_direction direction, const char *comment);
++		enum rte_pcapng_direction direction, const char *comment, uint64_t ts);
+ 
++/* enable the define for MTL */
++#define MTL_DPDK_HAS_PCAPNG_TS
++
++/**
++ * Format an mbuf for writing to file.
++ *
++ * @param port_id
++ *   The Ethernet port on which packet was received
++ *   or is going to be transmitted.
++ * @param queue
++ *   The queue on the Ethernet port where packet was received
++ *   or is going to be transmitted.
++ * @param mp
++ *   The mempool from which the "clone" mbufs are allocated.
++ * @param m
++ *   The mbuf to copy
++ * @param length
++ *   The upper limit on bytes to copy.  Passing UINT32_MAX
++ *   means all data (after offset).
++ * @param direction
++ *   The direction of the packer: receive, transmit or unknown.
++ * @param comment
++ *   Packet comment.
++ *
++ * @return
++ *   - The pointer to the new mbuf formatted for pcapng_write
++ *   - NULL if allocation fails.
++ */
++static inline struct rte_mbuf *
++rte_pcapng_copy(uint16_t port_id, uint32_t queue,
++		const struct rte_mbuf *m, struct rte_mempool *mp,
++		uint32_t length,
++		enum rte_pcapng_direction direction, const char *comment) {
++  return rte_pcapng_copy_ts(port_id, queue, m, mp, length, direction, comment, 0);
++}
+ 
+ /**
+  * Determine optimum mbuf data size.
+diff --git a/lib/pcapng/version.map b/lib/pcapng/version.map
+index 9f634b653e..9120f31f12 100644
+--- a/lib/pcapng/version.map
++++ b/lib/pcapng/version.map
+@@ -4,6 +4,7 @@ DPDK_25 {
+ 	rte_pcapng_add_interface;
+ 	rte_pcapng_close;
+ 	rte_pcapng_copy;
++	rte_pcapng_copy_ts;
+ 	rte_pcapng_fdopen;
+ 	rte_pcapng_mbuf_size;
+ 	rte_pcapng_write_packets;
+-- 
+2.34.1
+

--- a/patches/dpdk/25.03/hdr_split/0001-net-intel-ice-support-hdr-split-mbuf-callback.patch
+++ b/patches/dpdk/25.03/hdr_split/0001-net-intel-ice-support-hdr-split-mbuf-callback.patch
@@ -1,0 +1,216 @@
+From b4b8c41ed4243a3f77031c70e1de94abaefdcda5 Mon Sep 17 00:00:00 2001
+From: "Kasiewicz, Marek" <marek.kasiewicz@intel.com>
+Date: Fri, 11 Apr 2025 12:41:46 +0000
+Subject: [PATCH] net/intel/ice: support hdr split mbuf callback
+
+Signed-off-by: Kasiewicz, Marek <marek.kasiewicz@intel.com>
+---
+ drivers/net/intel/ice/ice_ethdev.c |  1 +
+ drivers/net/intel/ice/ice_rxtx.c   | 46 ++++++++++++++++++++++++++++++
+ drivers/net/intel/ice/ice_rxtx.h   |  5 ++++
+ lib/ethdev/ethdev_driver.h         |  6 ++++
+ lib/ethdev/rte_ethdev.c            | 14 +++++++++
+ lib/ethdev/rte_ethdev.h            | 14 +++++++++
+ lib/ethdev/version.map             |  1 +
+ 7 files changed, 87 insertions(+)
+
+diff --git a/drivers/net/intel/ice/ice_ethdev.c b/drivers/net/intel/ice/ice_ethdev.c
+index 21d3795954..a1059bb21a 100644
+--- a/drivers/net/intel/ice/ice_ethdev.c
++++ b/drivers/net/intel/ice/ice_ethdev.c
+@@ -324,6 +324,7 @@ static const struct eth_dev_ops ice_eth_dev_ops = {
+ 	.fec_get_capability           = ice_fec_get_capability,
+ 	.fec_get                      = ice_fec_get,
+ 	.fec_set                      = ice_fec_set,
++	.hdrs_mbuf_set_cb             = ice_hdrs_mbuf_set_cb,
+ 	.buffer_split_supported_hdr_ptypes_get = ice_buffer_split_supported_hdr_ptypes_get,
+ };
+ 
+diff --git a/drivers/net/intel/ice/ice_rxtx.c b/drivers/net/intel/ice/ice_rxtx.c
+index 807dbdc9e0..eaf87baf7f 100644
+--- a/drivers/net/intel/ice/ice_rxtx.c
++++ b/drivers/net/intel/ice/ice_rxtx.c
+@@ -488,6 +488,14 @@ ice_alloc_rx_queue_mbufs(struct ice_rx_queue *rxq)
+ 				PMD_DRV_LOG(ERR, "Failed to allocate payload mbuf for RX");
+ 				return -ENOMEM;
+ 			}
++			if (rxq->hdrs_mbuf_cb) {
++				struct rte_eth_hdrs_mbuf hdrs_mbuf;
++				int ret = rxq->hdrs_mbuf_cb(rxq->hdrs_mbuf_cb_priv, &hdrs_mbuf);
++				if (ret >= 0) {
++					mbuf_pay->buf_addr = hdrs_mbuf.buf_addr;
++					mbuf_pay->buf_iova = hdrs_mbuf.buf_iova;
++				}
++			}
+ 
+ 			mbuf_pay->next = NULL;
+ 			mbuf_pay->data_off = RTE_PKTMBUF_HEADROOM;
+@@ -1913,6 +1921,14 @@ ice_rx_alloc_bufs(struct ice_rx_queue *rxq)
+ 		} else {
+ 			mb->next = rxq->sw_split_buf[i].mbuf;
+ 			pay_addr = rte_cpu_to_le_64(rte_mbuf_data_iova_default(mb->next));
++			if (rxq->hdrs_mbuf_cb) {
++				struct rte_eth_hdrs_mbuf hdrs_mbuf;
++				int ret = rxq->hdrs_mbuf_cb(rxq->hdrs_mbuf_cb_priv, &hdrs_mbuf);
++				if (ret >= 0) {
++					mb->next->buf_addr = hdrs_mbuf.buf_addr;
++					mb->next->buf_iova = hdrs_mbuf.buf_iova;
++				}
++			}
+ 			rxdp[i].read.hdr_addr = dma_addr;
+ 			rxdp[i].read.pkt_addr = pay_addr;
+ 		}
+@@ -2602,6 +2618,14 @@ ice_recv_pkts(void *rx_queue,
+ 				rte_pktmbuf_free(nmb);
+ 				break;
+ 			}
++			if (rxq->hdrs_mbuf_cb) {
++				struct rte_eth_hdrs_mbuf hdrs_mbuf;
++				int ret = rxq->hdrs_mbuf_cb(rxq->hdrs_mbuf_cb_priv, &hdrs_mbuf);
++				if (ret >= 0) {
++					nmb_pay->buf_addr = hdrs_mbuf.buf_addr;
++					nmb_pay->buf_iova = hdrs_mbuf.buf_iova;
++				}
++			}
+ 
+ 			nmb->next = nmb_pay;
+ 			nmb_pay->next = NULL;
+@@ -4740,3 +4764,25 @@ ice_fdir_programming(struct ice_pf *pf, struct ice_fltr_desc *fdir_desc)
+ 
+ 
+ }
++
++int
++ice_hdrs_mbuf_set_cb(struct rte_eth_dev *dev, uint16_t rx_queue_id,
++					void *priv, rte_eth_hdrs_mbuf_callback_fn cb) {
++	struct ice_rx_queue *rxq;
++
++	rxq = dev->data->rx_queues[rx_queue_id];
++	if (!rxq) {
++		PMD_DRV_LOG(ERR, "RX queue %u not available or setup", rx_queue_id);
++		return -EINVAL;
++	}
++
++	if (rxq->hdrs_mbuf_cb) {
++		PMD_DRV_LOG(ERR, "RX queue %u has hdrs mbuf cb already", rx_queue_id);
++		return -EINVAL;
++	}
++
++	rxq->hdrs_mbuf_cb_priv = priv;
++	rxq->hdrs_mbuf_cb = cb;
++	PMD_DRV_LOG(NOTICE, "RX queue %u register hdrs mbuf cb at %p", rx_queue_id, cb);
++	return 0;
++}
+\ No newline at end of file
+diff --git a/drivers/net/intel/ice/ice_rxtx.h b/drivers/net/intel/ice/ice_rxtx.h
+index 276d40b57f..130a22885a 100644
+--- a/drivers/net/intel/ice/ice_rxtx.h
++++ b/drivers/net/intel/ice/ice_rxtx.h
+@@ -144,6 +144,9 @@ struct ice_rx_queue {
+ 	struct rte_eth_rxseg_split rxseg[ICE_RX_MAX_NSEG];
+ 	uint32_t rxseg_nb;
+ 	bool ts_enable; /* if rxq timestamp is enabled */
++
++	rte_eth_hdrs_mbuf_callback_fn hdrs_mbuf_cb;
++	void *hdrs_mbuf_cb_priv;
+ };
+ 
+ /* Offload features */
+@@ -295,6 +298,8 @@ uint16_t ice_xmit_pkts_vec_avx512_offload(void *tx_queue,
+ int ice_fdir_programming(struct ice_pf *pf, struct ice_fltr_desc *fdir_desc);
+ int ice_tx_done_cleanup(void *txq, uint32_t free_cnt);
+ int ice_get_monitor_addr(void *rx_queue, struct rte_power_monitor_cond *pmc);
++int ice_hdrs_mbuf_set_cb(struct rte_eth_dev *dev, uint16_t rx_queue_id,
++				void *priv, rte_eth_hdrs_mbuf_callback_fn cb);
+ 
+ #define FDIR_PARSING_ENABLE_PER_QUEUE(ad, on) do { \
+ 	int i; \
+diff --git a/lib/ethdev/ethdev_driver.h b/lib/ethdev/ethdev_driver.h
+index 2b4d2ae9c3..6cbffcabe1 100644
+--- a/lib/ethdev/ethdev_driver.h
++++ b/lib/ethdev/ethdev_driver.h
+@@ -1254,6 +1254,9 @@ typedef int (*eth_cman_config_set_t)(struct rte_eth_dev *dev,
+ typedef int (*eth_cman_config_get_t)(struct rte_eth_dev *dev,
+ 				struct rte_eth_cman_config *config);
+ 
++typedef int (*eth_hdrs_mbuf_set_cb_t)(struct rte_eth_dev *dev, uint16_t rx_queue_id,
++				void *priv, rte_eth_hdrs_mbuf_callback_fn cb);
++
+ /**
+  * @internal
+  * Dump Rx descriptor info to a file.
+@@ -1612,6 +1615,9 @@ struct eth_dev_ops {
+ 	/** Dump Tx descriptor info */
+ 	eth_tx_descriptor_dump_t eth_tx_descriptor_dump;
+ 
++	/** Set buffer split mbuf call back func */
++	eth_hdrs_mbuf_set_cb_t hdrs_mbuf_set_cb;
++
+ 	/** Get congestion management information */
+ 	eth_cman_info_get_t cman_info_get;
+ 	/** Initialize congestion management structure with default values */
+diff --git a/lib/ethdev/rte_ethdev.c b/lib/ethdev/rte_ethdev.c
+index 85798d0ebc..88f4e41a9d 100644
+--- a/lib/ethdev/rte_ethdev.c
++++ b/lib/ethdev/rte_ethdev.c
+@@ -7070,6 +7070,20 @@ rte_eth_ip_reassembly_conf_set(uint16_t port_id,
+ 	return ret;
+ }
+ 
++int
++rte_eth_hdrs_set_mbuf_callback(uint16_t port_id, uint16_t rx_queue_id, void *priv,
++			    rte_eth_hdrs_mbuf_callback_fn cb)
++{
++	struct rte_eth_dev *dev;
++
++	RTE_ETH_VALID_PORTID_OR_ERR_RET(port_id, -ENODEV);
++	dev = &rte_eth_devices[port_id];
++
++	if (*dev->dev_ops->hdrs_mbuf_set_cb == NULL)
++		return -ENOTSUP;
++	return eth_err(port_id, (*dev->dev_ops->hdrs_mbuf_set_cb)(dev, rx_queue_id, priv, cb));
++}
++
+ int
+ rte_eth_dev_priv_dump(uint16_t port_id, FILE *file)
+ {
+diff --git a/lib/ethdev/rte_ethdev.h b/lib/ethdev/rte_ethdev.h
+index ea7f8c4a1a..b48d2feaf5 100644
+--- a/lib/ethdev/rte_ethdev.h
++++ b/lib/ethdev/rte_ethdev.h
+@@ -6899,6 +6899,20 @@ rte_eth_tx_buffer(uint16_t port_id, uint16_t queue_id,
+ 	return rte_eth_tx_buffer_flush(port_id, queue_id, buffer);
+ }
+ 
++#define ST_HAS_DPDK_HDR_SPLIT
++
++struct rte_eth_hdrs_mbuf {
++	void *buf_addr;
++	rte_iova_t buf_iova;
++};
++
++typedef int (*rte_eth_hdrs_mbuf_callback_fn)(void *priv, struct rte_eth_hdrs_mbuf *mbuf);
++
++__rte_experimental
++int rte_eth_hdrs_set_mbuf_callback(uint16_t port_id, uint16_t rx_queue_id, void *priv,
++			rte_eth_hdrs_mbuf_callback_fn cb);
++
++
+ /**
+  * @warning
+  * @b EXPERIMENTAL: this API may change, or be removed, without prior notice
+diff --git a/lib/ethdev/version.map b/lib/ethdev/version.map
+index 3aacba8614..6dc32b5388 100644
+--- a/lib/ethdev/version.map
++++ b/lib/ethdev/version.map
+@@ -312,6 +312,7 @@ EXPERIMENTAL {
+ 
+ 	# added in 23.11
+ 	rte_eth_dev_rss_algo_name;
++	rte_eth_hdrs_set_mbuf_callback;
+ 	rte_eth_recycle_rx_queue_info_get;
+ 	rte_flow_group_set_miss_actions;
+ 	rte_flow_calc_table_hash;
+-- 
+2.34.1
+

--- a/script/build_dpdk.sh
+++ b/script/build_dpdk.sh
@@ -13,8 +13,8 @@ cd "${script_folder}"
 if [ -n "$1" ]; then
 	dpdk_ver=$1
 else
-	# default to latest 23.11
-	dpdk_ver=23.11
+	# default to latest 25.03
+	dpdk_ver=25.03
 fi
 
 echo "DPDK version: $dpdk_ver"


### PR DESCRIPTION
-  Add patches for DPDK 25.03, `0003-net-ice-revert-PF-ICE-rate-limit-to-non-queue-group-.patch` was dropped
- align mt_ipv4_udp to two-byte boundary: `mt_ipv4_udp` has to be aligned after c14fba6 commit from DPDK.
This commits adds alignment to `rte_ipv4_hdr` structure, which adds
the same requirement to all structures that starts with `rte_ipv4_hdr`.
- unhandled ret from rte_eth_link_get_nowait
