### PR TITLE
Test: Mark PTP tests as expected to fail

### DIFF
--- a/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/mixed/test_mixed_format.py
@@ -7,6 +7,7 @@ import pytest
 from mtl_engine.media_files import anc_files, audio_files, yuv_files
 
 
+@pytest.mark.xfail(reason="the test environment is not yet ready to run PTP tests")
 @pytest.mark.parametrize("test_mode", ["unicast", "multicast"])
 @pytest.mark.parametrize(
     "video_format",

--- a/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
+++ b/tests/validation/tests/single/ptp/test_mode/video/test_video_format.py
@@ -7,6 +7,7 @@ import pytest
 from mtl_engine.media_files import yuv_files
 
 
+@pytest.mark.xfail(reason="the test environment is not yet ready to run PTP tests")
 @pytest.mark.parametrize("test_mode", ["unicast", "multicast"])
 @pytest.mark.parametrize(
     "video_format",


### PR DESCRIPTION
The validation framework is not fully ready to run PTP tests due to lack of PF support. Mark all PTP tests as expected to fail.