### PR TITLE
st40p tx: undo zero-size guard from dd611004

### DIFF
--- a/lib/src/st2110/experimental/st40_pipeline_tx.c
+++ b/lib/src/st2110/experimental/st40_pipeline_tx.c
@@ -428,7 +428,6 @@ int st40p_tx_put_frame(st40p_tx_handle handle, struct st40_frame_info* frame_inf
     return -EIO;
   }
 
-
   framebuff->anc_frame->meta_num = frame_info->meta_num;
   framebuff->anc_frame->data_size = frame_info->udw_buffer_fill;
 


### PR DESCRIPTION
Commit dd611004 (“Add: GStreamer plugin 8331 input support (#1159)”) started failing TX submissions whenever the ancillary framebuffer still reported data_size == 0, even though the actual payload length already lives in frame_info->udw_buffer_fill. Drop that guard and simply trust the caller’s metadata so empty ANC payloads don’t abort otherwise valid frames.