### PR TITLE
Add: rtp_timestamp_delta_us to st30_pipeline_tx

### DIFF
--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -397,6 +397,12 @@ struct st30_tx_ops {
    */
   uint8_t tx_dst_mac[MTL_SESSION_PORT_MAX][MTL_MAC_ADDR_LEN];
 
+  /**
+   * Optional. The rtp timestamp delta(us) to the start time of frame.
+   * Zero means the rtp timestamp at the start of the frame.
+   */
+  int32_t rtp_timestamp_delta_us;
+
   /** Mandatory for ST30_TYPE_RTP_LEVEL. rtp ring queue size, must be power of 2 */
   uint32_t rtp_ring_size;
   /**

--- a/include/st30_pipeline_api.h
+++ b/include/st30_pipeline_api.h
@@ -132,6 +132,12 @@ struct st30p_tx_ops {
    */
   int (*notify_frame_done)(void* priv, struct st30_frame* frame);
 
+  /**
+   * Optional. The rtp timestamp delta(us) to the start time of frame.
+   * Zero means the rtp timestamp at the start of the frame.
+   */
+  int32_t rtp_timestamp_delta_us;
+
   /*
    * Optional. The size of fifo ring which used between the packet builder and pacing.
    * Leave to zero to use default value: the packet number within

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.c
@@ -173,6 +173,7 @@ static int tx_st30p_create_transport(struct mtl_main_impl* impl, struct st30p_tx
   }
   if (ops->flags & ST30P_TX_FLAG_USER_PACING) ops_tx.flags |= ST30_TX_FLAG_USER_PACING;
   ops_tx.pacing_way = ops->pacing_way;
+  ops_tx.rtp_timestamp_delta_us = ops->rtp_timestamp_delta_us;
 
   ops_tx.fmt = ops->fmt;
   ops_tx.channel = ops->channel;

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -316,6 +316,12 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
   pacing->cur_epoch_time = tx_audio_pacing_time(pacing, epochs);
   pacing->pacing_time_stamp = tx_audio_pacing_time_stamp(pacing, epochs);
   pacing->rtp_time_stamp = pacing->pacing_time_stamp;
+  if (s->ops.rtp_timestamp_delta_us) {
+    double rtp_timestamp_delta_us = s->ops.rtp_timestamp_delta_us;
+    int32_t rtp_timestamp_delta =
+        (rtp_timestamp_delta_us * NS_PER_US) * pacing->pkt_time_sampling / pacing->trs;
+    pacing->rtp_time_stamp += rtp_timestamp_delta;
+  }
   pacing->tsc_time_cursor = (double)mt_get_tsc(impl) + to_epoch;
   dbg("%s(%d), epochs %" PRIu64 ", rtp_time_stamp %u\n", __func__, s->idx, epochs,
       pacing->rtp_time_stamp);


### PR DESCRIPTION
Add support for RTP timestamp offset in st30, similar to provided in st20