### PR TITLE
Fix: MTL lcore management gets into a bad state

### DIFF
--- a/lib/src/mt_sch.c
+++ b/lib/src/mt_sch.c
@@ -653,6 +653,7 @@ static void lcore_shm_check_and_clean(struct mt_lcore_shm_entry* shm_entry,
   if (0 != strncmp(u_info->user, info->user, sizeof(u_info->user))) return;
   if (kill(shm_entry->pid, 0) != 0) {
     shm_entry->active = false;
+    info("%s, releasing lcore for dead process pid %d \n", __func__, shm_entry->pid);
   }
 }
 


### PR DESCRIPTION
If MTL is not gracefully shutdown, then lcore shared memory can gets into a bad state. Check if PID of specified lcore is active, if no then release it