### PR TITLE
ADD: Create versions.env with basic variables

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,0 +1,9 @@
+DPDK_VER=25.03
+ICE_VER=1.16.3
+ICE_DMID=843928
+IRDMA_VER=1.16.10
+IRDMA_DMID=843933
+
+DPDK_REPO=https://github.com/dpdk/dpdk/archive/refs/tags/v${DPDK_VER}.tar.gz
+ICE_REPO=https://downloadmirror.intel.com/${ICE_DMID}/ice-${ICE_VER}.tar.gz
+IRDMA_REPO=https://downloadmirror.intel.com/${IRDMA_DMID}/irdma-${IRDMA_VER}.tgz


### PR DESCRIPTION
ADD: Create `versions.env` with basic variables regarding latest recommended versions, that include the following:

- DPDK driver version and link
- ICE driver version and link
- IRDMA driver version and link

To use it, user can source it in his shell session and refer to params by name or use it as a reference for manual download of dependencies.

From now on every version of packages that are mandatory for this repository should be defined and updated in this file.