### PR TITLE
Fix: revert redundant mode in st30 st40 st41 rx sessions

### DIFF
--- a/lib/src/mt_util.h
+++ b/lib/src/mt_util.h
@@ -97,6 +97,13 @@ static inline bool st_is_valid_payload_type(int payload_type) {
 
 void mt_eth_macaddr_dump(enum mtl_port port, char* tag, struct rte_ether_addr* mac_addr);
 
+static inline bool st_rx_seq_drop(uint16_t new_id, uint16_t old_id, uint16_t delta) {
+  if ((new_id <= old_id) && ((old_id - new_id) < delta))
+    return true;
+  else
+    return false;
+}
+
 struct rte_mbuf* mt_build_pad(struct mtl_main_impl* impl, struct rte_mempool* mempool,
                               enum mtl_port port, uint16_t ether_type, uint16_t len);
 

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -132,12 +132,9 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   /* 0b00: progressive or not specified, do nothing */
 
   /* set if it is first pkt */
-  if (unlikely(s->latest_seq_id == -1)) {
-    s->latest_seq_id = seq_id - 1;
-  }
-
+  if (unlikely(s->latest_seq_id == -1)) s->latest_seq_id = seq_id - 1;
   /* drop old packet */
-  if (seq_id <= s->latest_seq_id) {
+  if (st_rx_seq_drop(seq_id, s->latest_seq_id, 5)) {
     dbg("%s(%d,%d), drop as pkt seq %d is old\n", __func__, s->idx, s_port, seq_id);
     ST_SESSION_STAT_INC(s, port_user_stats, stat_pkts_redundant);
     return 0;
@@ -145,7 +142,6 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   if (seq_id != (uint16_t)(s->latest_seq_id + 1)) {
     ST_SESSION_STAT_INC(s, port_user_stats.common, stat_pkts_out_of_order);
   }
-
   /* update seq id */
   s->latest_seq_id = seq_id;
 

--- a/lib/src/st2110/st_rx_fastmetadata_session.c
+++ b/lib/src/st2110/st_rx_fastmetadata_session.c
@@ -115,17 +115,13 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
   }
 
   /* set if it is first pkt */
-  if (unlikely(s->latest_seq_id == -1)) {
-    s->latest_seq_id = seq_id - 1;
-  }
-
+  if (unlikely(s->latest_seq_id == -1)) s->latest_seq_id = seq_id - 1;
   /* drop old packet */
-  if (seq_id <= s->latest_seq_id) {
+  if (st_rx_seq_drop(seq_id, s->latest_seq_id, 5)) {
     dbg("%s(%d,%d), drop as pkt seq %d is old\n", __func__, s->idx, s_port, seq_id);
     ST_SESSION_STAT_INC(s, port_user_stats, stat_pkts_redundant);
     return 0;
   }
-
   if (seq_id != (uint16_t)(s->latest_seq_id + 1)) {
     ST_SESSION_STAT_INC(s, port_user_stats.common, stat_pkts_out_of_order);
   }


### PR DESCRIPTION
Due to the seq_id wraparound the functionality didnt work, revert for now.

TODO: Add a patch that addresses issue described in 806c56b7fc8b04acb8ade7b70a00ad545ba7f83b.

This reverts commit 806c56b7fc8b04acb8ade7b70a00ad545ba7f83b.