### PR TITLE
Add: GStreamer st40p plugins PTS timestamping

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -369,6 +369,7 @@ The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked
 | tx-fps            | uint | Framerate of the video to which the ancillary data is synchronized.| [Supported video fps fractions](#231-supported-video-fps-fractions) | 25/1 |
 | tx-did            | uint | Data ID for the ancillary data.                                    | 0 to 255      | 0             |
 | tx-sdid           | uint | Secondary Data ID for the ancillary data.                          | 0 to 255      | 0             |
+| use-pts-for-timestamp | boolean | Use the pts timestamps as base for the RTS timestamp        | TRUE/FALSE    | FALSE         |
 
 #### 5.1.2. Example GStreamer Pipeline for Transmission
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -454,8 +454,8 @@ static GstFlowReturn gst_mtl_st40p_tx_chain(GstPad* pad, GstObject* parent,
 
       // By default, timestamping is handled by MTL.
       if (sink->use_pts_for_timestamp) {
-        frame->timestamp = GST_BUFFER_PTS(buf);
-        frame->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
+        frame_info->timestamp = GST_BUFFER_PTS(buf);
+        frame_info->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
       }
 
       cur_addr_buf = map_info.data + gst_buffer_get_size(buf) - bytes_to_write;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -98,6 +98,7 @@ enum {
   PROP_ST40P_TX_FRAMERATE,
   PROP_ST40P_TX_DID,
   PROP_ST40P_TX_SDID,
+  PROP_ST40P_TX_USE_PTS_FOR_TIMESTAMP,
   PROP_MAX
 };
 
@@ -173,6 +174,12 @@ static void gst_mtl_st40p_tx_class_init(Gst_Mtl_St40p_TxClass* klass) {
       g_param_spec_uint("tx-sdid", "Secondary Data ID",
                         "Secondary Data ID for the ancillary data", 0, 0xff, 0,
                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property(
+      gobject_class, PROP_ST40P_TX_USE_PTS_FOR_TIMESTAMP,
+      g_param_spec_boolean("use-pts-for-timestamp", "Use PTS for Timestamp",
+                           "Use PTS from buffer as timestamp.", FALSE,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
 
 static gboolean gst_mtl_st40p_tx_start(GstBaseSink* bsink) {
@@ -238,6 +245,9 @@ static void gst_mtl_st40p_tx_set_property(GObject* object, guint prop_id,
     case PROP_ST40P_TX_SDID:
       self->sdid = g_value_get_uint(value);
       break;
+    case PROP_ST40P_TX_USE_PTS_FOR_TIMESTAMP:
+      self->use_pts_for_timestamp = g_value_get_boolean(value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
       break;
@@ -266,6 +276,9 @@ static void gst_mtl_st40p_tx_get_property(GObject* object, guint prop_id, GValue
       break;
     case PROP_ST40P_TX_SDID:
       g_value_set_uint(value, sink->sdid);
+      break;
+    case PROP_ST40P_TX_USE_PTS_FOR_TIMESTAMP:
+      g_value_set_boolean(value, sink->use_pts_for_timestamp);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -322,12 +335,16 @@ static gboolean gst_mtl_st40p_tx_session_create(Gst_Mtl_St40p_Tx* sink) {
     return FALSE;
   }
 
+  if (sink->use_pts_for_timestamp) {
+    ops_tx.flags |= ST40P_TX_FLAG_USER_TIMESTAMP;
+  }
+
   ops_tx.interlaced = false;
   /* Only single ANC data packet is possible per frame. ANC_Count = 1 TODO: allow more */
   sink->frame_size = MAX_UDW_SIZE;
   ops_tx.max_udw_buff_size = MAX_UDW_SIZE;
 
-  ops_tx.flags |= ST30P_TX_FLAG_BLOCK_GET;
+  ops_tx.flags |= ST40P_TX_FLAG_BLOCK_GET;
   sink->tx_handle = st40p_tx_create(sink->mtl_lib_handle, &ops_tx);
   if (!sink->tx_handle) {
     GST_ERROR("Failed to create st40p tx handle");
@@ -434,6 +451,13 @@ static GstFlowReturn gst_mtl_st40p_tx_chain(GstPad* pad, GstObject* parent,
         GST_ERROR("Failed to get frame");
         return GST_FLOW_ERROR;
       }
+
+      // By default, timestamping is handled by MTL.
+      if (sink->use_pts_for_timestamp) {
+        frame->timestamp = GST_BUFFER_PTS(buf);
+        frame->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
+      }
+
       cur_addr_buf = map_info.data + gst_buffer_get_size(buf) - bytes_to_write;
       bytes_to_write_cur =
           bytes_to_write > sink->frame_size ? sink->frame_size : bytes_to_write;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -337,6 +337,7 @@ static gboolean gst_mtl_st40p_tx_session_create(Gst_Mtl_St40p_Tx* sink) {
 
   if (sink->use_pts_for_timestamp) {
     ops_tx.flags |= ST40P_TX_FLAG_USER_TIMESTAMP;
+    ops_tx.flags |= ST40P_TX_FLAG_USER_PACING;
   }
 
   ops_tx.interlaced = false;
@@ -455,7 +456,7 @@ static GstFlowReturn gst_mtl_st40p_tx_chain(GstPad* pad, GstObject* parent,
       // By default, timestamping is handled by MTL.
       if (sink->use_pts_for_timestamp) {
         frame_info->timestamp = GST_BUFFER_PTS(buf);
-        frame_info->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
+        frame_info->tfmt = ST10_TIMESTAMP_FMT_TAI;
       }
 
       cur_addr_buf = map_info.data + gst_buffer_get_size(buf) - bytes_to_write;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
@@ -70,6 +70,7 @@ struct _Gst_Mtl_St40p_Tx {
   guint fps_n, fps_d;
   guint did;
   guint sdid;
+  gboolean use_pts_for_timestamp;
 };
 
 G_END_DECLS

--- a/include/experimental/st40_pipeline_api.h
+++ b/include/experimental/st40_pipeline_api.h
@@ -42,6 +42,47 @@ struct st40_frame_info {
   void* priv;
 };
 
+/** Bit define for flags of struct st40p_tx_ops. */
+enum st40p_tx_flag {
+  /**
+   * Flag bit in flags of struct st40_tx_ops.
+   * P TX destination mac assigned by user
+   */
+  ST40P_TX_FLAG_USER_P_MAC = (MTL_BIT32(0)),
+  /**
+   * Flag bit in flags of struct st40_tx_ops.
+   * R TX destination mac assigned by user
+   */
+  ST40P_TX_FLAG_USER_R_MAC = (MTL_BIT32(1)),
+  /**
+   * Flag bit in flags of struct st40_tx_ops.
+   * User control the frame pacing by pass a timestamp in st40_tx_frame_meta,
+   * lib will wait until timestamp is reached for each frame.
+   */
+  ST40P_TX_FLAG_USER_PACING = (MTL_BIT32(3)),
+  /**
+   * Flag bit in flags of struct st40_tx_ops.
+   * If enabled, lib will assign the rtp timestamp to the value in
+   * st40_tx_frame_meta(ST10_TIMESTAMP_FMT_MEDIA_CLK is used)
+   */
+  ST40P_TX_FLAG_USER_TIMESTAMP = (MTL_BIT32(4)),
+  /**
+   * Flag bit in flags of struct st40_tx_ops.
+   * If enable the rtcp.
+   */
+  ST40P_TX_FLAG_ENABLE_RTCP = (MTL_BIT32(5)),
+  /**
+   * Flag bit in flags of struct st40_tx_ops.
+   * If use dedicated queue for TX.
+   */
+  ST40P_TX_FLAG_DEDICATE_QUEUE = (MTL_BIT32(6)),
+  /** Force the numa of the created session, both CPU and memory */
+  ST40P_TX_FLAG_FORCE_NUMA = (MTL_BIT32(8)),
+  /** Enable the st40p_tx_get_frame block behavior to wait until a frame becomes
+   available or timeout(default: 1s, use st40p_tx_set_block_timeout to customize)*/
+  ST40P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
+};
+
 /**
  * The structure describing how to create a tx st2110-40(ancillary) pipeline session.
  * Include the PCIE port and other required info

--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -477,9 +477,18 @@ st40p_tx_handle st40p_tx_create(mtl_handle mt, struct st40p_tx_ops* ops) {
   mt_pthread_mutex_init(&ctx->block_wake_mutex, NULL);
   mt_pthread_cond_wait_init(&ctx->block_wake_cond);
   ctx->block_timeout_ns = NS_PER_S;
-  if (ops->flags & ST40P_TX_FLAG_BLOCK_GET) {
+
+  if (ops->flags & ST40P_TX_FLAG_BLOCK_GET)
     ctx->block_get = true;
-  }
+
+  if (ops->flags & ST40P_TX_FLAG_USER_TIMESTAMP)
+    ctx->ops.flags |= ST40_TX_FLAG_USER_TIMESTAMP;
+
+  if (ops->flags & ST40P_TX_FLAG_USER_PACING)
+    ctx->ops.flags |= ST40_TX_FLAG_USER_PACING;
+
+  if (ops->flags & ST40P_TX_FLAG_ENABLE_RTCP)
+    ctx->ops.flags |= ST40_TX_FLAG_ENABLE_RTCP;
 
   /* copy ops */
   if (ops->name) {

--- a/lib/src/st2110/experimental/st40_pipeline_tx.h
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.h
@@ -52,47 +52,6 @@ struct st40p_tx_ctx {
   int stat_put_frame;
 };
 
-/** Bit define for flags of struct st40p_tx_ops. */
-enum st40p_tx_flag {
-  /**
-   * Flag bit in flags of struct st40_tx_ops.
-   * P TX destination mac assigned by user
-   */
-  ST40P_TX_FLAG_USER_P_MAC = (MTL_BIT32(0)),
-  /**
-   * Flag bit in flags of struct st40_tx_ops.
-   * R TX destination mac assigned by user
-   */
-  ST40P_TX_FLAG_USER_R_MAC = (MTL_BIT32(1)),
-  /**
-   * Flag bit in flags of struct st40_tx_ops.
-   * User control the frame pacing by pass a timestamp in st40_tx_frame_meta,
-   * lib will wait until timestamp is reached for each frame.
-   */
-  ST40P_TX_FLAG_USER_PACING = (MTL_BIT32(3)),
-  /**
-   * Flag bit in flags of struct st40_tx_ops.
-   * If enabled, lib will assign the rtp timestamp to the value in
-   * st40_tx_frame_meta(ST10_TIMESTAMP_FMT_MEDIA_CLK is used)
-   */
-  ST40P_TX_FLAG_USER_TIMESTAMP = (MTL_BIT32(4)),
-  /**
-   * Flag bit in flags of struct st40_tx_ops.
-   * If enable the rtcp.
-   */
-  ST40P_TX_FLAG_ENABLE_RTCP = (MTL_BIT32(5)),
-  /**
-   * Flag bit in flags of struct st40_tx_ops.
-   * If use dedicated queue for TX.
-   */
-  ST40P_TX_FLAG_DEDICATE_QUEUE = (MTL_BIT32(6)),
-  /** Force the numa of the created session, both CPU and memory */
-  ST40P_TX_FLAG_FORCE_NUMA = (MTL_BIT32(8)),
-  /** Enable the st40p_tx_get_frame block behavior to wait until a frame becomes
-   available or timeout(default: 1s, use st40p_tx_set_block_timeout to customize)*/
-  ST40P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
-};
-
 struct st40p_tx_frame {
   enum st40p_tx_frame_status stat;
   struct st40_frame_info frame_info;


### PR DESCRIPTION
    Fix the st40 pipeline mode API not including
    flags.
    
    Add parameters for PTS timestamping to the st40p
    pipeline plugin for the GSstreamer.
