### PR TITLE
Add: Automation for netsniff-ng packet capture

### DIFF
--- a/tests/validation/configs/test_config.yaml
+++ b/tests/validation/configs/test_config.yaml
@@ -3,6 +3,7 @@ mtl_path: .
 media_path: /mnt/media
 capture_cfg:
   enable: false
+  tool: netsniff-ng
   test_name: test_name
   pcap_dir: /home/ubuntu/pcap_files
   capture_time: 5

--- a/tests/validation/create_pcap_file/netsniff.py
+++ b/tests/validation/create_pcap_file/netsniff.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2025 Intel Corporation
+import logging
+import os
+
+from time import sleep
+
+from mfd_connect.exceptions import ConnectionCalledProcessError
+
+logger = logging.getLogger(__name__)
+
+STARTUP_WAIT = 2  # Default wait time after starting the process
+
+class NetsniffRecorder:
+    """
+    Class to handle the recording of network traffic using netsniff-ng.
+
+    Attributes:
+        host: Host object containing connection and network interfaces.
+        test_name (str): Name for the capture session (used for file naming).
+        pcap_dir (str): Directory to store the pcap files.
+        interface: Network interface to capture traffic on.
+        interface_index (int): Index of the network interface if not specified by interface.
+        silent (bool): Whether to run netsniff-ng in silent mode (no stdout) (default: True).
+        filter (str): Optional filter to apply to the capture. (default: None)
+    """
+
+    def __init__(
+            self,
+            host,
+            test_name: str,
+            pcap_dir: str,
+            interface = None,
+            interface_index: int = 0,
+            silent: bool = True,
+            filter: str | None = None,
+        ):
+        self.host = host
+        self.test_name = test_name
+        self.pcap_dir = pcap_dir
+        self.pcap_file = os.path.join(pcap_dir, f"{test_name}.pcap")
+        if interface is not None:
+            self.interface = interface
+        else:
+            self.interface = self.host.network_interfaces[interface_index].name
+        self.netsniff_process = None
+        self.silent = silent
+        self.filter = filter
+
+    def start(self, startup_wait=STARTUP_WAIT):
+        """
+        Starts the netsniff-ng
+        """
+        if not self.netsniff_process or not self.netsniff_process.running:
+            connection = self.host.connection
+            try:
+                logger.debug(f"NETSNIFF INTERFACE NAME: {self.interface}") # TODO: Remove this debug log after testing
+                cmd = [
+                    "netsniff-ng",
+                    "--silent" if self.silent else "",
+                    "--in",
+                    str(self.interface), # FIXME: It is not a proper interface name to be used here
+                    "--out",
+                    self.pcap_file,
+                    if filter f"-f {self.filter}" else "",
+                ]
+                logger.info(f"Running command: {' '.join(cmd)}")
+                self.netsniff_process = connection.start_process(
+                        " ".join(cmd), stderr_to_stdout=True
+                )
+                logger.info(
+                    f"PCAP file will be saved at: {os.path.abspath(self.pcap_file)}"
+                )
+
+                # Give netsniff-ng a moment to start and possibly error out
+                sleep(startup_wait)
+
+                if not self.netsniff_process.running:
+                    err = self.netsniff_process.stderr_text
+                    logger.error(f"netsniff-ng failed to start. Error output:\n{err}")
+                    return False
+                logger.info(f"netsniff-ng started with PID {self.netsniff_process.pid}.")
+                return True
+            except ConnectionCalledProcessError as e:
+                    logger.error(f"Failed to start netsniff-ng: {e}")
+                    return False
+
+
+    def capture(self, capture_time=20, startup_wait=2):
+        """
+        Starts netsniff-ng, captures for capture_time seconds, then stops.
+        :param capture_time: Duration in seconds to capture packets.
+        :param startup_wait: Time in seconds to wait after starting netsniff-ng (default: 2)
+        """
+        started = self.start(startup_wait=startup_wait)
+        if started:
+            logger.info(f"Capturing traffic for {capture_time} seconds...")
+            sleep(capture_time)
+            self.stop()
+            logger.info("Capture complete.")
+        else:
+            logger.error("netsniff-ng did not start; skipping capture.")
+
+
+    def stop(self):
+        """
+        Stops all netsniff-ng processes on the host using pkill.
+        """
+        connection = self.host.connection
+        try:
+            logger.info("Stopping netsniff-ng using pkill netsniff-ng...")
+            connection.execute_command("pkill netsniff-ng")
+            logger.info("netsniff-ng stopped (via pkill).")
+        except ConnectionCalledProcessError as e:
+            logger.error(f"Failed to stop netsniff-ng: {e}")

