### PR TITLE
Fix: Little-Endian st40_rfc8331_rtp_hdr struct in st40_api.h

### DIFF
--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -84,6 +84,25 @@ enum st40_type {
 /**
  * A structure describing a st2110-40(ancillary) rfc8331 rtp header
  */
+#ifdef MTL_LITTLE_ENDIAN
+MTL_PACK(struct st40_rfc8331_rtp_hdr {
+  /** Rtp rfc3550 base hdr */
+  struct st_rfc3550_rtp_hdr base;
+  /** Extended Sequence Number */
+  uint16_t seq_number_ext;
+  /** Number of octets of the ANC data RTP payload */
+  uint16_t length;
+
+  struct {
+    /** reserved */
+    uint32_t reserved : 22;
+    /** signaling the field specified by the RTP timestamp in an interlaced SDI raster */
+    uint32_t f : 2;
+    /** the count of the total number of ANC data packets carried in the RTP payload */
+    uint32_t anc_count : 8;
+  };
+});
+#else
 MTL_PACK(struct st40_rfc8331_rtp_hdr {
   /** Rtp rfc3550 base hdr */
   struct st_rfc3550_rtp_hdr base;
@@ -101,6 +120,7 @@ MTL_PACK(struct st40_rfc8331_rtp_hdr {
     uint32_t reserved : 22;
   };
 });
+#endif
 
 /**
  * A structure describing a st2110-40(ancillary) rfc8331 payload header


### PR DESCRIPTION
As mentioned in #1151, there seems to be no struct present for a Little-Endian version of `st40_rfc8331_rtp_hdr`. This PR adds it. The code is untested though, thus the PR is a draft for now.