### PR TITLE
Fix: prevent divide-by-zero in mt_srss_init

### DIFF
--- a/lib/src/datapath/mt_shared_rss.c
+++ b/lib/src/datapath/mt_shared_rss.c
@@ -418,7 +418,7 @@ int mt_srss_init(struct mtl_main_impl* impl) {
     srss->queue_mode =
         mt_pmd_is_native_af_xdp(impl, port) ? MT_QUEUE_MODE_XDP : MT_QUEUE_MODE_DPDK;
     srss->nb_rx_q = mt_if(impl, port)->nb_rx_q;
-        
+
     srss->lists_sz = 64 - 1; /* use odd count for better distribution */
     srss->lists = mt_rte_zmalloc_socket(sizeof(*srss->lists) * srss->lists_sz,
                                         mt_socket_id(impl, port));


### PR DESCRIPTION
Add validation to check if nb_rx_q is zero before it can be used in division. If nb_rx_q is zero, return -EINVAL with error message.

This prevents the divide-by-zero at line 459 where srss->nb_rx_q / srss->schs_cnt could fail if schs_cnt becomes zero (which happens when nb_rx_q is zero).