### PR TITLE
Fix: ts for audio frame matches the RTP ts of the 1st pkt

### DIFF
--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -1020,7 +1020,6 @@ struct st_rx_audio_session_impl {
   int latest_seq_id;      /* latest seq id */
 
   uint32_t first_pkt_rtp_ts; /* rtp time stamp for the first pkt */
-
   uint32_t tmstamp;
   size_t frame_recv_size;
 


### PR DESCRIPTION
Set timestamp to the RTP timestamp of the first packet of the audio frame
 (not the last one like currently) in st30 to ensure lipsync.