### PR TITLE
Docs: flex and byacc as required packages for libpcap in build.md

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -12,7 +12,7 @@ Please note that the DPDK dependency remains necessary when utilizing the XDP/ke
 
 ```bash
 sudo apt-get update
-sudo apt-get install git gcc meson python3 python3-pip pkg-config libnuma-dev libjson-c-dev libpcap-dev libgtest-dev libssl-dev systemtap-sdt-dev llvm clang
+sudo apt-get install git gcc meson python3 python3-pip pkg-config libnuma-dev libjson-c-dev libpcap-dev libgtest-dev libssl-dev systemtap-sdt-dev llvm clang flex byacc
 sudo pip install pyelftools ninja
 ```
 


### PR DESCRIPTION
In order to run ./configure in libpcap (1.2.2.), flex or lex and yacc/byacc must be installed.

Tested on Ubuntu 22.04.5 LTS.

```text
$ git clone https://github.com/the-tcpdump-group/libpcap.git -b libpcap-1.9
cd libpcap/
./configure
Cloning into 'libpcap'...
remote: Enumerating objects: 35600, done.
remote: Counting objects: 100% (595/595), done.
(...)
checking whether to build optimizer debugging code... no
checking whether to build parser debugging code... no
checking for flex... no
checking for lex... no
configure: error: Neither flex nor lex was found.

$ sudo apt install flex
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  libfl-dev libfl2 m4
Suggested packages:
  bison flex-doc m4-doc
The following NEW packages will be installed:
  flex libfl-dev libfl2 m4
0 upgraded, 4 newly installed, 0 to remove and 33 not upgraded.
Need to get 522 kB of archives.
After this operation, 1,502 kB of additional disk space will be used.
(...)

$ ./configure
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
(...)
checking whether to build optimizer debugging code... no
checking whether to build parser debugging code... no
checking for flex... flex
checking lex output file root... lex.yy
checking lex library... -lfl
checking whether yytext is a pointer... yes
checking for capable lex... yes
checking for bison... no
checking for byacc... no
checking for capable yacc/bison... insufficient
configure: error: yacc is insufficient to compile libpcap.
 libpcap requires Bison, a newer version of Berkeley YACC with support
 for reentrant parsers, or another YACC compatible with them.

$ sudo apt install yacc
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'byacc' instead of 'yacc'
The following NEW packages will be installed:
  byacc
0 upgraded, 1 newly installed, 0 to remove and 33 not upgraded.
Need to get 86.2 kB of archives.
(...)

$ ./configure
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking for gcc... gcc
checking whether the C compiler works... yes
(...) # no more errors
```

