### PR TITLE
    Add: Async session creation for st40p GStreamer

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -363,12 +363,13 @@ The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked
 - **Capabilities**: Any (GST_STATIC_CAPS_ANY)
 
 **Arguments**
-| Property Name     | Type | Description                                                        | Range         | Default Value |
-|-------------------|------|--------------------------------------------------------------------|---------------|---------------|
-| tx-framebuff-cnt  | uint | Number of framebuffers to be used for transmission.                | 0 to G_MAXUINT| 3             |
-| tx-fps            | uint | Framerate of the video to which the ancillary data is synchronized.| [Supported video fps fractions](#231-supported-video-fps-fractions) | 25/1 |
-| tx-did            | uint | Data ID for the ancillary data.                                    | 0 to 255      | 0             |
-| tx-sdid           | uint | Secondary Data ID for the ancillary data.                          | 0 to 255      | 0             |
+| Property Name        | Type    | Description                                                        | Range         | Default Value |
+|----------------------|---------|--------------------------------------------------------------------|---------------|---------------|
+| tx-framebuff-cnt     | uint    | Number of framebuffers to be used for transmission.                | 0 to G_MAXUINT| 3             |
+| tx-fps               | uint    | Framerate of the video to which the ancillary data is synchronized.| [Supported video fps fractions](#231-supported-video-fps-fractions) | 25/1 |
+| tx-did               | uint    | Data ID for the ancillary data.                                    | 0 to 255      | 0             |
+| tx-sdid              | uint    | Secondary Data ID for the ancillary data.                          | 0 to 255      | 0             |
+| async-session-create | boolean | Improve initialization time by creating a session in a separate thread. All buffers that arrive before the session is ready will be dropped. | TRUE/FALSE | FALSE |
 
 #### 5.1.2. Example GStreamer Pipeline for Transmission
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -201,7 +201,11 @@ static gboolean gst_mtl_st30p_tx_start(GstBaseSink* bsink) {
   }
 
   if (sink->async_session_create) {
-    pthread_mutex_init(&sink->session_mutex, NULL);
+    if (pthread_mutex_init(&sink->session_mutex, NULL)) {
+      GST_ERROR("Failed to initialize mutex");
+      return FALSE;
+    }
+
     sink->session_ready = FALSE;
   }
 
@@ -419,10 +423,21 @@ static gboolean gst_mtl_st30p_tx_sink_event(GstPad* pad, GstObject* parent,
       gst_event_parse_caps(event, &caps);
       if (sink->async_session_create) {
         thread_data = malloc(sizeof(GstMtlSt30pTxThreadData));
+        if (!thread_data) {
+          GST_ERROR("Failed to allocate memory for thread data");
+          return FALSE;
+        }
+
         thread_data->sink = sink;
         thread_data->caps = gst_caps_ref(caps);
         pthread_create(&sink->session_thread, NULL,
                        gst_mtl_st30p_tx_session_create_thread, thread_data);
+
+        if (&sink->session_thread == NULL) {
+          GST_ERROR("Failed to create session thread");
+          free(thread_data);
+          return FALSE;
+        }
       } else {
         ret = gst_mtl_st30p_tx_session_create(sink, caps);
         if (!ret) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -392,6 +392,11 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
   } else if (src->udw_size == 0) {
     src->udw_size = udw_size;
     src->anc_data = (char*)malloc(udw_size);
+    if(!src->anc_data) {
+      GST_ERROR("Failed to allocate memory for ancillary data");
+      return GST_FLOW_ERROR;
+    }
+
   } else if (src->udw_size != udw_size) {
     GST_INFO("Size of received ancillary data has changed");
     if (src->anc_data) {
@@ -400,6 +405,10 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
     }
     src->udw_size = udw_size;
     src->anc_data = (char*)malloc(udw_size);
+    if(!src->anc_data) {
+      GST_ERROR("Failed to allocate memory for ancillary data");
+      return GST_FLOW_ERROR;
+    }
   }
 
   *buffer = gst_buffer_new_allocate(NULL, src->udw_size, NULL);

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -378,7 +378,6 @@ static void* gst_mtl_st40p_tx_session_create_thread(void* data) {
   return NULL;
 }
 
-
 static gboolean gst_mtl_st40p_tx_sink_event(GstPad* pad, GstObject* parent,
                                             GstEvent* event) {
   GstMtlSt40pTxThreadData* thread_data;
@@ -517,10 +516,10 @@ static void gst_mtl_st40p_tx_finalize(GObject* object) {
   }
 
   if (sink->tx_handle && st40p_tx_free(sink->tx_handle))
-      GST_ERROR("Failed to free tx handle");
+    GST_ERROR("Failed to free tx handle");
 
   if (sink->mtl_lib_handle && gst_mtl_common_deinit_handle(&sink->mtl_lib_handle))
-      GST_ERROR("Failed to uninitialize MTL library");
+    GST_ERROR("Failed to uninitialize MTL library");
 }
 
 static gboolean plugin_init(GstPlugin* mtl_st40p_tx) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
@@ -62,6 +62,10 @@ struct _Gst_Mtl_St40p_Tx {
   st40p_tx_handle tx_handle;
   guint frame_size;
 
+  gboolean session_ready;
+  pthread_mutex_t session_mutex;
+  pthread_t session_thread;
+
   /* arguments */
   guint log_level;
   GeneralArgs generalArgs;  /* imtl initialization arguments */
@@ -70,6 +74,7 @@ struct _Gst_Mtl_St40p_Tx {
   guint fps_n, fps_d;
   guint did;
   guint sdid;
+  gboolean async_session_create;
 };
 
 G_END_DECLS


### PR DESCRIPTION
 Introduce async session creation for the st40p
    into GStreamer plugin.
    Unlike the st30p and st20p plugins,
    this implementation uses the START signal instead
    of the capabilities negotiation signal,
    as the st40p plugin accepts all caps.