### PR TITLE
Fix: First timestamp initialized to 0 in RTP mode

### DIFF
--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -189,6 +189,7 @@ static int tx_ancillary_session_init_hdr(struct mtl_main_impl* impl,
   rtp->base.ssrc = htonl(ssrc);
   s->st40_seq_id = 0;
   s->st40_ext_seq_id = 0;
+  s->st40_rtp_time = -1;
 
   info("%s(%d,%d), ip %u.%u.%u.%u port %u:%u\n", __func__, idx, s_port, dip[0], dip[1],
        dip[2], dip[3], s->st40_src_port[s_port], s->st40_dst_port[s_port]);

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -188,6 +188,7 @@ static int tx_audio_session_init_hdr(struct mtl_main_impl* impl,
   rtp->ssrc = htonl(ssrc);
 
   s->st30_seq_id = 0;
+  s->st30_rtp_time = -1;
 
   info("%s(%d,%d), ip %u.%u.%u.%u port %u:%u payload_type %u\n", __func__, idx, s_port,
        dip[0], dip[1], dip[2], dip[3], s->st30_src_port[s_port], s->st30_dst_port[s_port],

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -188,6 +188,7 @@ static int tx_fastmetadata_session_init_hdr(struct mtl_main_impl* impl,
   uint32_t ssrc = ops->ssrc ? ops->ssrc : s->idx + 0x323450;
   rtp->base.ssrc = htonl(ssrc);
   s->st41_seq_id = 0;
+  s->st41_rtp_time = -1;
 
   info("%s(%d,%d), ip %u.%u.%u.%u port %u:%u\n", __func__, idx, s_port, dip[0], dip[1],
        dip[2], dip[3], s->st41_src_port[s_port], s->st41_dst_port[s_port]);


### PR DESCRIPTION
In RTP mode, our API incorrectly initializes the first packet timestamp to 0 for ST40, ST41, and ST30 streams.

Fixes: be5563dd70af95475446c4cefe6d55e93f1543e9