### PR TITLE
Fix: RxTxApp requires a JSON url parameter

### DIFF
--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -2095,7 +2095,6 @@ static int st_json_parse_rx_st20p(int idx, json_object* st20p_obj,
     info("%s, no st20p url no file will be saved\n", __func__);
   }
 
-
   /* parse display option */
   st20p->display =
       json_object_get_boolean(st_json_object_object_get(st20p_obj, "display"));

--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -2091,7 +2091,10 @@ static int st_json_parse_rx_st20p(int idx, json_object* st20p_obj,
 
   /* parse st20p url */
   ret = parse_url(st20p_obj, "st20p_url", st20p->info.st20p_url);
-  if (ret < 0) return ret;
+  if (ret < 0) {
+    info("%s, no st20p url no file will be saved\n", __func__);
+  }
+
 
   /* parse display option */
   st20p->display =


### PR DESCRIPTION
Change the parser to accept the lack of a URL parameter
for rx session, as we can ignore the input and no
json examples have this included.

fixes: 353b64b595e85fc4e1e6ce078b2c3b1fad906db5