--- a/tests/validation/mtl_engine/GstreamerApp.py
+++ b/tests/validation/mtl_engine/GstreamerApp.py
@@ -6,7 +6,7 @@ import logging
 import os
 import time
 
-from mtl_engine.RxTxApp import prepare_tcpdump
+from mtl_engine.RxTxApp import prepare_tcpdump, prepare_netsniff
 
 from .execute import log_fail, run
 
@@ -331,6 +331,7 @@ def execute_test(
     tx_process = None
     rx_process = None
     tcpdump = prepare_tcpdump(capture_cfg, host)
+    netsniff = prepare_netsniff(capture_cfg, host)
 
     try:
         if tx_first:
@@ -383,10 +384,13 @@ def execute_test(
                 background=True,
                 enable_sudo=True,
             )
-        # --- Start tcpdump after pipelines are running ---
+        # --- Start packet capture after pipelines are running ---
         if tcpdump:
             logger.info("Starting tcpdump capture...")
             tcpdump.capture(capture_time=capture_cfg.get("capture_time", test_time))
+        if netsniff:
+            logger.info("Starting netsniff-ng capture...")
+            netsniff.capture(capture_time=capture_cfg.get("capture_time", test_time))
 
         # Let the test run for the specified duration
         logger.info(f"Running test for {test_time} seconds...")
@@ -444,6 +448,8 @@ def execute_test(
                 pass
         if tcpdump:
             tcpdump.stop()
+        if netsniff:
+            netsniff.stop()
 
     # Compare files for validation
     file_compare = compare_files(input_file, output_file)

--- a/tests/validation/mtl_engine/ffmpeg_app.py
+++ b/tests/validation/mtl_engine/ffmpeg_app.py
@@ -9,7 +9,7 @@ import re
 import time
 
 from mfd_connect import SSHConnection
-from mtl_engine.RxTxApp import prepare_tcpdump
+from mtl_engine.RxTxApp import prepare_tcpdump, prepare_netsniff
 
 from . import rxtxapp_config
 from .execute import log_fail, run
@@ -164,6 +164,7 @@ def execute_test(
     rx_proc = None
     tx_proc = None
     tcpdump = prepare_tcpdump(capture_cfg, host)
+    netsniff = prepare_netsniff(capture_cfg, host)
 
     try:
         # Start RX pipeline first
@@ -190,10 +191,13 @@ def execute_test(
             background=True,
             enable_sudo=True,
         )
-        # Start tcpdump after pipelines are running
+        # Start packet capture when pipelines are running
         if tcpdump:
             logger.info("Starting tcpdump capture...")
             tcpdump.capture(capture_time=capture_cfg.get("capture_time", test_time))
+        if netsniff:
+            logger.info("Starting netsniff-ng capture...")
+            netsniff.capture(capture_time=capture_cfg.get("capture_time", test_time))
 
         # Let the test run for the specified duration
         logger.info(f"Running test for {test_time} seconds...")
@@ -263,6 +267,8 @@ def execute_test(
                     pass
         if tcpdump:
             tcpdump.stop()
+        if netsniff:
+            netsniff.stop()
     passed = False
     match output_format:
         case "yuv":
@@ -331,6 +337,7 @@ def execute_test_rgb24(
     rx_proc = None
     tx_proc = None
     tcpdump = prepare_tcpdump(capture_cfg, host)
+    netsniff = prepare_netsniff(capture_cfg, host)
 
     try:
         # Start RX pipeline first
@@ -356,10 +363,13 @@ def execute_test_rgb24(
             background=True,
             enable_sudo=True,
         )
-        # Start tcpdump after pipelines are running
+        # Start packet capture when pipelines are running
         if tcpdump:
             logger.info("Starting tcpdump capture...")
             tcpdump.capture(capture_time=capture_cfg.get("capture_time", test_time))
+        if netsniff:
+            logger.info("Starting netsniff-ng capture...")
+            netsniff.capture(capture_time=capture_cfg.get("capture_time", test_time))
 
         logger.info(
             f"Waiting for RX process to complete (test_time: {test_time} seconds)..."
@@ -437,6 +447,8 @@ def execute_test_rgb24(
                     pass
         if tcpdump:
             tcpdump.stop()
+        if netsniff:
+            netsniff.stop()
     if not check_output_rgb24(rx_output, 1):
         log_fail("rx video sessions failed")
         return False
@@ -506,6 +518,7 @@ def execute_test_rgb24_multiple(
     tx_1_proc = None
     tx_2_proc = None
     tcpdump = prepare_tcpdump(capture_cfg, host)
+    netsniff = prepare_netsniff(capture_cfg, host)
 
     try:
         rx_proc = run(
@@ -538,10 +551,13 @@ def execute_test_rgb24_multiple(
             background=True,
             enable_sudo=True,
         )
-        # Start tcpdump after pipelines are running
+        # Start packet capture when pipelines are running
         if tcpdump:
             logger.info("Starting tcpdump capture...")
             tcpdump.capture(capture_time=capture_cfg.get("capture_time", test_time))
+        if netsniff:
+            logger.info("Starting netsniff-ng capture...")
+            netsniff.capture(capture_time=capture_cfg.get("capture_time", test_time))
 
         logger.info(f"Waiting for RX process (test_time: {test_time} seconds)...")
         rx_proc.wait()
@@ -611,6 +627,8 @@ def execute_test_rgb24_multiple(
                         pass
         if tcpdump:
             tcpdump.stop()
+        if netsniff:
+            netsniff.stop()
     if not check_output_rgb24(rx_output, 2):
         log_fail("rx video session failed")
         return False

--- a/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
@@ -27,7 +27,7 @@ def test_kernello_mixed_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_kernel_lo_{test_mode}_{video_format}_replicas{replicas}"

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
@@ -24,7 +24,7 @@ def test_kernello_st20p_video_format(
     st20p_file = yuv_files_422p10le[file]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_kernel_lo_st20p_{test_mode}_{file}_replicas{replicas}"

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
@@ -25,7 +25,7 @@ def test_kernello_st22p_video_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_kernel_lo_st22p_{test_mode}_{file}_replicas{replicas}"

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
@@ -28,7 +28,7 @@ def test_pmd_kernel_mixed_format(
     # rxtxapp.check_and_bind_interface(["0000:38:00.0","0000:38:00.1"], "pmd")
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_pmd_kernel_mixed_{test_mode}_{video_format}_replicas{replicas}"

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
@@ -28,7 +28,7 @@ def test_pmd_kernel_video_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_pmd_kernel_video_{test_mode}_{video_format}_replicas{replicas}"

--- a/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
@@ -29,7 +29,7 @@ def test_ptp_mixed_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_ptp_mixed_format_{test_mode}_{video_format}"
 

--- a/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
@@ -31,7 +31,7 @@ def test_ptp_video_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_ptp_video_format_{test_mode}_{video_format}_replicas{replicas}"

--- a/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
+++ b/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
@@ -24,7 +24,7 @@ def test_rss_mode_audio(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_rss_mode_audio_{audio_format}_{rss_mode}"
 

--- a/tests/validation/tests/single/rss_mode/video/test_performance.py
+++ b/tests/validation/tests/single/rss_mode/video/test_performance.py
@@ -29,7 +29,7 @@ def test_rss_mode_video_performance(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_rss_mode_video_performance_{video_format}_{rss_mode}"

--- a/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
+++ b/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
@@ -24,7 +24,7 @@ def test_rss_mode_video(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_rss_mode_video_{video_format}_{rss_mode}"
 

--- a/tests/validation/tests/single/rx_timing/mixed/test_mode.py
+++ b/tests/validation/tests/single/rx_timing/mixed/test_mode.py
@@ -24,7 +24,7 @@ def test_rx_timing_mode(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_rx_timing_mode_{test_mode}"
 

--- a/tests/validation/tests/single/rx_timing/video/test_replicas.py
+++ b/tests/validation/tests/single/rx_timing/video/test_replicas.py
@@ -19,7 +19,7 @@ def test_rx_timing_video_replicas(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = "test_rx_timing_video_replicas"
 

--- a/tests/validation/tests/single/rx_timing/video/test_video_format.py
+++ b/tests/validation/tests/single/rx_timing/video/test_video_format.py
@@ -33,7 +33,7 @@ def test_rx_timing_video_video_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_rx_timing_video_video_format_{video_format}"
 

--- a/tests/validation/tests/single/st20p/format/test_format.py
+++ b/tests/validation/tests/single/st20p/format/test_format.py
@@ -25,7 +25,7 @@ def test_422p10le(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_format_{file}"  # Set a unique pcap file name
 
@@ -182,7 +182,7 @@ def test_formats(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_format_formats_{format}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st20p/fps/test_fps.py
+++ b/tests/validation/tests/single/st20p/fps/test_fps.py
@@ -39,7 +39,7 @@ def test_fps(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_fps_{file}_{fps}"  # Set a unique pcap file name
 

--- a/tests/validation/tests/single/st20p/integrity/test_integrity.py
+++ b/tests/validation/tests/single/st20p/integrity/test_integrity.py
@@ -44,7 +44,7 @@ def test_integrity(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     # Set a unique pcap file name
     capture_cfg["test_name"] = (

--- a/tests/validation/tests/single/st20p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st20p/interlace/test_interlace.py
@@ -15,7 +15,7 @@ def test_interlace(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     # capture_time: 15
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_interlace_{file}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st20p/pacing/test_pacing.py
+++ b/tests/validation/tests/single/st20p/pacing/test_pacing.py
@@ -24,7 +24,7 @@ def test_pacing(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_pacing_{file}_{pacing}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st20p/packing/test_packing.py
+++ b/tests/validation/tests/single/st20p/packing/test_packing.py
@@ -24,7 +24,7 @@ def test_packing(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_packing_{file}_{packing}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
+++ b/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
@@ -33,7 +33,7 @@ def test_resolutions(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_resolutions_{file}"  # Set a unique pcap file name
 

--- a/tests/validation/tests/single/st20p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st20p/test_mode/test_multicast.py
@@ -22,7 +22,7 @@ def test_multicast(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_multicast_{file}"  # Set a unique pcap file name
 

--- a/tests/validation/tests/single/st22p/codec/test_codec.py
+++ b/tests/validation/tests/single/st22p/codec/test_codec.py
@@ -16,7 +16,7 @@ def test_codec(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_codec_{codec}_Penguin_1080p"
 

--- a/tests/validation/tests/single/st22p/format/test_format.py
+++ b/tests/validation/tests/single/st22p/format/test_format.py
@@ -22,7 +22,7 @@ def test_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_format_{format}"
 

--- a/tests/validation/tests/single/st22p/fps/test_fps.py
+++ b/tests/validation/tests/single/st22p/fps/test_fps.py
@@ -28,7 +28,7 @@ def test_fps(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_fps_{codec}_Penguin_1080p_{fps}"
 

--- a/tests/validation/tests/single/st22p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st22p/interlace/test_interlace.py
@@ -16,7 +16,7 @@ def test_interlace(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_interlace_{format}"
 

--- a/tests/validation/tests/single/st22p/quality/test_quality.py
+++ b/tests/validation/tests/single/st22p/quality/test_quality.py
@@ -16,7 +16,7 @@ def test_quality(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_quality_{quality}_Penguin_1080p"
 

--- a/tests/validation/tests/single/st22p/test_mode/test_unicast.py
+++ b/tests/validation/tests/single/st22p/test_mode/test_unicast.py
@@ -13,7 +13,7 @@ def test_unicast(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = "test_unicast_Penguin_1080p"
 

--- a/tests/validation/tests/single/st30p/integrity/test_integrity.py
+++ b/tests/validation/tests/single/st30p/integrity/test_integrity.py
@@ -36,7 +36,7 @@ def test_integrity(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_integrity_{audio_format}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
+++ b/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
@@ -30,7 +30,7 @@ def test_st30p_channel(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_st30p_channel_{audio_format}_{audio_channel}"  # e.g., test_st30p_channel_PCM8_M

--- a/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
+++ b/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
@@ -24,7 +24,7 @@ def test_st30p_format(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_st30p_format_{audio_format}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
+++ b/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
@@ -25,7 +25,7 @@ def test_st30p_ptime(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_st30p_ptime_{audio_format}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
+++ b/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
@@ -25,7 +25,7 @@ def test_st30p_sampling(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_st30p_sampling_{audio_format}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st30p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st30p/test_mode/test_multicast.py
@@ -23,7 +23,7 @@ def test_multicast(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_multicast_{audio_format}"  # Set a unique pcap file name

--- a/tests/validation/tests/single/st41/dit/test_dit.py
+++ b/tests/validation/tests/single/st41/dit/test_dit.py
@@ -36,7 +36,7 @@ def test_dit(
     st41_file = st41_files["st41_p29_long_file"]["filename"]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_dit_{dit}"
 

--- a/tests/validation/tests/single/st41/fps/test_fps.py
+++ b/tests/validation/tests/single/st41/fps/test_fps.py
@@ -47,7 +47,7 @@ def test_fps(
     k_bit = k_bit_mapping["k0"]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_fps_st41_{fps}"
 

--- a/tests/validation/tests/single/st41/k_bit/test_k_bit.py
+++ b/tests/validation/tests/single/st41/k_bit/test_k_bit.py
@@ -36,7 +36,7 @@ def test_k_bit(
     st41_file = st41_files["st41_p29_long_file"]["filename"]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_k_bit_{k_bit}"
 

--- a/tests/validation/tests/single/st41/no_chain/test_no_chain.py
+++ b/tests/validation/tests/single/st41/no_chain/test_no_chain.py
@@ -43,7 +43,7 @@ def test_no_chain(
     st41_file = st41_files["st41_p29_long_file"]["filename"]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_no_chain_{type_mode}"
 

--- a/tests/validation/tests/single/st41/payload_type/test_payload_type.py
+++ b/tests/validation/tests/single/st41/payload_type/test_payload_type.py
@@ -51,7 +51,7 @@ def test_payload_type(
     k_bit = k_bit_mapping["k0"]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_payload_type_{payload_type}_{type_mode}"
 

--- a/tests/validation/tests/single/st41/type_mode/test_type_mode.py
+++ b/tests/validation/tests/single/st41/type_mode/test_type_mode.py
@@ -45,7 +45,7 @@ def test_type_mode(
     dit = dit_mapping["dit0"]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = f"test_type_mode_{test_mode}_{type_mode}"
 

--- a/tests/validation/tests/single/virtio_user/test_virtio_user.py
+++ b/tests/validation/tests/single/virtio_user/test_virtio_user.py
@@ -33,7 +33,7 @@ def test_virtio_user(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_virtio_user_multicast_{video_format}_replicas{replicas}"

--- a/tests/validation/tests/single/xdp/test_mode/test_xdp_mode.py
+++ b/tests/validation/tests/single/xdp/test_mode/test_xdp_mode.py
@@ -27,7 +27,7 @@ def test_xdp_mode(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_xdp_mode_{test_mode}_{video_format}_replicas{replicas}"

--- a/tests/validation/tests/single/xdp/test_standard/test_standard.py
+++ b/tests/validation/tests/single/xdp/test_standard/test_standard.py
@@ -29,7 +29,7 @@ def test_xdp_standard(
     host = list(hosts.values())[0]
 
     # Get capture configuration from test_config.yaml
-    # This controls whether tcpdump capture is enabled, where to store the pcap, etc.
+    # Collect packet capture configuration and assign test_name
     capture_cfg = dict(test_config.get("capture_cfg", {}))
     capture_cfg["test_name"] = (
         f"test_xdp_standard_{standard_mode}_{test_mode}_{video_format}_replicas{replicas}"


### PR DESCRIPTION
Adds automation capabilities for netsniff-ng packet capture instead of tcpdump. As both should not be executed at once, such option was not added.
- in `tests/validation/configs/test_config.yaml` added `tool` in `.capture_cfg` with following options recognized: `tcpdump` for `tcpdump`, `netsniff` or `netsniff-ng` for `netsniff-ng`
- in `tests/validation/create_pcap_file/netsniff.py` created `NetsniffRecorder` class based on `TcpDumpRecorder` that can serve as `netsniff-ng` capturing process class
- added conditional execution of `netsniff-ng` packet capture in
  - `tests/validation/mtl_engine/GstreamerApp.py`,
  - `tests/validation/mtl_engine/ffmpeg_app.py`
  - and `tests/validation/mtl_engine/udp_app.py`
- modified comments about configuration collection and modification so they reflect actual situation

TODO:
- [ ] Eliminate duplication by creating a parent interface for capture
- [ ] Think if the capture can be done via a fixture with automated (code-less*) `test_name` generation

*code-less here means without interfering with the test code