### PR TITLE
Fix: Redundant mode in st30 st40 st41 rx sessions

### DIFF
--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -97,13 +97,6 @@ static inline bool st_is_valid_payload_type(int payload_type) {
 
 void mt_eth_macaddr_dump(enum mtl_port port, char* tag, struct rte_ether_addr* mac_addr);
 
-static inline bool st_rx_seq_drop(uint16_t new_id, uint16_t old_id, uint16_t delta) {
-  if ((new_id <= old_id) && ((old_id - new_id) < delta))
-    return true;
-  else
-    return false;
-}
-
 struct rte_mbuf* mt_build_pad(struct mtl_main_impl* impl, struct rte_mempool* mempool,
                               enum mtl_port port, uint16_t ether_type, uint16_t len);
 

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -132,9 +132,12 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   /* 0b00: progressive or not specified, do nothing */
 
   /* set if it is first pkt */
-  if (unlikely(s->latest_seq_id == -1)) s->latest_seq_id = seq_id - 1;
+  if (unlikely(s->latest_seq_id == -1)) {
+    s->latest_seq_id = seq_id - 1;
+  }
+
   /* drop old packet */
-  if (st_rx_seq_drop(seq_id, s->latest_seq_id, 5)) {
+  if (seq_id <= s->latest_seq_id) {
     dbg("%s(%d,%d), drop as pkt seq %d is old\n", __func__, s->idx, s_port, seq_id);
     ST_SESSION_STAT_INC(s, port_user_stats, stat_pkts_redundant);
     return 0;
@@ -142,6 +145,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   if (seq_id != (uint16_t)(s->latest_seq_id + 1)) {
     ST_SESSION_STAT_INC(s, port_user_stats.common, stat_pkts_out_of_order);
   }
+
   /* update seq id */
   s->latest_seq_id = seq_id;
 

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -293,10 +293,14 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   }
 
   /* set first seq_id - 1 */
-  if (unlikely(s->latest_seq_id == -1)) s->latest_seq_id = seq_id - 1;
+  if (unlikely(s->latest_seq_id == -1)) {
+    s->latest_seq_id = seq_id - 1;
+  }
+
   /* drop old packet */
-  if (st_rx_seq_drop(seq_id, s->latest_seq_id, 5)) {
-    dbg("%s(%d,%d), drop as pkt seq %d is old\n", __func__, s->idx, s_port, seq_id);
+  if (seq_id <= s->latest_seq_id) {
+    dbg("%s(%d,%d), drop as pkt seq %d is old last %d\n", __func__, s->idx, s_port,
+        seq_id, s->latest_seq_id);
     ST_SESSION_STAT_INC(s, port_user_stats, stat_pkts_redundant);
     if (s->enable_timing_parser) {
       enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
@@ -304,11 +308,13 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     }
     return -EIO;
   }
+
   if (seq_id != (uint16_t)(s->latest_seq_id + 1)) {
     ST_SESSION_STAT_INC(s, port_user_stats.common, stat_pkts_out_of_order);
-    dbg("%s(%d,%d), ooo, seq now %u last %d\n", __func__, s->idx, s_port, seq_id,
-        s->latest_seq_id);
+    info("%s(%d,%d), ooo, seq now %u last %d\n", __func__, s->idx, s_port, seq_id,
+         s->latest_seq_id);
   }
+
   /* update seq id */
   s->latest_seq_id = seq_id;
 
@@ -434,9 +440,12 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   }
 
   /* set first seq_id - 1 */
-  if (unlikely(s->latest_seq_id == -1)) s->latest_seq_id = seq_id - 1;
+  if (unlikely(s->latest_seq_id == -1)) {
+    s->latest_seq_id = seq_id - 1;
+  }
+
   /* drop old packet */
-  if (st_rx_seq_drop(seq_id, s->latest_seq_id, 5)) {
+  if (seq_id <= s->latest_seq_id) {
     dbg("%s(%d,%d), drop as pkt seq %d is old\n", __func__, s->idx, s_port, seq_id);
     ST_SESSION_STAT_INC(s, port_user_stats, stat_pkts_redundant);
     return -EIO;

--- a/lib/src/st2110/st_rx_fastmetadata_session.c
+++ b/lib/src/st2110/st_rx_fastmetadata_session.c
@@ -115,13 +115,17 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
   }
 
   /* set if it is first pkt */
-  if (unlikely(s->latest_seq_id == -1)) s->latest_seq_id = seq_id - 1;
+  if (unlikely(s->latest_seq_id == -1)) {
+    s->latest_seq_id = seq_id - 1;
+  }
+
   /* drop old packet */
-  if (st_rx_seq_drop(seq_id, s->latest_seq_id, 5)) {
+  if (seq_id <= s->latest_seq_id) {
     dbg("%s(%d,%d), drop as pkt seq %d is old\n", __func__, s->idx, s_port, seq_id);
     ST_SESSION_STAT_INC(s, port_user_stats, stat_pkts_redundant);
     return 0;
   }
+
   if (seq_id != (uint16_t)(s->latest_seq_id + 1)) {
     ST_SESSION_STAT_INC(s, port_user_stats.common, stat_pkts_out_of_order);
   }


### PR DESCRIPTION
St20 and St30 had a bug where we only treated
incoming packets as redundant if they were within
5 packets of the latest recieved packet. If the
change exceeded 5 packets, we would treat the
packet as OOO and put in into frame wchich lead
to corrupted streams and log spam.

OOO packets stats are now triggered when the packet is not the next expected packet (last sequence id + 1).