### PR TITLE
Ci: Fix the cicd upl gtest hardcoded nic pci's

### DIFF
--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -111,6 +111,8 @@ jobs:
 
           echo "TEST_PORT_P=$TEST_PORT_P" >> "$GITHUB_ENV"
           echo "TEST_PORT_R=$TEST_PORT_R" >> "$GITHUB_ENV"
+          sed -i "s+REPLACE_BY_CICD_TEST_PORT_P+${TEST_PORT_P}+" .github/workflows/upl_gtest.json
+          sed -i "s+REPLACE_BY_CICD_TEST_PORT_R+${TEST_PORT_R}+" .github/workflows/upl_gtest.json
           echo "Selected ports: P=$TEST_PORT_P, R=$TEST_PORT_R"
 
       - name: Start MtlManager at background

--- a/.github/workflows/upl_gtest.json
+++ b/.github/workflows/upl_gtest.json
@@ -11,12 +11,12 @@
     "wake_timeout_us" : "1000",
     "interfaces": [
         {
-            "port": "0000:49:01.0",
+            "port": "REPLACE_BY_CICD_TEST_PORT_P",
             "ip": "192.168.2.80",
             "netmask": "255.255.255.0"
         },
         {
-            "port": "0000:49:01.1",
+            "port": "REPLACE_BY_CICD_TEST_PORT_R",
             "ip": "192.168.2.81",
             "netmask": "255.255.255.0"
         }


### PR DESCRIPTION
In the cicd gtest workflow the upl_gtest.json had
hardcoded pci's for the nic's to use.