### PR TITLE
Fix failing smoke tests for CICD

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,9 +30,12 @@ jobs:
       - name: 'preparation: Get Runner ID'
         id: get-runner-id
         run: |
-          # Get the runner name from the GitHub environment variable
-          echo "runner_id=$RUNNER_NAME" >> "$GITHUB_OUTPUT"
-          echo "Using runner: $RUNNER_NAME (machine: $HOSTNAME)"
+          # Extract runner number from RUNNER_NAME (e.g., "cicd-1" -> "1")
+          RUNNER_NUMBER=$(echo "$RUNNER_NAME" | grep -o '[0-9]\+$' || echo "1")
+          # Format as runner-X
+          RUNNER_ID="runner-${RUNNER_NUMBER}"
+          echo "runner_id=$RUNNER_ID" >> "$GITHUB_OUTPUT"
+          echo "Using runner ID: $RUNNER_ID (from runner name: $RUNNER_NAME)"
       - name: 'preparation: Restore valid repository owner and print env'
         if: always()
         run: |
@@ -133,7 +136,7 @@ jobs:
           echo "VIRTUAL_ENV=$PWD/venv/bin/activate" >> "$GITHUB_ENV"
   validation-run-tests:
     needs: [validation-build-mtl]
-    runs-on: ${{ needs.validation-build-mtl.outputs.runner-id }}
+    runs-on: [self-hosted, "${{ needs.validation-build-mtl.outputs.runner-id }}"]
     timeout-minutes: 720
     env:
       PYTEST_RETRIES: '3'


### PR DESCRIPTION
This pull request updates the smoke test GitHub Actions workflow to improve runner selection and environment setup, as well as to ensure more robust artifact uploading. The most important changes are grouped below:

**Runner selection and environment setup:**

* Added a step to extract and format a unique runner ID from the `RUNNER_NAME` environment variable, and exposed it as a workflow output (`runner-id`) for downstream jobs.
* Changed the runner specification for the `validation-run-tests` job to use the dynamically determined `runner-id` output from the previous job, enabling more flexible and targeted runner selection.
* Updated the replacement of the `MTL_PATH_PLACEHOLDER` in the test configuration file to use the current workspace path instead of a secret, simplifying environment setup.

**Artifact upload robustness:**

* Modified the report upload step to always run, regardless of previous step outcomes, ensuring test reports are uploaded even if earlier steps fail.