### PR TITLE
Fix: Windows MTL build system, updated msys2_build.yml

### DIFF
--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,12 +74,8 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          NPCAP_ZIP="npcap-sdk-1.12.zip"
-          # Try multiple sources with retries
-          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://nmap.org/npcap/dist/$NPCAP_ZIP || \
-          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://fossies.org/windows/misc/$NPCAP_ZIP || \
-          (echo "Failed to download npcap-sdk from all sources" && exit 1)
-          unzip -d npcap-sdk "$NPCAP_ZIP"
+          wget https://nmap.org/npcap/dist/npcap-sdk-1.12.zip
+          unzip -d npcap-sdk npcap-sdk-1.12.zip
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 
       - name: Checkout MTL code

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -76,8 +76,8 @@ jobs:
         run: |
           wget https://nmap.org/npcap/dist/npcap-sdk-1.12.zip
           unzip -d npcap-sdk npcap-sdk-1.12.zip
-          cp npcap-sdk/Include/* ${MSYSTEM_PREFIX}/include/
-          cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
+          cp -r npcap-sdk/Include/* ${MSYSTEM_PREFIX}/include/
+          cp -r npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 
       - name: Checkout MTL code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,12 +74,8 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          NPCAP_ZIP="npcap-sdk-1.12.zip"
-          # Try multiple sources with retries
-          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://nmap.org/npcap/dist/$NPCAP_ZIP || \
-          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://fossies.org/windows/misc/$NPCAP_ZIP || \
-          (echo "Failed to download npcap-sdk from all sources" && exit 1)
-          unzip -d npcap-sdk "$NPCAP_ZIP"
+          wget https://nmap.org/npcap/dist/npcap-sdk-1.12.zip
+          unzip -d npcap-sdk npcap-sdk-1.12.zip
           cp npcap-sdk/Include/* ${MSYSTEM_PREFIX}/include/
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,8 +74,13 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          wget https://nmap.org/npcap/dist/npcap-sdk-1.12.zip
-          unzip -d npcap-sdk npcap-sdk-1.12.zip
+          NPCAP_ZIP="npcap-sdk-1.12.zip"
+          # Try multiple sources with retries
+          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://nmap.org/npcap/dist/$NPCAP_ZIP || \
+          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://fossies.org/windows/misc/$NPCAP_ZIP || \
+          (echo "Failed to download npcap-sdk from all sources" && exit 1)
+          unzip -d npcap-sdk "$NPCAP_ZIP"
+          cp npcap-sdk/Include/* ${MSYSTEM_PREFIX}/include/
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 
       - name: Checkout MTL code

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,8 +74,9 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          wget https://nmap.org/npcap/dist/npcap-sdk-1.12.zip
-          unzip -d npcap-sdk npcap-sdk-1.12.zip
+          NPCAP_VER="1.13"
+          wget https://nmap.org/npcap/dist/npcap-sdk-${NPCAP_VER}.zip
+          unzip -d npcap-sdk npcap-sdk-${NPCAP_VER}.zip
           cp -r npcap-sdk/Include/* ${MSYSTEM_PREFIX}/include/
           cp -r npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          NPCAP_VER="1.87"
+          NPCAP_VER="1.16"
           wget https://nmap.org/npcap/dist/npcap-sdk-${NPCAP_VER}.zip
           unzip -d npcap-sdk npcap-sdk-${NPCAP_VER}.zip
           cp -r npcap-sdk/Include/* ${MSYSTEM_PREFIX}/include/

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -71,14 +71,6 @@ jobs:
              SDL2_ttf:p
              dlfcn:p
 
-      - name: Setup Python3 action
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Setup Python3 pip install action
-        shell: cmd
-        run: python3 -m pip install meson==1.7.2 ninja
 
       - name: Install npcap-sdk
         run: |
@@ -120,7 +112,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: dpdk
-          key: dpdk-${{ matrix.dpdk }}-${{ matrix.sys }}-${{ steps.hash-patches.outputs.hash }}
+          key: dpdk-${{ matrix.dpdk }}-${{ matrix.sys }}-meson-1.10.1-${{ steps.hash-patches.outputs.hash }}
 
       - name: Checkout DPDK code
         if: ${{ steps.cache-dpdk.outputs.cache-hit != 'true' }}

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,8 +74,12 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          wget https://github.com/nmap/npcap/releases/download/v1.12/npcap-sdk-1.12.zip
-          unzip -d npcap-sdk npcap-sdk-1.12.zip
+          NPCAP_ZIP="npcap-sdk-1.12.zip"
+          # Try multiple sources with retries
+          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://nmap.org/npcap/dist/$NPCAP_ZIP || \
+          wget --retry=3 --timeout=30 -O "$NPCAP_ZIP" https://fossies.org/windows/misc/$NPCAP_ZIP || \
+          (echo "Failed to download npcap-sdk from all sources" && exit 1)
+          unzip -d npcap-sdk "$NPCAP_ZIP"
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 
       - name: Checkout MTL code

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          NPCAP_VER="1.13"
+          NPCAP_VER="1.87"
           wget https://nmap.org/npcap/dist/npcap-sdk-${NPCAP_VER}.zip
           unzip -d npcap-sdk npcap-sdk-${NPCAP_VER}.zip
           cp -r npcap-sdk/Include/* ${MSYSTEM_PREFIX}/include/

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -135,7 +135,6 @@ jobs:
 
       - name: Configure
         if: ${{ steps.cache-dpdk.outputs.cache-hit != 'true' }}
-        shell: bash
         run: |
           cd dpdk
           meson setup build

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install npcap-sdk
         run: |
-          wget https://nmap.org/npcap/dist/npcap-sdk-1.12.zip
+          wget https://github.com/nmap/npcap/releases/download/v1.12/npcap-sdk-1.12.zip
           unzip -d npcap-sdk npcap-sdk-1.12.zip
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -4,12 +4,6 @@ on:
   # allow manually trigger
   workflow_dispatch:
 
-env:
-  # FIXME: For some reason enabling jit debugging "fixes" random python crashes
-  # see https://github.com/msys2/MINGW-packages/issues/11864 and
-  # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3280#note_1678973
-  MSYS: winjitdebug
-
 permissions:
   contents: read
 
@@ -22,7 +16,7 @@ jobs:
       changed: ${{ steps.filter.outputs.msys2_build == 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
         with:
@@ -31,14 +25,16 @@ jobs:
   build:
     needs: changes
     if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.changes.outputs.changed == 'true' }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.win-ver }}
     strategy:
       fail-fast: false
       matrix:
-        sys:
-          - mingw64
-          - ucrt64
-        dpdk: [23.11, 23.07]
+        include:
+          - { sys: "mingw64", env: "x86_64", dpdk: "23.11", win-ver: "windows-2019" }
+          - { sys: "mingw64", env: "x86_64", dpdk: "23.11", win-ver: "windows-2022" }
+          # - { sys: "mingw64", env: "x86_64", dpdk: "23.11", win-ver: "windows-2025" }
+          # - { sys: "ucrt64",  env: "ucrt-x86_64", dpdk: "23.11", win-ver: "windows-2022" }
+          # - { sys: "clang64",  env: "clang-x86_64", dpdk: "23.11", win-ver: "windows-2022" }
     defaults:
       run:
         shell: msys2 {0}
@@ -48,26 +44,41 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Install dependencies
+      - name: Install msys2 dependencies
         uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff # v2
         with:
-          msystem: ${{ matrix.sys }}
+          msystem: ${{matrix.sys}}
           update: true
           install: >-
-            git
-            base-devel
-            unzip
+             mingw-w64-${{matrix.env}}-openssl
+             mingw-w64-${{matrix.env}}-gcc
+             mingw-w64-${{matrix.env}}-autotools
+             mingw-w64-${{matrix.env}}-cmake
+             mingw-w64-${{matrix.env}}-make
+             mingw-w64-${{matrix.env}}-ninja
+             git
+             base-devel
+             unzip
+             pactoys
           pacboy: >-
-            pkgconf:p
-            openssl:p
-            gcc:p
-            meson:p
-            json-c:p
-            libpcap:p
-            gtest:p
-            SDL2:p
-            SDL2_ttf:p
-            dlfcn:p
+             toolchain:p
+             pkgconf:p
+             meson:p
+             json-c:p
+             libpcap:p
+             gtest:p
+             SDL2:p
+             SDL2_ttf:p
+             dlfcn:p
+
+      - name: Setup Python3 action
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Setup Python3 pip install action
+        shell: cmd
+        run: python3 -m pip install meson==1.7.2 ninja
 
       - name: Install npcap-sdk
         run: |
@@ -75,7 +86,7 @@ jobs:
           unzip -d npcap-sdk npcap-sdk-1.12.zip
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 
-      - name: Checkout IMTL code
+      - name: Checkout MTL code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Checkout mman-win32 code
@@ -130,29 +141,34 @@ jobs:
           git am ../patches/dpdk/${{matrix.dpdk}}/*.patch
           git am ../patches/dpdk/${{matrix.dpdk}}/windows/*.patch
 
-      - name: Build and install DPDK
+      - name: Configure
         if: ${{ steps.cache-dpdk.outputs.cache-hit != 'true' }}
+        shell: bash
         run: |
           cd dpdk
-          meson setup build -Dplatform=generic
-          meson install -C build
+          meson setup build
+          meson compile -C build
+          # export CMAKE_INSTALL_PREFIX="${MSYSTEM_PREFIX}"
+          # CC=gcc CXX=g++ meson setup build --buildtype release
+          # CC=gcc CXX=g++ meson compile -C build
+          # DESTDIR="${MSYSTEM_PREFIX}" CC=gcc CXX=g++ ninja -C build install
 
-      - name: Install cached DPDK
-        if: ${{ steps.cache-dpdk.outputs.cache-hit == 'true' }}
+      - name: Install cached DPDK dependencies
         run: |
           cd dpdk
-          meson install -C build --no-rebuild
+          DESTDIR="${MSYSTEM_PREFIX}" meson install -C build --no-rebuild
 
-      - name: Build
-        run: |
-          ./build.sh
+      - name: Build MTL
+        run: CMAKE_INSTALL_PREFIX="${MSYSTEM_PREFIX}" ./build.sh
 
       - name: Build with debug
         run: |
+          export CMAKE_INSTALL_PREFIX="${MSYSTEM_PREFIX}"
           rm build -rf
           ./build.sh debugonly
 
       - name: Build with TAP
         run: |
+          export CMAKE_INSTALL_PREFIX="${MSYSTEM_PREFIX}"
           meson setup tap_build -Denable_tap=true
           meson install -C tap_build

--- a/.github/workflows/windows_build_with_gtest.yml
+++ b/.github/workflows/windows_build_with_gtest.yml
@@ -3,14 +3,6 @@ name: win_gtest
 on:
   # allow manually trigger
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - 'maint-**'
-  pull_request:
-    branches:
-      - main
-      - 'maint-**'
 
 concurrency:
   group: win-${{ github.head_ref || github.run_id }}
@@ -36,7 +28,7 @@ jobs:
       changed: ${{ steps.filter.outputs.windows_gtest == 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
         with:
@@ -45,16 +37,22 @@ jobs:
   Build_and_Test:
     needs: changes
     if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' && needs.changes.outputs.changed == 'true' }}
-    runs-on: [Windows, self-hosted]
+    runs-on: windows-2019
     timeout-minutes: 60
     defaults:
       run:
-        shell: C:\msys64\msys2.cmd {0}
+        shell: msys2.cmd {0}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
         with:
           egress-policy: audit
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
 
       - name: Update dependencies
         run: |
@@ -79,12 +77,12 @@ jobs:
           ref: v${{ env.DPDK_VERSION }}
           path: dpdk
           clean: true
-      
+
       - name: Apply patches for DPDK
         run: |
           cd dpdk
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          "C:\Program Files\Git\bin\git.exe" config user.name github-actions
+          "C:\Program Files\Git\bin\git.exe" config user.email github-actions@github.com
           for f in ../patches/dpdk/${{ env.DPDK_VERSION }}/*.patch; do patch -p1 < "$f"; done
           for f in ../patches/dpdk/${{ env.DPDK_VERSION }}/windows/*.patch; do patch -p1 < "$f"; done
 

--- a/lib/src/mt_tap.c
+++ b/lib/src/mt_tap.c
@@ -366,15 +366,15 @@ static struct rte_flow* tap_create_flow(struct mt_cni_impl* cni, uint16_t port_i
   action[1].type = RTE_FLOW_ACTION_TYPE_END;
   memset(pkt_buf, 0, sizeof(pkt_buf));
   memset(msk_buf, 0, sizeof(msk_buf));
-  snprintf(pkt_buf, 84, "%s",
+  snprintf(pkt_buf, 85, "%s",
            "00000000000100000000000208060001080006040000000000000001010101010000000000020"
            "2020202");
-  snprintf(pkt_buf, 12, "%02x%02x%02x%02x%02x%02x", tap_ctx->mac_addr.addr_bytes[0],
+  snprintf(pkt_buf, 13, "%02x%02x%02x%02x%02x%02x", tap_ctx->mac_addr.addr_bytes[0],
            tap_ctx->mac_addr.addr_bytes[1], tap_ctx->mac_addr.addr_bytes[2],
            tap_ctx->mac_addr.addr_bytes[3], tap_ctx->mac_addr.addr_bytes[4],
            tap_ctx->mac_addr.addr_bytes[5]);
   info("Flow bind to mac address %12.12s \n", pkt_buf);
-  snprintf(msk_buf, 84, "%s",
+  snprintf(msk_buf, 85, "%s",
            "FFFFFFFFFFFF000000000000FFFF0000000000000000000000000000000000000000000000000"
            "0000000");
   memset(pattern, 0, sizeof(pattern));

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -51,6 +51,7 @@ test_cpp_args += ['-Wvla']
 if is_windows
   test_c_args += ['-DWINDOWSENV']
   test_cpp_args += ['-DWINDOWSENV']
+  test_c_args += ['-I' + '..\..\lib\windows']
   ws2_32_dep = cpp_c.find_library('ws2_32', required: true)
 else
   ws2_32_dep = [] # add this when the code uses hton/ntoh

--- a/tests/tools/RxTxApp/meson.build
+++ b/tests/tools/RxTxApp/meson.build
@@ -63,7 +63,9 @@ app_c_args += ['-Wunused-parameter']
 if is_windows
   app_c_args += ['-DWINDOWSENV']
   windows_include_dir = '..\..\lib\windows'
+  windows_include_dir_2 = '..\..\..\..\lib\windows'
   app_c_args += ['-I' + windows_include_dir]
+  app_c_args += ['-I' + windows_include_dir_2]
 endif
 
 # simd build option, enable sse4.2 default, todo: do we need AVX2/AVX512 for app ?


### PR DESCRIPTION
FIXED: Windows MTL build system, update msys2_build.yml
- added mandatory fixes for windows build to work with DPDK
- run all build cases using mingw64 environment
- minor fixes to the code due to build failing

UPADTE: updated to allow msys2_build.yml to use GitHub hosted runner and set runner OS version to all 3 available windowses.