### PR TITLE
Add: RxTxApp User controlled pacing st30 and st20

### DIFF
--- a/app/src/app_platform.h
+++ b/app/src/app_platform.h
@@ -162,12 +162,12 @@ static inline void st_usleep(
 #endif
 }
 
-static inline int st_get_real_time(struct timespec* ts) {
-  return clock_gettime(CLOCK_REALTIME, ts);
+static inline int st_get_tai_time(struct timespec* ts) {
+  return clock_gettime(CLOCK_TAI, ts);
 }
 
-static inline int st_set_real_time(struct timespec* ts) {
-  return clock_settime(CLOCK_REALTIME, ts);
+static inline int st_set_tai_time(struct timespec* ts) {
+  return clock_settime(CLOCK_TAI, ts);
 }
 
 #ifdef APP_HAS_SSL

--- a/tests/tools/RxTxApp/src/app_base.h
+++ b/tests/tools/RxTxApp/src/app_base.h
@@ -67,8 +67,6 @@
 #define NS_PER_MS (1000 * 1000)
 #endif
 
-#define UTC_OFFSET (37) /* 2022/07 */
-
 #define ST_MAX(a, b) ((a) > (b) ? (a) : (b))
 #define ST_MIN(a, b) ((a) < (b) ? (a) : (b))
 
@@ -536,9 +534,8 @@ struct st_app_tx_st20p_session {
   bool st20p_frames_copied;
 
   struct st_display* display;
-  /* user pacing should point to ctx->user_pacing */
-
   double expect_fps;
+
   pthread_t st20p_app_thread;
   bool st20p_app_thread_stop;
 };
@@ -584,6 +581,12 @@ struct st_app_tx_st30p_session {
   int st30p_frame_size;
   uint8_t num_port;
   uint64_t last_stat_time_ns;
+  /* for now used only with user pacing to keep track of the frame timestamps */
+  uint64_t frame_time;
+  uint64_t packet_time;
+  uint64_t local_tai_base_time;
+  bool enabled_user_pacing;
+  struct st_user_pacing* user_pacing;
 
   char st30p_source_url[ST_APP_URL_MAX_LEN];
   uint8_t* st30p_source_begin;

--- a/tests/tools/RxTxApp/src/app_platform.h
+++ b/tests/tools/RxTxApp/src/app_platform.h
@@ -162,12 +162,12 @@ static inline void st_usleep(
 #endif
 }
 
-static inline int st_get_real_time(struct timespec* ts) {
-  return clock_gettime(CLOCK_REALTIME, ts);
+static inline int st_get_tai_time(struct timespec* ts) {
+  return clock_gettime(CLOCK_TAI, ts);
 }
 
-static inline int st_set_real_time(struct timespec* ts) {
-  return clock_settime(CLOCK_REALTIME, ts);
+static inline int st_set_tai_time(struct timespec* ts) {
+  return clock_settime(CLOCK_TAI, ts);
 }
 
 #ifdef APP_HAS_SSL

--- a/tests/tools/RxTxApp/src/args.c
+++ b/tests/tools/RxTxApp/src/args.c
@@ -152,6 +152,7 @@ enum st_args_cmd {
   ST_ARG_RSS_SCH_NB,
   ST_ARG_ALLOW_ACROSS_NUMA_CORE,
   ST_ARG_NO_MULTICAST,
+  ST_ARG_TX_USER_PACING_OFFSET,
   ST_ARG_MAX,
 };
 
@@ -300,6 +301,7 @@ static struct option st_app_args_options[] = {
     {"rss_sch_nb", required_argument, 0, ST_ARG_RSS_SCH_NB},
     {"allow_across_numa_core", no_argument, 0, ST_ARG_ALLOW_ACROSS_NUMA_CORE},
     {"no_multicast", no_argument, 0, ST_ARG_NO_MULTICAST},
+    {"tx_user_pacing_offset", required_argument, 0, ST_ARG_TX_USER_PACING_OFFSET},
 
     {0, 0, 0, 0}};
 
@@ -926,6 +928,9 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         break;
       case ST_ARG_NO_MULTICAST:
         p->flags |= MTL_FLAG_NO_MULTICAST;
+        break;
+      case ST_ARG_TX_USER_PACING_OFFSET:
+        ctx->user_pacing.user_pacing_offset = atoi(optarg);
         break;
       case '?':
         break;

--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -1043,6 +1043,8 @@ static int st_json_parse_st30p(int idx, json_object* st30p_obj,
   st30p->enable_rtcp =
       json_object_get_boolean(st_json_object_object_get(st30p_obj, "enable_rtcp"));
 
+  st30p->user_pacing = 
+      json_object_get_boolean(st_json_object_object_get(st30p_obj, "user_pacing"));
   return ST_JSON_SUCCESS;
 }
 

--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -2033,6 +2033,9 @@ static int st_json_parse_tx_st20p(int idx, json_object* st20p_obj,
   st20p->enable_rtcp =
       json_object_get_boolean(st_json_object_object_get(st20p_obj, "enable_rtcp"));
 
+  st20p->user_pacing =
+      json_object_get_boolean(st_json_object_object_get(st20p_obj, "user_pacing"));
+
   return ST_JSON_SUCCESS;
 }
 
@@ -2430,6 +2433,10 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
       json_object* dip_p = NULL;
       json_object* dip_r = NULL;
       json_object* dip_array = st_json_object_object_get(tx_group, "dip");
+      if (dip_array == NULL) { /* allow us to just use ip instead */
+        dip_array = st_json_object_object_get(tx_group, "ip");
+      }
+
       if (dip_array != NULL && json_object_get_type(dip_array) == json_type_array) {
         int len = json_object_array_length(dip_array);
         if (len < 1 || len > MTL_PORT_MAX) {
@@ -2707,6 +2714,13 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
             num_st30p++;
           }
         }
+      }
+      /* parse global pacing offset options*/
+      json_object* pacing_obj = st_json_object_object_get(tx_group, "user_pacing_offset");
+      if(pacing_obj) {
+        ctx->user_pacing_offset = json_object_get_int(pacing_obj);
+      } else {
+        ctx->user_pacing_offset = ST_APP_USER_PACING_DEFAULT_OFFSET;
       }
     }
   }

--- a/tests/tools/RxTxApp/src/parse_json.h
+++ b/tests/tools/RxTxApp/src/parse_json.h
@@ -274,6 +274,8 @@ typedef struct st_json_st20p_session {
   bool display;
   bool measure_latency;
   bool enable_rtcp;
+  bool user_pacing;
+  uint64_t user_pacing_offset;
 } st_json_st20p_session_t;
 
 typedef struct st_json_context {
@@ -288,6 +290,7 @@ typedef struct st_json_context {
   bool shared_rx_queues;
   bool tx_no_chain;
   char* log_file;
+  uint64_t user_pacing_offset;
 
   st_json_video_session_t* tx_video_sessions;
   int tx_video_session_cnt;

--- a/tests/tools/RxTxApp/src/parse_json.h
+++ b/tests/tools/RxTxApp/src/parse_json.h
@@ -242,6 +242,7 @@ typedef struct st_json_st30p_session {
   st_json_session_base_t base;
   st_json_audio_info_t info;
   bool enable_rtcp;
+  bool user_pacing;
 } st_json_st30p_session_t;
 
 typedef struct st_json_ancillary_session {

--- a/tests/tools/RxTxApp/src/rxtx_app.c
+++ b/tests/tools/RxTxApp/src/rxtx_app.c
@@ -206,7 +206,7 @@ static void st_app_ctx_init(struct st_app_context* ctx) {
   /* st22 */
   ctx->st22_bpp = 3; /* 3bit per pixel */
 
-  ctx->utc_offset = UTC_OFFSET;
+  ctx->utc_offset = 0;
 
   ctx->ptp_sync_delta_min = INT64_MAX;
   ctx->ptp_sync_delta_max = INT64_MIN;
@@ -661,11 +661,6 @@ uint64_t st_app_user_pacing_time(void* ctx, struct st_user_pacing *user_pacing, 
 
   offset = user_pacing->user_pacing_offset;
   tai_time = user_pacing->base_tai_time + offset + frame_time;
-
-  int64_t debug = tai_time - app_ptp_from_tai_time(ctx);;
-
-  if (debug < 0)
-    info("DEBUG %lld\n", (long long int)(debug));
 
   return tai_time;
 }

--- a/tests/tools/RxTxApp/src/rxtx_app.c
+++ b/tests/tools/RxTxApp/src/rxtx_app.c
@@ -108,7 +108,7 @@ static void app_ptp_sync_notify(void* priv, struct mtl_ptp_sync_notify_meta* met
   uint64_t to_ns = mtl_ptp_read_time_raw(ctx->st);
   int ret;
   struct timespec from_ts, to_ts;
-  st_get_real_time(&from_ts);
+  st_get_tai_time(&from_ts);
   from_ts.tv_sec += meta->master_utc_offset; /* utc offset */
   uint64_t from_ns = st_timespec_to_ns(&from_ts);
 
@@ -123,7 +123,7 @@ static void app_ptp_sync_notify(void* priv, struct mtl_ptp_sync_notify_meta* met
    * adjust the time frequency also  */
   st_ns_to_timespec(to_ns, &to_ts);
   to_ts.tv_sec -= meta->master_utc_offset; /* utc offset */
-  ret = st_set_real_time(&to_ts);
+  ret = st_set_tai_time(&to_ts);
   if (ret < 0) {
     err("%s, set real time to %" PRIu64 " fail, delta %" PRId64 "\n", __func__, to_ns,
         delta);
@@ -148,7 +148,7 @@ enum mtl_log_level app_get_log_level(void) {
 static uint64_t app_ptp_from_tai_time(void* priv) {
   struct st_app_context* ctx = priv;
   struct timespec spec;
-  st_get_real_time(&spec);
+  st_get_tai_time(&spec);
   spec.tv_sec -= ctx->utc_offset;
   return ((uint64_t)spec.tv_sec * NS_PER_S) + spec.tv_nsec;
 }
@@ -475,6 +475,10 @@ int main(int argc, char** argv) {
     }
   }
 
+  if (ctx->json_ctx->user_pacing_offset) {
+    ctx->user_pacing.user_pacing_offset = ctx->json_ctx->user_pacing_offset;
+  }
+
   ret = st_app_tx_video_sessions_init(ctx);
   if (ret < 0) {
     err("%s, st_app_tx_video_sessions_init fail %d\n", __func__, ret);
@@ -629,6 +633,43 @@ int main(int argc, char** argv) {
   return ret;
 }
 
+
+/**
+ * Returns the pacing time based on the user_pacing structure.
+ * If user_pacing is NULL, disabled, or an error occurs, returns 0.
+ * Otherwise, returns the calculated time.
+ */
+uint64_t st_app_user_pacing_time(void* ctx, struct st_user_pacing *user_pacing, uint64_t frame_time, bool restart_base_time) {
+  uint64_t tai_time, offset;
+
+  if (!user_pacing) return 0;
+
+  if (restart_base_time) {
+    pthread_mutex_lock(&user_pacing->base_tai_time_mutex);
+
+    user_pacing->base_tai_time = app_ptp_from_tai_time(ctx);
+    info ("%s, restart base tai time %lu\n", __func__, user_pacing->base_tai_time);
+
+    if (user_pacing->base_tai_time == 0) {
+      err("%s, get tai time fail\n", __func__);
+      pthread_mutex_unlock(&user_pacing->base_tai_time_mutex);
+      return 0;
+    }
+
+    pthread_mutex_unlock(&user_pacing->base_tai_time_mutex);
+  }
+
+  offset = user_pacing->user_pacing_offset;
+  tai_time = user_pacing->base_tai_time + offset + frame_time;
+
+  int64_t debug = tai_time - app_ptp_from_tai_time(ctx);;
+
+  if (debug < 0)
+    info("DEBUG %lld\n", (long long int)(debug));
+
+  return tai_time;
+}
+
 int st_set_mtl_log_file(struct st_app_context* ctx, const char* file) {
   FILE* f = fopen(file, "w");
   if (!f) {
@@ -657,3 +698,4 @@ void st_sha_dump(const char* tag, const unsigned char* sha) {
   }
   info("\n");
 }
+

--- a/tests/tools/RxTxApp/src/tx_st20p_app.c
+++ b/tests/tools/RxTxApp/src/tx_st20p_app.c
@@ -78,6 +78,22 @@ static void* app_tx_st20p_frame_thread(void* arg) {
       frame->user_meta = shas;
       frame->user_meta_size = sizeof(shas);
     }
+
+    if (s->enabled_user_pacing && s->user_pacing) {
+      bool restart_base_time;
+
+      if (!s->local_tai_base_time) {
+        restart_base_time = true;
+      } else {
+        restart_base_time = false;
+      }
+
+      frame->timestamp = st_app_user_pacing_time(s->ctx, s->user_pacing, s->frame_time, restart_base_time);
+      frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+      s->frame_time += s->expect_fps ? (NS_PER_S / s->expect_fps) : 0;
+      s->local_tai_base_time = s->user_pacing->base_tai_time;
+    }
+
     st20p_tx_put_frame(handle, frame);
   }
   info("%s(%d), stop\n", __func__, idx);
@@ -288,6 +304,17 @@ static int app_tx_st20p_init(struct st_app_context* ctx, st_json_st20p_session_t
   ops.notify_event = app_tx_st20p_notify_event;
   if (ctx->tx_static_pad) ops.flags |= ST20P_TX_FLAG_ENABLE_STATIC_PAD_P;
   if (st20p && st20p->enable_rtcp) ops.flags |= ST20P_TX_FLAG_ENABLE_RTCP;
+
+  if (st20p && st20p->user_pacing) {
+    ops.flags |= ST20P_TX_FLAG_USER_PACING;
+    s->enabled_user_pacing = true;
+
+    /* use global user pacing */
+    s->user_pacing = &(ctx->user_pacing);
+    s->frame_time = 0;
+    s->local_tai_base_time = 0;
+  }
+
   if (ctx->tx_ts_first_pkt) ops.flags |= ST20P_TX_FLAG_RTP_TIMESTAMP_FIRST_PKT;
   if (ctx->tx_ts_epoch) ops.flags |= ST20P_TX_FLAG_RTP_TIMESTAMP_EPOCH;
   if (ctx->tx_no_bulk) ops.flags |= ST20P_TX_FLAG_DISABLE_BULK;

--- a/tests/tools/RxTxApp/src/tx_st30p_app.c
+++ b/tests/tools/RxTxApp/src/tx_st30p_app.c
@@ -32,6 +32,22 @@ static void* app_tx_st30p_frame_thread(void* arg) {
       continue;
     }
     app_tx_st30p_build_frame(s, frame, s->st30p_frame_size);
+
+    if (s->enabled_user_pacing && s->user_pacing) {
+      bool restart_base_time;
+
+      if (!s->local_tai_base_time) {
+        restart_base_time = true;
+      } else {
+        restart_base_time = false;
+      }
+
+      frame->timestamp = st_app_user_pacing_time(s->ctx, s->user_pacing, s->frame_time, restart_base_time);
+      frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+      s->frame_time += s->expect_fps ? (NS_PER_S / s->expect_fps) : 0;
+      s->local_tai_base_time = s->user_pacing->base_tai_time;
+    }
+
     st30p_tx_put_frame(handle, frame);
   }
   info("%s(%d), stop\n", __func__, idx);
@@ -196,11 +212,28 @@ static int app_tx_st30p_init(struct st_app_context* ctx, st_json_st30p_session_t
   ops.channel = st30p ? st30p->info.audio_channel : 2;
   ops.sampling = st30p ? st30p->info.audio_sampling : ST30_SAMPLING_48K;
   ops.ptime = st30p ? st30p->info.audio_ptime : ST30_PTIME_1MS;
+
+  if (st30p && st30p->user_pacing) {
+    s->packet_time = st30_get_packet_time(ops.ptime);
+  } else {
+    s->packet_time = 10 * NS_PER_MS; /* default 10ms */
+  }
+
   /* set frame size to 10ms time */
   int framebuff_size = st30_calculate_framebuff_size(
-      ops.fmt, ops.ptime, ops.sampling, ops.channel, 10 * NS_PER_MS, &s->expect_fps);
+      ops.fmt, ops.ptime, ops.sampling, ops.channel, s->packet_time, &s->expect_fps);
   ops.framebuff_size = framebuff_size;
   ops.framebuff_cnt = 3;
+
+  if (st30p && st30p->user_pacing) {
+    ops.flags |= ST30P_TX_FLAG_USER_PACING;
+    s->enabled_user_pacing = true;
+
+    /* use global user pacing */
+    s->user_pacing = &(ctx->user_pacing);
+    s->frame_time = 0; 
+    s->local_tai_base_time = 0;
+  }
 
   ops.flags |= ST30P_TX_FLAG_BLOCK_GET;
   s->num_port = ops.port.num_port;


### PR DESCRIPTION
Enable user controlled pacing for both ST30 and ST20 pipeline mode APIs in the RxTxApp.
Use global time to allow for lip-sync testing.
Jump base time to the newest ST 2110 session every time a new session is created
for consistent synchronization.
The jumping base allows for precise timing without overhaul of the RxTxApp logic.