### PR TITLE
Fix: calculating pacing start_time

### DIFF
--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -655,9 +655,9 @@ static int tv_sync_pacing(struct mtl_main_impl* impl, struct st_tx_video_session
     if (required_tai) {
       to_epoch = 0;
     } else {
-      to_epoch = start_time_ptp - ptp_time;
       epochs++; /* assign to next */
       start_time_ptp = pacing_start_time(pacing, epochs);
+      to_epoch = start_time_ptp - ptp_time;
 
       if (to_epoch < 0) {
         /* should never happen */


### PR DESCRIPTION
Commit wrongly reversed the order of allocation
time for enw pacing start time.
Reverse it back.

Fixes: acea200ef8c935cdff64b04a46951bfd4b67f8f0