### PR TITLE
Fix: incorrect cleanup of the stats alarm handler

### DIFF
--- a/lib/src/mt_stat.c
+++ b/lib/src/mt_stat.c
@@ -180,7 +180,7 @@ int mt_stat_uinit(struct mtl_main_impl* impl) {
     mt_free(item);
   }
 
-  ret = rte_eal_alarm_cancel(stat_alarm_handler, impl);
+  ret = rte_eal_alarm_cancel(stat_alarm_handler, (void *)-1);
   if (ret < 0) err("%s, alarm cancel fail %d\n", __func__, ret);
   if (mgr->stat_tid) {
     rte_atomic32_set(&mgr->stat_stop, 1);

--- a/lib/src/mt_stat.c
+++ b/lib/src/mt_stat.c
@@ -180,7 +180,7 @@ int mt_stat_uinit(struct mtl_main_impl* impl) {
     mt_free(item);
   }
 
-  ret = rte_eal_alarm_cancel(stat_alarm_handler, (void *)-1);
+  ret = rte_eal_alarm_cancel(stat_alarm_handler, (void*)-1);
   if (ret < 0) err("%s, alarm cancel fail %d\n", __func__, ret);
   if (mgr->stat_tid) {
     rte_atomic32_set(&mgr->stat_stop, 1);


### PR DESCRIPTION
The current implementation may miss some of the
registered statistics callbacks alarms causing
segfault.

The stats thread can run the statystics after
stats_thread stopping
MTL: stat_thread, stop
MTL: * *    M T    D E V   S T A T E   * *
MTL: * *    E N D    S T A T E   * *

Use the generic handler deregistration
that ensures all registered callbacks are cleaned
up properly.