### PR TITLE
Add: GSstreamer st20p plugin parameter PTS clock

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -180,7 +180,8 @@ To be fixed in the future.
 |----------------------|----------|-------------------------------------------------------|-------------------------|---------------|
 | retry                | uint     | Number of times the MTL will try to get a frame.      | 0 to G_MAXUINT          | 10            |
 | tx-framebuff-num     | uint     | Number of framebuffers to be used for transmission.   | 0 to 8                  | 3             |
-| async-session-create | boolean | Improve initialization time by creating a session in a separate thread. All buffers that arrive before the session is ready will be dropped | TRUE/FALSE              | FALSE         |
+| async-session-create | boolean  | Improve initialization time by creating a session in a separate thread. All buffers that arrive before the session is ready will be dropped | TRUE/FALSE              | FALSE         |
+| use-pts-for-timestamp | boolean | Use the pts timestamps as base for the RTS timestamp  | TRUE/FALSE              | FALSE         |
 
 #### 3.1.2. Preparing Input Video
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.h
@@ -71,6 +71,7 @@ struct _Gst_Mtl_St20p_Tx {
   SessionPortArgs portArgs; /* imtl session device */
   guint framebuffer_num;
   gboolean async_session_create;
+  gboolean use_pts_for_timestamp;
 
   /* TODO add support for gpu direct */
 #ifdef MTL_GPU_DIRECT_ENABLED


### PR DESCRIPTION
Add the ability for MTL gstreamer st20p plugin to
use PTS clock for timestamping.