### PR TITLE
Add: GStreamer plugin 8331 input support

### DIFF
--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -395,16 +395,19 @@ The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked
 - **Capabilities**: Any (GST_STATIC_CAPS_ANY)
 
 **Arguments**
-| Property Name         | Type     | Description                                                        | Range          | Default Value |
-|-----------------------|----------|--------------------------------------------------------------------|----------------|---------------|
-| tx-framebuff-cnt      | uint     | Number of framebuffers to be used for transmission.                | 0 to G_MAXUINT | 3             |
+| Property Name         | Type     | Description                                                        | Range            | Default Value |
+|-----------------------|----------|--------------------------------------------------------------------|------------------|---------------|
+| tx-framebuff-cnt      | uint     | Number of framebuffers to be used for transmission.                | 0 to G_MAXUINT   | 3             |
 | tx-fps                | uint     | Framerate of the video to which the ancillary data is synchronized.| [Supported vid eo fps fractions](#231-supported-video-fps-fractions) | 25/1 |
-| tx-did                | uint     | Data ID for the ancillary data.                                    | 0 to 255       | 0             |
-| tx-sdid               | uint     | Secondary Data ID for the ancillary data.                          | 0 to 255       | 0             |
-| use-pts-for-pacing    | gboolean | [User controlled timestamping offset](#233-pts-controlled-pacing)  | TRUE/FALSE     | FALSE         |
-| pts-pacing-offset     | uint     | [User controlled timestamping offset](#233-pts-controlled-pacing)  | 0 to G_MAXUINT | 0             |
-| parse-8331-meta       | gboolean | Treat the input as rfc8331 payload data                            | TRUE/FALSE     | FALSE         |
-| max-combined-udw-size | uint     | Maximum combined size of all user data words to send in one buffer | 0 to G_MAXUINT | 20 * 255      |
+| tx-did                | uint     | Data ID for the ancillary data.                                    | 0 to 255         | 0             |
+| tx-sdid               | uint     | Secondary Data ID for the ancillary data.                          | 0 to 255         | 0             |
+| use-pts-for-pacing    | gboolean | [User controlled timestamping offset](#233-pts-controlled-pacing)  | TRUE/FALSE       | FALSE         |
+| pts-pacing-offset     | uint     | [User controlled timestamping offset](#233-pts-controlled-pacing)  | 0 to G_MAXUINT   | 0             |
+| parse-8331-meta       | gboolean | Treat the input as rfc8331 payload data                            | TRUE/FALSE       | FALSE         |
+| max-combined-udw-size | uint     | Maximum combined size of all user data words to send in one buffer | 0 to (20 * 255)  | 20 * 255      |
+
+> **Note:**  
+> If `parse-8331-meta` is not enabled, only one ANC packet per frame is supported. It is recommended to limit the `max-combined-udw-size` if you are only using this option, since by default `max-combined-udw-size` is set to its maximum value.
 
 #### 5.1.2. Example GStreamer Pipeline for Transmission
 

--- a/ecosystem/gstreamer_plugin/README.md
+++ b/ecosystem/gstreamer_plugin/README.md
@@ -395,14 +395,16 @@ The `mtl_st40p_tx` plugin supports all pad capabilities (the data is not checked
 - **Capabilities**: Any (GST_STATIC_CAPS_ANY)
 
 **Arguments**
-| Property Name      | Type     | Description                                                        | Range         | Default Value |
-|--------------------|----------|--------------------------------------------------------------------|---------------|---------------|
-| tx-framebuff-cnt   | uint     | Number of framebuffers to be used for transmission.                | 0 to G_MAXUINT| 3             |
-| tx-fps             | uint     | Framerate of the video to which the ancillary data is synchronized.| [Supported video fps fractions](#231-supported-video-fps-fractions) | 25/1 |
-| tx-did             | uint     | Data ID for the ancillary data.                                    | 0 to 255      | 0             |
-| tx-sdid            | uint     | Secondary Data ID for the ancillary data.                          | 0 to 255      | 0             |
-| use-pts-for-pacing | gboolean | [User controlled timestamping offset](#233-pts-controlled-pacing)  | 0 to G_MAXUINT | 0            |
-| pts-pacing-offset  | uint     | [User controlled timestamping offset](#233-pts-controlled-pacing)  | 0 to G_MAXUINT | 0            |
+| Property Name         | Type     | Description                                                        | Range          | Default Value |
+|-----------------------|----------|--------------------------------------------------------------------|----------------|---------------|
+| tx-framebuff-cnt      | uint     | Number of framebuffers to be used for transmission.                | 0 to G_MAXUINT | 3             |
+| tx-fps                | uint     | Framerate of the video to which the ancillary data is synchronized.| [Supported vid eo fps fractions](#231-supported-video-fps-fractions) | 25/1 |
+| tx-did                | uint     | Data ID for the ancillary data.                                    | 0 to 255       | 0             |
+| tx-sdid               | uint     | Secondary Data ID for the ancillary data.                          | 0 to 255       | 0             |
+| use-pts-for-pacing    | gboolean | [User controlled timestamping offset](#233-pts-controlled-pacing)  | TRUE/FALSE     | FALSE         |
+| pts-pacing-offset     | uint     | [User controlled timestamping offset](#233-pts-controlled-pacing)  | 0 to G_MAXUINT | 0             |
+| parse-8331-meta       | gboolean | Treat the input as rfc8331 payload data                            | TRUE/FALSE     | FALSE         |
+| max-combined-udw-size | uint     | Maximum combined size of all user data words to send in one buffer | 0 to G_MAXUINT | 20 * 255      |
 
 #### 5.1.2. Example GStreamer Pipeline for Transmission
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -506,7 +506,7 @@ static GstFlowReturn gst_mtl_st20p_tx_chain(GstPad* pad, GstObject* parent,
       frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
     }
 
-    mtl_memcpy(frame->addr[0], map_info.data, buffer_size);
+    memcpy(frame->addr[0], map_info.data, buffer_size);
     gst_memory_unmap(gst_buffer_memory, &map_info);
     st20p_tx_put_frame(sink->tx_handle, frame);
   }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st30p_tx.c
@@ -546,12 +546,12 @@ static GstFlowReturn gst_mtl_st30p_tx_chain(GstPad* pad, GstObject* parent,
       cur_addr_buf = map_info.data + gst_buffer_get_size(buf) - bytes_to_write;
 
       if (sink->cur_frame_available_size > bytes_to_write) {
-        mtl_memcpy(cur_addr_frame, cur_addr_buf, bytes_to_write);
+        memcpy(cur_addr_frame, cur_addr_buf, bytes_to_write);
         sink->cur_frame_available_size -= bytes_to_write;
         bytes_to_write = 0;
         break;
       } else {
-        mtl_memcpy(cur_addr_frame, cur_addr_buf, sink->cur_frame_available_size);
+        memcpy(cur_addr_frame, cur_addr_buf, sink->cur_frame_available_size);
 
         // By default, timestamping is handled by MTL.
         if (sink->use_pts_for_pacing) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -375,14 +375,15 @@ static void* gst_mtl_st40_rx_get_mbuf_with_timeout(Gst_Mtl_St40_Rx* src,
 static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer** buffer,
                                                  void* usrptr) {
   struct st40_rfc8331_rtp_hdr* hdr;
-  struct st40_rfc8331_payload_hdr* payload_hdr, payload_hdr_swapped;
+  struct st40_rfc8331_payload_hdr *payload_hdr, payload_hdr_swapped;
   GstMapInfo dest_info;
   guint16 data, fill_size;
   gint udw_size;
 
   hdr = (struct st40_rfc8331_rtp_hdr*)usrptr;
   payload_hdr = (struct st40_rfc8331_payload_hdr*)(&hdr[1]);
-  payload_hdr_swapped.swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
+  payload_hdr_swapped.swapped_second_hdr_chunk =
+      ntohl(payload_hdr->swapped_second_hdr_chunk);
   udw_size = payload_hdr_swapped.second_hdr_chunk.data_count & 0xff;
 
   if (udw_size == 0) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -375,16 +375,15 @@ static void* gst_mtl_st40_rx_get_mbuf_with_timeout(Gst_Mtl_St40_Rx* src,
 static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer** buffer,
                                                  void* usrptr) {
   struct st40_rfc8331_rtp_hdr* hdr;
-  struct st40_rfc8331_payload_hdr* payload_hdr;
+  struct st40_rfc8331_payload_hdr* payload_hdr, payload_hdr_swapped;
   GstMapInfo dest_info;
   guint16 data, fill_size;
   gint udw_size;
 
   hdr = (struct st40_rfc8331_rtp_hdr*)usrptr;
   payload_hdr = (struct st40_rfc8331_payload_hdr*)(&hdr[1]);
-  payload_hdr->swaped_second_hdr_chunk = ntohl(payload_hdr->swaped_second_hdr_chunk);
-  udw_size = payload_hdr->second_hdr_chunk.data_count & 0xff;
-  payload_hdr->swaped_second_hdr_chunk = htonl(payload_hdr->swaped_second_hdr_chunk);
+  payload_hdr_swapped.swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
+  udw_size = payload_hdr_swapped.second_hdr_chunk.data_count & 0xff;
 
   if (udw_size == 0) {
     GST_ERROR("Ancillary data size is 0");
@@ -398,6 +397,7 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
       free(src->anc_data);
       src->anc_data = NULL;
     }
+
     src->udw_size = udw_size;
     src->anc_data = (char*)malloc(udw_size);
   }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -140,7 +140,7 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_memory_block(Gst_Mtl_St40p_Tx* 
                                                               GstMapInfo map_info,
                                                               GstBuffer* buf);
 
-static void gst_mtl_st40p_tx_fill_meta(struct st40_frame_info *frame_info, void* data,
+static void gst_mtl_st40p_tx_fill_meta(struct st40_frame_info* frame_info, void* data,
                                        guint32 data_size, guint did, guint sdid);
 
 static GstFlowReturn gst_mtl_st40p_tx_parse_8331_meta(
@@ -482,7 +482,7 @@ static gboolean gst_mtl_st40p_tx_sink_event(GstPad* pad, GstObject* parent,
  * @param did Data Identifier (DID) to be set in the metadata.
  * @param sdid Secondary Data Identifier (SDID) to be set in the metadata.
  */
-static void gst_mtl_st40p_tx_fill_meta(struct st40_frame_info *frame_info, void* data,
+static void gst_mtl_st40p_tx_fill_meta(struct st40_frame_info* frame_info, void* data,
                                        guint32 data_size, guint did, guint sdid) {
   frame_info->meta[0].c = 0;
   frame_info->meta[0].line_number = 0;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -568,7 +568,7 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
     data_count = payload_header.second_hdr_chunk.data_count & 0xff;
 
     /* data count * 10 bits + 10 bit checksum*/
-    udw_byte_size = (((data_count) * UDW_WORD_BIT_SIZE) + UDW_WORD_BIT_SIZE);
+    udw_byte_size = (data_count * UDW_WORD_BIT_SIZE) + UDW_WORD_BIT_SIZE;
     /* round up to the nearest byte */
     udw_byte_size = (udw_byte_size + 7) / 8;
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -568,7 +568,7 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
     data_count = payload_header.second_hdr_chunk.data_count & 0xff;
 
     /* data count * 10 bits + 10 bit checksum*/
-    udw_byte_size = (((data_count)*10) + 10);
+    udw_byte_size = (((data_count) * UDW_WORD_BIT_SIZE) + UDW_WORD_BIT_SIZE);
     /* round up to the nearest byte */
     udw_byte_size = (udw_byte_size + 7) / 8;
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -133,21 +133,23 @@ static gboolean gst_mtl_st40p_tx_session_create(Gst_Mtl_St40p_Tx* sink);
 /**
  * Main processing functions for ST40p TX GStreamer plugin.
  */
-static GstFlowReturn gst_mtl_st40p_tx_parse_memory_block(Gst_Mtl_St40p_Tx* sink, GstMapInfo map_info, GstBuffer* buf);
+static GstFlowReturn gst_mtl_st40p_tx_parse_memory_block(Gst_Mtl_St40p_Tx* sink,
+                                                         GstMapInfo map_info,
+                                                         GstBuffer* buf);
 static GstFlowReturn gst_mtl_st40p_tx_parse_8331_memory_block(Gst_Mtl_St40p_Tx* sink,
-                                                           GstMapInfo map_info, GstBuffer* buf);
+                                                              GstMapInfo map_info,
+                                                              GstBuffer* buf);
 
-static void gst_mtl_st40p_tx_fill_meta(struct st40_frame* frame, void* data, guint32 data_size,
-                               guint did, guint sdid);
+static void gst_mtl_st40p_tx_fill_meta(struct st40_frame* frame, void* data,
+                                       guint32 data_size, guint did, guint sdid);
 
-static GstFlowReturn gst_mtl_st40p_tx_parse_8331_meta(struct st40_frame_info *frame_info,
-                                              struct st40_rfc8331_payload_hdr payload_header,
-                                              guint anc_idx,
-                                              guint data_offset);
+static GstFlowReturn gst_mtl_st40p_tx_parse_8331_meta(
+    struct st40_frame_info* frame_info, struct st40_rfc8331_payload_hdr payload_header,
+    guint anc_idx, guint data_offset);
 
 static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
     Gst_Mtl_St40p_Tx* sink, GstMapInfo map_info, gint bytes_left_to_process,
-    struct gst_st40_rfc8331_meta rfc8331_meta, guint anc_count,  GstBuffer* buf);
+    struct gst_st40_rfc8331_meta rfc8331_meta, guint anc_count, GstBuffer* buf);
 
 static void gst_mtl_st40p_tx_class_init(Gst_Mtl_St40p_TxClass* klass) {
   GObjectClass* gobject_class;
@@ -480,8 +482,8 @@ static gboolean gst_mtl_st40p_tx_sink_event(GstPad* pad, GstObject* parent,
  * @param did Data Identifier (DID) to be set in the metadata.
  * @param sdid Secondary Data Identifier (SDID) to be set in the metadata.
  */
-static void gst_mtl_st40p_tx_fill_meta(struct st40_frame* frame, void* data, guint32 data_size,
-                               guint did, guint sdid) {
+static void gst_mtl_st40p_tx_fill_meta(struct st40_frame* frame, void* data,
+                                       guint32 data_size, guint did, guint sdid) {
   frame->meta[0].c = 0;
   frame->meta[0].line_number = 0;
   frame->meta[0].hori_offset = 0;
@@ -496,10 +498,9 @@ static void gst_mtl_st40p_tx_fill_meta(struct st40_frame* frame, void* data, gui
 }
 
 /* we dont' really check the data here we let the st40 ancillary data to do so */
-static GstFlowReturn gst_mtl_st40p_tx_parse_8331_meta(struct st40_frame_info *frame_info,
-                                              struct st40_rfc8331_payload_hdr payload_header,
-                                              guint anc_idx,
-                                              guint udw_offset) {
+static GstFlowReturn gst_mtl_st40p_tx_parse_8331_meta(
+    struct st40_frame_info* frame_info, struct st40_rfc8331_payload_hdr payload_header,
+    guint anc_idx, guint udw_offset) {
   if (!frame_info || !frame_info->meta) {
     GST_ERROR("Failed to parse rfc8331 payload meta Null frame_info pointer");
     return GST_FLOW_ERROR;
@@ -530,7 +531,7 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
     struct gst_st40_rfc8331_meta rfc8331_meta, guint anc_count, GstBuffer* buf) {
   struct st40_frame_info* frame_info = NULL;
   struct st40_rfc8331_payload_hdr payload_header;
-  uint8_t *payload_cursor;
+  uint8_t* payload_cursor;
   guint data_count, buffer_size = map_info.size, udw_byte_size;
   guint16 udw;
 
@@ -574,11 +575,10 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
       return GST_FLOW_ERROR;
     }
 
-
-    /* we can use data_size for offset here as the data size is increased with every processed
-    udw so it shows the offset */
-    if (gst_mtl_st40p_tx_parse_8331_meta(
-            frame_info, payload_header, i,frame_info->anc_frame->data_size)) {
+    /* we can use data_size for offset here as the data size is increased with every
+    processed udw so it shows the offset */
+    if (gst_mtl_st40p_tx_parse_8331_meta(frame_info, payload_header, i,
+                                         frame_info->anc_frame->data_size)) {
       GST_ERROR("Failed to parse 8331 meta");
       return GST_FLOW_ERROR;
     }
@@ -621,7 +621,8 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
   }
 
   if (bytes_left_to_process > 0) {
-    GST_WARNING("Bytes left to process after parsing 8331 meta: %d", bytes_left_to_process);
+    GST_WARNING("Bytes left to process after parsing 8331 meta: %d",
+                bytes_left_to_process);
     /* If there are still bytes left, we can ignore them for now */
   }
 
@@ -629,8 +630,8 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
 }
 
 static GstFlowReturn gst_mtl_st40p_tx_parse_8331_memory_block(Gst_Mtl_St40p_Tx* sink,
-                                                           GstMapInfo map_info,
-                                                           GstBuffer* buf) {
+                                                              GstMapInfo map_info,
+                                                              GstBuffer* buf) {
   struct gst_st40_rfc8331_meta rfc8331_meta;
   struct st40_rfc8331_payload_hdr_common meta;
   guint bytes_left_to_process = map_info.size;
@@ -656,7 +657,8 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_memory_block(Gst_Mtl_St40p_Tx* 
   }
 
   ret = gst_mtl_st40p_tx_parse_8331_anc_words(sink, map_info, bytes_left_to_process,
-                                     rfc8331_meta, meta.first_hdr_chunk.anc_count, buf);
+                                              rfc8331_meta,
+                                              meta.first_hdr_chunk.anc_count, buf);
 
   if (ret) {
     GST_ERROR("Failed to parse 8331 gst buffer %d", ret);
@@ -684,8 +686,8 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_memory_block(Gst_Mtl_St40p_Tx* 
  * @return GST_FLOW_OK on success, GST_FLOW_ERROR on failure.
  */
 static GstFlowReturn gst_mtl_st40p_tx_parse_memory_block(Gst_Mtl_St40p_Tx* sink,
-                                                         GstMapInfo map_info,  GstBuffer* buf)
-{
+                                                         GstMapInfo map_info,
+                                                         GstBuffer* buf) {
   struct st40_frame_info* frame_info = NULL;
   uint8_t* cur_addr_buf;
   gint bytes_left_to_process, bytes_left_to_process_cur;
@@ -707,7 +709,7 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_memory_block(Gst_Mtl_St40p_Tx* sink,
     memcpy(frame_info->udw_buff_addr, cur_addr_buf, bytes_left_to_process_cur);
 
     gst_mtl_st40p_tx_fill_meta(frame_info->anc_frame, frame_info->udw_buff_addr,
-                       bytes_left_to_process_cur, sink->did, sink->sdid);
+                               bytes_left_to_process_cur, sink->did, sink->sdid);
 
     if (sink->use_pts_for_pacing) {
       frame_info->timestamp = GST_BUFFER_PTS(buf) += sink->pts_for_pacing_offset;
@@ -766,7 +768,6 @@ static GstFlowReturn gst_mtl_st40p_tx_chain(GstPad* pad, GstObject* parent,
     /* Unmap memory after processing */
     gst_memory_unmap(gst_buffer_memory, &map_info);
   }
-
 
   gst_buffer_unref(buf);
   return GST_FLOW_OK;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -219,9 +219,8 @@ static void gst_mtl_st40p_tx_class_init(Gst_Mtl_St40p_TxClass* klass) {
   g_object_class_install_property(
       gobject_class, PROP_ST40P_TX_PARSE_8331_META,
       g_param_spec_boolean("parse-8331-meta", "Parse 8331 meta",
-                           "Parse 8331 meta data from the ancillary data, requires you   "
-                           "to send the whole 8331 header in the buffer",
-                           FALSE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+                           "Interpret incoming buffers as RFC 8331 payload.", FALSE,
+                           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property(
       gobject_class, PROP_ST40P_TX_MAX_UDW_SIZE,

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -140,7 +140,7 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_memory_block(Gst_Mtl_St40p_Tx* 
                                                               GstMapInfo map_info,
                                                               GstBuffer* buf);
 
-static void gst_mtl_st40p_tx_fill_meta(struct st40_frame* frame, void* data,
+static void gst_mtl_st40p_tx_fill_meta(struct st40_frame_info *frame_info, void* data,
                                        guint32 data_size, guint did, guint sdid);
 
 static GstFlowReturn gst_mtl_st40p_tx_parse_8331_meta(
@@ -482,19 +482,19 @@ static gboolean gst_mtl_st40p_tx_sink_event(GstPad* pad, GstObject* parent,
  * @param did Data Identifier (DID) to be set in the metadata.
  * @param sdid Secondary Data Identifier (SDID) to be set in the metadata.
  */
-static void gst_mtl_st40p_tx_fill_meta(struct st40_frame* frame, void* data,
+static void gst_mtl_st40p_tx_fill_meta(struct st40_frame_info *frame_info, void* data,
                                        guint32 data_size, guint did, guint sdid) {
-  frame->meta[0].c = 0;
-  frame->meta[0].line_number = 0;
-  frame->meta[0].hori_offset = 0;
-  frame->meta[0].s = 0;
-  frame->meta[0].stream_num = 0;
-  frame->meta[0].did = did;
-  frame->meta[0].sdid = sdid;
-  frame->meta[0].udw_size = data_size;
-  frame->meta[0].udw_offset = 0;
-  frame->data = data;
-  frame->meta_num = 1;
+  frame_info->meta[0].c = 0;
+  frame_info->meta[0].line_number = 0;
+  frame_info->meta[0].hori_offset = 0;
+  frame_info->meta[0].s = 0;
+  frame_info->meta[0].stream_num = 0;
+  frame_info->meta[0].did = did;
+  frame_info->meta[0].sdid = sdid;
+  frame_info->meta[0].udw_size = data_size;
+  frame_info->meta[0].udw_offset = 0;
+  frame_info->udw_buffer_fill = data_size;
+  frame_info->meta_num = 1;
 }
 
 /* we dont' really check the data here we let the st40 ancillary data to do so */
@@ -716,12 +716,8 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_memory_block(Gst_Mtl_St40p_Tx* sink,
                                     : bytes_left_to_process;
 
     memcpy(frame_info->udw_buff_addr, cur_addr_buf, bytes_left_to_process_cur);
-    for (int i = 0; i < bytes_left_to_process_cur; i++) {
-      printf("%d", frame_info->udw_buff_addr[i]);
-    }
-    printf("\n");
 
-    gst_mtl_st40p_tx_fill_meta(frame_info->anc_frame, frame_info->udw_buff_addr,
+    gst_mtl_st40p_tx_fill_meta(frame_info, frame_info->udw_buff_addr,
                                bytes_left_to_process_cur, sink->did, sink->sdid);
 
     if (sink->use_pts_for_pacing) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -596,7 +596,8 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
      */
     for (int j = 0; j < data_count; j++) {
       if (frame_info->udw_buffer_fill >= frame_info->udw_buffer_size) {
-        GST_ERROR("UDW buffer overflow: fill=%u size=%zu", frame_info->udw_buffer_fill, frame_info->udw_buffer_size);
+        GST_ERROR("UDW buffer overflow: fill=%u size=%zu", frame_info->udw_buffer_fill,
+                  frame_info->udw_buffer_size);
         return GST_FLOW_ERROR;
       }
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
@@ -48,8 +48,8 @@
 #define __GST_MTL_ST40P_TX_H__
 
 #define ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT 20
-#define MAX_UDW_SIZE 255
 /* Maximum size for single User Data Words */
+#define MAX_UDW_SIZE 255
 #define UDW_WORD_BIT_SIZE 10
 /* Maximum buffer size for User Data Words */
 #define DEFAULT_MAX_UDW_SIZE (ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT * MAX_UDW_SIZE)

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
@@ -48,8 +48,9 @@
 #define __GST_MTL_ST40P_TX_H__
 
 #define ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT 20
+#define MAX_UDW_SIZE 255
 /* Maximum size for single User Data Words */
-#define DEFAULT_MAX_UDW_SIZE (ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT * 255)
+#define DEFAULT_MAX_UDW_SIZE (ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT * MAX_UDW_SIZE)
 /* rfc8331 header consist of rows 3 * 10 bits + 2 bits  */
 #define RFC_8331_WORD_BYTE_SIZE (4)
 #define RFC_8331_PAYLOAD_HEADER_SIZE 8
@@ -63,13 +64,6 @@ G_BEGIN_DECLS
 
 #define GST_TYPE_MTL_ST40P_TX (gst_mtl_st40p_tx_get_type())
 G_DECLARE_FINAL_TYPE(Gst_Mtl_St40p_Tx, gst_mtl_st40p_tx, GST, MTL_ST40P_TX, GstBaseSink)
-
-enum gst_st40p_rfc8331_payload_endian {
-  ST40_RFC8331_PAYLOAD_ENDIAN_SYSTEM,
-  ST40_RFC8331_PAYLOAD_ENDIAN_BIG,
-  ST40_RFC8331_PAYLOAD_ENDIAN_LITTLE,
-  ST40_RFC8331_PAYLOAD_ENDIAN_MAX
-};
 
 struct _Gst_Mtl_St40p_Tx {
   GstBaseSink element;

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
@@ -55,9 +55,9 @@
 #define RFC_8331_PAYLOAD_HEADER_SIZE 8
 
 #include <experimental/st40_pipeline_api.h>
+#include <st40_api.h>
 
 #include "gst_mtl_common.h"
-#include <st40_api.h>
 
 G_BEGIN_DECLS
 
@@ -91,10 +91,9 @@ struct _Gst_Mtl_St40p_Tx {
   guint max_combined_udw_size;
 };
 
-
 struct gst_st40_rfc8331_meta {
-  struct st40_rfc8331_payload_hdr_common *header_common;
-  struct st40_rfc8331_payload_hdr *headers[ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT];
+  struct st40_rfc8331_payload_hdr_common* header_common;
+  struct st40_rfc8331_payload_hdr* headers[ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT];
 };
 
 G_END_DECLS

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
@@ -50,6 +50,8 @@
 #define ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT 20
 #define MAX_UDW_SIZE 255
 /* Maximum size for single User Data Words */
+#define UDW_WORD_BIT_SIZE 10
+/* Maximum buffer size for User Data Words */
 #define DEFAULT_MAX_UDW_SIZE (ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT * MAX_UDW_SIZE)
 /* rfc8331 header consist of rows 3 * 10 bits + 2 bits  */
 #define RFC_8331_WORD_BYTE_SIZE (4)

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.h
@@ -47,14 +47,29 @@
 #ifndef __GST_MTL_ST40P_TX_H__
 #define __GST_MTL_ST40P_TX_H__
 
+#define ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT 20
+/* Maximum size for single User Data Words */
+#define DEFAULT_MAX_UDW_SIZE (ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT * 255)
+/* rfc8331 header consist of rows 3 * 10 bits + 2 bits  */
+#define RFC_8331_WORD_BYTE_SIZE (4)
+#define RFC_8331_PAYLOAD_HEADER_SIZE 8
+
 #include <experimental/st40_pipeline_api.h>
 
 #include "gst_mtl_common.h"
+#include <st40_api.h>
 
 G_BEGIN_DECLS
 
 #define GST_TYPE_MTL_ST40P_TX (gst_mtl_st40p_tx_get_type())
 G_DECLARE_FINAL_TYPE(Gst_Mtl_St40p_Tx, gst_mtl_st40p_tx, GST, MTL_ST40P_TX, GstBaseSink)
+
+enum gst_st40p_rfc8331_payload_endian {
+  ST40_RFC8331_PAYLOAD_ENDIAN_SYSTEM,
+  ST40_RFC8331_PAYLOAD_ENDIAN_BIG,
+  ST40_RFC8331_PAYLOAD_ENDIAN_LITTLE,
+  ST40_RFC8331_PAYLOAD_ENDIAN_MAX
+};
 
 struct _Gst_Mtl_St40p_Tx {
   GstBaseSink element;
@@ -72,6 +87,14 @@ struct _Gst_Mtl_St40p_Tx {
   guint sdid;
   gboolean use_pts_for_pacing;
   guint pts_for_pacing_offset;
+  gboolean parse_rfc8331_input;
+  guint max_combined_udw_size;
+};
+
+
+struct gst_st40_rfc8331_meta {
+  struct st40_rfc8331_payload_hdr_common *header_common;
+  struct st40_rfc8331_payload_hdr *headers[ST40_RFC8331_PAYLOAD_MAX_ANCILLARY_COUNT];
 };
 
 G_END_DECLS

--- a/include/experimental/st40_pipeline_api.h
+++ b/include/experimental/st40_pipeline_api.h
@@ -12,39 +12,6 @@
 extern "C" {
 #endif
 
-MTL_PACK(struct st40_rfc8331_payload_hdr_be {
-  union {
-    struct {
-      /** the ANC data uses luma (Y) data channel */
-      uint32_t c : 1;
-      /** line number corresponds to the location (vertical) of the ANC data packet */
-      uint32_t line_number : 11;
-      /** the location of the ANC data packet in the SDI raster */
-      uint32_t horizontal_offset : 12;
-      /** whether the data stream number of a multi-stream data mapping */
-      uint32_t s : 1;
-      /** the source data stream number of the ANC data packet */
-      uint32_t stream_num : 7;
-    } first_hdr_chunk;
-    /** Handle to make operating on first_hdr_chunk buffer easier */
-    uint32_t swapped_first_hdr_chunk;
-  };
-  union {
-    struct {
-      /** Data Identification Word */
-      uint32_t did : 10;
-      /** Secondary Data Identification Word */
-      uint32_t sdid : 10;
-      /** Data Count */
-      uint32_t data_count : 10;
-      /** Starting point of the UDW (user data words) */
-      uint32_t rsvd_for_udw : 2;
-    } second_hdr_chunk;
-    /** Handle to make operating on second_hdr_chunk buffer easier */
-    uint32_t swapped_second_hdr_chunk;
-  };
-});
-
 /** Handle to tx st2110-40 pipeline session of lib */
 typedef struct st40p_tx_ctx* st40p_tx_handle;
 

--- a/include/experimental/st40_pipeline_api.h
+++ b/include/experimental/st40_pipeline_api.h
@@ -17,8 +17,6 @@ typedef struct st40p_tx_ctx* st40p_tx_handle;
 
 /** The structure info for st40 frame meta. */
 struct st40_frame_info {
-  /** Pointer to the main ancillary frame buffer */
-  struct st40_frame* anc_frame;
   /** Pointer to the metadata array for this frame */
   struct st40_meta* meta;
   /** Pointer to the number of metadata entries in the frame */

--- a/include/experimental/st40_pipeline_api.h
+++ b/include/experimental/st40_pipeline_api.h
@@ -52,7 +52,7 @@ typedef struct st40p_tx_ctx* st40p_tx_handle;
 struct st40_frame_info {
   /** Pointer to the main ancillary frame buffer */
   struct st40_frame* anc_frame;
- /** Pointer to the metadata array for this frame */
+  /** Pointer to the metadata array for this frame */
   struct st40_meta* meta;
   /** Pointer to the number of metadata entries in the frame */
   uint32_t meta_num;

--- a/include/experimental/st40_pipeline_api.h
+++ b/include/experimental/st40_pipeline_api.h
@@ -12,17 +12,56 @@
 extern "C" {
 #endif
 
+MTL_PACK(struct st40_rfc8331_payload_hdr_be {
+  union {
+    struct {
+      /** the ANC data uses luma (Y) data channel */
+      uint32_t c : 1;
+      /** line number corresponds to the location (vertical) of the ANC data packet */
+      uint32_t line_number : 11;
+      /** the location of the ANC data packet in the SDI raster */
+      uint32_t horizontal_offset : 12;
+      /** whether the data stream number of a multi-stream data mapping */
+      uint32_t s : 1;
+      /** the source data stream number of the ANC data packet */
+      uint32_t stream_num : 7;
+    } first_hdr_chunk;
+    /** Handle to make operating on first_hdr_chunk buffer easier */
+    uint32_t swapped_first_hdr_chunk;
+  };
+  union {
+    struct {
+      /** Data Identification Word */
+      uint32_t did : 10;
+      /** Secondary Data Identification Word */
+      uint32_t sdid : 10;
+      /** Data Count */
+      uint32_t data_count : 10;
+      /** Starting point of the UDW (user data words) */
+      uint32_t rsvd_for_udw : 2;
+    } second_hdr_chunk;
+    /** Handle to make operating on second_hdr_chunk buffer easier */
+    uint32_t swapped_second_hdr_chunk;
+  };
+});
+
 /** Handle to tx st2110-40 pipeline session of lib */
 typedef struct st40p_tx_ctx* st40p_tx_handle;
 
 /** The structure info for st40 frame meta. */
 struct st40_frame_info {
-  /** frame buffer address */
+  /** Pointer to the main ancillary frame buffer */
   struct st40_frame* anc_frame;
+ /** Pointer to the metadata array for this frame */
+  struct st40_meta* meta;
+  /** Pointer to the number of metadata entries in the frame */
+  uint32_t meta_num;
   /** user data words buffer address */
-  void* udw_buff_addr;
+  uint8_t* udw_buff_addr;
   /** user data words buffer size */
   size_t udw_buffer_size;
+  /** user data words fill of the buffer */
+  uint32_t udw_buffer_fill;
   /** frame timestamp format */
   enum st10_timestamp_fmt tfmt;
   /** frame timestamp value */

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -84,25 +84,6 @@ enum st40_type {
 /**
  * A structure describing a st2110-40(ancillary) rfc8331 rtp header
  */
-#ifdef MTL_LITTLE_ENDIAN
-MTL_PACK(struct st40_rfc8331_rtp_hdr {
-  /** Rtp rfc3550 base hdr */
-  struct st_rfc3550_rtp_hdr base;
-  /** Extended Sequence Number */
-  uint16_t seq_number_ext;
-  /** Number of octets of the ANC data RTP payload */
-  uint16_t length;
-
-  struct {
-    /** reserved */
-    uint32_t reserved : 22;
-    /** signaling the field specified by the RTP timestamp in an interlaced SDI raster */
-    uint32_t f : 2;
-    /** the count of the total number of ANC data packets carried in the RTP payload */
-    uint32_t anc_count : 8;
-  };
-});
-#else
 MTL_PACK(struct st40_rfc8331_rtp_hdr {
   /** Rtp rfc3550 base hdr */
   struct st_rfc3550_rtp_hdr base;
@@ -120,7 +101,6 @@ MTL_PACK(struct st40_rfc8331_rtp_hdr {
     uint32_t reserved : 22;
   };
 });
-#endif
 
 /* A structure describing the first 32 bits of an ST 2110-40 (ancillary) payload header */
 #ifdef MTL_LITTLE_ENDIAN

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -125,18 +125,18 @@ MTL_PACK(struct st40_rfc8331_rtp_hdr {
 /* This structure is too hold the */
 #ifdef MTL_LITTLE_ENDIAN
 MTL_PACK(struct st40_rfc8331_payload_hdr_common {
-  union{
+  union {
     struct {
-    uint32_t reserved : 22;
-    uint32_t f : 2;
-    uint32_t anc_count : 8;
+      uint32_t reserved : 22;
+      uint32_t f : 2;
+      uint32_t anc_count : 8;
     } first_hdr_chunk;
     uint32_t swapped_handle;
   };
 });
 #else
 MTL_PACK(struct st40_rfc8331_payload_hdr_common {
-  union{
+  union {
     struct {
       uint32_t anc_count : 8;
       uint32_t f : 2;

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -122,7 +122,7 @@ MTL_PACK(struct st40_rfc8331_rtp_hdr {
 });
 #endif
 
-/* This structure is too hold the */
+/* A structure describing the first 32 bits of an ST 2110-40 (ancillary) payload header */
 #ifdef MTL_LITTLE_ENDIAN
 MTL_PACK(struct st40_rfc8331_payload_hdr_common {
   union {

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -84,6 +84,25 @@ enum st40_type {
 /**
  * A structure describing a st2110-40(ancillary) rfc8331 rtp header
  */
+#ifdef MTL_LITTLE_ENDIAN
+MTL_PACK(struct st40_rfc8331_rtp_hdr {
+  /** Rtp rfc3550 base hdr */
+  struct st_rfc3550_rtp_hdr base;
+  /** Extended Sequence Number */
+  uint16_t seq_number_ext;
+  /** Number of octets of the ANC data RTP payload */
+  uint16_t length;
+
+  struct {
+    /** reserved */
+    uint32_t reserved : 22;
+    /** signaling the field specified by the RTP timestamp in an interlaced SDI raster */
+    uint32_t f : 2;
+    /** the count of the total number of ANC data packets carried in the RTP payload */
+    uint32_t anc_count : 8;
+  };
+});
+#else
 MTL_PACK(struct st40_rfc8331_rtp_hdr {
   /** Rtp rfc3550 base hdr */
   struct st_rfc3550_rtp_hdr base;
@@ -101,6 +120,32 @@ MTL_PACK(struct st40_rfc8331_rtp_hdr {
     uint32_t reserved : 22;
   };
 });
+#endif
+
+/* This structure is too hold the */
+#ifdef MTL_LITTLE_ENDIAN
+MTL_PACK(struct st40_rfc8331_payload_hdr_common {
+  union{
+    struct {
+    uint32_t reserved : 22;
+    uint32_t f : 2;
+    uint32_t anc_count : 8;
+    } first_hdr_chunk;
+    uint32_t swapped_handle;
+  };
+});
+#else
+MTL_PACK(struct st40_rfc8331_payload_hdr_common {
+  union{
+    struct {
+      uint32_t anc_count : 8;
+      uint32_t f : 2;
+      uint32_t reserved : 22;
+    } first_hdr_chunk;
+    uint32_t swapped_handle;
+  };
+});
+#endif
 
 /**
  * A structure describing a st2110-40(ancillary) rfc8331 payload header
@@ -121,7 +166,7 @@ MTL_PACK(struct st40_rfc8331_payload_hdr {
       uint32_t c : 1;
     } first_hdr_chunk;
     /** Handle to make operating on first_hdr_chunk buffer easier */
-    uint32_t swaped_first_hdr_chunk;
+    uint32_t swapped_first_hdr_chunk;
   };
   union {
     struct {
@@ -135,7 +180,7 @@ MTL_PACK(struct st40_rfc8331_payload_hdr {
       uint32_t did : 10;
     } second_hdr_chunk;
     /** Handle to make operating on second_hdr_chunk buffer easier */
-    uint32_t swaped_second_hdr_chunk;
+    uint32_t swapped_second_hdr_chunk;
   };
 });
 #else
@@ -154,7 +199,7 @@ MTL_PACK(struct st40_rfc8331_payload_hdr {
       uint32_t stream_num : 7;
     } first_hdr_chunk;
     /** Handle to make operating on first_hdr_chunk buffer easier */
-    uint32_t swaped_first_hdr_chunk;
+    uint32_t swapped_first_hdr_chunk;
   };
   union {
     struct {
@@ -168,7 +213,7 @@ MTL_PACK(struct st40_rfc8331_payload_hdr {
       uint32_t rsvd_for_udw : 2;
     } second_hdr_chunk;
     /** Handle to make operating on second_hdr_chunk buffer easier */
-    uint32_t swaped_second_hdr_chunk;
+    uint32_t swapped_second_hdr_chunk;
   };
 });
 #endif

--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -400,7 +400,7 @@ int st40p_tx_put_frame(st40p_tx_handle handle, struct st40_frame_info* frame_inf
     return -EIO;
   }
 
-  if(!frame_info->anc_frame->data_size && frame_info->meta_num)
+  if (!frame_info->anc_frame->data_size && frame_info->meta_num)
     frame_info->anc_frame->data_size = frame_info->udw_buffer_fill;
 
   if (!frame_info->anc_frame->data_size) {
@@ -408,10 +408,11 @@ int st40p_tx_put_frame(st40p_tx_handle handle, struct st40_frame_info* frame_inf
     return -EIO;
   }
 
-  if(!frame_info->anc_frame->meta_num && frame_info->meta_num)
+  if (!frame_info->anc_frame->meta_num && frame_info->meta_num)
     frame_info->anc_frame->meta_num = frame_info->meta_num;
 
-  if (frame_info->anc_frame->meta_num > ST40_MAX_META || frame_info->anc_frame->meta_num < 1) {
+  if (frame_info->anc_frame->meta_num > ST40_MAX_META ||
+      frame_info->anc_frame->meta_num < 1) {
     err("%s(%d), frame %u meta_num %u invalid\n", __func__, idx, producer_idx,
         frame_info->meta_num);
     return -EIO;

--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -144,15 +144,15 @@ static int tx_st40p_asign_anc_frames(struct st40p_tx_ctx* ctx) {
   for (i = 0; i < ctx->framebuff_cnt; i++) {
     frame_info = &frames[i].frame_info;
 
-    frame_info->anc_frame = st40_tx_get_framebuffer(ctx->transport, i);
-    if (!frame_info->anc_frame) {
+    frames[i].anc_frame = st40_tx_get_framebuffer(ctx->transport, i);
+    if (!frames[i].anc_frame) {
       err("%s(%d), Failed to get framebuffer %u \n", __func__, idx, i);
       return -EIO;
     }
-    dbg("%s(%d), fb %p\n", __func__, idx, frame_info->anc_frame);
+    dbg("%s(%d), fb %p\n", __func__, idx, frames[i].anc_frame);
 
-    frame_info->meta = frame_info->anc_frame->meta;
-    frame_info->anc_frame->data = frame_info->udw_buff_addr;
+    frame_info->meta = frames[i].anc_frame->meta;
+    frames[i].anc_frame->data = frame_info->udw_buff_addr;
   }
   return 0;
 }
@@ -400,19 +400,19 @@ int st40p_tx_put_frame(st40p_tx_handle handle, struct st40_frame_info* frame_inf
     return -EIO;
   }
 
-  if (!frame_info->anc_frame->data_size && frame_info->meta_num)
-    frame_info->anc_frame->data_size = frame_info->udw_buffer_fill;
+  if (!framebuff->anc_frame->data_size && frame_info->meta_num)
+    framebuff->anc_frame->data_size = frame_info->udw_buffer_fill;
 
-  if (!frame_info->anc_frame->data_size) {
+  if (!framebuff->anc_frame->data_size) {
     err("%s(%d), frame %u data size is 0\n", __func__, idx, producer_idx);
     return -EIO;
   }
 
-  if (!frame_info->anc_frame->meta_num && frame_info->meta_num)
-    frame_info->anc_frame->meta_num = frame_info->meta_num;
+  if (!framebuff->anc_frame->meta_num && frame_info->meta_num)
+    framebuff->anc_frame->meta_num = frame_info->meta_num;
 
-  if (frame_info->anc_frame->meta_num > ST40_MAX_META ||
-      frame_info->anc_frame->meta_num < 1) {
+  if (framebuff->anc_frame->meta_num > ST40_MAX_META ||
+      framebuff->anc_frame->meta_num < 1) {
     err("%s(%d), frame %u meta_num %u invalid\n", __func__, idx, producer_idx,
         frame_info->meta_num);
     return -EIO;
@@ -421,7 +421,7 @@ int st40p_tx_put_frame(st40p_tx_handle handle, struct st40_frame_info* frame_inf
   framebuff->frame_info.udw_buffer_fill = 0;
   framebuff->stat = ST40P_TX_FRAME_READY;
   ctx->stat_put_frame++;
-  dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, producer_idx, frame_info->anc_frame);
+  dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, producer_idx, framebuff->anc_frame);
   return 0;
 }
 
@@ -630,5 +630,5 @@ void* st40p_tx_get_fb_addr(st40p_tx_handle handle, uint16_t idx) {
     return NULL;
   }
 
-  return ctx->framebuffs[idx].frame_info.anc_frame;
+  return ctx->framebuffs[idx].anc_frame;
 }

--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -244,6 +244,11 @@ static int tx_st40p_init_fbs(struct st40p_tx_ctx* ctx, struct st40p_tx_ops* ops)
   struct st40p_tx_frame *frames, *framebuff;
   struct st40_frame_info* frame_info;
 
+  if (!ops->max_udw_buff_size) {
+    err("%s(%d), invalid max_udw_buff_size %u\n", __func__, idx, ops->max_udw_buff_size);
+    return -EINVAL;
+  }
+
   frames = mt_rte_zmalloc_socket(sizeof(*frames) * ctx->framebuff_cnt, soc_id);
   if (!frames) {
     err("%s(%d), frames malloc failed\n", __func__, idx);

--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -379,8 +379,7 @@ struct st40_frame_info* st40p_tx_get_frame(st40p_tx_handle handle) {
 
   frame_info = &framebuff->frame_info;
   ctx->stat_get_frame_succ++;
-  dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, framebuff->idx,
-      frame_info);
+  dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, framebuff->idx, frame_info);
   return frame_info;
 }
 

--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -400,19 +400,24 @@ int st40p_tx_put_frame(st40p_tx_handle handle, struct st40_frame_info* frame_inf
     return -EIO;
   }
 
-  frame_info->anc_frame->data_size = frame_info->udw_buffer_size;
-  if (frame_info->udw_buffer_size == 0 && frame_info->anc_frame->data_size == 0) {
+  if(!frame_info->anc_frame->data_size && frame_info->meta_num)
+    frame_info->anc_frame->data_size = frame_info->udw_buffer_fill;
+
+  if (!frame_info->anc_frame->data_size) {
     err("%s(%d), frame %u data size is 0\n", __func__, idx, producer_idx);
     return -EIO;
   }
 
-  frame_info->anc_frame->meta_num = frame_info->meta_num;
-  if (frame_info->meta_num > ST40_MAX_META || frame_info->meta_num < 1) {
+  if(!frame_info->anc_frame->meta_num && frame_info->meta_num)
+    frame_info->anc_frame->meta_num = frame_info->meta_num;
+
+  if (frame_info->anc_frame->meta_num > ST40_MAX_META || frame_info->anc_frame->meta_num < 1) {
     err("%s(%d), frame %u meta_num %u invalid\n", __func__, idx, producer_idx,
         frame_info->meta_num);
     return -EIO;
   }
 
+  framebuff->frame_info.udw_buffer_fill = 0;
   framebuff->stat = ST40P_TX_FRAME_READY;
   ctx->stat_put_frame++;
   dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, producer_idx, frame_info->anc_frame);

--- a/lib/src/st2110/experimental/st40_pipeline_tx.h
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.h
@@ -56,6 +56,8 @@ struct st40p_tx_frame {
   enum st40p_tx_frame_status stat;
   struct st40_frame_info frame_info;
   uint16_t idx;
+  /** Pointer to the main ancillary frame buffer */
+  struct st40_frame* anc_frame;
 };
 
 #if defined(__cplusplus)

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -439,8 +439,8 @@ static int tx_ancillary_session_build_packet(struct st_tx_ancillary_session_impl
     pktBuff->second_hdr_chunk.sdid = st40_add_parity_bits(src->meta[idx].sdid);
     pktBuff->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
 
-    pktBuff->swaped_first_hdr_chunk = htonl(pktBuff->swaped_first_hdr_chunk);
-    pktBuff->swaped_second_hdr_chunk = htonl(pktBuff->swaped_second_hdr_chunk);
+    pktBuff->swapped_first_hdr_chunk = htonl(pktBuff->swapped_first_hdr_chunk);
+    pktBuff->swapped_second_hdr_chunk = htonl(pktBuff->swapped_second_hdr_chunk);
     int i = 0;
     int offset = src->meta[idx].udw_offset;
     for (; i < udw_size; i++) {
@@ -527,8 +527,8 @@ static int tx_ancillary_session_build_rtp_packet(struct st_tx_ancillary_session_
     pktBuff->second_hdr_chunk.sdid = st40_add_parity_bits(src->meta[idx].sdid);
     pktBuff->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
 
-    pktBuff->swaped_first_hdr_chunk = htonl(pktBuff->swaped_first_hdr_chunk);
-    pktBuff->swaped_second_hdr_chunk = htonl(pktBuff->swaped_second_hdr_chunk);
+    pktBuff->swapped_first_hdr_chunk = htonl(pktBuff->swapped_first_hdr_chunk);
+    pktBuff->swapped_second_hdr_chunk = htonl(pktBuff->swapped_second_hdr_chunk);
     int i = 0;
     int offset = src->meta[idx].udw_offset;
     for (; i < udw_size; i++) {

--- a/tests/tools/RxTxApp/src/rx_ancillary_app.c
+++ b/tests/tools/RxTxApp/src/rx_ancillary_app.c
@@ -13,8 +13,8 @@ static void app_rx_anc_handle_rtp(struct st_app_rx_anc_session* s, void* usrptr)
   dbg("%s(%d), anc_count %d\n", __func__, s->idx, anc_count);
 
   for (idx = 0; idx < anc_count; idx++) {
-    payload_hdr->swaped_first_hdr_chunk = ntohl(payload_hdr->swaped_first_hdr_chunk);
-    payload_hdr->swaped_second_hdr_chunk = ntohl(payload_hdr->swaped_second_hdr_chunk);
+    payload_hdr->swapped_first_hdr_chunk = ntohl(payload_hdr->swapped_first_hdr_chunk);
+    payload_hdr->swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
     if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.did) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.sdid) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.data_count)) {
@@ -26,7 +26,7 @@ static void app_rx_anc_handle_rtp(struct st_app_rx_anc_session* s, void* usrptr)
     // verify checksum
     uint16_t checksum = 0;
     checksum = st40_get_udw(udw_size + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
-    payload_hdr->swaped_second_hdr_chunk = htonl(payload_hdr->swaped_second_hdr_chunk);
+    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
     if (checksum !=
         st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk)) {
       err("%s(%d), anc frame checksum error\n", __func__, s->idx);

--- a/tests/tools/RxTxApp/src/tx_ancillary_app.c
+++ b/tests/tools/RxTxApp/src/tx_ancillary_app.c
@@ -225,8 +225,8 @@ static void app_tx_anc_build_rtp(struct st_app_tx_anc_session* s, void* usrptr,
   payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x43);
   payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x02);
   payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
-  payload_hdr->swaped_first_hdr_chunk = htonl(payload_hdr->swaped_first_hdr_chunk);
-  payload_hdr->swaped_second_hdr_chunk = htonl(payload_hdr->swaped_second_hdr_chunk);
+  payload_hdr->swapped_first_hdr_chunk = htonl(payload_hdr->swapped_first_hdr_chunk);
+  payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
   for (int i = 0; i < udw_size; i++) {
     st40_set_udw(i + 3, st40_add_parity_bits(s->st40_frame_cursor[i]),
                  (uint8_t*)&payload_hdr->second_hdr_chunk);

--- a/tests/unittest/st40_test.cpp
+++ b/tests/unittest/st40_test.cpp
@@ -62,8 +62,8 @@ static int tx_anc_build_rtp_packet(tests_context* s, struct st40_rfc8331_rtp_hdr
     payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x43);
     payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x02);
     payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
-    payload_hdr->swaped_first_hdr_chunk = htonl(payload_hdr->swaped_first_hdr_chunk);
-    payload_hdr->swaped_second_hdr_chunk = htonl(payload_hdr->swaped_second_hdr_chunk);
+    payload_hdr->swapped_first_hdr_chunk = htonl(payload_hdr->swapped_first_hdr_chunk);
+    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
     rtp->anc_count = 1;
     for (int i = 0; i < udw_size; i++) {
       st40_set_udw(i + 3,
@@ -135,8 +135,8 @@ static void rx_handle_rtp(tests_context* s, struct st40_rfc8331_rtp_hdr* hdr) {
   int idx, total_size, payload_len;
 
   for (idx = 0; idx < anc_count; idx++) {
-    payload_hdr->swaped_first_hdr_chunk = ntohl(payload_hdr->swaped_first_hdr_chunk);
-    payload_hdr->swaped_second_hdr_chunk = ntohl(payload_hdr->swaped_second_hdr_chunk);
+    payload_hdr->swapped_first_hdr_chunk = ntohl(payload_hdr->swapped_first_hdr_chunk);
+    payload_hdr->swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
     if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.did) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.sdid) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.data_count)) {
@@ -149,7 +149,7 @@ static void rx_handle_rtp(tests_context* s, struct st40_rfc8331_rtp_hdr* hdr) {
     // verify checksum
     uint16_t checksum = 0;
     checksum = st40_get_udw(udw_size + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
-    payload_hdr->swaped_second_hdr_chunk = htonl(payload_hdr->swaped_second_hdr_chunk);
+    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
     if (checksum !=
         st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk)) {
       s->sha_fail_cnt++;


### PR DESCRIPTION
Add support for 8331 adjacent ancillary data
input for the GStreamer st40 ancillary data plugin.
Which allows the user to take input from 
https://www.[ietf.org/rfc/rfc8331.html](https://www.ietf.org/rfc/rfc8331.html)
Starting ANC_Count  and ending with word_align.

Add support for buffer size for UDW support
that allows the user to change the size of the
buffers, set it to the maximum by default 
as the wasted size of appropriately 
2kb * framebuffer count is acceptable.

Change the st40p api to hide the metadata,
which should be clearer for users. 

Refactor: Isolate the parsing of data into
gst_mtl_st40p_tx_parse_*  functions.

Fix the issue with the GST buffer size being taken from
the whole GstBuffer instead of the mapped
GstMemory.

    
    