### PR TITLE
Fix: handler return error

### DIFF
--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2778,7 +2778,7 @@ static int rv_pkt_rx_tasklet(struct st_rx_video_session_impl* s) {
 
       check_err_status = rv_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
 
-     if (check_err_status < 0) {
+      if (check_err_status < 0) {
         dbg("%s(%d,%d), handle mbuf fail %d\n", __func__, s->idx, s_port,
             check_err_status);
       }

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2736,6 +2736,8 @@ static int rv_pkt_rx_tasklet(struct st_rx_video_session_impl* s) {
   uint16_t rv;
   int num_port = s->ops.num_port;
 
+  int check_err_status;
+
   bool done = true;
 
   if (s->dma_dev) {
@@ -2774,7 +2776,13 @@ static int rv_pkt_rx_tasklet(struct st_rx_video_session_impl* s) {
         s->in_continuous_burst[s_port] = true;
       }
 
-      rv_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
+      check_err_status = rv_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
+
+     if (check_err_status < 0) {
+        dbg("%s(%d,%d), handle mbuf fail %d\n", __func__, s->idx, s_port,
+            check_err_status);
+      }
+
       rte_pktmbuf_free_bulk(&mbuf[0], rv);
 
       done = false;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2738,8 +2738,6 @@ static int rv_pkt_rx_tasklet(struct st_rx_video_session_impl* s) {
 
   bool done = true;
 
-  static int check_err_code;
-
   if (s->dma_dev) {
     rv_dma_dequeue(s);
     /* check if has pending pkts in dma */
@@ -2776,11 +2774,7 @@ static int rv_pkt_rx_tasklet(struct st_rx_video_session_impl* s) {
         s->in_continuous_burst[s_port] = true;
       }
 
-      check_err_code = rv_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
-      if (check_err_code < 0) {
-        err("%s(%d,%d), handle mbuf fail %d\n", __func__, s->idx, s_port, check_err_code);
-      }
-
+      rv_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
       rte_pktmbuf_free_bulk(&mbuf[0], rv);
 
       done = false;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -2778,8 +2778,7 @@ static int rv_pkt_rx_tasklet(struct st_rx_video_session_impl* s) {
 
       check_err_code = rv_handle_mbuf(&s->priv[s_port], &mbuf[0], rv);
       if (check_err_code < 0) {
-        err("%s(%d,%d), handle mbuf fail %d\n", __func__, s->idx, s_port,
-            check_err_code);
+        err("%s(%d,%d), handle mbuf fail %d\n", __func__, s->idx, s_port, check_err_code);
       }
 
       rte_pktmbuf_free_bulk(&mbuf[0], rv);


### PR DESCRIPTION
* The error counter is incremented for each individual packet that fails (handler_ret < 0), providing more accurate per-packet error statistics.
* The return value from rv_handle_mbuf is now checked. If it is negative, an debug message in bulk for whole iteration  is logged.