### PR TITLE
Ci: Remove hugepage reservation from nightly tests workflow

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -52,9 +52,6 @@ jobs:
           sudo rmmod irdma || true
           sudo ./script/nicctl.sh create_vf "${TEST_PF_PORT_P}" || true
           sudo ./script/nicctl.sh create_vf "${TEST_PF_PORT_R}" || true
-      - name: Setup hugepages
-        run: |
-          sudo sysctl -w vm.nr_hugepages=32768
       - name: 'preparation: Start MtlManager at background'
         run: |
           sudo MtlManager &


### PR DESCRIPTION
Remove the hugepage reservation step from the nightly tests workflow, as it is related to hardware.