### PR TITLE
Add: support for planar16le

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -130,6 +130,21 @@ executable('PerfP10LeToRfc4175422be10', perf_p10le_to_rfc4175_422be10_sources,
   dependencies: [asan_dep, mtl, libpthread, ws2_32_dep]
 )
 
+executable('PerfRfc4175422be10ToP16Le', perf_rfc4175_422be10_to_p16le_sources,
+  c_args : app_c_args,
+  link_args: app_ld_args,
+  # asan should be always the first dep
+  dependencies: [asan_dep, mtl, libpthread, ws2_32_dep]
+)
+
+executable('PerfP16LeToRfc4175422be10', perf_p16le_to_rfc4175_422be10_sources,
+  c_args : app_c_args,
+  link_args: app_ld_args,
+  # asan should be always the first dep
+  dependencies: [asan_dep, mtl, libpthread, ws2_32_dep]
+)
+
+
 executable('PerfRfc4175422be10ToLe', perf_rfc4175_422be10_to_le_sources,
   c_args : app_c_args,
   link_args: app_ld_args,

--- a/app/perf/meson.build
+++ b/app/perf/meson.build
@@ -3,6 +3,8 @@
 
 perf_rfc4175_422be10_to_p10le_sources = files('rfc4175_422be10_to_p10le.c', '../sample/sample_util.c')
 perf_p10le_to_rfc4175_422be10_sources = files('p10le_to_rfc4175_422be10.c', '../sample/sample_util.c')
+perf_rfc4175_422be10_to_p16le_sources = files('rfc4175_422be10_to_p16le.c', '../sample/sample_util.c')
+perf_p16le_to_rfc4175_422be10_sources = files('p16le_to_rfc4175_422be10.c', '../sample/sample_util.c')
 perf_rfc4175_422be10_to_le_sources = files('rfc4175_422be10_to_le.c', '../sample/sample_util.c')
 perf_rfc4175_422le10_to_be_sources = files('rfc4175_422le10_to_be.c', '../sample/sample_util.c')
 perf_rfc4175_422be10_to_le8_sources = files('rfc4175_422be10_to_le8.c', '../sample/sample_util.c')

--- a/app/perf/p16le_to_rfc4175_422be10.c
+++ b/app/perf/p16le_to_rfc4175_422be10.c
@@ -1,0 +1,206 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2022 Intel Corporation
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../sample/sample_util.h"
+
+static void fill_422_planar_le16(uint16_t* y, uint16_t* b, uint16_t* r, int w, int h) {
+  int pg_size = w * h / 2;
+
+  for (int pg = 0; pg < pg_size; pg++) {
+    *b++ = (0 + pg * 4) << 6;
+    *y++ = (1 + pg * 4) << 6;
+    *r++ = (2 + pg * 4) << 6;
+    *y++ = (3 + pg * 4) << 6;
+  }
+}
+
+static int perf_cvt_planar_le16_to_422_10_pg2(mtl_handle st, int w, int h, int frames,
+                                              int fb_cnt) {
+  size_t fb_pg2_size = (size_t)w * h * 5 / 2;
+  //  mtl_udma_handle dma = mtl_udma_create(st, 128, MTL_PORT_P);
+  struct st20_rfc4175_422_10_pg2_be* pg_be =
+      (struct st20_rfc4175_422_10_pg2_be*)malloc(fb_pg2_size * fb_cnt);
+  size_t planar_size = (size_t)w * h * 2 * sizeof(uint16_t);
+  float planar_size_m = (float)planar_size / 1024 / 1024;
+  uint16_t* p10_u16 = (uint16_t*)mtl_hp_malloc(st, planar_size * fb_cnt, MTL_PORT_P);
+  uint16_t* p10_u16_b = p10_u16 + w * h;
+  uint16_t* p10_u16_r = p10_u16 + w * h * 3 / 2;
+  //  mtl_iova_t p10_u16_y_iova = mtl_hp_virt2iova(st, p10_u16);
+  //  mtl_iova_t p10_u16_b_iova = p10_u16_y_iova + planar_size / 2;
+  //  mtl_iova_t p10_u16_r_iova = p10_u16_b_iova + planar_size / 4;
+  //  mtl_iova_t p10_u16_y_in_iova, p10_u16_b_in_iova, p10_u16_r_in_iova;
+  enum mtl_simd_level cpu_level = mtl_get_simd_level();
+
+  struct st20_rfc4175_422_10_pg2_be* pg_be_out;
+  uint16_t* p10_u16_in;
+  uint16_t* p10_u16_b_in;
+  uint16_t* p10_u16_r_in;
+
+  for (int i = 0; i < fb_cnt; i++) {
+    p10_u16_in = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+    p10_u16_b_in = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+    p10_u16_r_in = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+    fill_422_planar_le16(p10_u16_in, p10_u16_b_in, p10_u16_r_in, w, h);
+  }
+
+  clock_t start, end;
+  float duration;
+
+  start = clock();
+  for (int i = 0; i < frames; i++) {
+    pg_be_out = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+    p10_u16_in = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+    p10_u16_b_in = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+    p10_u16_r_in = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+    st20_yuv422p16le_to_rfc4175_422be10_simd(p10_u16_in, p10_u16_b_in, p10_u16_r_in,
+                                             pg_be_out, w, h, MTL_SIMD_LEVEL_NONE);
+  }
+  end = clock();
+  duration = (float)(end - start) / CLOCKS_PER_SEC;
+  info("scalar, time: %f secs with %d frames(%dx%d,%fm@%d buffers)\n", duration, frames,
+       w, h, planar_size_m, fb_cnt);
+
+  if (cpu_level >= MTL_SIMD_LEVEL_AVX512) {
+    start = clock();
+    for (int i = 0; i < frames; i++) {
+      pg_be_out = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+      p10_u16_in = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+      p10_u16_b_in = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+      p10_u16_r_in = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+      st20_yuv422p16le_to_rfc4175_422be10_simd(p10_u16_in, p10_u16_b_in, p10_u16_r_in,
+                                               pg_be_out, w, h, MTL_SIMD_LEVEL_AVX512);
+    }
+    end = clock();
+    float duration_simd = (float)(end - start) / CLOCKS_PER_SEC;
+    info("avx512, time: %f secs with %d frames(%dx%d@%d buffers)\n", duration_simd,
+         frames, w, h, fb_cnt);
+    info("avx512, %fx performance to scalar\n", duration / duration_simd);
+    /*    if (dma) {
+          start = clock();
+          for (int i = 0; i < frames; i++) {
+            pg_be_out = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+            p10_u16_in = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+            p10_u16_b_in = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+            p10_u16_r_in = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+            p10_u16_y_in_iova = p10_u16_y_iova + (i % fb_cnt) * (planar_size);
+            p10_u16_b_in_iova = p10_u16_b_iova + (i % fb_cnt) * (planar_size);
+            p10_u16_r_in_iova = p10_u16_r_iova + (i % fb_cnt) * (planar_size);
+            st20_yuv422p10le_to_rfc4175_422be10_simd_dma(
+                dma, p10_u16_in, p10_u16_y_in_iova, p10_u16_b_in, p10_u16_b_in_iova,
+                p10_u16_r_in, p10_u16_r_in_iova, pg_be_out, w, h, MTL_SIMD_LEVEL_AVX512);
+          }
+          end = clock();
+          float duration_simd = (float)(end - start) / CLOCKS_PER_SEC;
+          info("avx512+dma, time: %f secs with %d frames(%dx%d@%d buffers)\n",
+       duration_simd, frames, w, h, fb_cnt); info("avx512+dma, %fx performance to
+       scalar\n", duration / duration_simd);
+        }*/
+  }
+  /*
+    if (cpu_level >= MTL_SIMD_LEVEL_AVX512_VBMI2) {
+      start = clock();
+      for (int i = 0; i < frames; i++) {
+        pg_be_out = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+        p10_u16_in = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+        p10_u16_b_in = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+        p10_u16_r_in = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+        st20_yuv422p10le_to_rfc4175_422be10_simd(p10_u16_in, p10_u16_b_in, p10_u16_r_in,
+                                                 pg_be_out, w, h,
+                                                 MTL_SIMD_LEVEL_AVX512_VBMI2);
+      }
+      end = clock();
+      float duration_vbmi = (float)(end - start) / CLOCKS_PER_SEC;
+      info("avx512_vbmi, time: %f secs with %d frames(%dx%d@%d buffers)\n", duration_vbmi,
+           frames, w, h, fb_cnt);
+      info("avx512_vbmi, %fx performance to scalar\n", duration / duration_vbmi);
+      if (dma) {
+        start = clock();
+        for (int i = 0; i < frames; i++) {
+          pg_be_out = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+          p10_u16_in = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+          p10_u16_b_in = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+          p10_u16_r_in = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+          p10_u16_y_in_iova = p10_u16_y_iova + (i % fb_cnt) * (planar_size);
+          p10_u16_b_in_iova = p10_u16_b_iova + (i % fb_cnt) * (planar_size);
+          p10_u16_r_in_iova = p10_u16_r_iova + (i % fb_cnt) * (planar_size);
+          st20_yuv422p10le_to_rfc4175_422be10_simd_dma(
+              dma, p10_u16_in, p10_u16_y_in_iova, p10_u16_b_in, p10_u16_b_in_iova,
+              p10_u16_r_in, p10_u16_r_in_iova, pg_be_out, w, h,
+              MTL_SIMD_LEVEL_AVX512_VBMI2);
+        }
+        end = clock();
+        float duration_simd = (float)(end - start) / CLOCKS_PER_SEC;
+        info("avx512_vbmi+dma, time: %f secs with %d frames(%dx%d@%d buffers)\n",
+             duration_simd, frames, w, h, fb_cnt);
+        info("avx512_vbmi+dma, %fx performance to scalar\n", duration / duration_simd);
+      }
+    } */
+
+  free(pg_be);
+  mtl_hp_free(st, p10_u16);
+  //  if (dma) mtl_udma_free(dma);
+
+  return 0;
+}
+
+static void* perf_thread(void* arg) {
+  struct st_sample_context* ctx = arg;
+  mtl_handle dev_handle = ctx->st;
+  int frames = ctx->perf_frames;
+  int fb_cnt = ctx->perf_fb_cnt;
+
+  unsigned int lcore = 0;
+  int ret = mtl_get_lcore(dev_handle, &lcore);
+  if (ret < 0) {
+    return NULL;
+  }
+  mtl_bind_to_lcore(dev_handle, pthread_self(), lcore);
+  info("%s, run in lcore %u\n", __func__, lcore);
+
+  perf_cvt_planar_le16_to_422_10_pg2(dev_handle, 640, 480, frames, fb_cnt);
+  perf_cvt_planar_le16_to_422_10_pg2(dev_handle, 1280, 720, frames, fb_cnt);
+  perf_cvt_planar_le16_to_422_10_pg2(dev_handle, 1920, 1080, frames, fb_cnt);
+  perf_cvt_planar_le16_to_422_10_pg2(dev_handle, 1920 * 2, 1080 * 2, frames, fb_cnt);
+  perf_cvt_planar_le16_to_422_10_pg2(dev_handle, 1920 * 4, 1080 * 4, frames, fb_cnt);
+
+  mtl_put_lcore(dev_handle, lcore);
+
+  return NULL;
+}
+
+int main(int argc, char** argv) {
+  struct st_sample_context ctx;
+  int ret;
+
+  memset(&ctx, 0, sizeof(ctx));
+  ret = tx_sample_parse_args(&ctx, argc, argv);
+  if (ret < 0) return ret;
+
+  ctx.st = mtl_init(&ctx.param);
+  if (!ctx.st) {
+    err("%s: mtl_init fail\n", __func__);
+    return -EIO;
+  }
+
+  pthread_t thread;
+  ret = pthread_create(&thread, NULL, perf_thread, &ctx);
+  if (ret) goto exit;
+  pthread_join(thread, NULL);
+
+exit:
+  /* release sample(st) dev */
+  if (ctx.st) {
+    mtl_uninit(ctx.st);
+    ctx.st = NULL;
+  }
+  return ret;
+}

--- a/app/perf/perf_test.sh
+++ b/app/perf/perf_test.sh
@@ -23,6 +23,8 @@ perf_func() {
 
 perf_func PerfRfc4175422be10ToP10Le
 perf_func PerfP10LeToRfc4175422be10
+perf_func PerfRfc4175422be10ToP16Le
+perf_func PerfP16LeToRfc4175422be10
 perf_func PerfRfc4175422be10ToLe
 perf_func PerfRfc4175422le10ToBe
 perf_func PerfRfc4175422be10ToLe8

--- a/app/perf/rfc4175_422be10_to_p16le.c
+++ b/app/perf/rfc4175_422be10_to_p16le.c
@@ -1,0 +1,182 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2022 Intel Corporation
+ */
+
+#include "../sample/sample_util.h"
+
+static int perf_cvt_422_10_pg2_to_planar_le16(mtl_handle st, int w, int h, int frames,
+                                              int fb_cnt) {
+  size_t fb_pg2_size = (size_t)w * h * 5 / 2;
+  //  mtl_udma_handle dma = mtl_udma_create(st, 128, MTL_PORT_P);
+  struct st20_rfc4175_422_10_pg2_be* pg_be =
+      (struct st20_rfc4175_422_10_pg2_be*)mtl_hp_malloc(st, fb_pg2_size * fb_cnt,
+                                                        MTL_PORT_P);
+  //  mtl_iova_t pg_be_iova = mtl_hp_virt2iova(st, pg_be);
+  //  mtl_iova_t pg_be_in_iova;
+  size_t planar_size = (size_t)w * h * 2 * sizeof(uint16_t);
+  float planar_size_m = (float)planar_size / 1024 / 1024;
+  uint16_t* p10_u16 = (uint16_t*)malloc(planar_size * fb_cnt);
+  uint16_t* p10_u16_b = p10_u16 + w * h;
+  uint16_t* p10_u16_r = p10_u16 + w * h * 3 / 2;
+  enum mtl_simd_level cpu_level = mtl_get_simd_level();
+
+  struct st20_rfc4175_422_10_pg2_be* pg_be_in;
+  uint16_t* p10_u16_out;
+  uint16_t* p10_u16_b_out;
+  uint16_t* p10_u16_r_out;
+
+  for (int i = 0; i < fb_cnt; i++) {
+    pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+    fill_rfc4175_422_10_pg2_data(pg_be_in, w, h);
+  }
+
+  clock_t start, end;
+  float duration;
+
+  start = clock();
+  for (int i = 0; i < frames; i++) {
+    pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+    p10_u16_out = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+    p10_u16_b_out = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+    p10_u16_r_out = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+    st20_rfc4175_422be10_to_yuv422p16le_simd(pg_be_in, p10_u16_out, p10_u16_b_out,
+                                             p10_u16_r_out, w, h, MTL_SIMD_LEVEL_NONE);
+  }
+  end = clock();
+  duration = (float)(end - start) / CLOCKS_PER_SEC;
+  info("scalar, time: %f secs with %d frames(%dx%d,%fm@%d buffers)\n", duration, frames,
+       w, h, planar_size_m, fb_cnt);
+
+  if (cpu_level >= MTL_SIMD_LEVEL_AVX512) {
+    start = clock();
+    for (int i = 0; i < frames; i++) {
+      pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+      p10_u16_out = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+      p10_u16_b_out = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+      p10_u16_r_out = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+      st20_rfc4175_422be10_to_yuv422p16le_simd(pg_be_in, p10_u16_out, p10_u16_b_out,
+                                               p10_u16_r_out, w, h,
+                                               MTL_SIMD_LEVEL_AVX512);
+    }
+    end = clock();
+    float duration_simd = (float)(end - start) / CLOCKS_PER_SEC;
+    info("avx512, time: %f secs with %d frames(%dx%d@%d buffers)\n", duration_simd,
+         frames, w, h, fb_cnt);
+    info("avx512, %fx performance to scalar\n", duration / duration_simd);
+    /*
+        if (dma) {
+          start = clock();
+          for (int i = 0; i < frames; i++) {
+            pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+            pg_be_in_iova = pg_be_iova + (i % fb_cnt) * (fb_pg2_size);
+            p10_u16_out = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+            p10_u16_b_out = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+            p10_u16_r_out = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+            st20_rfc4175_422be10_to_yuv422p16le_simd_dma(
+                dma, pg_be_in, pg_be_in_iova, p10_u16_out, p10_u16_b_out, p10_u16_r_out,
+       w, h, MTL_SIMD_LEVEL_AVX512);
+          }
+          end = clock();
+          float duration_simd = (float)(end - start) / CLOCKS_PER_SEC;
+          info("dma+avx512, time: %f secs with %d frames(%dx%d@%d buffers)\n",
+       duration_simd, frames, w, h, fb_cnt); info("dma+avx512, %fx performance to
+       scalar\n", duration / duration_simd);
+        }*/
+  }
+  /*
+    if (cpu_level >= MTL_SIMD_LEVEL_AVX512_VBMI2) {
+      start = clock();
+      for (int i = 0; i < frames; i++) {
+        pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+        p10_u16_out = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+        p10_u16_b_out = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+        p10_u16_r_out = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+        st20_rfc4175_422be10_to_yuv422p16le_simd(pg_be_in, p10_u16_out, p10_u16_b_out,
+                                                 p10_u16_r_out, w, h,
+                                                 MTL_SIMD_LEVEL_AVX512_VBMI2);
+      }
+      end = clock();
+      float duration_vbmi = (float)(end - start) / CLOCKS_PER_SEC;
+      info("avx512_vbmi, time: %f secs with %d frames(%dx%d@%d buffers)\n", duration_vbmi,
+           frames, w, h, fb_cnt);
+      info("avx512_vbmi, %fx performance to scalar\n", duration / duration_vbmi);
+
+      if (dma) {
+        start = clock();
+        for (int i = 0; i < frames; i++) {
+          pg_be_in = pg_be + (i % fb_cnt) * (fb_pg2_size / sizeof(*pg_be));
+          pg_be_in_iova = pg_be_iova + (i % fb_cnt) * (fb_pg2_size);
+          p10_u16_out = p10_u16 + (i % fb_cnt) * (planar_size / sizeof(*p10_u16));
+          p10_u16_b_out = p10_u16_b + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_b));
+          p10_u16_r_out = p10_u16_r + (i % fb_cnt) * (planar_size / sizeof(*p10_u16_r));
+          st20_rfc4175_422be10_to_yuv422p16le_simd_dma(
+              dma, pg_be_in, pg_be_in_iova, p10_u16_out, p10_u16_b_out, p10_u16_r_out, w,
+    h, MTL_SIMD_LEVEL_AVX512_VBMI2);
+        }
+        end = clock();
+        float duration_vbmi = (float)(end - start) / CLOCKS_PER_SEC;
+        info("dma+avx512_vbmi, time: %f secs with %d frames(%dx%d@%d buffers)\n",
+             duration_vbmi, frames, w, h, fb_cnt);
+        info("dma+avx512_vbmi, %fx performance to scalar\n", duration / duration_vbmi);
+      }
+    }*/
+
+  mtl_hp_free(st, pg_be);
+  free(p10_u16);
+  //  if (dma) mtl_udma_free(dma);
+
+  return 0;
+}
+
+static void* perf_thread(void* arg) {
+  struct st_sample_context* ctx = arg;
+  mtl_handle dev_handle = ctx->st;
+  int frames = ctx->perf_frames;
+  int fb_cnt = ctx->perf_fb_cnt;
+
+  unsigned int lcore = 0;
+  int ret = mtl_get_lcore(dev_handle, &lcore);
+  if (ret < 0) {
+    return NULL;
+  }
+  mtl_bind_to_lcore(dev_handle, pthread_self(), lcore);
+  info("%s, run in lcore %u\n", __func__, lcore);
+
+  perf_cvt_422_10_pg2_to_planar_le16(dev_handle, 640, 480, frames, fb_cnt);
+  perf_cvt_422_10_pg2_to_planar_le16(dev_handle, 1280, 720, frames, fb_cnt);
+  perf_cvt_422_10_pg2_to_planar_le16(dev_handle, 1920, 1080, frames, fb_cnt);
+  perf_cvt_422_10_pg2_to_planar_le16(dev_handle, 1920 * 2, 1080 * 2, frames, fb_cnt);
+  perf_cvt_422_10_pg2_to_planar_le16(dev_handle, 1920 * 4, 1080 * 4, frames, fb_cnt);
+
+  mtl_put_lcore(dev_handle, lcore);
+
+  return NULL;
+}
+
+int main(int argc, char** argv) {
+  struct st_sample_context ctx;
+  int ret;
+
+  memset(&ctx, 0, sizeof(ctx));
+  ret = tx_sample_parse_args(&ctx, argc, argv);
+  if (ret < 0) return ret;
+
+  ctx.st = mtl_init(&ctx.param);
+  if (!ctx.st) {
+    err("%s: mtl_init fail\n", __func__);
+    return -EIO;
+  }
+
+  pthread_t thread;
+  ret = pthread_create(&thread, NULL, perf_thread, &ctx);
+  if (ret) goto exit;
+  pthread_join(thread, NULL);
+
+exit:
+  /* release sample(st) dev */
+  if (ctx.st) {
+    mtl_uninit(ctx.st);
+    ctx.st = NULL;
+  }
+  return ret;
+}

--- a/app/tools/convert_app_args.c
+++ b/app/tools/convert_app_args.c
@@ -60,6 +60,9 @@ static enum cvt_frame_fmt cvt_parse_fmt(const char* sfmt) {
   if (!strcmp(sfmt, "yuv422p12le")) {
     return CVT_FRAME_FMT_YUV422PLANAR12LE;
   }
+  if (!strcmp(sfmt, "yuv422p16le")) {
+    return CVT_FRAME_FMT_YUV422PLANAR16LE;
+  }
   if (!strcmp(sfmt, "yuv444p10le")) {
     return CVT_FRAME_FMT_YUV444PLANAR10LE;
   }

--- a/app/tools/convert_app_base.h
+++ b/app/tools/convert_app_base.h
@@ -50,7 +50,7 @@ enum cvt_frame_fmt {
   CVT_FRAME_FMT_RGBRFC4175PG4BE10,
   /** RFC4175 in ST2110, two RGB 12 bit pixel groups on 9 bytes, big endian */
   CVT_FRAME_FMT_RGBRFC4175PG2BE12,
-  /** YUV 422 planar 10bit little endian with 6 bit padding */
+  /** YUV 422 planar 16bit little endian */
   CVT_FRAME_FMT_YUV422PLANAR16LE,
   /** max value of this enum */
   CVT_FRAME_FMT_MAX,

--- a/app/tools/convert_app_base.h
+++ b/app/tools/convert_app_base.h
@@ -50,6 +50,8 @@ enum cvt_frame_fmt {
   CVT_FRAME_FMT_RGBRFC4175PG4BE10,
   /** RFC4175 in ST2110, two RGB 12 bit pixel groups on 9 bytes, big endian */
   CVT_FRAME_FMT_RGBRFC4175PG2BE12,
+  /** YUV 422 planar 10bit little endian with 6 bit padding */
+  CVT_FRAME_FMT_YUV422PLANAR16LE,
   /** max value of this enum */
   CVT_FRAME_FMT_MAX,
 };

--- a/include/st_convert_api.h
+++ b/include/st_convert_api.h
@@ -998,6 +998,20 @@ static inline int st20_rfc4175_444le12_to_gbrp12le(struct st20_rfc4175_444_12_pg
   return st20_rfc4175_444le12_to_444p12le(pg, g, r, b, w, h);
 }
 
+// Convert rfc4175_422be10 to yuv422p16le with 6 bit padding (no optimization so far).
+static inline int st20_rfc4175_422be10_to_yuv422p16le(
+    struct st20_rfc4175_422_10_pg2_be* pg, uint16_t* y, uint16_t* b, uint16_t* r,
+    uint32_t w, uint32_t h) {
+  return st20_rfc4175_422be10_to_yuv422p16le_simd(pg, y, b, r, w, h, MTL_SIMD_LEVEL_MAX);
+}
+
+// Lossy conversion from yuv422p16le to rfc4175_422be10 (no optimization so far).
+static inline int st20_yuv422p16le_to_rfc4175_422be10(
+    uint16_t* y, uint16_t* b, uint16_t* r, struct st20_rfc4175_422_10_pg2_be* pg,
+    uint32_t w, uint32_t h) {
+  return st20_yuv422p16le_to_rfc4175_422be10_simd(y, b, r, pg, w, h, MTL_SIMD_LEVEL_MAX);
+}
+
 /**
  * Convert AM824 subframe to AES3 subframe.
  *

--- a/include/st_convert_api.h
+++ b/include/st_convert_api.h
@@ -998,14 +998,50 @@ static inline int st20_rfc4175_444le12_to_gbrp12le(struct st20_rfc4175_444_12_pg
   return st20_rfc4175_444le12_to_444p12le(pg, g, r, b, w, h);
 }
 
-// Convert rfc4175_422be10 to yuv422p16le with 6 bit padding (no optimization so far).
+/**
+ * Convert rfc4175_422be10 to yuv422p16le (10 bit with 6-bit padding).
+ *
+ * @param pg
+ *   Point to pg(rfc4175_422be10) data.
+ * @param y
+ *   Point to Y(yuv422p16le) vector.
+ * @param b
+ *   Point to b(yuv422p16le) vector.
+ * @param r
+ *   Point to r(yuv422p16le) vector.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
 static inline int st20_rfc4175_422be10_to_yuv422p16le(
     struct st20_rfc4175_422_10_pg2_be* pg, uint16_t* y, uint16_t* b, uint16_t* r,
     uint32_t w, uint32_t h) {
   return st20_rfc4175_422be10_to_yuv422p16le_simd(pg, y, b, r, w, h, MTL_SIMD_LEVEL_MAX);
 }
 
-// Lossy conversion from yuv422p16le to rfc4175_422be10 (no optimization so far).
+/**
+ * Lossy conversion from yuv422p16le to rfc4175_422be10.
+ *
+ * @param y
+ *   Point to Y(yuv422p16le) vector.
+ * @param b
+ *   Point to b(yuv422p16le) vector.
+ * @param r
+ *   Point to r(yuv422p16le) vector.
+ * @param pg
+ *   Point to pg(rfc4175_422be10) data.
+ * @param w
+ *   The st2110-20(video) width.
+ * @param h
+ *   The st2110-20(video) height.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if convert fail.
+ */
 static inline int st20_yuv422p16le_to_rfc4175_422be10(
     uint16_t* y, uint16_t* b, uint16_t* r, struct st20_rfc4175_422_10_pg2_be* pg,
     uint32_t w, uint32_t h) {

--- a/include/st_convert_internal.h
+++ b/include/st_convert_internal.h
@@ -1482,14 +1482,13 @@ static inline int st20_rfc4175_422be10_to_yuv422p10le_2way_cpuva(
       (uint16_t*)r_decimated, decimator);
 }
 
-/* Convert rfc4175_422be10 to yuv422p16le (10 bit with 6-bit padding) without
- * optimization*/
+/* Convert rfc4175_422be10 to yuv422p16le (10 bit with 6-bit padding)*/
 int st20_rfc4175_422be10_to_yuv422p16le_simd(struct st20_rfc4175_422_10_pg2_be* pg,
                                              uint16_t* y, uint16_t* b, uint16_t* r,
                                              uint32_t w, uint32_t h,
                                              enum mtl_simd_level level);
 
-// Lossy conversion from yuv422p16le to rfc4175_422be10 (no optimization so far).
+/* Lossy conversion from yuv422p16le to rfc4175_422be10 */
 int st20_yuv422p16le_to_rfc4175_422be10_simd(uint16_t* y, uint16_t* b, uint16_t* r,
                                              struct st20_rfc4175_422_10_pg2_be* pg,
                                              uint32_t w, uint32_t h,

--- a/include/st_convert_internal.h
+++ b/include/st_convert_internal.h
@@ -1482,6 +1482,19 @@ static inline int st20_rfc4175_422be10_to_yuv422p10le_2way_cpuva(
       (uint16_t*)r_decimated, decimator);
 }
 
+/* Convert rfc4175_422be10 to yuv422p16le (10 bit with 6-bit padding) without
+ * optiomzation*/
+int st20_rfc4175_422be10_to_yuv422p16le_simd(struct st20_rfc4175_422_10_pg2_be* pg,
+                                             uint16_t* y, uint16_t* b, uint16_t* r,
+                                             uint32_t w, uint32_t h,
+                                             enum mtl_simd_level level);
+
+// Lossy conversion from yuv422p16le to rfc4175_422be10 (no optimization so far).
+int st20_yuv422p16le_to_rfc4175_422be10_simd(uint16_t* y, uint16_t* b, uint16_t* r,
+                                             struct st20_rfc4175_422_10_pg2_be* pg,
+                                             uint32_t w, uint32_t h,
+                                             enum mtl_simd_level level);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/st_convert_internal.h
+++ b/include/st_convert_internal.h
@@ -1483,7 +1483,7 @@ static inline int st20_rfc4175_422be10_to_yuv422p10le_2way_cpuva(
 }
 
 /* Convert rfc4175_422be10 to yuv422p16le (10 bit with 6-bit padding) without
- * optiomzation*/
+ * optimization*/
 int st20_rfc4175_422be10_to_yuv422p16le_simd(struct st20_rfc4175_422_10_pg2_be* pg,
                                              uint16_t* y, uint16_t* b, uint16_t* r,
                                              uint32_t w, uint32_t h,

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -148,6 +148,8 @@ enum st_frame_fmt {
   ST_FRAME_FMT_YUV422CUSTOM8 = 13,
   /** YUV 420 planar 8bit */
   ST_FRAME_FMT_YUV420PLANAR8 = 14,
+  /** YUV 422 planar 10bit little endian, with 6-bit padding in least significant bits*/
+  ST_FRAME_FMT_YUV422PLANAR16LE = 15,
   /** End of yuv format list, new yuv should be inserted before this */
   ST_FRAME_FMT_YUV_END,
 
@@ -208,6 +210,8 @@ enum st_frame_fmt {
 #define ST_FMT_CAP_UYVY (MTL_BIT64(ST_FRAME_FMT_UYVY))
 /** ST format cap of ST_FRAME_FMT_YUV422RFC4175PG2BE10 */
 #define ST_FMT_CAP_YUV422RFC4175PG2BE10 (MTL_BIT64(ST_FRAME_FMT_YUV422RFC4175PG2BE10))
+/** ST format cap of ST_FRAME_FMT_YUV422PLANAR16LE (10 bit with 6 bit padding)*/
+#define ST_FMT_CAP_YUV422PLANAR16LE (MTL_BIT64(ST_FRAME_FMT_YUV422PLANAR16LE))
 
 /** ST format cap of ST_FRAME_FMT_ARGB */
 #define ST_FMT_CAP_ARGB (MTL_BIT64(ST_FRAME_FMT_ARGB))

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -498,8 +498,8 @@ static int rx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_rx
   if (ops->flags & ST20P_RX_FLAG_USE_MULTI_THREADS)
     ops_rx.flags |= ST20_RX_FLAG_USE_MULTI_THREADS;
   if (ops->flags & ST20P_RX_FLAG_PKT_CONVERT) {
-    uint64_t pkt_cvt_output_cap =
-        ST_FMT_CAP_YUV422PLANAR10LE | ST_FMT_CAP_Y210 | ST_FMT_CAP_UYVY;
+    uint64_t pkt_cvt_output_cap = ST_FMT_CAP_YUV422PLANAR10LE | ST_FMT_CAP_Y210 |
+                                  ST_FMT_CAP_UYVY | ST_FMT_CAP_YUV422PLANAR16LE;
     if (ops->transport_fmt != ST20_FMT_YUV_422_10BIT) {
       err("%s(%d), only 422 10bit support packet convert\n", __func__, idx);
       return -EIO;

--- a/lib/src/st2110/st_avx512.h
+++ b/lib/src/st2110/st_avx512.h
@@ -119,4 +119,12 @@ int st20_rfc4175_422be10_to_yuv420p8_avx512(struct st20_rfc4175_422_10_pg2_be* p
                                             uint8_t* y, uint8_t* b, uint8_t* r,
                                             uint32_t w, uint32_t h);
 
+int st20_rfc4175_422be10_to_yuv422p16le_avx512(struct st20_rfc4175_422_10_pg2_be* pg,
+                                               uint16_t* y, uint16_t* b, uint16_t* r,
+                                               uint32_t w, uint32_t h);
+
+int st20_yuv422p16le_to_rfc4175_422be10_avx512(uint16_t* y, uint16_t* b, uint16_t* r,
+                                               struct st20_rfc4175_422_10_pg2_be* pg,
+                                               uint32_t w, uint32_t h);
+
 #endif

--- a/lib/src/st2110/st_convert.c
+++ b/lib/src/st2110/st_convert.c
@@ -515,6 +515,148 @@ static int convert_gbrp12le_to_rfc4175_444be12(struct st_frame* src,
   return ret;
 }
 
+// 10bit with 6bit padding
+static int convert_rfc4175_422be10_to_yuv422p16le(struct st_frame* src,
+                                                  struct st_frame* dst) {
+  int ret = 0;
+  struct st20_rfc4175_422_10_pg2_be* be10 = NULL;
+  uint16_t* y = NULL;
+  uint16_t* b = NULL;
+  uint16_t* r = NULL;
+  uint32_t h = st_frame_data_height(dst);
+
+  if (!has_lines_padding(src, dst)) {
+    be10 = src->addr[0];
+    y = dst->addr[0];
+    b = dst->addr[1];
+    r = dst->addr[2];
+    ret = st20_rfc4175_422be10_to_yuv422p16le(be10, y, b, r, dst->width, h);
+  } else {
+    for (uint32_t line = 0; line < h; line++) {
+      be10 = src->addr[0] + src->linesize[0] * line;
+      y = dst->addr[0] + dst->linesize[0] * line;
+      b = dst->addr[1] + dst->linesize[1] * line;
+      r = dst->addr[2] + dst->linesize[2] * line;
+      ret = st20_rfc4175_422be10_to_yuv422p16le(be10, y, b, r, dst->width, 1);
+    }
+  }
+  return ret;
+}
+
+static int convert_yuv422p16le_to_rfc4175_422be10(struct st_frame* src,
+                                                  struct st_frame* dst) {
+  int ret = 0;
+  struct st20_rfc4175_422_10_pg2_be* be10 = NULL;
+  uint16_t* y = NULL;
+  uint16_t* b = NULL;
+  uint16_t* r = NULL;
+  uint32_t h = st_frame_data_height(dst);
+
+  if (!has_lines_padding(src, dst)) {
+    y = src->addr[0];
+    b = src->addr[1];
+    r = src->addr[2];
+    be10 = dst->addr[0];
+    ret = st20_yuv422p16le_to_rfc4175_422be10(y, b, r, be10, dst->width, h);
+  } else {
+    for (uint32_t line = 0; line < h; line++) {
+      y = src->addr[0] + src->linesize[0] * line;
+      b = src->addr[1] + src->linesize[1] * line;
+      r = src->addr[2] + src->linesize[2] * line;
+      be10 = dst->addr[0] + dst->linesize[0] * line;
+      ret = st20_yuv422p16le_to_rfc4175_422be10(y, b, r, be10, dst->width, 1);
+    }
+  }
+  return ret;
+}
+
+int st20_rfc4175_422be10_to_yuv422p16le_scalar(struct st20_rfc4175_422_10_pg2_be* pg,
+                                               uint16_t* y, uint16_t* b, uint16_t* r,
+                                               uint32_t w, uint32_t h) {
+  uint32_t cnt = w * h / 2; /* two pgs in one convert */
+  uint16_t cb, y0, cr, y1;
+
+  for (uint32_t pg2 = 0; pg2 < cnt; pg2++) {
+    cb = (pg->Cb00 << 2) + pg->Cb00_;
+    cb <<= 6;
+    y0 = (pg->Y00 << 4) + pg->Y00_;
+    y0 <<= 6;
+    cr = (pg->Cr00 << 6) + pg->Cr00_;
+    cr <<= 6;
+    y1 = (pg->Y01 << 8) + pg->Y01_;
+    y1 <<= 6;
+
+    *b++ = cb;
+    *y++ = y0;
+    *r++ = cr;
+    *y++ = y1;
+    pg++;
+  }
+
+  return 0;
+}
+
+int st20_rfc4175_422be10_to_yuv422p16le_simd(struct st20_rfc4175_422_10_pg2_be* pg,
+                                             uint16_t* y, uint16_t* b, uint16_t* r,
+                                             uint32_t w, uint32_t h,
+                                             enum mtl_simd_level level) {
+  enum mtl_simd_level cpu_level = mtl_get_simd_level();
+  int ret;
+
+  MTL_MAY_UNUSED(cpu_level);
+  MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
+
+  /* the last option */
+  return st20_rfc4175_422be10_to_yuv422p16le_scalar(pg, y, b, r, w, h);
+}
+
+static int st20_yuv422p16le_to_rfc4175_422be10_scalar(
+    uint16_t* y, uint16_t* b, uint16_t* r, struct st20_rfc4175_422_10_pg2_be* pg,
+    uint32_t w, uint32_t h) {
+  uint32_t cnt = w * h / 2; /* two pgs in one convert */
+  uint16_t cb, y0, cr, y1;
+
+  for (uint32_t pg2 = 0; pg2 < cnt; pg2++) {
+    cb = *b++;
+    y0 = *y++;
+    cr = *r++;
+    y1 = *y++;
+
+    cb >>= 6;
+    pg->Cb00 = cb >> 2;
+    pg->Cb00_ = cb;
+    y0 >>= 6;
+    pg->Y00 = y0 >> 4;
+    pg->Y00_ = y0;
+    cr >>= 6;
+    pg->Cr00 = cr >> 6;
+    pg->Cr00_ = cr;
+    y1 >>= 6;
+    pg->Y01 = y1 >> 8;
+    pg->Y01_ = y1;
+
+    pg++;
+  }
+
+  return 0;
+}
+
+int st20_yuv422p16le_to_rfc4175_422be10_simd(uint16_t* y, uint16_t* b, uint16_t* r,
+                                             struct st20_rfc4175_422_10_pg2_be* pg,
+                                             uint32_t w, uint32_t h,
+                                             enum mtl_simd_level level) {
+  enum mtl_simd_level cpu_level = mtl_get_simd_level();
+  int ret;
+
+  MTL_MAY_UNUSED(level);
+  MTL_MAY_UNUSED(cpu_level);
+  MTL_MAY_UNUSED(ret);
+
+  /* the last option */
+  return st20_yuv422p16le_to_rfc4175_422be10_scalar(y, b, r, pg, w, h);
+}
+
 static const struct st_frame_converter converters[] = {
     {
         .src_fmt = ST_FRAME_FMT_YUV422RFC4175PG2BE10,
@@ -610,6 +752,16 @@ static const struct st_frame_converter converters[] = {
         .src_fmt = ST_FRAME_FMT_GBRPLANAR12LE,
         .dst_fmt = ST_FRAME_FMT_RGBRFC4175PG2BE12,
         .convert_func = convert_gbrp12le_to_rfc4175_444be12,
+    },
+    {
+        .src_fmt = ST_FRAME_FMT_YUV422RFC4175PG2BE10,
+        .dst_fmt = ST_FRAME_FMT_YUV422PLANAR16LE,  // 6bit padding
+        .convert_func = convert_rfc4175_422be10_to_yuv422p16le,
+    },
+    {
+        .src_fmt = ST_FRAME_FMT_YUV422PLANAR16LE,
+        .dst_fmt = ST_FRAME_FMT_YUV422RFC4175PG2BE10,
+        .convert_func = convert_yuv422p16le_to_rfc4175_422be10,
     },
 };
 

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -451,7 +451,7 @@ static const struct st_frame_fmt_desc st_frame_fmt_descs[] = {
         .sampling = ST_FRAME_SAMPLING_MAX,
     },
     {
-        /* ST_FRAME_FMT_YUV422PLANAR16LE (6 bit padding) */
+        /* ST_FRAME_FMT_YUV422PLANAR16LE */
         .fmt = ST_FRAME_FMT_YUV422PLANAR16LE,
         .name = "YUV422PLANAR16LE",
         .planes = 3,

--- a/lib/src/st2110/st_fmt.c
+++ b/lib/src/st2110/st_fmt.c
@@ -450,6 +450,13 @@ static const struct st_frame_fmt_desc st_frame_fmt_descs[] = {
         .planes = 1,
         .sampling = ST_FRAME_SAMPLING_MAX,
     },
+    {
+        /* ST_FRAME_FMT_YUV422PLANAR16LE (6 bit padding) */
+        .fmt = ST_FRAME_FMT_YUV422PLANAR16LE,
+        .name = "YUV422PLANAR16LE",
+        .planes = 3,
+        .sampling = ST_FRAME_SAMPLING_422,
+    },
 };
 
 enum st_frame_fmt st_codec_codestream_fmt(enum st22_codec codec) {
@@ -590,6 +597,9 @@ size_t st_frame_size(enum st_frame_fmt fmt, uint32_t width, uint32_t height,
     case ST_FRAME_FMT_YUV420CUSTOM8:
     case ST_FRAME_FMT_YUV420PLANAR8:
       size = st20_frame_size(ST20_FMT_YUV_420_8BIT, width, height);
+      break;
+    case ST_FRAME_FMT_YUV422PLANAR16LE:
+      size = st20_frame_size(ST20_FMT_YUV_422_16BIT, width, height);
       break;
     default:
       err("%s, invalid fmt %d\n", __func__, fmt);

--- a/lib/src/st2110/st_fmt.h
+++ b/lib/src/st2110/st_fmt.h
@@ -78,6 +78,22 @@ static inline void st20_unpack_pg2be_422le12(struct st20_rfc4175_422_12_pg2_be* 
   *y01 = y1;
 }
 
+static inline void st20_unpack_pg2be_422le16(struct st20_rfc4175_422_10_pg2_be* pg,
+                                             uint16_t* cb00, uint16_t* y00,
+                                             uint16_t* cr00, uint16_t* y01) {
+  uint16_t cb, y0, cr, y1;
+
+  cb = (pg->Cb00 << 8) + (pg->Cb00_ << 6);
+  y0 = (pg->Y00 << 10) + (pg->Y00_ << 6);
+  cr = (pg->Cr00 << 12) + (pg->Cr00_ << 6);
+  y1 = (pg->Y01 << 14) + (pg->Y01_ << 6);
+
+  *cb00 = cb;
+  *y00 = y0;
+  *cr00 = cr;
+  *y01 = y1;
+}
+
 void st_frame_init_plane_single_src(struct st_frame* frame, void* addr, mtl_iova_t iova);
 
 enum st_frame_fmt st_codec_codestream_fmt(enum st22_codec codec);

--- a/plugins/sample/convert_plugin_sample.c
+++ b/plugins/sample/convert_plugin_sample.c
@@ -149,7 +149,8 @@ st_plugin_priv st_plugin_create(mtl_handle st) {
   c_dev.input_fmt_caps = ST_FMT_CAP_YUV422PLANAR10LE | ST_FMT_CAP_UYVY | ST_FMT_CAP_V210 |
                          ST_FMT_CAP_YUV422RFC4175PG2BE10;
   c_dev.output_fmt_caps = ST_FMT_CAP_YUV422PLANAR10LE | ST_FMT_CAP_UYVY |
-                          ST_FMT_CAP_V210 | ST_FMT_CAP_YUV422RFC4175PG2BE10;
+                          ST_FMT_CAP_V210 | ST_FMT_CAP_YUV422RFC4175PG2BE10 |
+                          ST_FMT_CAP_YUV422PLANAR16LE;
   c_dev.create_session = converter_create_session;
   c_dev.free_session = converter_free_session;
   c_dev.notify_frame_available = converter_frame_available;

--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -1909,6 +1909,8 @@ static int parse_st20p_format(json_object* st20p_obj, st_json_st20p_session_t* s
     st20p->info.format = ST_FRAME_FMT_GBRPLANAR12LE;
   } else if (strcmp(format, "RGBRFC4175PG2BE12") == 0) {
     st20p->info.format = ST_FRAME_FMT_RGBRFC4175PG2BE12;
+  } else if (strcmp(format, "YUV422PLANAR16LE") == 0) {
+    st20p->info.format = ST_FRAME_FMT_YUV422PLANAR16LE;
   } else {
     err("%s, invalid output format %s\n", __func__, format);
     return -ST_JSON_NOT_VALID;

--- a/tests/unittest/cvt_test.cpp
+++ b/tests/unittest/cvt_test.cpp
@@ -251,6 +251,8 @@ TEST(Cvt, yuv422p10le_to_rfc4175_422be10_scalar) {
 TEST(Cvt, yuv422p10le_to_rfc4175_422be10_avx512) {
   test_cvt_yuv422p10le_to_rfc4175_422be10(1920, 1080, MTL_SIMD_LEVEL_AVX512,
                                           MTL_SIMD_LEVEL_AVX512);
+  test_cvt_yuv422p10le_to_rfc4175_422be10(722, 111, MTL_SIMD_LEVEL_AVX512,
+                                          MTL_SIMD_LEVEL_AVX512);
   test_cvt_yuv422p10le_to_rfc4175_422be10(722, 111, MTL_SIMD_LEVEL_NONE,
                                           MTL_SIMD_LEVEL_AVX512);
   test_cvt_yuv422p10le_to_rfc4175_422be10(722, 111, MTL_SIMD_LEVEL_AVX512,


### PR DESCRIPTION
added FRAME_FMT_YUV422PLANAR16LE, implemented conversion to and from RFC4175_42210BE in scalar and AVX512 