### PR TITLE
Add: Guard mechanism against all-redundant state

### DIFF
--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -156,9 +156,20 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
           s_port, tmstamp, s->tmstamp);
     }
 
+    s->redundant_error_cnt[s_port]++;
     ST_SESSION_STAT_INC(s, port_user_stats, stat_pkts_redundant);
-    return -EIO;
+
+    for (int i = 0; i < s->ops.num_port; i++) {
+      if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
+        return -EIO;
+      }
+    }
+    warn(
+        "%s(%d), redundant error threshold reached, accept packet seq %u (old seq_id "
+        "%d), timestamp %u (old timestamp %ld)\n",
+        __func__, s->idx, seq_id, s->session_seq_id, tmstamp, s->tmstamp);
   }
+  s->redundant_error_cnt[s_port] = 0;
 
   /* hole in seq id packets going into the session check if the seq_id of the session is
    * consistent */


### PR DESCRIPTION
If the session ancillary seq_id or any other session timestamp somehow moves backward in time, the MTL RX will wait indefinitely for that threshold to be reached. While this state should never occur under normal conditions, we can implement a threshold guard that accepts the packet after a while.