### PR TITLE
Fix: RL pacing on DPDK 25.03

### DIFF
--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -344,6 +344,7 @@ static int cni_traffic(struct mtl_main_impl* impl) {
   for (int i = 0; i < num_ports; i++) {
     cni = cni_get_entry(impl, i);
     if (!cni->rxq) continue;
+    if (rte_atomic32_read(&impl->inf[i].resetting)) continue;
 
     struct mt_rx_pcap* pcap = &cni->pcap;
     /* if any pcap progress */

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -708,6 +708,8 @@ struct mt_interface {
   struct rte_ether_addr* mcast_mac_lists; /* pool of multicast mac addrs */
   uint32_t mcast_nb;                      /* number of address */
   uint32_t status;                        /* MT_IF_STAT_* */
+  /* The port is temporarily off, e.g. during rte_tm_hierarchy_commit */
+  rte_atomic32_t resetting;
 
   /* default tx mbuf_pool */
   struct rte_mempool* tx_mbuf_pool;


### PR DESCRIPTION
- Use an eight-level hierarchical schedule for PF
- Don't use shapers for non-leaf nodes, as thier rules are now correctly inherated to leaf nodes
- Stop calling rte_eth_rx_burst() while rte_tm_hierarchy_commit() is in progress, as it causes error logs.
- Rename dev_rl_init_root to dev_rl_init_nonleaf_nodes and move it out of dev_rl_shaper_add