### PR TITLE
Fix: Use parallel compilation in build_ice_driver

### DIFF
--- a/script/build_ice_driver.sh
+++ b/script/build_ice_driver.sh
@@ -59,7 +59,7 @@ if [ "$sourced" -eq 0 ]; then
 	git am ../../patches/ice_drv/"${ICE_VER}"/*.patch
 
 	cd src
-	make
+	make -j
 	sudo make install
 	sudo rmmod ice
 	sudo modprobe ice


### PR DESCRIPTION
In script build_ice_driver.sh speed up the build
process by utilizing multiple CPU cores.