### PR TITLE
Fix: GSstreamer build script path resolution

### DIFF
--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -182,6 +182,7 @@ function setup_ubuntu_install_dependencies() {
 		echo "Installing GStreamer dependencies"
 		apt install -y \
 			gstreamer1.0-plugins-base \
+			libgstreamer-plugins-base1.0-dev \
 			gstreamer1.0-plugins-good \
 			gstreamer1.0-tools \
 			gstreamer1.0-libav \

--- a/ecosystem/gstreamer_plugin/build.sh
+++ b/ecosystem/gstreamer_plugin/build.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 BUILD_DIR="builddir"
 DEBUG=false
 
+SCRIPT_NAME=$(basename "${BASH_SOURCE[0]}")
+SCRIPT_PATH=$(readlink -qe "${BASH_SOURCE[0]}")
+SCRIPT_FOLDER=${SCRIPT_PATH/$SCRIPT_NAME/}
+cd "${SCRIPT_FOLDER}" || exit 1
+
 # Parse command-line arguments
 for arg in "$@"; do
 	case "$arg" in


### PR DESCRIPTION
Using relative paths for build script made it
prone to fail and to produce unexpected results
when executed from different working directories.

Add a check to ensure the script always runs from
its own directory.

Fixes: 12098baf5f94d18983954c265aa3783851c8869d