### PR TITLE
Add: experimental st40p api flag for queue stats

### DIFF
--- a/include/experimental/st40_pipeline_api.h
+++ b/include/experimental/st40_pipeline_api.h
@@ -88,6 +88,10 @@ enum st40p_tx_flag {
   /** Enable the st40p_tx_get_frame block behavior to wait until a frame becomes
    available or timeout(default: 1s, use st40p_tx_set_block_timeout to customize)*/
   ST40P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
+  /**
+   * Enable accurate statistics to be shown in the stat dump for the frmaebuffers
+   */
+  ST40P_TX_FLAG_ACCURATE_FRAMEBUFF_STATISTICS = (MTL_BIT32(25)),
 };
 
 /**

--- a/lib/src/st2110/experimental/st40_pipeline_tx.h
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.h
@@ -47,6 +47,7 @@ struct st40p_tx_ctx {
   uint64_t block_timeout_ns;
 
   /* get frame stat */
+  bool stat_enable_detailed_framebuffer_status;
   int stat_get_frame_try;
   int stat_get_frame_succ;
   int stat_put_frame;


### PR DESCRIPTION
Add experimental st40p api flag for our
framebuffer queue statistics. This will allow
the user to see clearly how many frames are in
which queue state.

Example output:
TX_st40p(0,st40sink), stat free: 15
TX_st40p(0,st40sink), stat in_user: 0
TX_st40p(0,st40sink), stat ready: 12
TX_st40p(0,st40sink), stat in_transmitting: 1

We are assuming this may be inaccurate, as no
locking is done on the queue, but it is
useful for debugging purposes.

We could possibly replace the current stats for
consumer/producer.

For now, we are keeping it as an optional
feature.