### PR TITLE
Fix: Race condition in pipelines

### DIFF
--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -112,6 +112,12 @@ static int tx_st40p_frame_done(void* priv, uint16_t frame_idx,
 
   framebuff = &ctx->framebuffs[frame_idx];
 
+  frame_info = &framebuff->frame_info;
+  frame_info->tfmt = meta->tfmt;
+  frame_info->timestamp = meta->timestamp;
+  frame_info->epoch = meta->epoch;
+  frame_info->rtp_timestamp = meta->rtp_timestamp;
+
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST40P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
@@ -123,12 +129,6 @@ static int tx_st40p_frame_done(void* priv, uint16_t frame_idx,
         frame_idx);
   }
   mt_pthread_mutex_unlock(&ctx->lock);
-
-  frame_info = &framebuff->frame_info;
-  frame_info->tfmt = meta->tfmt;
-  frame_info->timestamp = meta->timestamp;
-  frame_info->epoch = meta->epoch;
-  frame_info->rtp_timestamp = meta->rtp_timestamp;
 
   if (ctx->ops.notify_frame_done) { /* notify app which frame done */
     ctx->ops.notify_frame_done(ctx->ops.priv, frame_info);

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -112,6 +112,12 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   int ret;
   struct st20p_tx_frame* framebuff = &ctx->framebuffs[frame_idx];
 
+  struct st_frame* frame = tx_st20p_user_frame(ctx, framebuff);
+  frame->tfmt = meta->tfmt;
+  frame->timestamp = meta->timestamp;
+  frame->epoch = meta->epoch;
+  frame->rtp_timestamp = meta->rtp_timestamp;
+
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST20P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
@@ -123,12 +129,6 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
         frame_idx);
   }
   mt_pthread_mutex_unlock(&ctx->lock);
-
-  struct st_frame* frame = tx_st20p_user_frame(ctx, framebuff);
-  frame->tfmt = meta->tfmt;
-  frame->timestamp = meta->timestamp;
-  frame->epoch = meta->epoch;
-  frame->rtp_timestamp = meta->rtp_timestamp;
 
   if (ctx->ops.notify_frame_done &&
       !framebuff->frame_done_cb_called) { /* notify app which frame done */

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -133,6 +133,12 @@ static int tx_st22p_frame_done(void* priv, uint16_t frame_idx,
   int ret;
   struct st22p_tx_frame* framebuff = &ctx->framebuffs[frame_idx];
 
+  framebuff->src.tfmt = meta->tfmt;
+  framebuff->dst.tfmt = meta->tfmt;
+  framebuff->src.timestamp = meta->timestamp;
+  framebuff->dst.timestamp = meta->timestamp;
+  framebuff->src.rtp_timestamp = framebuff->dst.rtp_timestamp = meta->rtp_timestamp;
+
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST22P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
@@ -144,12 +150,6 @@ static int tx_st22p_frame_done(void* priv, uint16_t frame_idx,
         frame_idx);
   }
   mt_pthread_mutex_unlock(&ctx->lock);
-
-  framebuff->src.tfmt = meta->tfmt;
-  framebuff->dst.tfmt = meta->tfmt;
-  framebuff->src.timestamp = meta->timestamp;
-  framebuff->dst.timestamp = meta->timestamp;
-  framebuff->src.rtp_timestamp = framebuff->dst.rtp_timestamp = meta->rtp_timestamp;
 
   if (ctx->ops.notify_frame_done) { /* notify app which frame done */
     struct st_frame* frame = tx_st22p_user_frame(ctx, framebuff);

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.c
@@ -108,6 +108,12 @@ static int tx_st30p_frame_done(void* priv, uint16_t frame_idx,
   int ret;
   struct st30p_tx_frame* framebuff = &ctx->framebuffs[frame_idx];
 
+  struct st30_frame* frame = &framebuff->frame;
+  frame->tfmt = meta->tfmt;
+  frame->timestamp = meta->timestamp;
+  frame->epoch = meta->epoch;
+  frame->rtp_timestamp = meta->rtp_timestamp;
+
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST30P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
@@ -119,12 +125,6 @@ static int tx_st30p_frame_done(void* priv, uint16_t frame_idx,
         frame_idx);
   }
   mt_pthread_mutex_unlock(&ctx->lock);
-
-  struct st30_frame* frame = &framebuff->frame;
-  frame->tfmt = meta->tfmt;
-  frame->timestamp = meta->timestamp;
-  frame->epoch = meta->epoch;
-  frame->rtp_timestamp = meta->rtp_timestamp;
 
   if (ctx->ops.notify_frame_done) { /* notify app which frame done */
     ctx->ops.notify_frame_done(ctx->ops.priv, frame);


### PR DESCRIPTION
The status of frames was changed to TX_FRAME_FREE before the frame_done() finished modifing the frame, which made it possible that a frame obtained by the get_frame() function was modified after it had been retrieved.