### PR TITLE
Ci: Run test framework without sudo in workflows

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -56,9 +56,6 @@ jobs:
       - name: 'execution: Run nightly-bare-metal tests in virtual environment'
         run: |
           tests/validation/.venv/bin/python3 -m pytest --topology_config=tests/validation/configs/topology_config.yaml --test_config=tests/validation/configs/test_config.yaml -m nightly  --template=html/index.html --report=report.html
-      - name: Restore repository owner
-        run: |
-          sudo chown -R "${USER}" .
       - name: "upload report"
         if: always()
         id: upload-report

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -55,7 +55,7 @@ jobs:
           sudo MtlManager &
       - name: 'execution: Run nightly-bare-metal tests in virtual environment'
         run: |
-          sudo tests/validation/.venv/bin/python3 -m pytest --topology_config=tests/validation/configs/topology_config.yaml --test_config=tests/validation/configs/test_config.yaml -m nightly  --template=html/index.html --report=report.html
+          tests/validation/.venv/bin/python3 -m pytest --topology_config=tests/validation/configs/topology_config.yaml --test_config=tests/validation/configs/test_config.yaml -m nightly  --template=html/index.html --report=report.html
       - name: Restore repository owner
         run: |
           sudo chown -R "${USER}" .

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -63,9 +63,6 @@ jobs:
       - name: 'execution: Run validation-bare-metal tests in virtual environment'
         run: |
           tests/validation/.venv/bin/python3 -m pytest --topology_config=tests/validation/configs/topology_config.yaml --test_config=tests/validation/configs/test_config.yaml -m smoke  --template=html/index.html --report=report.html
-      - name: Restore repository owner
-        run: |
-          sudo chown -R "${USER}" .
       - name: "upload report"
         id: upload-report
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -62,7 +62,7 @@ jobs:
           sudo MtlManager &
       - name: 'execution: Run validation-bare-metal tests in virtual environment'
         run: |
-          sudo tests/validation/.venv/bin/python3 -m pytest --topology_config=tests/validation/configs/topology_config.yaml --test_config=tests/validation/configs/test_config.yaml -m smoke  --template=html/index.html --report=report.html
+          tests/validation/.venv/bin/python3 -m pytest --topology_config=tests/validation/configs/topology_config.yaml --test_config=tests/validation/configs/test_config.yaml -m smoke  --template=html/index.html --report=report.html
       - name: Restore repository owner
         run: |
           sudo chown -R "${USER}" .


### PR DESCRIPTION
Running the test framework with sudo causes root to become the owner of some directories. This causes problems with permissions when trying to checkout in workflows.
Run the framework without sudo. Remove the no longer needed chown step in the workflow.