### PR TITLE
Ci: Extend process shutdown wait time and nightly test scope

### DIFF
--- a/tests/validation/mtl_engine/execute.py
+++ b/tests/validation/mtl_engine/execute.py
@@ -67,11 +67,13 @@ def killproc(proc: subprocess.Popen, sigint: bool = False):
     else:
         proc.terminate()
 
+    time.sleep(5)
+
     for _ in range(5):
         result = proc.poll()
         if result is not None:
             return result
-        time.sleep(1)  # wait a little longer for proc to terminate
+        time.sleep(5)  # wait a little longer for proc to terminate
 
     # failed to terminate proc, so kill it
     proc.kill()
@@ -79,7 +81,7 @@ def killproc(proc: subprocess.Popen, sigint: bool = False):
         result = proc.poll()
         if result is not None:
             return result
-        time.sleep(1)  # give system more time to kill proc
+        time.sleep(5)  # give system more time to kill proc
 
     # failed to kill proc
     if result is None:

--- a/tests/validation/tests/single/st20p/format/test_format.py
+++ b/tests/validation/tests/single/st20p/format/test_format.py
@@ -83,6 +83,7 @@ convert1_formats = dict(
 )
 
 
+@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [yuv_files_422rfc10["Penguin_1080p"]],

--- a/tests/validation/tests/single/st20p/integrity/test_integrity.py
+++ b/tests/validation/tests/single/st20p/integrity/test_integrity.py
@@ -15,6 +15,7 @@ from mtl_engine.media_files import yuv_files_422p10le, yuv_files_422rfc10
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st20p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st20p/interlace/test_interlace.py
@@ -6,6 +6,7 @@ import pytest
 from mtl_engine.media_files import yuv_files_interlace
 
 
+@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     list(yuv_files_interlace.values()),

--- a/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
+++ b/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
@@ -6,6 +6,7 @@ import pytest
 from mtl_engine.media_files import yuv_files_422rfc10
 
 
+@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     list(yuv_files_422rfc10.values()),

--- a/tests/validation/tests/single/st20p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st20p/test_mode/test_multicast.py
@@ -6,6 +6,7 @@ import pytest
 from mtl_engine.media_files import yuv_files_422rfc10
 
 
+@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [


### PR DESCRIPTION
Extend process shutdown wait time and nightly test scope Addresses frequent test failures where new test runs fail due to VFIO resources still being held by incompletely terminated processes from previous test executions