### PR TITLE
Test: Support for PFs in tests fxitures

### DIFF
--- a/tests/validation/common/nicctl.py
+++ b/tests/validation/common/nicctl.py
@@ -24,10 +24,10 @@ class Nicctl:
             return str(self.connection.path(self.mtl_path, "script", self.tool_name))
         return str(self.connection.path(nicctl_path, self.tool_name))
 
-    def _parse_vf_list(self, output: str, all: bool = True) -> list:
+    def _parse_vf_list(self, output: str) -> list:
         if "No VFs found" in output:
             return []
-        vf_info_regex = r"\d{1,3}\s+(.+)\s+vfio" if all else r"(\d{4}:\S+)"
+        vf_info_regex = r"(\d{4}[0-9a-fA-F:.]+)\(?\S*\)?\s+\S*\s*vfio"
         return re.findall(vf_info_regex, output)
 
     def vfio_list(self, pci_addr: str = "all") -> list:
@@ -35,7 +35,7 @@ class Nicctl:
         resp = self.connection.execute_command(
             f"{self.nicctl} list {pci_addr}", shell=True
         )
-        return self._parse_vf_list(resp.stdout, "all" in pci_addr)
+        return self._parse_vf_list(resp.stdout)
 
     def create_vfs(self, pci_id: str, num_of_vfs: int = 6) -> list:
         """Create VFs on NIC.
@@ -68,3 +68,124 @@ class Nicctl:
                 self.create_vfs(nic_pci)
                 self.host.vfs = self.vfio_list(nic_pci)
         return self.host.vfs
+
+    def bind_pmd(self, pci_id: str) -> None:
+        """Bind VF to DPDK PMD driver."""
+        self.connection.execute_command(self.nicctl + " bind_pmd " + pci_id, shell=True)
+
+    def bind_kernel(self, pci_id: str) -> None:
+        """Bind VF to kernel driver."""
+        self.connection.execute_command(
+            self.nicctl + " bind_kernel " + pci_id, shell=True
+        )
+
+
+class InterfaceSetup:
+    def __init__(self, hosts, mtl_path):
+        self.hosts = hosts
+        self.mtl_path = mtl_path
+        self.nicctl_objs = {
+            host.name: Nicctl(mtl_path, host) for host in hosts.values()
+        }
+        self.customs = []
+        self.cleanups = []
+
+    def get_test_interfaces(self, interface_type="VF", count=2, host=None) -> dict:
+        """
+        Creates VFs and binds them into dpdk or bind PF into dpdk.
+
+        :param interface_type: VF - create X VFs on first available test adapter,
+                               PF - prepare list of PFs PCI addresses for test,
+                               xxVFxPF - create xx number VFs per each PF. E.G if you need 3 VFs
+                                    on every PF and you have 2 PF then pass 3VFxPF param with count=6
+                                    if you type just VFxPF then one VF will be created on each PF.
+        :param count: total number of VFs or PFs needed for test.
+        :param host: You can specify host if you need to test only on this host
+        :return: Returns dictionary with list of PCI addresses of VFs or PFs per host name.
+        """
+        if host:
+            hosts = [host]
+        else:
+            hosts = list(self.hosts.values())
+        selected_interfaces = {k.name: [] for k in hosts}
+        for host in hosts:
+            if getattr(host.topology.extra_info, "custom_interface", None):
+                selected_interfaces[host.name] = [
+                    host.topology.extra_info["custom_interface"]
+                ]
+                self.customs.append(host.name)
+                if len(selected_interfaces[host.name]) < count:
+                    raise Exception(
+                        f"Not enough interfaces for test on host {host.name} in extra_info.custom_interface"
+                    )
+            else:
+                if interface_type.lower() == "vf":
+                    vfs = self.nicctl_objs[host.name].create_vfs(
+                        host.network_interfaces[0].pci_address.lspci, count
+                    )
+                    selected_interfaces[host.name] = vfs
+                    self.register_cleanup(
+                        self.nicctl_objs[host.name],
+                        host.network_interfaces[0].pci_address.lspci,
+                        interface_type,
+                    )
+                elif interface_type.lower() == "pf":
+                    try:
+                        selected_interfaces[host.name] = []
+                        for i in range(count):
+                            self.nicctl_objs[host.name].bind_pmd(
+                                host.network_interfaces[i].pci_address.lspci
+                            )
+                            selected_interfaces[host.name].append(
+                                str(host.network_interfaces[i])
+                            )
+                            self.register_cleanup(
+                                self.nicctl_objs[host.name],
+                                host.network_interfaces[i].pci_address.lspci,
+                                interface_type,
+                            )
+                    except IndexError:
+                        raise Exception(
+                            f"Not enough interfaces for test on host {host.name} in topology config."
+                        )
+                elif "vfxpf" in interface_type.lower():
+                    vfs_count = interface_type.lower().split("vfxpf")[0]
+                    vfs_count = int(vfs_count) if vfs_count else 1
+                    for i in range(count // vfs_count):
+                        try:
+                            vfs = self.nicctl_objs[host.name].create_vfs(
+                                host.network_interfaces[i].pci_address.lspci, vfs_count
+                            )
+                            selected_interfaces[host.name].extend(vfs)
+                            self.register_cleanup(
+                                self.nicctl_objs[host.name],
+                                host.network_interfaces[i].pci_address.lspci,
+                                "VF",
+                            )
+                        except IndexError:
+                            raise Exception(
+                                f"Not enough interfaces for test on host {host.name} in topology config. "
+                                f"Expected {count // vfs_count} adapters "
+                                f"to be able to create total {count} VFs - {vfs_count} per adapter"
+                            )
+                else:
+                    raise Exception(f"Unknown interface type {interface_type}")
+        return selected_interfaces
+
+    def get_interfaces_list_single(self, interface_type="VF", count=2) -> list:
+        """
+        Wrapper for get_test_interfaces method if you use only single node tests and need only list of interfaces
+        """
+        host = list(self.hosts.values())[0]
+        selected_interfaces = self.get_test_interfaces(interface_type, count, host=host)
+        return selected_interfaces[host.name]
+
+    def register_cleanup(self, nicctl, interface, if_type):
+        self.cleanups.append((nicctl, interface, if_type))
+
+    def cleanup(self):
+        for nicctl, interface, if_type in self.cleanups:
+            if if_type.lower() == "vf":
+                nicctl.disable_vf(interface)
+            elif if_type.lower() == "pf":
+                nicctl.bind_kernel(interface)

--- a/tests/validation/configs/examples/test_config.yaml
+++ b/tests/validation/configs/examples/test_config.yaml
@@ -18,3 +18,4 @@ ebu_server:
   user: user
   password: password
   proxy: false
+interface_type: VF

--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -11,7 +11,7 @@ from typing import Any, Dict
 
 import pytest
 from common.mtl_manager.mtlManager import MtlManager
-from common.nicctl import Nicctl
+from common.nicctl import InterfaceSetup, Nicctl
 from compliance.compliance_client import PcapComplianceClient
 from create_pcap_file.netsniff import NetsniffRecorder, calculate_packets_per_frame
 from mfd_common_libs.custom_logger import add_logging_level
@@ -123,6 +123,13 @@ def nic_port_list(hosts: dict, mtl_path) -> None:
         vfs = nicctl.vfio_list(host.network_interfaces[0].pci_address.lspci)
         # Store VFs on the host object for later use
         host.vfs = vfs
+
+
+@pytest.fixture(scope="function")
+def setup_interfaces(hosts, test_config, mtl_path):
+    interface_setup = InterfaceSetup(hosts, mtl_path)
+    yield interface_setup
+    interface_setup.cleanup()
 
 
 @pytest.fixture(scope="session")

--- a/tests/validation/mtl_engine/ffmpeg_app.py
+++ b/tests/validation/mtl_engine/ffmpeg_app.py
@@ -57,6 +57,7 @@ def execute_test(
     test_time: int,
     build: str,
     host,
+    nic_port_list,
     type_: str,
     video_format: str,
     pg_format: str,
@@ -65,13 +66,9 @@ def execute_test(
     multiple_sessions: bool = False,
     tx_is_ffmpeg: bool = True,
 ):
-    # Initialize logging for this test
-    init_test_logging()
-
     case_id = os.environ.get("PYTEST_CURRENT_TEST", "ffmpeg_test")
     case_id = case_id[: case_id.rfind("(") - 1] if "(" in case_id else case_id
 
-    nic_port_list = host.vfs
     video_size, fps = decode_video_format_16_9(video_format)
     match output_format:
         case "yuv":
@@ -234,6 +231,7 @@ def execute_test_rgb24(
     test_time: int,
     build: str,
     host,
+    nic_port_list,
     type_: str,
     video_format: str,
     pg_format: str,
@@ -241,7 +239,6 @@ def execute_test_rgb24(
 ):
     # Initialize logging for this test
     init_test_logging()
-    nic_port_list = host.vfs
     video_size, fps = decode_video_format_16_9(video_format)
     logger.info(f"Creating RX config for RGB24 test with video_format: {video_format}")
     try:
@@ -348,8 +345,6 @@ def execute_test_rgb24_multiple(
     video_url_list: list,
     host,
 ):
-    # Initialize logging for this test
-    init_test_logging()
     video_size_1, fps_1 = decode_video_format_16_9(video_format_list[0])
     video_size_2, fps_2 = decode_video_format_16_9(video_format_list[1])
     logger.info(

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import ffmpeg_app
 from mtl_engine.media_files import yuv_files
 
@@ -23,7 +24,7 @@ def test_rx_ffmpeg_tx_ffmpeg(
     test_time,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     video_format,
     test_time_multipler,
     output_format,
@@ -31,6 +32,9 @@ def test_rx_ffmpeg_tx_ffmpeg(
     prepare_ramdisk,
 ):
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     video_file = yuv_files[video_format]
 
@@ -38,6 +42,7 @@ def test_rx_ffmpeg_tx_ffmpeg(
         test_time=test_time * test_time_multipler,
         build=build,
         host=host,
+        nic_port_list=interfaces_list,
         type_="frame",
         video_format=video_format,
         pg_format=video_file["format"],

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import ffmpeg_app
 from mtl_engine.media_files import yuv_files
 
@@ -23,13 +24,16 @@ def test_rx_ffmpeg_tx_ffmpeg_rgb24(
     test_time,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     video_format,
     test_time_mutlipler,
     test_config,
     prepare_ramdisk,
 ):
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     video_file = yuv_files[video_format]
 
@@ -41,4 +45,5 @@ def test_rx_ffmpeg_tx_ffmpeg_rgb24(
         video_format=video_format,
         pg_format=video_file["format"],
         video_url=os.path.join(media, video_file["filename"]),
+        nic_port_list=interfaces_list,
     )

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import ffmpeg_app
 from mtl_engine.media_files import yuv_files
 
@@ -25,7 +26,7 @@ def test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple(
     test_time,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     video_format_1,
     video_format_2,
     test_time_mutlipler,
@@ -33,6 +34,9 @@ def test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple(
     prepare_ramdisk,
 ):
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF"), count=4
+    )
 
     video_file_1 = yuv_files[video_format_1]
     video_file_2 = yuv_files[video_format_2]
@@ -40,7 +44,7 @@ def test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple(
     ffmpeg_app.execute_test_rgb24_multiple(
         test_time=test_time * test_time_mutlipler,
         build=build,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         type_="frame",
         video_format_list=[video_format_1, video_format_2],
         pg_format=video_file_1["format"],

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_rxtxapp.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_rxtxapp.py
@@ -4,6 +4,7 @@
 import os
 
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import ffmpeg_app
 from mtl_engine.media_files import yuv_files
 
@@ -27,7 +28,7 @@ def test_rx_ffmpeg_tx_rxtxapp(
     test_time,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     video_format,
     multiple_sessions,
     test_time_multipler,
@@ -36,12 +37,16 @@ def test_rx_ffmpeg_tx_rxtxapp(
     prepare_ramdisk,
 ):
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     video_file = yuv_files[video_format]
 
     ffmpeg_app.execute_test(
         test_time=test_time * test_time_multipler,
         build=build,
         host=host,
+        nic_port_list=interfaces_list,
         type_="frame",
         video_format=video_format,
         pg_format=video_file["format"],

--- a/tests/validation/tests/single/gstreamer/anc_format/test_anc_format.py
+++ b/tests/validation/tests/single/gstreamer/anc_format/test_anc_format.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.media_creator as media_create
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import GstreamerApp
 
 TMP_INPUT_FILE = "/tmp/test_anc.txt"
@@ -16,7 +17,7 @@ def test_st40p_fps_size(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     file_size_kb,
     fps,
     framebuff,
@@ -26,6 +27,9 @@ def test_st40p_fps_size(
 ):
     # Get the first host for remote execution
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     input_file_path = media_create.create_text_file(
         size_kb=file_size_kb,
@@ -35,7 +39,7 @@ def test_st40p_fps_size(
 
     tx_config = GstreamerApp.setup_gstreamer_st40p_tx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[0],
         input_path=input_file_path,
         tx_payload_type=113,
         tx_queues=4,
@@ -47,7 +51,7 @@ def test_st40p_fps_size(
 
     rx_config = GstreamerApp.setup_gstreamer_st40p_rx_pipeline(
         build=build,
-        nic_port_list=host.vfs[1],
+        nic_port_list=interfaces_list[1],
         output_path=TMP_OUTPUT_FILE,
         rx_payload_type=113,
         rx_queues=4,
@@ -80,7 +84,7 @@ def test_st40p_framebuff(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     file_size_kb,
     fps,
     framebuff,
@@ -90,6 +94,9 @@ def test_st40p_framebuff(
 ):
     # Get the first host for remote execution
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     # Base the timeout on parameter to make sure the amount of time between RX and TX
     # is less than the timeout period
     timeout_period = 20
@@ -102,7 +109,7 @@ def test_st40p_framebuff(
 
     tx_config = GstreamerApp.setup_gstreamer_st40p_tx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[0],
         input_path=input_file_path,
         tx_payload_type=113,
         tx_queues=4,
@@ -114,7 +121,7 @@ def test_st40p_framebuff(
 
     rx_config = GstreamerApp.setup_gstreamer_st40p_rx_pipeline(
         build=build,
-        nic_port_list=host.vfs[1],
+        nic_port_list=interfaces_list[1],
         output_path=TMP_OUTPUT_FILE,
         rx_payload_type=113,
         rx_queues=4,
@@ -146,7 +153,7 @@ def test_st40p_format_8331(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     fps,
     framebuff,
     test_time,
@@ -155,6 +162,9 @@ def test_st40p_format_8331(
 ):
     # Get the first host for remote execution
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     # Based on this parameters
     timeout_period = 15
 
@@ -166,7 +176,7 @@ def test_st40p_format_8331(
 
     tx_config = GstreamerApp.setup_gstreamer_st40p_tx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[0],
         input_path=input_file_path,
         tx_payload_type=113,
         tx_queues=4,
@@ -179,7 +189,7 @@ def test_st40p_format_8331(
 
     rx_config = GstreamerApp.setup_gstreamer_st40p_rx_pipeline(
         build=build,
-        nic_port_list=host.vfs[1],
+        nic_port_list=interfaces_list[1],
         output_path=TMP_OUTPUT_FILE,
         rx_payload_type=113,
         rx_queues=4,

--- a/tests/validation/tests/single/gstreamer/audio_format/test_audio_format.py
+++ b/tests/validation/tests/single/gstreamer/audio_format/test_audio_format.py
@@ -5,6 +5,7 @@ import os
 
 import mtl_engine.media_creator as media_create
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import GstreamerApp
 
 
@@ -15,7 +16,7 @@ def test_audio_format(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     audio_format,
     audio_channel,
     audio_rate,
@@ -25,6 +26,9 @@ def test_audio_format(
 ):
     # Get the first host for remote execution
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     input_file_path = os.path.join(media, "test_audio.pcm")
 
@@ -40,7 +44,7 @@ def test_audio_format(
 
     tx_config = GstreamerApp.setup_gstreamer_st30_tx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[0],
         input_path=input_file_path,
         tx_payload_type=111,
         tx_queues=4,
@@ -51,7 +55,7 @@ def test_audio_format(
 
     rx_config = GstreamerApp.setup_gstreamer_st30_rx_pipeline(
         build=build,
-        nic_port_list=host.vfs[1],
+        nic_port_list=interfaces_list[1],
         output_path=os.path.join(media, "output_audio.pcm"),
         rx_payload_type=111,
         rx_queues=4,

--- a/tests/validation/tests/single/gstreamer/video_format/test_video_format.py
+++ b/tests/validation/tests/single/gstreamer/video_format/test_video_format.py
@@ -5,6 +5,7 @@ import os
 
 import mtl_engine.media_creator as media_create
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import GstreamerApp
 from mtl_engine.media_files import gstreamer_formats
 
@@ -14,7 +15,7 @@ def test_video_format(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     file,
     test_time,
     test_config,
@@ -24,6 +25,9 @@ def test_video_format(
 
     # Get the first host for remote execution
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     input_file_path = media_create.create_video_file(
         width=video_file["width"],
@@ -37,7 +41,7 @@ def test_video_format(
 
     tx_config = GstreamerApp.setup_gstreamer_st20p_tx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[0],
         input_path=input_file_path,
         width=video_file["width"],
         height=video_file["height"],
@@ -49,7 +53,7 @@ def test_video_format(
 
     rx_config = GstreamerApp.setup_gstreamer_st20p_rx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[1],
         output_path=os.path.join(media, "output_video.yuv"),
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/gstreamer/video_resolution/test_video_resolution.py
+++ b/tests/validation/tests/single/gstreamer/video_resolution/test_video_resolution.py
@@ -5,6 +5,7 @@ import os
 
 import mtl_engine.media_creator as media_create
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import GstreamerApp
 from mtl_engine.media_files import yuv_files
 from tests.xfail import SDBQ1971_conversion_v210_720p_error
@@ -15,7 +16,7 @@ def test_video_resolutions(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     file,
     request,
     test_time,
@@ -27,6 +28,9 @@ def test_video_resolutions(
 
     # Get the first host for remote execution
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     SDBQ1971_conversion_v210_720p_error(
         video_format=video_file["format"],
@@ -46,7 +50,7 @@ def test_video_resolutions(
 
     tx_config = GstreamerApp.setup_gstreamer_st20p_tx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[0],
         input_path=input_file_path,
         width=video_file["width"],
         height=video_file["height"],
@@ -58,7 +62,7 @@ def test_video_resolutions(
 
     rx_config = GstreamerApp.setup_gstreamer_st20p_rx_pipeline(
         build=build,
-        nic_port_list=host.vfs[0],
+        nic_port_list=interfaces_list[1],
         output_path=os.path.join(media, "output_video.yuv"),
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
@@ -18,7 +18,6 @@ def test_kernello_mixed_format(
     test_mode,
     video_format,
     replicas,
-    test_config,
     prepare_ramdisk,
 ):
     video_file = yuv_files[video_format]
@@ -29,7 +28,10 @@ def test_kernello_mixed_format(
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=["kernel:lo", "kernel:lo"],
+        nic_port_list=[
+            "kernel:lo",
+            "kernel:lo",
+        ],  # Note: keeping hardcoded for kernel loopback test
         test_mode=test_mode,
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
@@ -18,15 +18,18 @@ def test_kernello_st20p_video_format(
     test_mode,
     file,
     replicas,
-    test_config,
     prepare_ramdisk,
 ):
     st20p_file = yuv_files_422p10le[file]
+    host = list(hosts.values())[0]
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=["kernel:lo", "kernel:lo"],
+        nic_port_list=[
+            "kernel:lo",
+            "kernel:lo",
+        ],  # Note: keeping hardcoded for kernel loopback test
         test_mode=test_mode,
         width=st20p_file["width"],
         height=st20p_file["height"],
@@ -39,7 +42,6 @@ def test_kernello_st20p_video_format(
     config = rxtxapp.change_replicas(
         config=config, session_type="st20p", replicas=replicas
     )
-    host = list(hosts.values())[0]
     rxtxapp.execute_test(
         config=config,
         build=build,

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
@@ -18,7 +18,6 @@ def test_kernello_st22p_video_format(
     test_mode,
     file,
     replicas,
-    test_config,
     prepare_ramdisk,
 ):
     st22p_file = yuv_files_422rfc10[file]
@@ -27,7 +26,10 @@ def test_kernello_st22p_video_format(
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st22p_sessions(
         config=config,
-        nic_port_list=["kernel:lo", "kernel:lo"],
+        nic_port_list=[
+            "kernel:lo",
+            "kernel:lo",
+        ],  # Note: keeping hardcoded for kernel loopback test
         test_mode=test_mode,
         width=st22p_file["width"],
         height=st22p_file["height"],

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
@@ -18,19 +18,20 @@ def test_pmd_kernel_mixed_format(
     test_mode,
     video_format,
     replicas,
-    test_config,
     prepare_ramdisk,
 ):
     video_file = yuv_files[video_format]
     audio_file = audio_files["PCM24"]
     ancillary_file = anc_files["text_p50"]
     host = list(hosts.values())[0]
-    # rxtxapp.check_and_bind_interface(["0000:38:00.0","0000:38:00.1"], "pmd")
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=["0000:4b:00.0", "kernel:eth2"],
+        nic_port_list=[
+            "0000:4b:00.0",
+            "kernel:eth2",
+        ],  # Note: keeping hardcoded for kernel socket test
         test_mode=test_mode,
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
@@ -18,7 +18,6 @@ def test_pmd_kernel_video_format(
     test_mode,
     video_format,
     replicas,
-    test_config,
     prepare_ramdisk,
 ):
 
@@ -30,7 +29,10 @@ def test_pmd_kernel_video_format(
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=["0000:4b:00.0", "kernel:eth2"],
+        nic_port_list=[
+            "0000:4b:00.0",
+            "kernel:eth2",
+        ],  # Note: keeping hardcoded for kernel socket test
         test_mode=test_mode,
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/performance/test_1tx_1nic_1port.py
+++ b/tests/validation/tests/single/performance/test_1tx_1nic_1port.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_result_note
 from mtl_engine.media_files import yuv_files
 
@@ -30,7 +31,7 @@ def test_perf_1tx_1nic_1port(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     video_format,
     test_config,
@@ -38,11 +39,14 @@ def test_perf_1tx_1nic_1port(
 ):
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF"), count=1
+    )
 
     config = rxtxapp.create_empty_performance_config()
     config = rxtxapp.add_perf_st20p_session_tx(
         config=config,
-        nic_port=host.vfs[0],
+        nic_port=interfaces_list[0],
         ip="192.168.17.101",
         dip="239.168.48.9",
         width=video_file["width"],

--- a/tests/validation/tests/single/performance/test_1tx_1rx_2nics_2ports.py
+++ b/tests/validation/tests/single/performance/test_1tx_1rx_2nics_2ports.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_result_note
 from mtl_engine.media_files import yuv_files
 
@@ -30,7 +31,7 @@ def test_perf_1tx_1rx_2nics_2ports(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     video_format,
     test_config,
@@ -44,11 +45,14 @@ def test_perf_1tx_1rx_2nics_2ports(
 
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VFxPF")
+    )
 
     config = rxtxapp.create_empty_performance_config()
     config = rxtxapp.add_perf_st20p_session_tx(
         config=config,
-        nic_port=host.vfs[0],
+        nic_port=interfaces_list[0],
         ip="192.168.17.101",
         dip="239.168.48.9",
         width=video_file["width"],
@@ -60,7 +64,7 @@ def test_perf_1tx_1rx_2nics_2ports(
     )
     config = rxtxapp.add_perf_st20p_session_rx(
         config=config,
-        nic_port=host.vfs[1],
+        nic_port=interfaces_list[1],
         ip="192.168.17.102",
         sip="239.168.48.9",
         width=video_file["width"],

--- a/tests/validation/tests/single/performance/test_2tx_2nics_2ports.py
+++ b/tests/validation/tests/single/performance/test_2tx_2nics_2ports.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_result_note
 from mtl_engine.media_files import yuv_files
 
@@ -30,6 +31,7 @@ def test_perf_2tx_2nics_2ports(
     hosts,
     build,
     media,
+    setup_interfaces: InterfaceSetup,
     nic_port_list,
     test_time,
     video_format,
@@ -44,11 +46,14 @@ def test_perf_2tx_2nics_2ports(
 
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VFxPF")
+    )
 
     config = rxtxapp.create_empty_performance_config()
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[0],
+        nic_port=interfaces_list[0],
         ip="192.168.17.101",
         dip="239.168.48.9",
         video_format=video_format,
@@ -57,7 +62,7 @@ def test_perf_2tx_2nics_2ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[1],
+        nic_port=interfaces_list[1],
         ip="192.168.17.102",
         dip="239.168.48.9",
         video_format=video_format,

--- a/tests/validation/tests/single/performance/test_2tx_2rx_4nics_4ports.py
+++ b/tests/validation/tests/single/performance/test_2tx_2rx_4nics_4ports.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_result_note
 from mtl_engine.media_files import yuv_files
 
@@ -30,7 +31,7 @@ def test_perf_2tx_2rx_4nics_4ports(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     video_format,
     test_config,
@@ -44,11 +45,14 @@ def test_perf_2tx_2rx_4nics_4ports(
 
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VFxPF"), count=4
+    )
 
     config = rxtxapp.create_empty_performance_config()
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[0],
+        nic_port=interfaces_list[0],
         ip="192.168.17.101",
         dip="239.168.48.9",
         video_format=video_format,
@@ -57,7 +61,7 @@ def test_perf_2tx_2rx_4nics_4ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[1],
+        nic_port=interfaces_list[1],
         ip="192.168.17.102",
         dip="239.168.48.9",
         video_format=video_format,
@@ -66,7 +70,7 @@ def test_perf_2tx_2rx_4nics_4ports(
     )
     config = rxtxapp.add_perf_video_session_rx(
         config=config,
-        nic_port=nic_port_list[2],
+        nic_port=interfaces_list[2],
         ip="192.168.17.103",
         sip="239.168.48.9",
         video_format=video_format,
@@ -74,7 +78,7 @@ def test_perf_2tx_2rx_4nics_4ports(
     )
     config = rxtxapp.add_perf_video_session_rx(
         config=config,
-        nic_port=nic_port_list[3],
+        nic_port=interfaces_list[3],
         ip="192.168.17.104",
         sip="239.168.48.9",
         video_format=video_format,

--- a/tests/validation/tests/single/performance/test_4tx_4nics_4ports.py
+++ b/tests/validation/tests/single/performance/test_4tx_4nics_4ports.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_result_note
 from mtl_engine.media_files import yuv_files
 
@@ -30,7 +31,7 @@ def test_perf_4tx_4nics_4ports(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     video_format,
     test_config,
@@ -41,11 +42,14 @@ def test_perf_4tx_4nics_4ports(
 
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VFxPF"), count=4
+    )
 
     config = rxtxapp.create_empty_performance_config()
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[0],
+        nic_port=interfaces_list[0],
         ip="192.168.17.101",
         dip="239.168.48.9",
         video_format=video_format,
@@ -54,7 +58,7 @@ def test_perf_4tx_4nics_4ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[1],
+        nic_port=interfaces_list[1],
         ip="192.168.17.102",
         dip="239.168.48.9",
         video_format=video_format,
@@ -63,7 +67,7 @@ def test_perf_4tx_4nics_4ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[2],
+        nic_port=interfaces_list[2],
         ip="192.168.17.103",
         dip="239.168.48.9",
         video_format=video_format,
@@ -72,7 +76,7 @@ def test_perf_4tx_4nics_4ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[3],
+        nic_port=interfaces_list[3],
         ip="192.168.17.104",
         dip="239.168.48.9",
         video_format=video_format,

--- a/tests/validation/tests/single/performance/test_4tx_4rx_4nics_8ports.py
+++ b/tests/validation/tests/single/performance/test_4tx_4rx_4nics_8ports.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_result_note
 from mtl_engine.media_files import yuv_files
 
@@ -30,6 +31,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     hosts,
     build,
     media,
+    setup_interfaces: InterfaceSetup,
     nic_port_list,
     test_time,
     video_format,
@@ -41,11 +43,16 @@ def test_perf_4tx_4rx_4nics_8ports(
 
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "2VFxPF"), count=8
+    )
+    # interface_list contains 8 addresses of vfs for 4 pfs in order:
+    # first 2 addresses - nic0, second 2 addresses nic1 etc.
 
     config = rxtxapp.create_empty_performance_config()
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[0],  # from NIC 0 to NIC 1
+        nic_port=interfaces_list[0],  # from NIC 0 to NIC 1
         ip="192.168.17.101",
         dip="192.168.17.105",
         video_format=video_format,
@@ -54,7 +61,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[1],  # from NIC 1 to NIC 2
+        nic_port=interfaces_list[2],  # from NIC 1 to NIC 2
         ip="192.168.17.102",
         dip="192.168.17.106",
         video_format=video_format,
@@ -63,7 +70,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[2],  # from NIC 2 to NIC 3
+        nic_port=interfaces_list[4],  # from NIC 2 to NIC 3
         ip="192.168.17.103",
         dip="192.168.17.107",
         video_format=video_format,
@@ -72,7 +79,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     )
     config = rxtxapp.add_perf_video_session_tx(
         config=config,
-        nic_port=nic_port_list[3],  # from NIC 3 to NIC 0
+        nic_port=interfaces_list[6],  # from NIC 3 to NIC 0
         ip="192.168.17.104",
         dip="192.168.17.108",
         video_format=video_format,
@@ -81,7 +88,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     )
     config = rxtxapp.add_perf_video_session_rx(
         config=config,
-        nic_port=nic_port_list[4],
+        nic_port=interfaces_list[3],  # NIC 1 Rx
         ip="192.168.17.105",
         sip="192.168.17.101",
         video_format=video_format,
@@ -89,7 +96,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     )
     config = rxtxapp.add_perf_video_session_rx(
         config=config,
-        nic_port=nic_port_list[5],
+        nic_port=interfaces_list[5],  # NIC 2 Rx
         ip="192.168.17.106",
         sip="192.168.17.102",
         video_format=video_format,
@@ -97,7 +104,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     )
     config = rxtxapp.add_perf_video_session_rx(
         config=config,
-        nic_port=nic_port_list[6],
+        nic_port=interfaces_list[7],  # NIC 3 Rx
         ip="192.168.17.107",
         sip="192.168.17.103",
         video_format=video_format,
@@ -105,7 +112,7 @@ def test_perf_4tx_4rx_4nics_8ports(
     )
     config = rxtxapp.add_perf_video_session_rx(
         config=config,
-        nic_port=nic_port_list[7],
+        nic_port=interfaces_list[1],  # NIC 0 Rx
         ip="192.168.17.108",
         sip="192.168.17.104",
         video_format=video_format,

--- a/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
@@ -4,6 +4,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import anc_files, audio_files, yuv_files
 
 
@@ -24,7 +25,7 @@ def test_ptp_mixed_format(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_mode,
     video_format,
@@ -35,11 +36,14 @@ def test_ptp_mixed_format(
     audio_file = audio_files["PCM24"]
     ancillary_file = anc_files["text_p50"]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         width=video_file["width"],
         height=video_file["height"],
@@ -51,7 +55,7 @@ def test_ptp_mixed_format(
     )
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         audio_format="PCM24",
         audio_channel=["U02"],
@@ -62,7 +66,7 @@ def test_ptp_mixed_format(
     )
     config = rxtxapp.add_ancillary_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         type_="frame",
         ancillary_format="closed_caption",

--- a/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
@@ -4,6 +4,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
@@ -18,7 +19,7 @@ def test_ptp_video_format(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_mode,
     video_format,
@@ -30,11 +31,14 @@ def test_ptp_video_format(
         pytest.skip("Skipping 4k tests with more than 3 replicas")
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
+++ b/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
@@ -5,6 +5,7 @@ import logging
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
 from common.integrity.integrity_runner import FileAudioIntegrityRunner
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_fail
 from mtl_engine.integrity import get_sample_size
 from mtl_engine.media_files import audio_files
@@ -31,7 +32,7 @@ def test_rss_mode_audio(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     rss_mode,
     test_config,
@@ -40,13 +41,16 @@ def test_rss_mode_audio(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     out_file_url = host.connection.path(media_file_path).parent / "out.pcm"
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         audio_format=media_file_info["format"],
         audio_channel=["U02"],

--- a/tests/validation/tests/single/rss_mode/video/test_performance.py
+++ b/tests/validation/tests/single/rss_mode/video/test_performance.py
@@ -5,6 +5,7 @@ import logging
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_result_note
 from mtl_engine.media_files import yuv_files
 
@@ -27,8 +28,7 @@ logger = logging.getLogger(__name__)
 def test_rss_mode_video_performance(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     rss_mode,
     test_config,
@@ -37,11 +37,14 @@ def test_rss_mode_video_performance(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
+++ b/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
@@ -22,8 +23,7 @@ from mtl_engine.media_files import yuv_files
 def test_rss_mode_video(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     rss_mode,
     test_config,
@@ -32,11 +32,14 @@ def test_rss_mode_video(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/rx_timing/mixed/test_mode.py
+++ b/tests/validation/tests/single/rx_timing/mixed/test_mode.py
@@ -4,6 +4,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import anc_files, audio_files, yuv_files
 
 
@@ -12,7 +13,7 @@ def test_rx_timing_mode(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_mode,
     test_config,
@@ -22,11 +23,14 @@ def test_rx_timing_mode(
     audio_file = audio_files["PCM24"]
     ancillary_file = anc_files["text_p50"]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         width=video_file["width"],
         height=video_file["height"],
@@ -38,7 +42,7 @@ def test_rx_timing_mode(
     )
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         audio_format="PCM24",
         audio_channel=["U02"],
@@ -49,7 +53,7 @@ def test_rx_timing_mode(
     )
     config = rxtxapp.add_ancillary_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         type_="frame",
         ancillary_format="closed_caption",

--- a/tests/validation/tests/single/rx_timing/video/test_replicas.py
+++ b/tests/validation/tests/single/rx_timing/video/test_replicas.py
@@ -3,6 +3,7 @@
 import os
 
 import mtl_engine.RxTxApp as rxtxapp
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
@@ -10,18 +11,21 @@ def test_rx_timing_video_replicas(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
 ):
     video_file = yuv_files["i1080p60"]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/rx_timing/video/test_video_format.py
+++ b/tests/validation/tests/single/rx_timing/video/test_video_format.py
@@ -4,6 +4,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
@@ -23,7 +24,7 @@ def test_rx_timing_video_video_format(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     video_format,
     test_config,
@@ -31,11 +32,14 @@ def test_rx_timing_video_video_format(
 ):
     video_file = yuv_files[video_format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=video_file["width"],
         height=video_file["height"],

--- a/tests/validation/tests/single/st20p/format/test_format.py
+++ b/tests/validation/tests/single/st20p/format/test_format.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le, yuv_files_422rfc10
 
 
@@ -16,8 +17,7 @@ from mtl_engine.media_files import yuv_files_422p10le, yuv_files_422rfc10
 def test_422p10le(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -29,11 +29,14 @@ def test_422p10le(
     """
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],
@@ -86,7 +89,13 @@ convert1_formats = dict(
 )
 @pytest.mark.parametrize("format", convert1_formats.keys())
 def test_convert_on_rx(
-    hosts, build, media, nic_port_list, test_time, format, media_file
+    hosts,
+    build,
+    setup_interfaces: InterfaceSetup,
+    test_time,
+    format,
+    media_file,
+    test_config,
 ):
     """
     Send file in YUV_422_10bit pixel formats with supported convertion on RX side
@@ -94,10 +103,13 @@ def test_convert_on_rx(
     media_file_info, media_file_path = media_file
     output_format = convert1_formats[format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         packing="GPM",
         width=media_file_info["width"],
@@ -146,8 +158,8 @@ convert2_formats = dict(
 def test_tx_rx_conversion(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
+    test_config,
     test_time,
     format,
     media_file,
@@ -158,10 +170,13 @@ def test_tx_rx_conversion(
     media_file_info, media_file_path = media_file
     text_format, transport_format, _ = convert2_formats[format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         packing="GPM",
         width=media_file_info["width"],
@@ -186,8 +201,7 @@ def test_tx_rx_conversion(
 def test_formats(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     format,
     test_config,
@@ -200,11 +214,14 @@ def test_formats(
     media_file_info, media_file_path = media_file
     text_format, file_format = pixel_formats[format]
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         packing="GPM",
         width=media_file_info["width"],

--- a/tests/validation/tests/single/st20p/fps/test_fps.py
+++ b/tests/validation/tests/single/st20p/fps/test_fps.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422rfc10
 
 
@@ -32,8 +33,7 @@ from mtl_engine.media_files import yuv_files_422rfc10
 def test_fps(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     fps,
     test_config,
@@ -42,11 +42,14 @@ def test_fps(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st20p/integrity/test_integrity.py
+++ b/tests/validation/tests/single/st20p/integrity/test_integrity.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mfd_common_libs.log_levels import TEST_PASS
 from mtl_engine.const import LOG_FOLDER
 from mtl_engine.execute import log_fail
@@ -35,8 +36,7 @@ logger = logging.getLogger(__name__)
 def test_integrity(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -49,11 +49,14 @@ def test_integrity(
     os.makedirs(log_dir, exist_ok=True)
     out_file_url = os.path.join(log_dir, "out.yuv")
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         height=media_file_info["height"],
         width=media_file_info["width"],

--- a/tests/validation/tests/single/st20p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st20p/interlace/test_interlace.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_interlace
 
 
@@ -16,8 +17,7 @@ from mtl_engine.media_files import yuv_files_interlace
 def test_interlace(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -25,11 +25,14 @@ def test_interlace(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st20p/pacing/test_pacing.py
+++ b/tests/validation/tests/single/st20p/pacing/test_pacing.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422rfc10
 
 
@@ -21,8 +22,7 @@ from mtl_engine.media_files import yuv_files_422rfc10
 def test_pacing(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     pacing,
     test_config,
@@ -31,11 +31,14 @@ def test_pacing(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st20p/packing/test_packing.py
+++ b/tests/validation/tests/single/st20p/packing/test_packing.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422rfc10
 
 
@@ -21,8 +22,7 @@ from mtl_engine.media_files import yuv_files_422rfc10
 def test_packing(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     packing,
     test_config,
@@ -31,11 +31,14 @@ def test_packing(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
+++ b/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422rfc10
 
 
@@ -16,8 +17,7 @@ from mtl_engine.media_files import yuv_files_422rfc10
 def test_resolutions(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -27,11 +27,14 @@ def test_resolutions(
     media_file_info, media_file_path = media_file
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st20p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st20p/test_mode/test_multicast.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422rfc10
 
 
@@ -20,8 +21,7 @@ from mtl_engine.media_files import yuv_files_422rfc10
 def test_multicast(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -30,11 +30,14 @@ def test_multicast(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st22p/codec/test_codec.py
+++ b/tests/validation/tests/single/st22p/codec/test_codec.py
@@ -4,6 +4,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
@@ -18,8 +19,7 @@ from mtl_engine.media_files import yuv_files_422p10le
 def test_codec(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     codec,
     test_config,
@@ -28,11 +28,14 @@ def test_codec(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st22p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st22p/format/test_format.py
+++ b/tests/validation/tests/single/st22p/format/test_format.py
@@ -4,6 +4,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
@@ -16,8 +17,7 @@ from mtl_engine.media_files import yuv_files_422p10le
 def test_format(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -25,11 +25,14 @@ def test_format(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st22p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st22p/fps/test_fps.py
+++ b/tests/validation/tests/single/st22p/fps/test_fps.py
@@ -4,6 +4,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
@@ -33,8 +34,7 @@ from mtl_engine.media_files import yuv_files_422p10le
 def test_fps(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     fps,
     codec,
@@ -44,11 +44,14 @@ def test_fps(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st22p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st22p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st22p/interlace/test_interlace.py
@@ -4,6 +4,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_interlace
 
 
@@ -16,8 +17,7 @@ from mtl_engine.media_files import yuv_files_interlace
 def test_interlace(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -25,11 +25,14 @@ def test_interlace(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st22p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st22p/quality/test_quality.py
+++ b/tests/validation/tests/single/st22p/quality/test_quality.py
@@ -4,6 +4,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
@@ -18,8 +19,7 @@ from mtl_engine.media_files import yuv_files_422p10le
 def test_quality(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     quality,
     test_config,
@@ -28,11 +28,14 @@ def test_quality(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st22p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st22p/test_mode/test_unicast.py
+++ b/tests/validation/tests/single/st22p/test_mode/test_unicast.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
@@ -15,8 +16,7 @@ from mtl_engine.media_files import yuv_files_422p10le
 def test_unicast(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -24,11 +24,14 @@ def test_unicast(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st22p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/st30p/integrity/test_integrity.py
+++ b/tests/validation/tests/single/st30p/integrity/test_integrity.py
@@ -6,6 +6,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mfd_common_libs.log_levels import TEST_PASS
 from mtl_engine.const import LOG_FOLDER
 from mtl_engine.execute import log_fail
@@ -32,7 +33,7 @@ def test_integrity(
     hosts,
     build,
     media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -40,6 +41,9 @@ def test_integrity(
 ):
     media_file_info, media_file_path = media_file
 
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     # Ensure the output directory exists.
     log_dir = os.path.join(os.getcwd(), LOG_FOLDER, "latest")
     os.makedirs(log_dir, exist_ok=True)
@@ -49,7 +53,7 @@ def test_integrity(
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         audio_format=media_file_info["format"],
         audio_channel=["U02"],

--- a/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
+++ b/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
@@ -5,6 +5,7 @@ import logging
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
 from common.integrity.integrity_runner import FileAudioIntegrityRunner
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_fail
 from mtl_engine.integrity import get_channel_number, get_sample_size
 from mtl_engine.media_files import audio_files
@@ -34,8 +35,7 @@ logger = logging.getLogger(__name__)
 def test_st30p_channel(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     audio_channel,
     request,
@@ -49,12 +49,15 @@ def test_st30p_channel(
     SDBQ1001_audio_channel_check(audio_channel, media_file_info["format"], request)
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     out_file_url = host.connection.path(media_file_path).parent / "out.pcm"
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         audio_format=media_file_info["format"],
         audio_channel=[audio_channel],

--- a/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
+++ b/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
@@ -5,6 +5,7 @@ import logging
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
 from common.integrity.integrity_runner import FileAudioIntegrityRunner
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_fail
 from mtl_engine.integrity import get_sample_size
 from mtl_engine.media_files import audio_files
@@ -31,8 +32,7 @@ logger = logging.getLogger(__name__)
 def test_st30p_format(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -40,12 +40,15 @@ def test_st30p_format(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     out_file_url = host.connection.path(media_file_path).parent / "out.pcm"
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         audio_format=media_file_info["format"],
         audio_channel=["U02"],

--- a/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
+++ b/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
@@ -5,6 +5,7 @@ import logging
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
 from common.integrity.integrity_runner import FileAudioIntegrityRunner
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_fail
 from mtl_engine.integrity import get_sample_size
 from mtl_engine.media_files import audio_files
@@ -31,8 +32,7 @@ logger = logging.getLogger(__name__)
 def test_st30p_ptime(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     audio_ptime,
     test_config,
@@ -41,12 +41,15 @@ def test_st30p_ptime(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
     out_file_url = host.connection.path(media_file_path).parent / "out.pcm"
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         audio_format=media_file_info["format"],
         audio_channel=["U02"],

--- a/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
+++ b/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
@@ -5,6 +5,7 @@ import logging
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
 from common.integrity.integrity_runner import FileAudioIntegrityRunner
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import log_fail
 from mtl_engine.integrity import get_sample_number, get_sample_size
 from mtl_engine.media_files import audio_files
@@ -31,8 +32,7 @@ logger = logging.getLogger(__name__)
 def test_st30p_sampling(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     audio_sampling,
     test_config,
@@ -41,13 +41,16 @@ def test_st30p_sampling(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     out_file_url = host.connection.path(media_file_path).parent / "out.pcm"
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         audio_format=media_file_info["format"],
         audio_channel=["U02"],

--- a/tests/validation/tests/single/st30p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st30p/test_mode/test_multicast.py
@@ -4,6 +4,7 @@ import os
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.execute import LOG_FOLDER
 from mtl_engine.media_files import audio_files
 
@@ -26,8 +27,7 @@ from mtl_engine.media_files import audio_files
 def test_multicast(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
     prepare_ramdisk,
@@ -35,6 +35,9 @@ def test_multicast(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     # Ensure the output directory exists.
     log_dir = os.path.join(os.getcwd(), LOG_FOLDER, "latest")
@@ -44,7 +47,7 @@ def test_multicast(
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st30p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         audio_format=media_file_info["format"],
         audio_channel=["U02"],

--- a/tests/validation/tests/single/st41/dit/test_dit.py
+++ b/tests/validation/tests/single/st41/dit/test_dit.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import st41_files
 
 payload_type_mapping = {
@@ -31,8 +32,7 @@ k_bit_mapping = {
 def test_dit(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     dit,
     test_config,
@@ -49,12 +49,15 @@ def test_dit(
     k_bit = k_bit_mapping["k0"]
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st41_sessions(
         config=config,
         no_chain=False,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         payload_type=payload_type,
         type_=type_mode,

--- a/tests/validation/tests/single/st41/fps/test_fps.py
+++ b/tests/validation/tests/single/st41/fps/test_fps.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import st41_files
 
 payload_type_mapping = {
@@ -34,8 +35,7 @@ k_bit_mapping = {
 def test_fps(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     fps,
     test_config,
@@ -53,12 +53,15 @@ def test_fps(
     k_bit = k_bit_mapping["k0"]
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st41_sessions(
         config=config,
         no_chain=False,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         payload_type=payload_type,
         type_=type_mode,

--- a/tests/validation/tests/single/st41/k_bit/test_k_bit.py
+++ b/tests/validation/tests/single/st41/k_bit/test_k_bit.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import st41_files
 
 payload_type_mapping = {
@@ -31,8 +32,7 @@ k_bit_mapping = {
 def test_k_bit(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     k_bit,
     test_config,
@@ -49,12 +49,15 @@ def test_k_bit(
     dit = dit_mapping["dit0"]
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st41_sessions(
         config=config,
         no_chain=False,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         payload_type=payload_type,
         type_=type_mode,

--- a/tests/validation/tests/single/st41/no_chain/test_no_chain.py
+++ b/tests/validation/tests/single/st41/no_chain/test_no_chain.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import st41_files
 
 payload_type_mapping = {
@@ -31,8 +32,7 @@ k_bit_mapping = {
 def test_no_chain(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     type_mode,
     test_config,
@@ -49,12 +49,15 @@ def test_no_chain(
     dit = dit_mapping["dit0"]
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st41_sessions(
         config=config,
         no_chain=True,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         payload_type=payload_type,
         type_=type_mode,

--- a/tests/validation/tests/single/st41/payload_type/test_payload_type.py
+++ b/tests/validation/tests/single/st41/payload_type/test_payload_type.py
@@ -2,6 +2,7 @@
 # Copyright(c) 2024-2025 Intel Corporation
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import st41_files
 
 payload_type_mapping = {
@@ -32,8 +33,7 @@ k_bit_mapping = {
 def test_payload_type(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     payload_type,
     type_mode,
@@ -50,12 +50,15 @@ def test_payload_type(
     k_bit = k_bit_mapping["k0"]
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st41_sessions(
         config=config,
         no_chain=False,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="unicast",
         payload_type=payload_type_mapping[payload_type],
         type_=type_mode,

--- a/tests/validation/tests/single/st41/type_mode/test_type_mode.py
+++ b/tests/validation/tests/single/st41/type_mode/test_type_mode.py
@@ -3,6 +3,7 @@
 
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import st41_files
 
 payload_type_mapping = {
@@ -32,8 +33,7 @@ k_bit_mapping = {
 def test_type_mode(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     test_mode,
     type_mode,
@@ -51,12 +51,15 @@ def test_type_mode(
     dit = dit_mapping["dit0"]
 
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st41_sessions(
         config=config,
         no_chain=False,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode=test_mode,
         payload_type=payload_type,
         type_=type_mode,

--- a/tests/validation/tests/single/udp/librist/test_sessions_cnt.py
+++ b/tests/validation/tests/single/udp/librist/test_sessions_cnt.py
@@ -2,6 +2,7 @@
 # Copyright(c) 2024-2025 Intel Corporation
 
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import udp_app
 
 
@@ -23,7 +24,7 @@ from mtl_engine import udp_app
 def test_udp_sessions_cnt(
     hosts,
     build,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     sleep_us,
     sleep_step,
@@ -32,10 +33,13 @@ def test_udp_sessions_cnt(
     prepare_ramdisk,
 ):
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     udp_app.execute_test_librist(
         build=build,
-        nic_port_list=nic_port_list,
+        nic_port_list=interfaces_list,
         test_time=test_time,
         sleep_us=sleep_us,
         sleep_step=sleep_step,

--- a/tests/validation/tests/single/udp/sample/test_sessions_cnt.py
+++ b/tests/validation/tests/single/udp/sample/test_sessions_cnt.py
@@ -2,18 +2,28 @@
 # Copyright(c) 2024-2025 Intel Corporation
 
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine import udp_app
 
 
 @pytest.mark.parametrize("sessions_cnt", [1, 2, 5, 7])
 def test_udp_sessions_cnt(
-    hosts, build, nic_port_list, test_time, sessions_cnt, test_config, prepare_ramdisk
+    hosts,
+    build,
+    setup_interfaces: InterfaceSetup,
+    test_time,
+    sessions_cnt,
+    test_config,
+    prepare_ramdisk,
 ):
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     udp_app.execute_test_sample(
         build=build,
-        nic_port_list=nic_port_list,
+        nic_port_list=interfaces_list,
         test_time=test_time,
         sessions_cnt=sessions_cnt,
         host=host,

--- a/tests/validation/tests/single/virtio_user/test_virtio_user.py
+++ b/tests/validation/tests/single/virtio_user/test_virtio_user.py
@@ -2,6 +2,7 @@
 # Copyright(c) 2024-2025 Intel Corporation
 import mtl_engine.RxTxApp as rxtxapp
 import pytest
+from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
@@ -28,8 +29,7 @@ from mtl_engine.media_files import yuv_files
 def test_virtio_user(
     hosts,
     build,
-    media,
-    nic_port_list,
+    setup_interfaces: InterfaceSetup,
     test_time,
     replicas,
     test_config,
@@ -38,11 +38,14 @@ def test_virtio_user(
 ):
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
 
     config = rxtxapp.create_empty_config()
     config = rxtxapp.add_st20p_sessions(
         config=config,
-        nic_port_list=host.vfs,
+        nic_port_list=interfaces_list,
         test_mode="multicast",
         width=media_file_info["width"],
         height=media_file_info["height"],

--- a/tests/validation/tests/single/xdp/test_mode/test_xdp_mode.py
+++ b/tests/validation/tests/single/xdp/test_mode/test_xdp_mode.py
@@ -18,7 +18,6 @@ def test_xdp_mode(
     test_mode,
     video_format,
     replicas,
-    test_config,
     prepare_ramdisk,
 ):
     video_file = yuv_files[video_format]

--- a/tests/validation/tests/single/xdp/test_standard/test_standard.py
+++ b/tests/validation/tests/single/xdp/test_standard/test_standard.py
@@ -20,7 +20,6 @@ def test_xdp_standard(
     video_format,
     replicas,
     standard_mode,
-    test_config,
     prepare_ramdisk,
 ):
     video_file = yuv_files[video_format]


### PR DESCRIPTION
Refactor fixtures to support either VFs and PFs in tests as test interfaces. 
Use new test config param for choosing if tests shall use VFs or PFs: "interface_type"
Single node tests refactored except kernel_socket and xdp (different network interfaces - needs another approach) 
Dual node tests will be done in next PR
