### PR TITLE
Add: logging directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ dkms.conf
 # Ours
 .*
 *.log
+*.log_*
+logs_*
 *.patch
 !patches/*.patch
 !ecosystem/*.patch


### PR DESCRIPTION
Add logging directories to .gitignore for the
reproduction automatic tests for GStreamer.