### PR TITLE
Add: handling case where RL is lower then expected

### DIFF
--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -62,9 +62,11 @@ extern "C" {
 #define ST20_TX_FLAG_ENABLE_VSYNC (MTL_BIT32(5))
 /**
  * Flag bit in flags of struct st20_tx_ops.
- * If disable the static RL pad interval profiling.
+ * If enable the static RL pad interval profiling.
+ * Static padding is trained only for e810, it is not recommended to use this flag
+ * for other NICs.
  */
-#define ST20_TX_FLAG_DISABLE_STATIC_PAD_P (MTL_BIT32(6))
+#define ST20_TX_FLAG_ENABLE_STATIC_PAD_P (MTL_BIT32(6))
 /**
  * Flag bit in flags of struct st20_tx_ops.
  * If enable the rtcp.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -446,9 +446,11 @@ enum st20p_tx_flag {
    */
   ST20P_TX_FLAG_ENABLE_VSYNC = (MTL_BIT32(5)),
   /**
-   * If disable the static RL pad interval profiling.
+   * If enable the static RL pad interval profiling.
+   * Static padding is trained only for e810, it is not recommended to use this flag
+   * for other NICs.
    */
-  ST20P_TX_FLAG_DISABLE_STATIC_PAD_P = (MTL_BIT32(6)),
+  ST20P_TX_FLAG_ENABLE_STATIC_PAD_P = (MTL_BIT32(6)),
   /**
    * If enable the rtcp.
    */

--- a/lib/src/datapath/mt_queue.c
+++ b/lib/src/datapath/mt_queue.c
@@ -45,7 +45,20 @@ static uint16_t rx_csq_burst(struct mt_rxq_entry* entry, struct rte_mbuf** rx_pk
 
 static uint16_t rx_dpdk_burst(struct mt_rxq_entry* entry, struct rte_mbuf** rx_pkts,
                               const uint16_t nb_pkts) {
-  return mt_dpdk_rx_burst(entry->rxq, rx_pkts, nb_pkts);
+  enum mtl_port port_id = entry->rxq->port;
+  struct mt_interface* inf = mt_if(entry->parent, port_id);
+  int ret;
+
+  /* Trylock as we should not block in tasklates */
+  ret = mt_pthread_rwlock_tryrdlock(&inf->rl_rwlock);
+  if (ret) {
+    dbg("%s(%d), try lock fail %d\n", __func__, port_id, ret);
+    return 0;
+  }
+  ret = mt_dpdk_rx_burst(entry->rxq, rx_pkts, nb_pkts);
+  mt_pthread_rwlock_unlock(&inf->rl_rwlock);
+
+  return ret;
 }
 
 struct mt_rxq_entry* mt_rxq_get(struct mtl_main_impl* impl, enum mtl_port port,
@@ -163,7 +176,20 @@ static uint16_t tx_tsq_burst(struct mt_txq_entry* entry, struct rte_mbuf** tx_pk
 
 static uint16_t tx_dpdk_burst(struct mt_txq_entry* entry, struct rte_mbuf** tx_pkts,
                               uint16_t nb_pkts) {
-  return mt_dpdk_tx_burst(entry->txq, tx_pkts, nb_pkts);
+  enum mtl_port port_id = entry->txq->port;
+  struct mt_interface* inf = mt_if(entry->parent, port_id);
+  uint16_t ret;
+
+  /* Trylock as we should not block in tasklates */
+  ret = mt_pthread_rwlock_tryrdlock(&inf->rl_rwlock);
+  if (ret) {
+    dbg("%s(%d), try lock fail %d\n", __func__, port_id, ret);
+    return 0;
+  }
+  ret = mt_dpdk_tx_burst(entry->txq, tx_pkts, nb_pkts);
+  mt_pthread_rwlock_unlock(&inf->rl_rwlock);
+
+  return ret;
 }
 
 struct mt_txq_entry* mt_txq_get(struct mtl_main_impl* impl, enum mtl_port port,

--- a/lib/src/mt_cni.c
+++ b/lib/src/mt_cni.c
@@ -344,7 +344,6 @@ static int cni_traffic(struct mtl_main_impl* impl) {
   for (int i = 0; i < num_ports; i++) {
     cni = cni_get_entry(impl, i);
     if (!cni->rxq) continue;
-    if (rte_atomic32_read(&impl->inf[i].resetting)) continue;
 
     struct mt_rx_pcap* pcap = &cni->pcap;
     /* if any pcap progress */

--- a/lib/src/mt_flow.c
+++ b/lib/src/mt_flow.c
@@ -27,6 +27,7 @@ static struct rte_flow* rte_rx_flow_create_raw(struct mt_interface* inf, uint16_
   struct rte_flow_item_raw spec = {0};
   struct rte_flow_item_raw mask = {0};
   struct rte_flow_action_queue to_queue = {0};
+  int ret;
 
   uint16_t port_id = inf->port_id;
   char pkt_buf[] =
@@ -58,9 +59,17 @@ static struct rte_flow* rte_rx_flow_create_raw(struct mt_interface* inf, uint16_
   action[0].conf = &to_queue;
   action[1].type = RTE_FLOW_ACTION_TYPE_END;
 
-  mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
+  ret = mt_pthread_rwlock_wrlock(&inf->rl_rwlock);
+  if (ret) {
+    err("%s(%d), failed to acquire write lock, ret %d\n", __func__, port_id, ret);
+    return NULL;
+  }
   r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
-  mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+  ret = mt_pthread_rwlock_unlock(&inf->rl_rwlock);
+  if (ret) {
+    err("%s(%d), failed to release write lock, ret %d\n", __func__, port_id, ret);
+    return NULL;
+  }
   if (!r_flow) {
     err("%s(%d), rte_flow_create fail for queue %d, %s\n", __func__, port_id, q,
         mt_string_safe(error.message));
@@ -175,9 +184,17 @@ static struct rte_flow* rte_rx_flow_create(struct mt_interface* inf, uint16_t q,
     return NULL;
   }
 
-  mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
+  ret = mt_pthread_rwlock_wrlock(&inf->rl_rwlock);
+  if (ret) {
+    err("%s(%d), failed to acquire write lock, ret %d\n", __func__, port_id, ret);
+    return NULL;
+  }
   r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
-  mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+  ret = mt_pthread_rwlock_unlock(&inf->rl_rwlock);
+  if (ret) {
+    err("%s(%d), failed to release write lock, ret %d\n", __func__, port_id, ret);
+    return NULL;
+  }
 
   /* WA specific for e810 for PF interfaces */
   if (!has_ip_flow && !r_flow) {
@@ -192,9 +209,17 @@ static struct rte_flow* rte_rx_flow_create(struct mt_interface* inf, uint16_t q,
       return NULL;
     }
 
-    mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
+    ret = mt_pthread_rwlock_wrlock(&inf->rl_rwlock);
+    if (ret) {
+      err("%s(%d), failed to acquire write lock, ret %d\n", __func__, port_id, ret);
+      return NULL;
+    }
     r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
-    mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+    ret = mt_pthread_rwlock_unlock(&inf->rl_rwlock);
+    if (ret) {
+      err("%s(%d), failed to release write lock, ret %d\n", __func__, port_id, ret);
+      return NULL;
+    }
   }
 
   if (!r_flow) {
@@ -264,6 +289,7 @@ static int rx_flow_free(struct mt_interface* inf, struct mt_rx_flow_rsp* rsp) {
   enum mtl_port port = inf->port;
   struct rte_flow_error error;
   int ret;
+  int rwlock_ret;
   int max_retry = 5;
   int retry = 0;
 
@@ -273,9 +299,18 @@ retry:
     rsp->flow_id = -1;
   }
   if (rsp->flow) {
-    mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
+    rwlock_ret = mt_pthread_rwlock_wrlock(&inf->rl_rwlock);
+    if (rwlock_ret) {
+      err("%s(%d), failed to acquire write lock, ret %d\n", __func__, port, rwlock_ret);
+      return rwlock_ret;
+    }
     ret = rte_flow_destroy(inf->port_id, rsp->flow, &error);
-    mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+    rwlock_ret = mt_pthread_rwlock_unlock(&inf->rl_rwlock);
+    if (rwlock_ret) {
+      err("%s(%d), failed to release write lock, ret %d\n", __func__, port, rwlock_ret);
+      return rwlock_ret;
+    }
+
     if (ret < 0) {
       err("%s(%d), flow destroy fail, queue %d, retry %d\n", __func__, port,
           rsp->queue_id, retry);

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -704,8 +704,6 @@ struct mt_interface {
   struct rte_ether_addr* mcast_mac_lists; /* pool of multicast mac addrs */
   uint32_t mcast_nb;                      /* number of address */
   uint32_t status;                        /* MT_IF_STAT_* */
-  /* The port is temporarily off, e.g. during rte_tm_hierarchy_commit */
-  rte_atomic32_t resetting;
 
   /* default tx mbuf_pool */
   struct rte_mempool* tx_mbuf_pool;
@@ -715,11 +713,9 @@ struct mt_interface {
   uint16_t nb_rx_desc;
 
   struct rte_mbuf* pad;
-  /*
-   * protect rl and fdir for vf.
-   * _atomic_set_cmd(): There is incomplete cmd 112
-   */
-  pthread_mutex_t vf_cmd_mutex;
+
+  /* protect port during reset when changing RL speed */
+  pthread_rwlock_t rl_rwlock;
 
   /* tx queue resources */
   uint16_t nb_tx_q;

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -616,13 +616,9 @@ struct mt_sch_mgr {
   enum mt_lcore_type local_lcores_type[RTE_MAX_LCORE];
 };
 
-struct mt_audio_pacing_train_result {
-  uint64_t input_bps;    /* input, byte per sec */
-  uint64_t profiled_bps; /* profiled result */
-};
-
 struct mt_pacing_train_result {
-  uint64_t rl_bps;           /* input, byte per sec */
+  uint64_t input_bps;           /* input, byte per sec */
+  uint64_t profiled_bps;     /* profiled result */
   float pacing_pad_interval; /* result */
 };
 
@@ -742,8 +738,6 @@ struct mt_interface {
   bool tx_rl_root_active;
   /* video rl pacing train result */
   struct mt_pacing_train_result pt_results[MT_MAX_RL_ITEMS];
-  /* audio rl pacing train result */
-  struct mt_audio_pacing_train_result audio_pt_results[MT_MAX_RL_ITEMS];
 
   /* function ops per interface(pf/vf) */
   uint64_t (*ptp_get_time_fn)(struct mtl_main_impl* impl, enum mtl_port port);

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -617,7 +617,7 @@ struct mt_sch_mgr {
 };
 
 struct mt_pacing_train_result {
-  uint64_t input_bps;           /* input, byte per sec */
+  uint64_t input_bps;        /* input, byte per sec */
   uint64_t profiled_bps;     /* profiled result */
   float pacing_pad_interval; /* result */
 };

--- a/lib/src/mt_platform.h
+++ b/lib/src/mt_platform.h
@@ -93,6 +93,55 @@ static inline int mt_pthread_mutex_destroy(pthread_mutex_t* mutex) {
   return pthread_mutex_destroy(mutex);
 }
 
+static inline int mt_pthread_rwlock_init(pthread_rwlock_t* rwlock,
+                                         pthread_rwlockattr_t* attr) {
+  return pthread_rwlock_init(rwlock, attr);
+}
+
+static inline int mt_pthread_rwlock_pref_wr_init(pthread_rwlock_t* rwlock) {
+  pthread_rwlockattr_t rwlock_attr;
+  int ret;
+
+  ret = pthread_rwlockattr_init(&rwlock_attr);
+  if (ret) return ret;
+
+  ret = pthread_rwlockattr_setkind_np(&rwlock_attr,
+                                      PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+  if (ret) {
+    pthread_rwlockattr_destroy(&rwlock_attr);
+    return ret;
+  }
+
+  ret = pthread_rwlock_init(rwlock, &rwlock_attr);
+  pthread_rwlockattr_destroy(&rwlock_attr);
+
+  return ret;
+}
+
+static inline int mt_pthread_rwlock_rdlock(pthread_rwlock_t* rwlock) {
+  return pthread_rwlock_rdlock(rwlock);
+}
+
+static inline int mt_pthread_rwlock_tryrdlock(pthread_rwlock_t* rwlock) {
+  return pthread_rwlock_tryrdlock(rwlock);
+}
+
+static inline int mt_pthread_rwlock_wrlock(pthread_rwlock_t* rwlock) {
+  return pthread_rwlock_wrlock(rwlock);
+}
+
+static inline int mt_pthread_rwlock_trywrlock(pthread_rwlock_t* rwlock) {
+  return pthread_rwlock_trywrlock(rwlock);
+}
+
+static inline int mt_pthread_rwlock_unlock(pthread_rwlock_t* rwlock) {
+  return pthread_rwlock_unlock(rwlock);
+}
+
+static inline int mt_pthread_rwlock_destroy(pthread_rwlock_t* rwlock) {
+  return pthread_rwlock_destroy(rwlock);
+}
+
 static inline int mt_pthread_cond_init(pthread_cond_t* cond,
                                        pthread_condattr_t* cond_attr) {
   return pthread_cond_init(cond, cond_attr);

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -252,7 +252,7 @@ int mt_build_port_map(struct mtl_main_impl* impl, char** ports, enum mtl_port* m
 }
 
 int mt_pacing_train_pad_result_add(struct mtl_main_impl* impl, enum mtl_port port,
-                               uint64_t input_bps, float pad_interval) {
+                                   uint64_t input_bps, float pad_interval) {
   struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {
@@ -267,7 +267,7 @@ int mt_pacing_train_pad_result_add(struct mtl_main_impl* impl, enum mtl_port por
 }
 
 int mt_pacing_train_pad_result_search(struct mtl_main_impl* impl, enum mtl_port port,
-                                  uint64_t rl_bps, float* pad_interval) {
+                                      uint64_t rl_bps, float* pad_interval) {
   struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {
@@ -282,7 +282,7 @@ int mt_pacing_train_pad_result_search(struct mtl_main_impl* impl, enum mtl_port 
 }
 
 int mt_pacing_train_bps_result_add(struct mtl_main_impl* impl, enum mtl_port port,
-                                     uint64_t input_bps, uint64_t profiled_bps) {
+                                   uint64_t input_bps, uint64_t profiled_bps) {
   struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {
@@ -297,7 +297,7 @@ int mt_pacing_train_bps_result_add(struct mtl_main_impl* impl, enum mtl_port por
 }
 
 int mt_pacing_train_bps_result_search(struct mtl_main_impl* impl, enum mtl_port port,
-                                        uint64_t input_bps, uint64_t* profiled_bps) {
+                                      uint64_t input_bps, uint64_t* profiled_bps) {
   struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {

--- a/lib/src/mt_util.c
+++ b/lib/src/mt_util.c
@@ -251,13 +251,13 @@ int mt_build_port_map(struct mtl_main_impl* impl, char** ports, enum mtl_port* m
   return 0;
 }
 
-int mt_pacing_train_result_add(struct mtl_main_impl* impl, enum mtl_port port,
-                               uint64_t rl_bps, float pad_interval) {
+int mt_pacing_train_pad_result_add(struct mtl_main_impl* impl, enum mtl_port port,
+                               uint64_t input_bps, float pad_interval) {
   struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {
-    if (ptr[i].rl_bps) continue;
-    ptr[i].rl_bps = rl_bps;
+    if (ptr[i].input_bps) continue;
+    ptr[i].input_bps = input_bps;
     ptr[i].pacing_pad_interval = pad_interval;
     return 0;
   }
@@ -266,12 +266,12 @@ int mt_pacing_train_result_add(struct mtl_main_impl* impl, enum mtl_port port,
   return -ENOMEM;
 }
 
-int mt_pacing_train_result_search(struct mtl_main_impl* impl, enum mtl_port port,
+int mt_pacing_train_pad_result_search(struct mtl_main_impl* impl, enum mtl_port port,
                                   uint64_t rl_bps, float* pad_interval) {
   struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {
-    if (rl_bps == ptr[i].rl_bps) {
+    if (rl_bps == ptr[i].input_bps && ptr[i].pacing_pad_interval) {
       *pad_interval = ptr[i].pacing_pad_interval;
       return 0;
     }
@@ -281,9 +281,9 @@ int mt_pacing_train_result_search(struct mtl_main_impl* impl, enum mtl_port port
   return -EINVAL;
 }
 
-int mt_audio_pacing_train_result_add(struct mtl_main_impl* impl, enum mtl_port port,
+int mt_pacing_train_bps_result_add(struct mtl_main_impl* impl, enum mtl_port port,
                                      uint64_t input_bps, uint64_t profiled_bps) {
-  struct mt_audio_pacing_train_result* ptr = &mt_if(impl, port)->audio_pt_results[0];
+  struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {
     if (ptr[i].input_bps) continue;
@@ -296,12 +296,12 @@ int mt_audio_pacing_train_result_add(struct mtl_main_impl* impl, enum mtl_port p
   return -ENOMEM;
 }
 
-int mt_audio_pacing_train_result_search(struct mtl_main_impl* impl, enum mtl_port port,
+int mt_pacing_train_bps_result_search(struct mtl_main_impl* impl, enum mtl_port port,
                                         uint64_t input_bps, uint64_t* profiled_bps) {
-  struct mt_audio_pacing_train_result* ptr = &mt_if(impl, port)->audio_pt_results[0];
+  struct mt_pacing_train_result* ptr = &mt_if(impl, port)->pt_results[0];
 
   for (int i = 0; i < MT_MAX_RL_ITEMS; i++) {
-    if (input_bps == ptr[i].input_bps) {
+    if (input_bps == ptr[i].input_bps && ptr[i].profiled_bps) {
       *profiled_bps = ptr[i].profiled_bps;
       return 0;
     }

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -59,12 +59,12 @@ void mt_mbuf_sanity_check(struct rte_mbuf** mbufs, uint16_t nb, char* tag);
 int mt_pacing_train_pad_result_add(struct mtl_main_impl* impl, enum mtl_port port,
                                    uint64_t input_bps, float pad_interval);
 int mt_pacing_train_pad_result_search(struct mtl_main_impl* impl, enum mtl_port port,
-                                  uint64_t input_bps, float* pad_interval);
+                                      uint64_t input_bps, float* pad_interval);
 
 int mt_pacing_train_bps_result_add(struct mtl_main_impl* impl, enum mtl_port port,
                                    uint64_t input_bps, uint64_t profiled_bps);
 int mt_pacing_train_bps_result_search(struct mtl_main_impl* impl, enum mtl_port port,
-                                  uint64_t input_bps, uint64_t* profiled_bps);
+                                      uint64_t input_bps, uint64_t* profiled_bps);
 
 enum mtl_port mt_port_by_name(struct mtl_main_impl* impl, const char* name);
 int mt_build_port_map(struct mtl_main_impl* impl, char** ports, enum mtl_port* maps,

--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -56,15 +56,15 @@ int mt_ring_dequeue_clean(struct rte_ring* ring);
 
 void mt_mbuf_sanity_check(struct rte_mbuf** mbufs, uint16_t nb, char* tag);
 
-int mt_pacing_train_result_add(struct mtl_main_impl* impl, enum mtl_port port,
-                               uint64_t rl_bps, float pad_interval);
-int mt_pacing_train_result_search(struct mtl_main_impl* impl, enum mtl_port port,
-                                  uint64_t rl_bps, float* pad_interval);
+int mt_pacing_train_pad_result_add(struct mtl_main_impl* impl, enum mtl_port port,
+                                   uint64_t input_bps, float pad_interval);
+int mt_pacing_train_pad_result_search(struct mtl_main_impl* impl, enum mtl_port port,
+                                  uint64_t input_bps, float* pad_interval);
 
-int mt_audio_pacing_train_result_add(struct mtl_main_impl* impl, enum mtl_port port,
-                                     uint64_t input_bps, uint64_t profiled_bps);
-int mt_audio_pacing_train_result_search(struct mtl_main_impl* impl, enum mtl_port port,
-                                        uint64_t input_bps, uint64_t* profiled_bps);
+int mt_pacing_train_bps_result_add(struct mtl_main_impl* impl, enum mtl_port port,
+                                   uint64_t input_bps, uint64_t profiled_bps);
+int mt_pacing_train_bps_result_search(struct mtl_main_impl* impl, enum mtl_port port,
+                                  uint64_t input_bps, uint64_t* profiled_bps);
 
 enum mtl_port mt_port_by_name(struct mtl_main_impl* impl, const char* name);
 int mt_build_port_map(struct mtl_main_impl* impl, char** ports, enum mtl_port* maps,

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -299,8 +299,8 @@ static int tx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_tx
   if (ops->flags & ST20P_TX_FLAG_USER_TIMESTAMP)
     ops_tx.flags |= ST20_TX_FLAG_USER_TIMESTAMP;
   if (ops->flags & ST20P_TX_FLAG_ENABLE_VSYNC) ops_tx.flags |= ST20_TX_FLAG_ENABLE_VSYNC;
-  if (ops->flags & ST20P_TX_FLAG_DISABLE_STATIC_PAD_P)
-    ops_tx.flags |= ST20_TX_FLAG_DISABLE_STATIC_PAD_P;
+  if (ops->flags & ST20P_TX_FLAG_ENABLE_STATIC_PAD_P)
+    ops_tx.flags |= ST20_TX_FLAG_ENABLE_STATIC_PAD_P;
   if (ops->flags & ST20P_TX_FLAG_ENABLE_RTCP) {
     ops_tx.flags |= ST20_TX_FLAG_ENABLE_RTCP;
     ops_tx.rtcp = ops->rtcp;

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -1257,7 +1257,7 @@ static int tx_audio_session_init_rl(struct mtl_main_impl* impl,
     port = mt_port_logic2phy(s->port_maps, i);
 
     uint64_t initial_bytes_per_sec = tx_audio_session_initial_rl_bps(s);
-    int profiled = mt_audio_pacing_train_result_search(impl, port, initial_bytes_per_sec,
+    int profiled = mt_pacing_train_bps_result_search(impl, port, initial_bytes_per_sec,
                                                        &profiled_per_sec);
 
     /* pad pkt */
@@ -1297,7 +1297,7 @@ static int tx_audio_session_init_rl(struct mtl_main_impl* impl,
           return -EIO;
         }
 
-        mt_audio_pacing_train_result_add(impl, port, initial_bytes_per_sec, trained);
+        mt_pacing_train_bps_result_add(impl, port, initial_bytes_per_sec, trained);
         info("%s(%d), trained bytes_per_sec %" PRIu64 "\n", __func__, idx, trained);
         int ret = mt_txq_set_tx_bps(rl_port->queue[j], trained);
         if (ret < 0) {

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -1258,7 +1258,7 @@ static int tx_audio_session_init_rl(struct mtl_main_impl* impl,
 
     uint64_t initial_bytes_per_sec = tx_audio_session_initial_rl_bps(s);
     int profiled = mt_pacing_train_bps_result_search(impl, port, initial_bytes_per_sec,
-                                                       &profiled_per_sec);
+                                                     &profiled_per_sec);
 
     /* pad pkt */
     rl_port->pad = mt_build_pad(impl, mt_sys_tx_mempool(impl, port), port,

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -430,15 +430,15 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
   /* If the measured speed is lower than expected. Set higher bps and retrain to add
    * padding */
   if (measured_bps < rl_bps) {
-    info("%s(%d), measured bps %"PRIu64" is lower then set bps %"PRIu64"\n",
-         __func__, idx, (uint64_t)measured_bps, rl_bps);
+    info("%s(%d), measured bps %" PRIu64 " is lower than set bps %" PRIu64 "\n", __func__,
+         idx, (uint64_t)measured_bps, rl_bps);
     if (!mt_pacing_train_bps_result_search(impl, port, rl_bps, &bps_to_set)) {
       err("%s(%d), measured speed is too low on already trained bps\n", __func__, idx);
       return -EINVAL;
     }
 
     bps_to_set = (rl_bps * rl_bps) / measured_bps;
-    info("%s(%d), increase bps to %"PRIu64"\n", __func__, idx, bps_to_set);
+    info("%s(%d), increase bps to %" PRIu64 "\n", __func__, idx, bps_to_set);
     mt_pacing_train_bps_result_add(impl, port, rl_bps, bps_to_set);
     mt_txq_set_tx_bps(queue, bps_to_set);
     ret = tv_train_pacing(impl, s, s_port);

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -427,18 +427,18 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
   pkts_per_frame = pkts_per_frame * reactive;
   measured_bps = s->st20_pkt_size * pkts_per_sec * reactive;
 
-  /* If the measured speed is lower then expected. Set higher bps and retrain to add
+  /* If the measured speed is lower than expected. Set higher bps and retrain to add
    * padding */
   if (measured_bps < rl_bps) {
-    info("%s(%d), measured bps %ld is lower then set bps %ld\n", __func__, idx,
-         (uint64_t)measured_bps, rl_bps);
+    info("%s(%d), measured bps %"PRIu64" is lower then set bps %"PRIu64"\n",
+         __func__, idx, (uint64_t)measured_bps, rl_bps);
     if (!mt_pacing_train_bps_result_search(impl, port, rl_bps, &bps_to_set)) {
       err("%s(%d), measured speed is too low on already trained bps\n", __func__, idx);
       return -EINVAL;
     }
 
-    bps_to_set = rl_bps / measured_bps * rl_bps;
-    info("%s(%d), increase bps to %ld\n", __func__, idx, bps_to_set);
+    bps_to_set = (rl_bps * rl_bps) / measured_bps;
+    info("%s(%d), increase bps to %"PRIu64"\n", __func__, idx, bps_to_set);
     mt_pacing_train_bps_result_add(impl, port, rl_bps, bps_to_set);
     mt_txq_set_tx_bps(queue, bps_to_set);
     ret = tv_train_pacing(impl, s, s_port);

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -331,7 +331,7 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
     info("%s(%d), user customized pad_interval %u\n", __func__, idx, resolved);
     return 0;
   }
-  if (!(s->ops.flags & ST20_TX_FLAG_DISABLE_STATIC_PAD_P)) {
+  if ((s->ops.flags & ST20_TX_FLAG_ENABLE_STATIC_PAD_P)) {
     resolved = st20_pacing_static_profiling(impl, s, s_port);
     if (resolved) {
       s->pacing.pad_interval = resolved;

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -322,6 +322,8 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
   float pad_interval;
   uint64_t rl_bps = tv_rl_bps(s);
   uint64_t train_start_time, train_end_time;
+  double measured_bps;
+  uint64_t bps_to_set;
 
   uint16_t resolved = s->ops.pad_interval;
   if (resolved) {
@@ -338,7 +340,7 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
     }
   }
 
-  ret = mt_pacing_train_result_search(impl, port, rl_bps, &pad_interval);
+  ret = mt_pacing_train_pad_result_search(impl, port, rl_bps, &pad_interval);
   if (ret >= 0) {
     s->pacing.pad_interval = pad_interval;
     info("%s(%d), use pre-train pad_interval %f\n", __func__, idx, pad_interval);
@@ -423,10 +425,23 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
     reactive = (s->ops.height == 480) ? 487.0 / 525.0 : 576.0 / 625.0;
   }
   pkts_per_frame = pkts_per_frame * reactive;
-  if (pkts_per_frame < s->st20_total_pkts) {
-    err("%s(%d), error pkts_per_frame %f, st20_total_pkts %d\n", __func__, idx,
-        pkts_per_frame, s->st20_total_pkts);
-    return -EINVAL;
+  measured_bps = s->st20_pkt_size * pkts_per_sec * reactive;
+
+  if (measured_bps < rl_bps) {
+    /* The measured speed is lower then expected. Set higher bps and retrain to add padding */
+    info("%s(%d), measured bps %ld, set bps %ld, increasing rl bps\n", __func__, idx,
+      (uint64_t)measured_bps, rl_bps);
+
+    if (!mt_pacing_train_bps_result_search(impl, port, rl_bps, &bps_to_set)) {
+      err("%s(%d), measured speed is too low on already trained bps\n", __func__, idx);
+      return -EINVAL;
+    }
+
+    bps_to_set = rl_bps / measured_bps * rl_bps;
+    mt_pacing_train_bps_result_add(impl, port, rl_bps, bps_to_set);
+    mt_txq_set_tx_bps(queue, bps_to_set);
+    ret = tv_train_pacing(impl, s, s_port);
+    return ret;
   }
 
   pad_interval = (float)s->st20_total_pkts / (pkts_per_frame - s->st20_total_pkts);
@@ -437,7 +452,7 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
   }
 
   s->pacing.pad_interval = pad_interval;
-  mt_pacing_train_result_add(impl, port, rl_bps, pad_interval);
+  mt_pacing_train_pad_result_add(impl, port, rl_bps, pad_interval);
   train_end_time = mt_get_tsc(impl);
   info("%s(%d,%d), trained pad_interval %f pkts_per_frame %f with time %fs\n", __func__,
        idx, s_port, pad_interval, pkts_per_frame,
@@ -2526,6 +2541,7 @@ static int tv_init_hw(struct mtl_main_impl* impl, struct st_tx_video_sessions_mg
     struct mt_txq_flow flow;
     memset(&flow, 0, sizeof(flow));
     flow.bytes_per_sec = tv_rl_bps(s);
+    mt_pacing_train_bps_result_search(impl, i, flow.bytes_per_sec, &flow.bytes_per_sec);
     mtl_memcpy(&flow.dip_addr, &s->ops.dip_addr[i], MTL_IP_ADDR_LEN);
     flow.dst_port = s->ops.udp_port[i];
     if (ST21_TX_PACING_WAY_TSN == s->pacing_way[i])
@@ -3858,6 +3874,7 @@ int st20_tx_queue_fatal_error(struct mtl_main_impl* impl,
   struct mt_txq_flow flow;
   memset(&flow, 0, sizeof(flow));
   flow.bytes_per_sec = tv_rl_bps(s);
+  mt_pacing_train_bps_result_search(impl, s_port, flow.bytes_per_sec, &flow.bytes_per_sec);
   mtl_memcpy(&flow.dip_addr, &s->ops.dip_addr[s_port], MTL_IP_ADDR_LEN);
   flow.dst_port = s->ops.udp_port[s_port];
   s->queue[s_port] = mt_txq_get(impl, port, &flow);

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -427,17 +427,18 @@ static int tv_train_pacing(struct mtl_main_impl* impl, struct st_tx_video_sessio
   pkts_per_frame = pkts_per_frame * reactive;
   measured_bps = s->st20_pkt_size * pkts_per_sec * reactive;
 
+  /* If the measured speed is lower then expected. Set higher bps and retrain to add
+   * padding */
   if (measured_bps < rl_bps) {
-    /* The measured speed is lower then expected. Set higher bps and retrain to add padding */
-    info("%s(%d), measured bps %ld, set bps %ld, increasing rl bps\n", __func__, idx,
-      (uint64_t)measured_bps, rl_bps);
-
+    info("%s(%d), measured bps %ld is lower then set bps %ld\n", __func__, idx,
+         (uint64_t)measured_bps, rl_bps);
     if (!mt_pacing_train_bps_result_search(impl, port, rl_bps, &bps_to_set)) {
       err("%s(%d), measured speed is too low on already trained bps\n", __func__, idx);
       return -EINVAL;
     }
 
     bps_to_set = rl_bps / measured_bps * rl_bps;
+    info("%s(%d), increase bps to %ld\n", __func__, idx, bps_to_set);
     mt_pacing_train_bps_result_add(impl, port, rl_bps, bps_to_set);
     mt_txq_set_tx_bps(queue, bps_to_set);
     ret = tv_train_pacing(impl, s, s_port);
@@ -3874,7 +3875,8 @@ int st20_tx_queue_fatal_error(struct mtl_main_impl* impl,
   struct mt_txq_flow flow;
   memset(&flow, 0, sizeof(flow));
   flow.bytes_per_sec = tv_rl_bps(s);
-  mt_pacing_train_bps_result_search(impl, s_port, flow.bytes_per_sec, &flow.bytes_per_sec);
+  mt_pacing_train_bps_result_search(impl, s_port, flow.bytes_per_sec,
+                                    &flow.bytes_per_sec);
   mtl_memcpy(&flow.dip_addr, &s->ops.dip_addr[s_port], MTL_IP_ADDR_LEN);
   flow.dst_port = s->ops.udp_port[s_port];
   s->queue[s_port] = mt_txq_get(impl, port, &flow);

--- a/tests/tools/RxTxApp/src/app_base.h
+++ b/tests/tools/RxTxApp/src/app_base.h
@@ -654,7 +654,7 @@ struct st_app_context {
   int tx_video_rtp_ring_size; /* the ring size for tx video rtp type */
   uint16_t tx_start_vrx;
   uint16_t tx_pad_interval;
-  bool tx_no_static_pad;
+  bool tx_static_pad;
   bool tx_ts_first_pkt;
   bool tx_ts_epoch;
   int32_t tx_ts_delta_us;

--- a/tests/tools/RxTxApp/src/args.c
+++ b/tests/tools/RxTxApp/src/args.c
@@ -57,7 +57,7 @@ enum st_args_cmd {
   ST_ARG_PACING_WAY,
   ST_ARG_START_VRX,
   ST_ARG_PAD_INTERVAL,
-  ST_ARG_NO_PAD_STATIC,
+  ST_ARG_PAD_STATIC,
   ST_ARG_SHAPING,
   ST_ARG_TIMESTAMP_FIRST_PKT,
   ST_ARG_TIMESTAMP_EPOCH,
@@ -209,7 +209,7 @@ static struct option st_app_args_options[] = {
     {"pacing_way", required_argument, 0, ST_ARG_PACING_WAY},
     {"start_vrx", required_argument, 0, ST_ARG_START_VRX},
     {"pad_interval", required_argument, 0, ST_ARG_PAD_INTERVAL},
-    {"no_static_pad", no_argument, 0, ST_ARG_NO_PAD_STATIC},
+    {"static_pad", no_argument, 0, ST_ARG_PAD_STATIC},
     {"shaping", required_argument, 0, ST_ARG_SHAPING},
     {"ts_first_pkt", no_argument, 0, ST_ARG_TIMESTAMP_FIRST_PKT},
     {"ts_delta_us", required_argument, 0, ST_ARG_TIMESTAMP_DELTA_US},
@@ -600,8 +600,8 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
       case ST_ARG_PAD_INTERVAL:
         ctx->tx_pad_interval = atoi(optarg);
         break;
-      case ST_ARG_NO_PAD_STATIC:
-        ctx->tx_no_static_pad = true;
+      case ST_ARG_PAD_STATIC:
+        ctx->tx_static_pad = true;
         break;
       case ST_ARG_TIMESTAMP_FIRST_PKT:
         ctx->tx_ts_first_pkt = true;

--- a/tests/tools/RxTxApp/src/legacy/tx_video_app.c
+++ b/tests/tools/RxTxApp/src/legacy/tx_video_app.c
@@ -790,7 +790,7 @@ static int app_tx_video_init(struct st_app_context* ctx, st_json_video_session_t
   ops.pad_interval = ctx->tx_pad_interval;
   ops.rtp_timestamp_delta_us = ctx->tx_ts_delta_us;
   if (s->enable_vsync) ops.flags |= ST20_TX_FLAG_ENABLE_VSYNC;
-  if (ctx->tx_no_static_pad) ops.flags |= ST20_TX_FLAG_DISABLE_STATIC_PAD_P;
+  if (ctx->tx_static_pad) ops.flags |= ST20_TX_FLAG_ENABLE_STATIC_PAD_P;
   if (ctx->tx_ts_first_pkt) ops.flags |= ST20_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT;
   if (ctx->tx_ts_epoch) ops.flags |= ST20_TX_FLAG_RTP_TIMESTAMP_EPOCH;
   if (ctx->tx_no_bulk) ops.flags |= ST20_TX_FLAG_DISABLE_BULK;

--- a/tests/tools/RxTxApp/src/tx_st20p_app.c
+++ b/tests/tools/RxTxApp/src/tx_st20p_app.c
@@ -286,7 +286,7 @@ static int app_tx_st20p_init(struct st_app_context* ctx, st_json_st20p_session_t
   ops.pad_interval = ctx->tx_pad_interval;
   ops.rtp_timestamp_delta_us = ctx->tx_ts_delta_us;
   ops.notify_event = app_tx_st20p_notify_event;
-  if (ctx->tx_no_static_pad) ops.flags |= ST20P_TX_FLAG_DISABLE_STATIC_PAD_P;
+  if (ctx->tx_static_pad) ops.flags |= ST20P_TX_FLAG_ENABLE_STATIC_PAD_P;
   if (st20p && st20p->enable_rtcp) ops.flags |= ST20P_TX_FLAG_ENABLE_RTCP;
   if (ctx->tx_ts_first_pkt) ops.flags |= ST20P_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT;
   if (ctx->tx_ts_epoch) ops.flags |= ST20P_TX_FLAG_RTP_TIMESTAMP_EPOCH;


### PR DESCRIPTION
- Increase RL speed if measured speed turns out too low while training pacing
- Refactor functions responsible for storing and retrieving pacing train result
- Adjust dev_tx_queue_set_rl_rate() to handle IAFV on DPDK 25.03
- Add wrapper function of rwlock
- Use rwlock to protect DPDK port during resets.
- STATIC_PAD to be disabled by default