### PR TITLE
Add: Ability to drop old frames

### DIFF
--- a/doc/usdt.md
+++ b/doc/usdt.md
@@ -736,10 +736,16 @@ sudo bpftrace -e 'usdt::st40:rx_mbuf_enqueue_fail { printf("%s m%d,s%d: mbuf %p 
 
 #### 2.5.6. st40p pipeline tracing
 
-The ST40 pipeline helpers (used by `RxSt40PipelineSample`, `TxSt40PipelineSample`, or any app built on `st40_pipeline_api.h`) expose their own provider to focus on frame-level callbacks rather than mbuf activity. Today only the RX side wires USDT probes (TX helpers reuse the regular logging path):
+The ST40 pipeline helpers (used by `RxSt40PipelineSample`, `TxSt40PipelineSample`, or any app built on `st40_pipeline_api.h`) expose their own provider to focus on frame-level callbacks across both TX and RX paths:
 
 ```c
 provider st40p {
+  /* tx */
+  probe tx_frame_get(int idx, int f_idx, void* va);
+  probe tx_frame_put(int idx, int f_idx, void* va);
+  probe tx_frame_next(int idx, int f_idx);
+  probe tx_frame_done(int idx, int f_idx, uint32_t tmstamp);
+  probe tx_frame_drop(int idx, int f_idx, uint32_t tmstamp);
   /* rx */
   probe rx_frame_available(int idx, int f_idx, uint32_t meta_num);
   probe rx_frame_get(int idx, int f_idx, uint32_t meta_num);
@@ -747,6 +753,19 @@ provider st40p {
   /* attach to enable on-demand dumps */
   probe rx_frame_dump(int idx, char* dump_file, uint32_t meta_num, uint32_t bytes);
 }
+```
+
+To watch for ancillary frames that arrive too late to flush, hook the TX drop probe (customize the process name for your setup):
+
+```bash
+sudo bpftrace -e 'usdt::st40p:tx_frame_drop { printf("%s s%d: drop frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof TxSt40PipelineSample)
+```
+
+Example output like below:
+
+```text
+09:33:12 s0: drop frame 0(timestamp:241037184)
+09:33:12 s0: drop frame 1(timestamp:241037728)
 ```
 
 Typical RX-side traces (customize the process name/PID for your sample or RxTxApp process):
@@ -868,6 +887,21 @@ Example output like below:
 09:22:58 s0: done frame 1(timestamp:3639352297)
 ```
 
+#### 2.6.5. tx_frame_drop USDT
+
+usage: customize the application process name as your setup
+
+```bash
+sudo bpftrace -e 'usdt::st20p:tx_frame_drop { printf("%s s%d: drop frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof RxTxApp)
+```
+
+Example output like below:
+
+```text
+09:25:04 s0: drop frame 0(timestamp:3639471120)
+09:25:04 s0: drop frame 1(timestamp:3639472621)
+```
+
 And if you want to trace all st20p tx events, use below bpftrace script.
 
 ```bash
@@ -875,11 +909,12 @@ sudo bpftrace -e '
 usdt::st20p:tx_frame_get { printf("%s s%d: get frame %d(addr:%p)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st20p:tx_frame_put { printf("%s s%d: put frame %d(addr:%p,stat:%d)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2, arg3); }
 usdt::st20p:tx_frame_done { printf("%s s%d: done frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
+usdt::st20p:tx_frame_drop { printf("%s s%d: drop frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st20p:tx_frame_next { printf("%s s%d: next frame %d\n", strftime("%H:%M:%S", nsecs), arg0, arg1); }
 ' -p $(pidof RxTxApp)
 ```
 
-#### 2.6.5. rx_frame_get USDT
+#### 2.6.6. rx_frame_get USDT
 
 usage: customize the application process name as your setup
 
@@ -895,7 +930,7 @@ Example output like below:
 10:37:16 s0: get frame 2(addr:0x3209a17000)
 ```
 
-#### 2.6.6. rx_frame_put USDT
+#### 2.6.7. rx_frame_put USDT
 
 usage: customize the application process name as your setup
 
@@ -911,7 +946,7 @@ Example output like below:
 10:37:33 s0: put frame 2(addr:0x3209a17000)
 ```
 
-#### 2.6.7. rx_frame_available USDT
+#### 2.6.8. rx_frame_available USDT
 
 usage: customize the application process name as your setup
 
@@ -937,7 +972,7 @@ usdt::st20p:rx_frame_available { printf("%s s%d: available frame %d(addr:%p, tms
 ' -p $(pidof RxTxApp)
 ```
 
-#### 2.6.8. tx_frame_dump USDT
+#### 2.6.9. tx_frame_dump USDT
 
 Usage: Attaching to this hook initiates the process, which continues to dump frames to a local file every 5 seconds until detachment occurs.
 
@@ -952,7 +987,7 @@ Example output like below:
 13:26:46 s0: dump frame 0x3206217000 size 8294400 to imtl_usdt_st20ptx_s0_1920_1080_CzYDQe.yuv
 ```
 
-#### 2.6.9. rx_frame_dump USDT
+#### 2.6.10. rx_frame_dump USDT
 
 Usage: Attaching to this hook initiates the process, which continues to dump frames to a local file every 5 seconds until detachment occurs.
 
@@ -1207,18 +1242,34 @@ Example output like below:
 15:05:38 s0: done frame 1(timestamp:380834179)
 ```
 
+#### 2.8.5. tx_frame_drop USDT
+
+usage: customize the application process name as your setup
+
+```bash
+sudo bpftrace -e 'usdt::st22p:tx_frame_drop { printf("%s s%d: drop frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof RxTxApp)
+```
+
+Example output like below:
+
+```text
+15:06:42 s0: drop frame 0(timestamp:380846682)
+15:06:42 s0: drop frame 1(timestamp:380848184)
+```
+
 And if you want to trace all st22p tx events, use below bpftrace script.
 
 ```bash
 sudo bpftrace -e '
 usdt::st22p:tx_frame_get { printf("%s s%d: get frame %d(addr:%p)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st22p:tx_frame_put { printf("%s s%d: put frame %d(addr:%p)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
+usdt::st22p:tx_frame_drop { printf("%s s%d: drop frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st22p:tx_frame_done { printf("%s s%d: done frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st22p:tx_frame_next { printf("%s s%d: next frame %d\n", strftime("%H:%M:%S", nsecs), arg0, arg1); }
 ' -p $(pidof RxTxApp)
 ```
 
-#### 2.8.5. rx_frame_get USDT
+#### 2.8.6. rx_frame_get USDT
 
 usage: customize the application process name as your setup
 
@@ -1234,7 +1285,7 @@ Example output like below:
 15:10:54 s0: get frame 2(addr:0x320830e600)
 ```
 
-#### 2.8.6. rx_frame_put USDT
+#### 2.8.7. rx_frame_put USDT
 
 usage: customize the application process name as your setup
 
@@ -1250,7 +1301,7 @@ Example output like below:
 15:11:08 s0: put frame 2(addr:0x320830e600)
 ```
 
-#### 2.8.7. rx_frame_available USDT
+#### 2.8.8. rx_frame_available USDT
 
 usage: customize the application process name as your setup
 
@@ -1276,7 +1327,7 @@ usdt::st22p:rx_frame_available { printf("%s s%d: available frame %d(addr:%p, tms
 ' -p $(pidof RxTxApp)
 ```
 
-#### 2.8.8. tx_frame_dump USDT
+#### 2.8.9. tx_frame_dump USDT
 
 Usage: Attaching to this hook initiates the process, which continues to dump frames to a local file every 5 seconds until detachment occurs.
 
@@ -1291,7 +1342,7 @@ Example output like below:
 15:22:04 s0: dump frame 0x3205b0e600 size 5184000 to imtl_usdt_st22ptx_s0_1920_1080_oOJwjO.yuv
 ```
 
-#### 2.8.9. rx_frame_dump USDT
+#### 2.8.10. rx_frame_dump USDT
 
 Usage: Attaching to this hook initiates the process, which continues to dump frames to a local file every 5 seconds until detachment occurs.
 
@@ -1306,7 +1357,7 @@ Example output like below:
 15:23:04 s0: dump frame 0x3207d0e600 size 5184000 to imtl_usdt_st22prx_s0_1920_1080_N72BCd.yuv
 ```
 
-#### 2.8.10. tx_encode_get USDT
+#### 2.8.11. tx_encode_get USDT
 
 usage: customize the application process name as your setup
 
@@ -1321,7 +1372,7 @@ Example output like below:
 16:20:25 s0: get encode 1(src:0x320610e600,dst:0x32032400fc)
 ```
 
-#### 2.8.11. tx_encode_put USDT
+#### 2.8.12. tx_encode_put USDT
 
 usage: customize the application process name as your setup
 
@@ -1345,7 +1396,7 @@ usdt::st22p:tx_encode_put { printf("%s s%d: put encode %d(src:%p,dst:%p), result
 ' -p $(pidof RxTxApp)
 ```
 
-#### 2.8.12. rx_decode_get USDT
+#### 2.8.13. rx_decode_get USDT
 
 usage: customize the application process name as your setup
 
@@ -1361,7 +1412,7 @@ Example output like below:
 16:18:43 s0: get decode 2(src:0x3208f0e600,dst:0x320830e600), codestream size: 777600
 ```
 
-#### 2.8.13. rx_decode_put USDT
+#### 2.8.14. rx_decode_put USDT
 
 usage: customize the application process name as your setup
 
@@ -1471,18 +1522,34 @@ Example output like below:
 15:51:58 s0: done frame 2(timestamp:447476096)
 ```
 
+#### 2.9.5. tx_frame_drop USDT
+
+usage: customize the application process name as your setup
+
+```bash
+sudo bpftrace -e 'usdt::st30p:tx_frame_drop { printf("%s s%d: drop frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }' -p $(pidof RxTxApp)
+```
+
+Example output like below:
+
+```text
+15:52:11 s0: drop frame 0(timestamp:447476608)
+15:52:11 s0: drop frame 1(timestamp:447477088)
+```
+
 And if you want to trace all st30p tx events, use below bpftrace script.
 
 ```bash
 sudo bpftrace -e '
 usdt::st30p:tx_frame_get { printf("%s s%d: get frame %d(addr:%p)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st30p:tx_frame_put { printf("%s s%d: put frame %d(addr:%p)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
+usdt::st30p:tx_frame_drop { printf("%s s%d: drop frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st30p:tx_frame_done { printf("%s s%d: done frame %d(timestamp:%u)\n", strftime("%H:%M:%S", nsecs), arg0, arg1, arg2); }
 usdt::st30p:tx_frame_next { printf("%s s%d: next frame %d\n", strftime("%H:%M:%S", nsecs), arg0, arg1); }
 ' -p $(pidof RxTxApp)
 ```
 
-#### 2.9.5. rx_frame_get USDT
+#### 2.9.6. rx_frame_get USDT
 
 usage: customize the application process name as your setup
 
@@ -1498,7 +1565,7 @@ Example output like below:
 15:57:50 s0: get frame 2(addr:0x32034009c0)
 ```
 
-#### 2.9.6. rx_frame_put USDT
+#### 2.9.7. rx_frame_put USDT
 
 usage: customize the application process name as your setup
 
@@ -1514,7 +1581,7 @@ Example output like below:
 15:58:14 s0: put frame 2(addr:0x32034009c0)
 ```
 
-#### 2.9.7. rx_frame_available USDT
+#### 2.9.8. rx_frame_available USDT
 
 usage: customize the application process name as your setup
 
@@ -1540,7 +1607,7 @@ usdt::st30p:rx_frame_available { printf("%s s%d: available frame %d(addr:%p, tms
 ' -p $(pidof RxTxApp)
 ```
 
-#### 2.9.8. tx_frame_dump USDT
+#### 2.9.9. tx_frame_dump USDT
 
 Usage: This utility is designed to capture and store audio frames transmitted over the network. Attaching to this hook initiates the process, which continues to dump frames to a local file until detachment occurs.
 
@@ -1568,7 +1635,7 @@ Then use ffmpeg tools to convert ram PCM file to a wav, customize the format as 
 ffmpeg -f s24be -ar 48000 -ac 2 -i imtl_usdt_st30ptx_s0_48000_24_c2_LgAKKR.pcm dump.wav
 ```
 
-#### 2.9.9. rx_frame_dump USDT
+#### 2.9.10. rx_frame_dump USDT
 
 Usage: Similar to tx_frame_dump hook, this utility is designed to capture and store audio frames received over the network. Attaching to this hook initiates the process, which continues to dump frames to a local file until detachment occurs.
 

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1172,6 +1172,13 @@ struct st20_tx_ops {
                            struct st20_tx_frame_meta* meta);
 
   /**
+   * Optional. Callback triggered when a frame epoch is omitted/skipped in the lib.
+   * This occurs when the transmission timing falls behind schedule and an epoch
+   * must be skipped to maintain synchronization. (or in the user pacing mode
+   * when the user time is behind the lib sending time).
+   */
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
+  /**
    * Optional. The event callback when there is some event(vsync or others) happened for
    * this session. Only non-block method can be used in this callback as it run from lcore
    * routine. Args point to the meta data of each event. Ex, cast to struct
@@ -1320,6 +1327,14 @@ struct st22_tx_ops {
    */
   int (*notify_frame_done)(void* priv, uint16_t frame_idx,
                            struct st22_tx_frame_meta* meta);
+
+  /**
+   * Optional. Callback triggered when a frame epoch is omitted/skipped in the lib.
+   * This occurs when the transmission timing falls behind schedule and an epoch
+   * must be skipped to maintain synchronization. (or in the user pacing mode
+   * when the user time is behind the lib sending time).
+   */
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
 
   /**
    * Optional. The event callback when there is some event(vsync or others) happened for

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -385,6 +385,14 @@ struct st30_tx_ops {
   int (*notify_frame_done)(void* priv, uint16_t frame_idx,
                            struct st30_tx_frame_meta* meta);
 
+  /**
+   * Optional. Callback triggered when a frame epoch is omitted/skipped in the lib.
+   * This occurs when the transmission timing falls behind schedule and an epoch
+   * must be skipped to maintain synchronization. (or in the user pacing mode
+   * when the user time is behind the lib sending time).
+   */
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
+
   /*
    * Optional. The size of fifo ring which used between the packet builder and pacing.
    * Leave to zero to use default value: the packet number within

--- a/include/st30_pipeline_api.h
+++ b/include/st30_pipeline_api.h
@@ -52,6 +52,13 @@ enum st30p_tx_flag {
   /** Enable the st30p_tx_get_frame block behavior to wait until a frame becomes
    available or timeout(default: 1s, use st30p_tx_set_block_timeout to customize)*/
   ST30P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
+
+  /**
+   * Drop frames when the mtl reports late frames (transport can't keep up).
+   * When late frame is detected, next frame from pipeline is ommited.
+   * Untill we resume normal frame sending.
+   */
+  ST30P_TX_FLAG_DROP_WHEN_LATE = (MTL_BIT32(16)),
 };
 
 /** The structure info for st30 frame meta. */
@@ -130,10 +137,18 @@ struct st30p_tx_ops {
   int (*notify_frame_available)(void* priv);
   /**
    * Optional. Callback when frame done.
-   * And only non-block method can be used within this callback as it run from lcore
-   * tasklet routine.
+   * If TX_FLAG_DROP_WHEN_LATE is enabled AND notify_frame_late is set,
+   * then this will be called only when notify_frame_late is NOT called.
    */
   int (*notify_frame_done)(void* priv, struct st30_frame* frame);
+  /**
+   * Optional. Callback when frame timing issues occur.
+   * If ST30P_TX_FLAG_DROP_WHEN_LATE is enabled: triggered when a frame is dropped
+   * from the pipeline due to late transmission.
+   * If ST30P_TX_FLAG_DROP_WHEN_LATE is disabled: triggered when the transport
+   * layer reports late frame delivery.
+   */
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
 
   /**
    * Optional. The rtp timestamp delta(us) to the start time of frame.

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -337,6 +337,8 @@ struct st40_tx_ops {
   int (*notify_frame_done)(void* priv, uint16_t frame_idx,
                            struct st40_tx_frame_meta* meta);
 
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
+
   /** Optional. UDP source port number, leave as 0 to use same port as dst */
   uint16_t udp_src_port[MTL_SESSION_PORT_MAX];
   /**

--- a/include/st40_pipeline_api.h
+++ b/include/st40_pipeline_api.h
@@ -71,6 +71,12 @@ enum st40p_tx_flag {
    */
   ST40P_TX_FLAG_USER_PACING = (MTL_BIT32(3)),
   /**
+   * Drop frames when the mtl reports late frames (transport can't keep up).
+   * When late frame is detected, next frame from pipeline is ommited.
+   * Untill we resume normal frame sending.
+   */
+  ST40P_TX_FLAG_DROP_WHEN_LATE = (MTL_BIT32(7)),
+  /**
    * Flag bit in flags of struct st40_tx_ops.
    * If enabled, lib will assign the rtp timestamp to the value in
    * st40_tx_frame_meta(ST10_TIMESTAMP_FMT_MEDIA_CLK is used)
@@ -94,10 +100,6 @@ enum st40p_tx_flag {
   /** Enable the st40p_tx_get_frame block behavior to wait until a frame becomes
    available or timeout(default: 1s, use st40p_tx_set_block_timeout to customize)*/
   ST40P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
-  /**
-   ** Enable verbose reporting of framebuffer statuses in statistics output
-   */
-  ST40P_TX_FLAG_ACCURATE_FRAMEBUFF_STATISTICS = (MTL_BIT32(25)),
 };
 
 /**
@@ -128,11 +130,21 @@ struct st40p_tx_ops {
    */
   int (*notify_frame_available)(void* priv);
   /**
-   * Optional. Callback when frame done.
+   * Optional. Callback when frame done. If TX_FLAG_DROP_WHEN_LATE is enabled
+   * this will be called only when the notify_frame_late is not triggered.
    * And only non-block method can be used within this callback as it run from lcore
    * tasklet routine.
    */
   int (*notify_frame_done)(void* priv, struct st40_frame_info* frame_info);
+
+  /**
+   * Optional. Callback when frame timing issues occur.
+   * If ST40P_TX_FLAG_DROP_WHEN_LATE is enabled: triggered when a frame is dropped
+   * from the pipeline due to late transmission.
+   * If ST40P_TX_FLAG_DROP_WHEN_LATE is disabled: triggered when the transport
+   * layer reports late frame delivery.
+   */
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
 
   /**
    * Optional. tx destination mac address.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -387,6 +387,12 @@ enum st22p_tx_flag {
    */
   ST22P_TX_FLAG_USER_PACING = (MTL_BIT32(3)),
   /**
+   * Drop frames when the mtl reports late frames (transport can't keep up).
+   * When late frame is detected, next frame from pipeline is ommited.
+   * Untill we resume normal frame sending.
+   */
+  ST22P_TX_FLAG_DROP_WHEN_LATE = (MTL_BIT32(12)),
+  /**
    * If enabled, lib will assign the rtp timestamp to the value in
    * tx_frame_meta(ST10_TIMESTAMP_FMT_MEDIA_CLK is used)
    */
@@ -414,7 +420,7 @@ enum st22p_tx_flag {
   ST22P_TX_FLAG_FORCE_NUMA = (MTL_BIT32(9)),
   /** Enable the st22p_tx_get_frame block behavior to wait until a frame becomes
    available or timeout(default: 1s, use st22p_tx_set_block_timeout to customize) */
-  ST22P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
+  ST22P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15))
 };
 
 /** Bit define for flags of struct st20p_tx_ops. */
@@ -439,6 +445,12 @@ enum st20p_tx_flag {
    * aligned with virtual receiver read schedule.
    */
   ST20P_TX_FLAG_USER_PACING = (MTL_BIT32(3)),
+  /**
+   * Drop frames when the mtl reports late frames (transport can't keep up).
+   * When late frame is detected, next frame from pipeline is ommited.
+   * Untill we resume normal frame sending.
+   */
+  ST20P_TX_FLAG_DROP_WHEN_LATE = (MTL_BIT32(12)),
   /**
    * If enabled, lib will assign the rtp timestamp to the value of timestamp in
    * st_frame.timestamp (if needed the value will be converted to
@@ -877,11 +889,21 @@ struct st20p_tx_ops {
    */
   int (*notify_frame_available)(void* priv);
   /**
-   * Optional. Callback when frame done in the lib.
+   * Optional. Callback when frame done in the lib. If TX_FLAG_DROP_WHEN_LATE is enabled
+   * this will be called only when the notify_frame_late is not triggered.
    * And only non-block method can be used within this callback as it run from lcore
    * tasklet routine.
    */
   int (*notify_frame_done)(void* priv, struct st_frame* frame);
+
+  /**
+   * Optional. Callback when frame timing issues occur.
+   * If ST20P_TX_FLAG_DROP_WHEN_LATE is enabled: triggered when a frame is dropped
+   * from the pipeline due to late transmission.
+   * If ST20P_TX_FLAG_DROP_WHEN_LATE is disabled: triggered when the transport
+   * layer reports late frame delivery.
+   */
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
 
   /** Optional. Linesize for transport frame, only for non-convert mode */
   size_t transport_linesize;
@@ -1048,11 +1070,21 @@ struct st22p_tx_ops {
    */
   int (*notify_frame_available)(void* priv);
   /**
-   * Optional. Callback when frame done in the lib.
+   * Optional. Callback when frame done in the lib. If TX_FLAG_DROP_WHEN_LATE is enabled
+   * this will be called only when the notify_frame_late is not triggered.
    * And only non-block method can be used within this callback as it run from lcore
    * tasklet routine.
    */
   int (*notify_frame_done)(void* priv, struct st_frame* frame);
+
+  /**
+   * Optional. Callback when frame timing issues occur.
+   * If ST22P_TX_FLAG_DROP_WHEN_LATE is enabled: triggered when a frame is dropped
+   * from the pipeline due to late transmission.
+   * If ST22P_TX_FLAG_DROP_WHEN_LATE is disabled: triggered when the transport
+   * layer reports late frame delivery.
+   */
+  int (*notify_frame_late)(void* priv, uint64_t epoch_skipped);
 
   /** Optional for ST22P_TX_FLAG_ENABLE_RTCP. RTCP info */
   struct st_tx_rtcp_ops rtcp;

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -667,6 +667,11 @@ int mtl_uninit(mtl_handle mt) {
 int mtl_start(mtl_handle mt) {
   struct mtl_main_impl* impl = mt;
 
+  if (!impl) {
+    err("%s, null handle\n", __func__);
+    return -EINVAL;
+  }
+
   if (impl->type != MT_HANDLE_MAIN) {
     err("%s, invalid type %d\n", __func__, impl->type);
     return -EIO;

--- a/lib/src/mt_usdt.h
+++ b/lib/src/mt_usdt.h
@@ -106,6 +106,8 @@
   MT_DTRACE_PROBE4(st20p, tx_frame_put, idx, f_idx, va, stat)
 #define MT_USDT_ST20P_TX_FRAME_DONE(idx, f_idx, tmstamp) \
   MT_DTRACE_PROBE3(st20p, tx_frame_done, idx, f_idx, tmstamp)
+#define MT_USDT_ST20P_TX_FRAME_DROP(idx, f_idx, tmstamp) \
+  MT_DTRACE_PROBE3(st20p, tx_frame_drop, idx, f_idx, tmstamp)
 #define MT_USDT_ST20P_TX_FRAME_NEXT(idx, f_idx) \
   MT_DTRACE_PROBE2(st20p, tx_frame_next, idx, f_idx)
 #define MT_USDT_ST20P_TX_FRAME_DUMP(idx, file, va, sz) \
@@ -128,6 +130,8 @@
   MT_DTRACE_PROBE3(st30p, tx_frame_put, idx, f_idx, va)
 #define MT_USDT_ST30P_TX_FRAME_DONE(idx, f_idx, tmstamp) \
   MT_DTRACE_PROBE3(st30p, tx_frame_done, idx, f_idx, tmstamp)
+#define MT_USDT_ST30P_TX_FRAME_DROP(idx, f_idx, tmstamp) \
+  MT_DTRACE_PROBE3(st30p, tx_frame_drop, idx, f_idx, tmstamp)
 #define MT_USDT_ST30P_TX_FRAME_NEXT(idx, f_idx) \
   MT_DTRACE_PROBE2(st30p, tx_frame_next, idx, f_idx)
 #define MT_USDT_ST30P_TX_FRAME_DUMP(idx, file, frames) \
@@ -143,6 +147,17 @@
 #define MT_USDT_ST30P_RX_FRAME_DUMP(idx, file, frames) \
   MT_DTRACE_PROBE3(st30p, rx_frame_dump, idx, file, frames)
 #define MT_USDT_ST30P_RX_FRAME_DUMP_ENABLED() ST30P_RX_FRAME_DUMP_ENABLED()
+
+#define MT_USDT_ST40P_TX_FRAME_GET(idx, f_idx, va) \
+  MT_DTRACE_PROBE3(st40p, tx_frame_get, idx, f_idx, va)
+#define MT_USDT_ST40P_TX_FRAME_PUT(idx, f_idx, va) \
+  MT_DTRACE_PROBE3(st40p, tx_frame_put, idx, f_idx, va)
+#define MT_USDT_ST40P_TX_FRAME_DONE(idx, f_idx, tmstamp) \
+  MT_DTRACE_PROBE3(st40p, tx_frame_done, idx, f_idx, tmstamp)
+#define MT_USDT_ST40P_TX_FRAME_DROP(idx, f_idx, tmstamp) \
+  MT_DTRACE_PROBE3(st40p, tx_frame_drop, idx, f_idx, tmstamp)
+#define MT_USDT_ST40P_TX_FRAME_NEXT(idx, f_idx) \
+  MT_DTRACE_PROBE2(st40p, tx_frame_next, idx, f_idx)
 
 #define MT_USDT_ST20_TX_FRAME_NEXT(m_idx, s_idx, f_idx, va, tmstamp) \
   MT_DTRACE_PROBE5(st20, tx_frame_next, m_idx, s_idx, f_idx, va, tmstamp)
@@ -236,6 +251,8 @@
   MT_DTRACE_PROBE5(st22p, tx_frame_put, idx, f_idx, va, stat, size)
 #define MT_USDT_ST22P_TX_FRAME_DONE(idx, f_idx, tmstamp) \
   MT_DTRACE_PROBE3(st22p, tx_frame_done, idx, f_idx, tmstamp)
+#define MT_USDT_ST22P_TX_FRAME_DROP(idx, f_idx, tmstamp) \
+  MT_DTRACE_PROBE3(st22p, tx_frame_drop, idx, f_idx, tmstamp)
 #define MT_USDT_ST22P_TX_FRAME_NEXT(idx, f_idx) \
   MT_DTRACE_PROBE2(st22p, tx_frame_next, idx, f_idx)
 #define MT_USDT_ST22P_TX_FRAME_DUMP(idx, file, va, sz) \

--- a/lib/src/mt_usdt_provider.d
+++ b/lib/src/mt_usdt_provider.d
@@ -80,6 +80,7 @@ provider st20p {
   probe tx_frame_put(int idx, int f_idx, void* va, int stat);
   probe tx_frame_next(int idx, int f_idx);
   probe tx_frame_done(int idx, int f_idx, uint32_t tmstamp);
+  probe tx_frame_drop(int idx, int f_idx, uint32_t tmstamp);
   /* attach to enable the frame dump at runtime */
   probe tx_frame_dump(int idx, char* dump_file, void* va, uint32_t data_size);
   /* rx */
@@ -110,6 +111,7 @@ provider st22p {
   probe tx_frame_put(int idx, int f_idx, void* va, int stat, uint32_t data_size);
   probe tx_frame_next(int idx, int f_idx);
   probe tx_frame_done(int idx, int f_idx, uint32_t tmstamp);
+  probe tx_frame_drop(int idx, int f_idx, uint32_t tmstamp);
   /* attach to enable the frame dump at runtime */
   probe tx_frame_dump(int idx, char* dump_file, void* va, uint32_t data_size);
   /* rx */
@@ -132,6 +134,7 @@ provider st30p {
   probe tx_frame_put(int idx, int f_idx, void* va);
   probe tx_frame_next(int idx, int f_idx);
   probe tx_frame_done(int idx, int f_idx, uint32_t tmstamp);
+  probe tx_frame_drop(int idx, int f_idx, uint32_t tmstamp);
   /* attach to enable the frame dump at runtime */
   probe tx_frame_dump(int idx, char* dump_file, int frames);
   /* rx */
@@ -143,6 +146,12 @@ provider st30p {
 }
 
 provider st40p {
+  /* tx */
+  probe tx_frame_get(int idx, int f_idx, void* va);
+  probe tx_frame_put(int idx, int f_idx, void* va);
+  probe tx_frame_next(int idx, int f_idx);
+  probe tx_frame_done(int idx, int f_idx, uint32_t tmstamp);
+  probe tx_frame_drop(int idx, int f_idx, uint32_t tmstamp)
   /* rx */
   probe rx_frame_get(int idx, int f_idx, uint32_t meta_num);
   probe rx_frame_put(int idx, int f_idx, uint32_t meta_num);

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.h
@@ -65,9 +65,9 @@ struct st20p_rx_ctx {
   rte_atomic32_t stat_convert_fail;
   rte_atomic32_t stat_busy;
   /* get frame stat */
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -11,16 +11,12 @@ static const char* st20p_tx_frame_stat_name[ST20P_TX_FRAME_STATUS_MAX] = {
     "free", "ready", "in_converting", "converted", "in_user", "in_transmitting",
 };
 
+static const char* st20p_tx_frame_stat_name_short[ST20P_TX_FRAME_STATUS_MAX] = {
+    "F", "R", "IC", "C", "U", "T",
+};
+
 static const char* tx_st20p_stat_name(enum st20p_tx_frame_status stat) {
   return st20p_tx_frame_stat_name[stat];
-}
-
-static uint16_t tx_st20p_next_idx(struct st20p_tx_ctx* ctx, uint16_t idx) {
-  /* point to next */
-  uint16_t next_idx = idx;
-  next_idx++;
-  if (next_idx >= ctx->framebuff_cnt) next_idx = 0;
-  return next_idx;
 }
 
 static inline struct st_frame* tx_st20p_user_frame(struct st20p_tx_ctx* ctx,
@@ -47,26 +43,35 @@ static void tx_st20p_notify_frame_available(struct st20p_tx_ctx* ctx) {
 }
 
 static struct st20p_tx_frame* tx_st20p_next_available(
-    struct st20p_tx_ctx* ctx, uint16_t idx_start, enum st20p_tx_frame_status desired) {
-  uint16_t idx = idx_start;
+    struct st20p_tx_ctx* ctx, enum st20p_tx_frame_status desired) {
   struct st20p_tx_frame* framebuff;
 
-  /* check ready frame from idx_start */
-  while (1) {
+  /* check ready frame from start */
+  for (int idx = 0; idx < ctx->framebuff_cnt; idx++) {
     framebuff = &ctx->framebuffs[idx];
     if (desired == framebuff->stat) {
-      /* find one desired */
       return framebuff;
-    }
-    idx = tx_st20p_next_idx(ctx, idx);
-    if (idx == idx_start) {
-      /* loop all frames end */
-      break;
     }
   }
 
-  /* no any desired frame */
   return NULL;
+}
+
+static struct st20p_tx_frame* tx_st20p_newest_available(
+    struct st20p_tx_ctx* ctx, enum st20p_tx_frame_status desired) {
+  struct st20p_tx_frame* framebuff = NULL;
+  struct st20p_tx_frame* framebuff_newest = NULL;
+
+  for (uint16_t idx = 0; idx < ctx->framebuff_cnt; idx++) {
+    framebuff = &ctx->framebuffs[idx];
+    if ((desired == framebuff->stat &&
+         (!framebuff_newest ||
+          !mt_seq32_greater(framebuff->seq_number, framebuff_newest->seq_number)))) {
+      framebuff_newest = framebuff;
+    }
+  }
+
+  return framebuff_newest;
 }
 
 static int tx_st20p_next_frame(void* priv, uint16_t* next_frame_idx,
@@ -77,8 +82,7 @@ static int tx_st20p_next_frame(void* priv, uint16_t* next_frame_idx,
   if (!ctx->ready) return -EBUSY; /* not ready */
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st20p_next_available(ctx, ctx->framebuff_consumer_idx, ST20P_TX_FRAME_CONVERTED);
+  framebuff = tx_st20p_newest_available(ctx, ST20P_TX_FRAME_CONVERTED);
   /* not any converted frame */
   if (!framebuff) {
     mt_pthread_mutex_unlock(&ctx->lock);
@@ -98,11 +102,50 @@ static int tx_st20p_next_frame(void* priv, uint16_t* next_frame_idx,
     meta->user_meta = framebuff->user_meta;
     meta->user_meta_size = framebuff->user_meta_data_size;
   }
+
   /* point to next */
-  ctx->framebuff_consumer_idx = tx_st20p_next_idx(ctx, framebuff->idx);
   mt_pthread_mutex_unlock(&ctx->lock);
-  dbg("%s(%d), frame %u succ\n", __func__, ctx->idx, framebuff->idx);
+  dbg("%s(%d), frame %u succ, frame_idx: %u\n", __func__, ctx->idx, framebuff->idx,
+      framebuff->idx);
   MT_USDT_ST20P_TX_FRAME_NEXT(ctx->idx, framebuff->idx);
+  return 0;
+}
+
+int st20p_tx_late_frame_drop(void* handle, uint64_t epoch_skipped) {
+  struct st20p_tx_ctx* ctx = handle;
+  int cidx = ctx->idx;
+  struct st20p_tx_frame* framebuff;
+
+  if (ctx->type != MT_ST20_HANDLE_PIPELINE_TX) {
+    err("%s(%d), invalid type %d\n", __func__, cidx, ctx->type);
+    return 0;
+  }
+
+  if (!ctx->ready) return -EBUSY; /* not ready */
+  mt_pthread_mutex_lock(&ctx->lock);
+  framebuff = tx_st20p_newest_available(ctx, ST20P_TX_FRAME_CONVERTED);
+  /* not any converted frame */
+  if (!framebuff) {
+    mt_pthread_mutex_unlock(&ctx->lock);
+    return -EBUSY;
+  }
+
+  framebuff->stat = ST20P_TX_FRAME_FREE;
+  ctx->stat_drop_frame++;
+  dbg("%s(%d), drop frame %u succ\n", __func__, cidx, framebuff->idx);
+  mt_pthread_mutex_unlock(&ctx->lock);
+
+  if (ctx->ops.notify_frame_late) {
+    ctx->ops.notify_frame_late(ctx->ops.priv, epoch_skipped);
+  } else if (ctx->ops.notify_frame_done &&
+             !framebuff->frame_done_cb_called) { /* notify app which frame done */
+    ctx->ops.notify_frame_done(ctx->ops.priv, tx_st20p_user_frame(ctx, framebuff));
+    framebuff->frame_done_cb_called = true;
+  }
+
+  /* notify app can get frame */
+  tx_st20p_notify_frame_available(ctx);
+  MT_USDT_ST20P_TX_FRAME_DROP(cidx, framebuff->idx, framebuff->dst.rtp_timestamp);
   return 0;
 }
 
@@ -117,12 +160,11 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   frame->timestamp = meta->timestamp;
   frame->epoch = meta->epoch;
   frame->rtp_timestamp = meta->rtp_timestamp;
-
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST20P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
     framebuff->stat = ST20P_TX_FRAME_FREE;
-    dbg("%s(%d), done_idx %u\n", __func__, ctx->idx, frame_idx);
+    dbg("%s(%d), frame_idx: %u\n", __func__, ctx->idx, frame_idx);
   } else {
     ret = -EIO;
     err("%s(%d), err status %d for frame %u\n", __func__, ctx->idx, framebuff->stat,
@@ -167,8 +209,7 @@ static struct st20_convert_frame_meta* tx_st20p_convert_get_frame(void* priv) {
   if (!ctx->ready) return NULL; /* not ready */
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st20p_next_available(ctx, ctx->framebuff_convert_idx, ST20P_TX_FRAME_READY);
+  framebuff = tx_st20p_newest_available(ctx, ST20P_TX_FRAME_READY);
   /* not any free frame */
   if (!framebuff) {
     mt_pthread_mutex_unlock(&ctx->lock);
@@ -176,11 +217,10 @@ static struct st20_convert_frame_meta* tx_st20p_convert_get_frame(void* priv) {
   }
 
   framebuff->stat = ST20P_TX_FRAME_IN_CONVERTING;
-  /* point to next */
-  ctx->framebuff_convert_idx = tx_st20p_next_idx(ctx, framebuff->idx);
   mt_pthread_mutex_unlock(&ctx->lock);
 
-  dbg("%s(%d), frame %u succ\n", __func__, idx, framebuff->idx);
+  dbg("%s(%d), frame %u succ, frame_idx: %u\n", __func__, idx, framebuff->idx,
+      framebuff->idx);
   return &framebuff->convert_frame;
 }
 
@@ -203,15 +243,20 @@ static int tx_st20p_convert_put_frame(void* priv, struct st20_convert_frame_meta
     return -EIO;
   }
 
+  mt_pthread_mutex_lock(&ctx->lock);
   if ((result < 0) || (data_size <= 0)) {
-    dbg("%s(%d), frame %u result %d data_size %" PRIu64 "\n", __func__, idx, convert_idx,
-        result, data_size);
+    dbg("%s(%d), frame %u result %d data_size %" PRIu64 ", frame_idx: %u\n", __func__,
+        idx, convert_idx, result, data_size, convert_idx);
+
     framebuff->stat = ST20P_TX_FRAME_FREE;
+    mt_pthread_mutex_unlock(&ctx->lock);
+
     /* notify app can get frame */
     tx_st20p_notify_frame_available(ctx);
     rte_atomic32_inc(&ctx->stat_convert_fail);
   } else {
     framebuff->stat = ST20P_TX_FRAME_CONVERTED;
+    mt_pthread_mutex_unlock(&ctx->lock);
   }
 
   if (ctx->ops.notify_frame_done && !framebuff->frame_done_cb_called) {
@@ -224,13 +269,8 @@ static int tx_st20p_convert_put_frame(void* priv, struct st20_convert_frame_meta
 
 static int tx_st20p_convert_dump(void* priv) {
   struct st20p_tx_ctx* ctx = priv;
-  struct st20p_tx_frame* framebuff = ctx->framebuffs;
 
   if (!ctx->ready) return -EBUSY; /* not ready */
-
-  uint16_t convert_idx = ctx->framebuff_convert_idx;
-  notice("TX_st20p(%s), cv(%d:%s)\n", ctx->ops_name, convert_idx,
-         tx_st20p_stat_name(framebuff[convert_idx].stat));
 
   int convert_fail = rte_atomic32_read(&ctx->stat_convert_fail);
   rte_atomic32_set(&ctx->stat_convert_fail, 0);
@@ -296,6 +336,11 @@ static int tx_st20p_create_transport(struct mtl_main_impl* impl, struct st20p_tx
   if (ctx->derive && ops->flags & ST20P_TX_FLAG_EXT_FRAME)
     ops_tx.flags |= ST20_TX_FLAG_EXT_FRAME;
   if (ops->flags & ST20P_TX_FLAG_USER_PACING) ops_tx.flags |= ST20_TX_FLAG_USER_PACING;
+  if (ops->flags & ST20P_TX_FLAG_DROP_WHEN_LATE) {
+    ops_tx.notify_frame_late = st20p_tx_late_frame_drop;
+  } else if (ops->notify_frame_late) {
+    ops_tx.notify_frame_late = ops->notify_frame_late;
+  }
   if (ops->flags & ST20P_TX_FLAG_USER_TIMESTAMP)
     ops_tx.flags |= ST20_TX_FLAG_USER_TIMESTAMP;
   if (ops->flags & ST20P_TX_FLAG_ENABLE_VSYNC) ops_tx.flags |= ST20_TX_FLAG_ENABLE_VSYNC;
@@ -489,20 +534,34 @@ static int tx_st20p_get_converter(struct mtl_main_impl* impl, struct st20p_tx_ct
 static int tx_st20p_stat(void* priv) {
   struct st20p_tx_ctx* ctx = priv;
   struct st20p_tx_frame* framebuff = ctx->framebuffs;
+  uint16_t status_counts[ST20P_TX_FRAME_STATUS_MAX] = {0};
 
   if (!ctx->ready) return -EBUSY; /* not ready */
 
-  uint16_t producer_idx = ctx->framebuff_producer_idx;
-  uint16_t consumer_idx = ctx->framebuff_consumer_idx;
-  notice("TX_st20p(%d,%s), p(%d:%s) c(%d:%s)\n", ctx->idx, ctx->ops_name, producer_idx,
-         tx_st20p_stat_name(framebuff[producer_idx].stat), consumer_idx,
-         tx_st20p_stat_name(framebuff[consumer_idx].stat));
+  for (uint16_t j = 0; j < ctx->framebuff_cnt; j++) {
+    enum st20p_tx_frame_status stat = framebuff[j].stat;
+    if (stat < ST20P_TX_FRAME_STATUS_MAX) {
+      status_counts[stat]++;
+    }
+  }
 
-  notice("TX_st20p(%d), frame get try %d succ %d, put %d\n", ctx->idx,
-         ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame);
+  char status_str[256];
+  int offset = 0;
+  for (uint16_t i = 0; i < ST20P_TX_FRAME_STATUS_MAX; i++) {
+    if (status_counts[i] > 0) {
+      offset += snprintf(status_str + offset, sizeof(status_str) - offset, "%s:%u ",
+                         st20p_tx_frame_stat_name_short[i], status_counts[i]);
+    }
+  }
+  notice("TX_st20p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+
+  notice("TX_st20p(%d), frame get try %d succ %d, put %d, drop %d\n", ctx->idx,
+         ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame,
+         ctx->stat_drop_frame);
   ctx->stat_get_frame_try = 0;
   ctx->stat_get_frame_succ = 0;
   ctx->stat_put_frame = 0;
+  ctx->stat_drop_frame = 0;
 
   return 0;
 }
@@ -553,8 +612,8 @@ static void tx_st20p_framebuffs_flush(struct st20p_tx_ctx* ctx) {
         break;
       }
 
-      dbg("%s(%d), frame %u are still in %s, retry %d\n", __func__, ctx->idx, i,
-          tx_st20p_stat_name(framebuff->stat), retry);
+      dbg("%s(%d), frame %u are still in %s, retry %d, frame_idx: %u\n", __func__,
+          ctx->idx, i, tx_st20p_stat_name(framebuff->stat), retry, i);
       retry++;
       if (retry > 100) {
         info("%s(%d), frame %u are still in %s, retry %d\n", __func__, ctx->idx, i,
@@ -592,15 +651,13 @@ struct st_frame* st20p_tx_get_frame(st20p_tx_handle handle) {
   ctx->stat_get_frame_try++;
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st20p_next_available(ctx, ctx->framebuff_producer_idx, ST20P_TX_FRAME_FREE);
+  framebuff = tx_st20p_next_available(ctx, ST20P_TX_FRAME_FREE);
   if (!framebuff && ctx->block_get) { /* wait here */
     mt_pthread_mutex_unlock(&ctx->lock);
     st20p_tx_get_block_wait(ctx);
     /* get again */
     mt_pthread_mutex_lock(&ctx->lock);
-    framebuff =
-        tx_st20p_next_available(ctx, ctx->framebuff_producer_idx, ST20P_TX_FRAME_FREE);
+    framebuff = tx_st20p_next_available(ctx, ST20P_TX_FRAME_FREE);
   }
   /* not any free frame */
   if (!framebuff) {
@@ -610,8 +667,7 @@ struct st_frame* st20p_tx_get_frame(st20p_tx_handle handle) {
 
   framebuff->stat = ST20P_TX_FRAME_IN_USER;
   framebuff->frame_done_cb_called = false;
-  /* point to next */
-  ctx->framebuff_producer_idx = tx_st20p_next_idx(ctx, framebuff->idx);
+  framebuff->seq_number = ctx->framebuff_sequence_number++;
   mt_pthread_mutex_unlock(&ctx->lock);
 
   dbg("%s(%d), frame %u succ\n", __func__, idx, framebuff->idx);

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.h
@@ -24,6 +24,7 @@ struct st20p_tx_frame {
   struct st_frame dst; /* converted */
   struct st20_convert_frame_meta convert_frame;
   uint16_t idx;
+  uint32_t seq_number;
   void* user_meta; /* the meta data from user */
   size_t user_meta_buffer_size;
   size_t user_meta_data_size;
@@ -41,9 +42,7 @@ struct st20p_tx_ctx {
 
   st20_tx_handle transport;
   uint16_t framebuff_cnt;
-  uint16_t framebuff_producer_idx;
-  uint16_t framebuff_convert_idx;
-  uint16_t framebuff_consumer_idx;
+  uint32_t framebuff_sequence_number;
   struct st20p_tx_frame* framebuffs;
   pthread_mutex_t lock;
   int usdt_frame_cnt;
@@ -66,9 +65,10 @@ struct st20p_tx_ctx {
   rte_atomic32_t stat_convert_fail;
   rte_atomic32_t stat_busy;
   /* get frame stat */
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
+  uint32_t stat_drop_frame;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.h
@@ -67,13 +67,13 @@ struct st22p_rx_ctx {
   rte_atomic32_t stat_decode_fail;
   rte_atomic32_t stat_busy;
   /* get frame stat */
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
-  /* get frame stat */
-  int stat_decode_get_frame_try;
-  int stat_decode_get_frame_succ;
-  int stat_decode_put_frame;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
+  uint32_t stat_drop_frame;
+  uint32_t stat_decode_get_frame_try;
+  uint32_t stat_decode_get_frame_succ;
+  uint32_t stat_decode_put_frame;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -10,6 +10,10 @@ static const char* st22p_tx_frame_stat_name[ST22P_TX_FRAME_STATUS_MAX] = {
     "free", "in_user", "ready", "in_encoding", "encoded", "in_trans",
 };
 
+static const char* st22p_tx_frame_stat_name_short[ST22P_TX_FRAME_STATUS_MAX] = {
+    "F", "U", "R", "IE", "E", "T",
+};
+
 static const char* tx_st22p_stat_name(enum st22p_tx_frame_status stat) {
   return st22p_tx_frame_stat_name[stat];
 }
@@ -17,14 +21,6 @@ static const char* tx_st22p_stat_name(enum st22p_tx_frame_status stat) {
 static inline struct st_frame* tx_st22p_user_frame(struct st22p_tx_ctx* ctx,
                                                    struct st22p_tx_frame* framebuff) {
   return ctx->derive ? &framebuff->dst : &framebuff->src;
-}
-
-static uint16_t tx_st22p_next_idx(struct st22p_tx_ctx* ctx, uint16_t idx) {
-  /* point to next */
-  uint16_t next_idx = idx;
-  next_idx++;
-  if (next_idx >= ctx->framebuff_cnt) next_idx = 0;
-  return next_idx;
 }
 
 static void tx_st22p_block_wake(struct st22p_tx_ctx* ctx) {
@@ -69,26 +65,36 @@ static void tx_st22p_encode_notify_frame_ready(struct st22p_tx_ctx* ctx) {
 }
 
 static struct st22p_tx_frame* tx_st22p_next_available(
-    struct st22p_tx_ctx* ctx, uint16_t idx_start, enum st22p_tx_frame_status desired) {
-  uint16_t idx = idx_start;
+    struct st22p_tx_ctx* ctx, enum st22p_tx_frame_status desired) {
   struct st22p_tx_frame* framebuff;
 
-  /* check ready frame from idx_start */
-  while (1) {
+  /* check ready frame from start */
+  for (int idx = 0; idx < ctx->framebuff_cnt; idx++) {
     framebuff = &ctx->framebuffs[idx];
     if (desired == framebuff->stat) {
-      /* find one desired */
       return framebuff;
-    }
-    idx = tx_st22p_next_idx(ctx, idx);
-    if (idx == idx_start) {
-      /* loop all frames end */
-      break;
     }
   }
 
   /* no any desired frame */
   return NULL;
+}
+
+static struct st22p_tx_frame* tx_st22p_newest_available(
+    struct st22p_tx_ctx* ctx, enum st22p_tx_frame_status desired) {
+  struct st22p_tx_frame* framebuff = NULL;
+  struct st22p_tx_frame* framebuff_newest = NULL;
+
+  for (uint16_t idx = 0; idx < ctx->framebuff_cnt; idx++) {
+    framebuff = &ctx->framebuffs[idx];
+    if ((desired == framebuff->stat &&
+         (!framebuff_newest ||
+          !mt_seq32_greater(framebuff->seq_number, framebuff_newest->seq_number)))) {
+      framebuff_newest = framebuff;
+    }
+  }
+
+  return framebuff_newest;
 }
 
 static int tx_st22p_next_frame(void* priv, uint16_t* next_frame_idx,
@@ -99,8 +105,7 @@ static int tx_st22p_next_frame(void* priv, uint16_t* next_frame_idx,
   if (!ctx->ready) return -EBUSY; /* not ready */
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st22p_next_available(ctx, ctx->framebuff_consumer_idx, ST22P_TX_FRAME_ENCODED);
+  framebuff = tx_st22p_newest_available(ctx, ST22P_TX_FRAME_ENCODED);
   /* not any encoded frame */
   if (!framebuff) {
     mt_pthread_mutex_unlock(&ctx->lock);
@@ -119,11 +124,46 @@ static int tx_st22p_next_frame(void* priv, uint16_t* next_frame_idx,
         framebuff->idx, meta->timestamp);
   }
   meta->codestream_size = framebuff->dst.data_size;
-  /* point to next */
-  ctx->framebuff_consumer_idx = tx_st22p_next_idx(ctx, framebuff->idx);
   mt_pthread_mutex_unlock(&ctx->lock);
-  dbg("%s(%d), frame %u succ\n", __func__, ctx->idx, framebuff->idx);
+  dbg("%s(%d), frame %u succ, frame_idx: %u\n", __func__, ctx->idx, framebuff->idx,
+      framebuff->idx);
   MT_USDT_ST22P_TX_FRAME_NEXT(ctx->idx, framebuff->idx);
+  return 0;
+}
+
+int st22p_tx_late_frame_drop(void* handle, uint64_t epoch_skipped) {
+  struct st22p_tx_ctx* ctx = handle;
+  int cidx = ctx->idx;
+  struct st22p_tx_frame* framebuff;
+
+  if (ctx->type != MT_ST20_HANDLE_PIPELINE_TX) {
+    err("%s(%d), invalid type %d\n", __func__, cidx, ctx->type);
+    return 0;
+  }
+
+  if (!ctx->ready) return -EBUSY; /* not ready */
+  mt_pthread_mutex_lock(&ctx->lock);
+  framebuff = tx_st22p_newest_available(ctx, ST22P_TX_FRAME_ENCODED);
+  /* not any converted frame */
+  if (!framebuff) {
+    mt_pthread_mutex_unlock(&ctx->lock);
+    return -EBUSY;
+  }
+
+  framebuff->stat = ST22P_TX_FRAME_FREE;
+  ctx->stat_drop_frame++;
+  dbg("%s(%d), drop frame %u succ\n", __func__, cidx, framebuff->idx);
+  mt_pthread_mutex_unlock(&ctx->lock);
+
+  if (ctx->ops.notify_frame_late) {
+    ctx->ops.notify_frame_late(ctx->ops.priv, epoch_skipped);
+  } else if (ctx->ops.notify_frame_done) {
+    ctx->ops.notify_frame_done(ctx->ops.priv, tx_st22p_user_frame(ctx, framebuff));
+  }
+
+  /* notify app can get frame */
+  tx_st22p_notify_frame_available(ctx);
+  MT_USDT_ST22P_TX_FRAME_DONE(ctx->idx, framebuff->idx, framebuff->dst.rtp_timestamp);
   return 0;
 }
 
@@ -218,15 +258,13 @@ static struct st22_encode_frame_meta* tx_st22p_encode_get_frame(void* priv) {
   ctx->stat_encode_get_frame_try++;
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st22p_next_available(ctx, ctx->framebuff_encode_idx, ST22P_TX_FRAME_READY);
+  framebuff = tx_st22p_next_available(ctx, ST22P_TX_FRAME_READY);
   if (!framebuff && ctx->encode_block_get) { /* wait here for block mode */
     mt_pthread_mutex_unlock(&ctx->lock);
     tx_st22p_encode_get_block_wait(ctx);
     /* get again */
     mt_pthread_mutex_lock(&ctx->lock);
-    framebuff =
-        tx_st22p_next_available(ctx, ctx->framebuff_encode_idx, ST22P_TX_FRAME_READY);
+    framebuff = tx_st22p_next_available(ctx, ST22P_TX_FRAME_READY);
   }
   /* not any free frame */
   if (!framebuff) {
@@ -236,8 +274,6 @@ static struct st22_encode_frame_meta* tx_st22p_encode_get_frame(void* priv) {
   }
 
   framebuff->stat = ST22P_TX_FRAME_IN_ENCODING;
-  /* point to next */
-  ctx->framebuff_encode_idx = tx_st22p_next_idx(ctx, framebuff->idx);
   mt_pthread_mutex_unlock(&ctx->lock);
 
   ctx->stat_encode_get_frame_succ++;
@@ -271,6 +307,7 @@ static int tx_st22p_encode_put_frame(void* priv, struct st22_encode_frame_meta* 
     return -EIO;
   }
 
+  mt_pthread_mutex_lock(&ctx->lock);
   ctx->stat_encode_put_frame++;
   dbg("%s(%d), frame %u result %d data_size %" PRIu64 "\n", __func__, idx, encode_idx,
       result, data_size);
@@ -280,10 +317,12 @@ static int tx_st22p_encode_put_frame(void* priv, struct st22_encode_frame_meta* 
          __func__, idx, encode_idx, result, data_size, ST22_ENCODE_MIN_FRAME_SZ,
          max_size);
     framebuff->stat = ST22P_TX_FRAME_FREE;
+    mt_pthread_mutex_unlock(&ctx->lock);
     tx_st22p_notify_frame_available(ctx);
     rte_atomic32_inc(&ctx->stat_encode_fail);
   } else {
     framebuff->stat = ST22P_TX_FRAME_ENCODED;
+    mt_pthread_mutex_unlock(&ctx->lock);
   }
 
   MT_USDT_ST22P_TX_ENCODE_PUT(idx, framebuff->idx, frame->src->addr[0],
@@ -294,22 +333,32 @@ static int tx_st22p_encode_put_frame(void* priv, struct st22_encode_frame_meta* 
 static int tx_st22p_encode_dump(void* priv) {
   struct st22p_tx_ctx* ctx = priv;
   struct st22p_tx_frame* framebuff = ctx->framebuffs;
+  uint16_t status_counts[ST22P_TX_FRAME_STATUS_MAX] = {0};
 
   if (!ctx->ready) return -EBUSY; /* not ready */
-
-  uint16_t producer_idx = ctx->framebuff_producer_idx;
-  uint16_t encode_idx = ctx->framebuff_encode_idx;
-  uint16_t consumer_idx = ctx->framebuff_consumer_idx;
-  notice("TX_ST22P(%s), p(%d:%s) e(%d:%s) c(%d:%s)\n", ctx->ops_name, producer_idx,
-         tx_st22p_stat_name(framebuff[producer_idx].stat), encode_idx,
-         tx_st22p_stat_name(framebuff[encode_idx].stat), consumer_idx,
-         tx_st22p_stat_name(framebuff[consumer_idx].stat));
 
   int encode_fail = rte_atomic32_read(&ctx->stat_encode_fail);
   rte_atomic32_set(&ctx->stat_encode_fail, 0);
   if (encode_fail) {
     notice("TX_ST22P(%s), encode fail %d\n", ctx->ops_name, encode_fail);
   }
+
+  for (uint16_t j = 0; j < ctx->framebuff_cnt; j++) {
+    enum st22p_tx_frame_status stat = framebuff[j].stat;
+    if (stat < ST22P_TX_FRAME_STATUS_MAX) {
+      status_counts[stat]++;
+    }
+  }
+
+  char status_str[256];
+  int offset = 0;
+  for (uint16_t i = 0; i < ST22P_TX_FRAME_STATUS_MAX; i++) {
+    if (status_counts[i] > 0) {
+      offset += snprintf(status_str + offset, sizeof(status_str) - offset, "%s:%u ",
+                         st22p_tx_frame_stat_name_short[i], status_counts[i]);
+    }
+  }
+  notice("TX_st22p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   notice("TX_ST22P(%s), frame get try %d succ %d, put %d\n", ctx->ops_name,
          ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame);
@@ -630,15 +679,13 @@ struct st_frame* st22p_tx_get_frame(st22p_tx_handle handle) {
   ctx->stat_get_frame_try++;
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st22p_next_available(ctx, ctx->framebuff_producer_idx, ST22P_TX_FRAME_FREE);
+  framebuff = tx_st22p_next_available(ctx, ST22P_TX_FRAME_FREE);
   if (!framebuff && ctx->block_get) {
     mt_pthread_mutex_unlock(&ctx->lock);
     tx_st22p_get_block_wait(ctx);
     /* get again */
     mt_pthread_mutex_lock(&ctx->lock);
-    framebuff =
-        tx_st22p_next_available(ctx, ctx->framebuff_producer_idx, ST22P_TX_FRAME_FREE);
+    framebuff = tx_st22p_next_available(ctx, ST22P_TX_FRAME_FREE);
   }
   /* not any free frame */
   if (!framebuff) {
@@ -647,8 +694,7 @@ struct st_frame* st22p_tx_get_frame(st22p_tx_handle handle) {
   }
 
   framebuff->stat = ST22P_TX_FRAME_IN_USER;
-  /* point to next */
-  ctx->framebuff_producer_idx = tx_st22p_next_idx(ctx, framebuff->idx);
+  framebuff->seq_number = ctx->framebuff_sequence_number++;
   mt_pthread_mutex_unlock(&ctx->lock);
 
   dbg("%s(%d), frame %u succ\n", __func__, idx, framebuff->idx);

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.h
@@ -24,6 +24,7 @@ struct st22p_tx_frame {
   struct st_frame dst; /* encoded */
   struct st22_encode_frame_meta encode_frame;
   uint16_t idx;
+  uint32_t seq_number;
 };
 
 struct st22p_tx_ctx {
@@ -38,9 +39,7 @@ struct st22p_tx_ctx {
 
   st22_tx_handle transport;
   uint16_t framebuff_cnt;
-  uint16_t framebuff_producer_idx;
-  uint16_t framebuff_encode_idx;
-  uint16_t framebuff_consumer_idx;
+  uint32_t framebuff_sequence_number;
   struct st22p_tx_frame* framebuffs;
   pthread_mutex_t lock; /* protect framebuffs */
 
@@ -67,13 +66,14 @@ struct st22p_tx_ctx {
 
   rte_atomic32_t stat_encode_fail;
   /* get frame stat */
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
+  uint32_t stat_drop_frame;
   /* get frame stat */
-  int stat_encode_get_frame_try;
-  int stat_encode_get_frame_succ;
-  int stat_encode_put_frame;
+  uint32_t stat_encode_get_frame_try;
+  uint32_t stat_encode_get_frame_succ;
+  uint32_t stat_encode_put_frame;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.h
@@ -52,10 +52,10 @@ struct st30p_rx_ctx {
   bool block_wake_pending;
 
   /* get frame stat */
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
-  int stat_busy;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
+  uint32_t stat_busy;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.c
@@ -14,16 +14,11 @@ static const char* st30p_tx_frame_stat_name[ST30P_TX_FRAME_STATUS_MAX] = {
     "in_transmitting",
 };
 
+static const char* st30p_tx_frame_stat_name_short[ST30P_TX_FRAME_STATUS_MAX] = {"F", "U",
+                                                                                "R", "T"};
+
 static const char* tx_st30p_stat_name(enum st30p_tx_frame_status stat) {
   return st30p_tx_frame_stat_name[stat];
-}
-
-static uint16_t tx_st30p_next_idx(struct st30p_tx_ctx* ctx, uint16_t idx) {
-  /* point to next */
-  uint16_t next_idx = idx;
-  next_idx++;
-  if (next_idx >= ctx->framebuff_cnt) next_idx = 0;
-  return next_idx;
 }
 
 static void tx_st30p_block_wake(struct st30p_tx_ctx* ctx) {
@@ -45,26 +40,34 @@ static void tx_st30p_notify_frame_available(struct st30p_tx_ctx* ctx) {
 }
 
 static struct st30p_tx_frame* tx_st30p_next_available(
-    struct st30p_tx_ctx* ctx, uint16_t idx_start, enum st30p_tx_frame_status desired) {
-  uint16_t idx = idx_start;
+    struct st30p_tx_ctx* ctx, enum st30p_tx_frame_status desired) {
   struct st30p_tx_frame* framebuff;
 
-  /* check ready frame from idx_start */
-  while (1) {
+  for (int idx = 0; idx < ctx->framebuff_cnt; idx++) {
     framebuff = &ctx->framebuffs[idx];
     if (desired == framebuff->stat) {
-      /* find one desired */
       return framebuff;
-    }
-    idx = tx_st30p_next_idx(ctx, idx);
-    if (idx == idx_start) {
-      /* loop all frames end */
-      break;
     }
   }
 
   /* no any desired frame */
   return NULL;
+}
+
+static struct st30p_tx_frame* tx_st30p_newest_available(
+    struct st30p_tx_ctx* ctx, enum st30p_tx_frame_status desired) {
+  struct st30p_tx_frame* framebuff_newest = NULL;
+
+  for (uint16_t idx = 0; idx < ctx->framebuff_cnt; idx++) {
+    struct st30p_tx_frame* framebuff = &ctx->framebuffs[idx];
+    if ((desired == framebuff->stat) &&
+        (!framebuff_newest ||
+         !mt_seq32_greater(framebuff->seq_number, framebuff_newest->seq_number))) {
+      framebuff_newest = framebuff;
+    }
+  }
+
+  return framebuff_newest;
 }
 
 static int tx_st30p_next_frame(void* priv, uint16_t* next_frame_idx,
@@ -77,8 +80,7 @@ static int tx_st30p_next_frame(void* priv, uint16_t* next_frame_idx,
   if (!ctx->ready) return -EBUSY; /* not ready */
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st30p_next_available(ctx, ctx->framebuff_consumer_idx, ST30P_TX_FRAME_READY);
+  framebuff = tx_st30p_newest_available(ctx, ST30P_TX_FRAME_READY);
   /* not any converted frame */
   if (!framebuff) {
     mt_pthread_mutex_unlock(&ctx->lock);
@@ -94,11 +96,44 @@ static int tx_st30p_next_frame(void* priv, uint16_t* next_frame_idx,
     meta->timestamp = frame->timestamp;
   }
 
-  /* point to next */
-  ctx->framebuff_consumer_idx = tx_st30p_next_idx(ctx, framebuff->idx);
   mt_pthread_mutex_unlock(&ctx->lock);
   dbg("%s(%d), frame %u succ\n", __func__, ctx->idx, framebuff->idx);
   MT_USDT_ST30P_TX_FRAME_NEXT(ctx->idx, framebuff->idx);
+  return 0;
+}
+
+static int st30p_tx_late_frame_drop(void* handle, uint64_t epoch_skipped) {
+  struct st30p_tx_ctx* ctx = handle;
+  struct st30p_tx_frame* framebuff;
+
+  if (ctx->type != MT_ST30_HANDLE_PIPELINE_TX) {
+    err("%s(%d), invalid type %d\n", __func__, ctx->idx, ctx->type);
+    return 0;
+  }
+
+  if (!ctx->ready) return -EBUSY;
+
+  mt_pthread_mutex_lock(&ctx->lock);
+  framebuff = tx_st30p_newest_available(ctx, ST30P_TX_FRAME_READY);
+  if (!framebuff) {
+    mt_pthread_mutex_unlock(&ctx->lock);
+    return -EBUSY;
+  }
+
+  framebuff->stat = ST30P_TX_FRAME_FREE;
+  ctx->stat_drop_frame++;
+  dbg("%s(%d), drop frame %u succ\n", __func__, ctx->idx, framebuff->idx);
+  mt_pthread_mutex_unlock(&ctx->lock);
+
+  if (ctx->ops.notify_frame_late) {
+    ctx->ops.notify_frame_late(ctx->ops.priv, epoch_skipped);
+  } else if (ctx->ops.notify_frame_done) {
+    ctx->ops.notify_frame_done(ctx->ops.priv, &framebuff->frame);
+  }
+
+  tx_st30p_notify_frame_available(ctx);
+  MT_USDT_ST30P_TX_FRAME_DONE(ctx->idx, framebuff->idx, framebuff->frame.rtp_timestamp);
+
   return 0;
 }
 
@@ -133,7 +168,7 @@ static int tx_st30p_frame_done(void* priv, uint16_t frame_idx,
   /* notify app can get frame */
   tx_st30p_notify_frame_available(ctx);
 
-  MT_USDT_ST30P_TX_FRAME_DONE(ctx->idx, frame_idx, frame->rtp_timestamp);
+  MT_USDT_ST30P_TX_FRAME_DROP(ctx->idx, frame_idx, frame->rtp_timestamp);
   return ret;
 }
 
@@ -172,6 +207,11 @@ static int tx_st30p_create_transport(struct mtl_main_impl* impl, struct st30p_tx
     ops_tx.flags |= ST30_TX_FLAG_FORCE_NUMA;
   }
   if (ops->flags & ST30P_TX_FLAG_USER_PACING) ops_tx.flags |= ST30_TX_FLAG_USER_PACING;
+  if (ops->flags & ST30P_TX_FLAG_DROP_WHEN_LATE) {
+    ops_tx.notify_frame_late = st30p_tx_late_frame_drop;
+  } else if (ops->notify_frame_late) {
+    ops_tx.notify_frame_late = ops->notify_frame_late;
+  }
   ops_tx.pacing_way = ops->pacing_way;
   ops_tx.rtp_timestamp_delta_us = ops->rtp_timestamp_delta_us;
 
@@ -258,20 +298,34 @@ static int tx_st30p_init_fbs(struct st30p_tx_ctx* ctx, struct st30p_tx_ops* ops)
 static int tx_st30p_stat(void* priv) {
   struct st30p_tx_ctx* ctx = priv;
   struct st30p_tx_frame* framebuff = ctx->framebuffs;
+  uint16_t status_counts[ST30P_TX_FRAME_STATUS_MAX] = {0};
 
   if (!ctx->ready) return -EBUSY; /* not ready */
 
-  uint16_t producer_idx = ctx->framebuff_producer_idx;
-  uint16_t consumer_idx = ctx->framebuff_consumer_idx;
-  notice("TX_st30p(%d,%s), p(%d:%s) c(%d:%s)\n", ctx->idx, ctx->ops_name, producer_idx,
-         tx_st30p_stat_name(framebuff[producer_idx].stat), consumer_idx,
-         tx_st30p_stat_name(framebuff[consumer_idx].stat));
+  for (uint16_t j = 0; j < ctx->framebuff_cnt; j++) {
+    enum st30p_tx_frame_status stat = framebuff[j].stat;
+    if (stat < ST30P_TX_FRAME_STATUS_MAX) {
+      status_counts[stat]++;
+    }
+  }
 
-  notice("TX_st30p(%d), frame get try %d succ %d, put %d\n", ctx->idx,
-         ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame);
+  char status_str[256];
+  int offset = 0;
+  for (uint16_t i = 0; i < ST30P_TX_FRAME_STATUS_MAX; i++) {
+    if (status_counts[i] > 0) {
+      offset += snprintf(status_str + offset, sizeof(status_str) - offset, "%s:%u ",
+                         st30p_tx_frame_stat_name_short[i], status_counts[i]);
+    }
+  }
+  notice("TX_st30p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+
+  notice("TX_st30p(%d), frame get try %d succ %d, put %d, drop %d\n", ctx->idx,
+         ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame,
+         ctx->stat_drop_frame);
   ctx->stat_get_frame_try = 0;
   ctx->stat_get_frame_succ = 0;
   ctx->stat_put_frame = 0;
+  ctx->stat_drop_frame = 0;
 
   return 0;
 }
@@ -384,15 +438,13 @@ struct st30_frame* st30p_tx_get_frame(st30p_tx_handle handle) {
   ctx->stat_get_frame_try++;
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st30p_next_available(ctx, ctx->framebuff_producer_idx, ST30P_TX_FRAME_FREE);
+  framebuff = tx_st30p_next_available(ctx, ST30P_TX_FRAME_FREE);
   if (!framebuff && ctx->block_get) { /* wait here */
     mt_pthread_mutex_unlock(&ctx->lock);
     tx_st30p_get_block_wait(ctx);
     /* get again */
     mt_pthread_mutex_lock(&ctx->lock);
-    framebuff =
-        tx_st30p_next_available(ctx, ctx->framebuff_producer_idx, ST30P_TX_FRAME_FREE);
+    framebuff = tx_st30p_next_available(ctx, ST30P_TX_FRAME_FREE);
   }
   /* not any free frame */
   if (!framebuff) {
@@ -401,8 +453,7 @@ struct st30_frame* st30p_tx_get_frame(st30p_tx_handle handle) {
   }
 
   framebuff->stat = ST30P_TX_FRAME_IN_USER;
-  /* point to next */
-  ctx->framebuff_producer_idx = tx_st30p_next_idx(ctx, framebuff->idx);
+  framebuff->seq_number = ctx->framebuff_seq_number++;
   mt_pthread_mutex_unlock(&ctx->lock);
 
   struct st30_frame* frame = &framebuff->frame;
@@ -429,9 +480,11 @@ int st30p_tx_put_frame(st30p_tx_handle handle, struct st30_frame* frame) {
     return -EIO;
   }
 
+  mt_pthread_mutex_lock(&ctx->lock);
   if (ST30P_TX_FRAME_IN_USER != framebuff->stat) {
     err("%s(%d), frame %u not in user %d\n", __func__, idx, producer_idx,
         framebuff->stat);
+    mt_pthread_mutex_unlock(&ctx->lock);
     return -EIO;
   }
 
@@ -439,6 +492,7 @@ int st30p_tx_put_frame(st30p_tx_handle handle, struct st30_frame* frame) {
   ctx->stat_put_frame++;
   MT_USDT_ST30P_TX_FRAME_PUT(idx, framebuff->idx, frame->addr);
   dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, producer_idx, frame->addr);
+  mt_pthread_mutex_unlock(&ctx->lock);
   return 0;
 }
 
@@ -638,6 +692,25 @@ void* st30p_tx_get_fb_addr(st30p_tx_handle handle, uint16_t idx) {
 int st30p_tx_get_session_stats(st30p_tx_handle handle, struct st30_tx_user_stats* stats) {
   struct st30p_tx_ctx* ctx = handle;
   int cidx;
+  struct st30p_tx_frame* framebuff = ctx->framebuffs;
+  uint16_t status_counts[ST30P_TX_FRAME_STATUS_MAX] = {0};
+
+  for (uint16_t j = 0; j < ctx->framebuff_cnt; j++) {
+    enum st30p_tx_frame_status stat = framebuff[j].stat;
+    if (stat < ST30P_TX_FRAME_STATUS_MAX) {
+      status_counts[stat]++;
+    }
+  }
+
+  char status_str[256];
+  int offset = 0;
+  for (uint16_t i = 0; i < ST30P_TX_FRAME_STATUS_MAX; i++) {
+    if (status_counts[i] > 0) {
+      offset += snprintf(status_str + offset, sizeof(status_str) - offset, "%s:%u ",
+                         st30p_tx_frame_stat_name_short[i], status_counts[i]);
+    }
+  }
+  notice("TX_st30p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   if (!handle || !stats) {
     err("%s, invalid handle %p or stats %p\n", __func__, handle, stats);

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.h
@@ -20,6 +20,7 @@ struct st30p_tx_frame {
   enum st30p_tx_frame_status stat;
   struct st30_frame frame;
   uint16_t idx;
+  uint32_t seq_number;
 };
 
 struct st30p_tx_ctx {
@@ -33,8 +34,7 @@ struct st30p_tx_ctx {
 
   st30_tx_handle transport;
   uint16_t framebuff_cnt;
-  uint16_t framebuff_producer_idx;
-  uint16_t framebuff_consumer_idx;
+  uint32_t framebuff_seq_number;
   struct st30p_tx_frame* framebuffs;
   pthread_mutex_t lock;
   bool ready;
@@ -52,9 +52,10 @@ struct st30p_tx_ctx {
   uint64_t block_timeout_ns;
 
   /* get frame stat */
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
+  uint32_t stat_drop_frame;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.h
@@ -47,10 +47,11 @@ struct st40p_rx_ctx {
   uint32_t usdt_dump_frame_cnt;
 
   /* stat */
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
-  int stat_busy;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
+  uint32_t stat_busy;
+  uint32_t stat_drop_frame;
 };
 
 struct st40p_rx_frame {

--- a/lib/src/st2110/pipeline/st40_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_tx.c
@@ -14,16 +14,15 @@ static const char* st40p_tx_frame_stat_name[ST40P_TX_FRAME_STATUS_MAX] = {
     "in_transmitting",
 };
 
+static const char* st40p_tx_frame_stat_name_short[ST40P_TX_FRAME_STATUS_MAX] = {
+    "F",
+    "U",
+    "R",
+    "T",
+};
+
 static const char* tx_st40p_stat_name(enum st40p_tx_frame_status stat) {
   return st40p_tx_frame_stat_name[stat];
-}
-
-static uint16_t tx_st40p_next_idx(struct st40p_tx_ctx* ctx, uint16_t idx) {
-  /* point to next */
-  uint16_t next_idx = idx;
-  next_idx++;
-  if (next_idx >= ctx->framebuff_cnt) next_idx = 0;
-  return next_idx;
 }
 
 static void tx_st40p_block_wake(struct st40p_tx_ctx* ctx) {
@@ -44,22 +43,32 @@ static void tx_st40p_notify_frame_available(struct st40p_tx_ctx* ctx) {
   }
 }
 
+static struct st40p_tx_frame* tx_st40p_newest_available(
+    struct st40p_tx_ctx* ctx, enum st40p_tx_frame_status desired) {
+  struct st40p_tx_frame* framebuff = NULL;
+  struct st40p_tx_frame* framebuff_newest = NULL;
+
+  for (uint16_t idx = 0; idx < ctx->framebuff_cnt; idx++) {
+    framebuff = &ctx->framebuffs[idx];
+    if ((desired == framebuff->stat &&
+         (!framebuff_newest ||
+          !mt_seq32_greater(framebuff->seq_number, framebuff_newest->seq_number)))) {
+      framebuff_newest = framebuff;
+    }
+  }
+
+  return framebuff_newest;
+}
+
 static struct st40p_tx_frame* tx_st40p_next_available(
-    struct st40p_tx_ctx* ctx, uint16_t idx_start, enum st40p_tx_frame_status desired) {
-  uint16_t idx = idx_start;
+    struct st40p_tx_ctx* ctx, enum st40p_tx_frame_status desired) {
   struct st40p_tx_frame* framebuff;
 
   /* check ready frame from idx_start */
-  while (1) {
+  for (uint16_t idx = 0; idx < ctx->framebuff_cnt; idx++) {
     framebuff = &ctx->framebuffs[idx];
     if (desired == framebuff->stat) {
-      /* find one desired */
       return framebuff;
-    }
-    idx = tx_st40p_next_idx(ctx, idx);
-    if (idx == idx_start) {
-      /* loop all frames end */
-      break;
     }
   }
 
@@ -76,8 +85,7 @@ static int tx_st40p_next_frame(void* priv, uint16_t* next_frame_idx,
   if (!ctx->ready) return -EBUSY; /* not ready */
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st40p_next_available(ctx, ctx->framebuff_consumer_idx, ST40P_TX_FRAME_READY);
+  framebuff = tx_st40p_newest_available(ctx, ST40P_TX_FRAME_READY);
   /* not any converted frame */
   if (!framebuff) {
     mt_pthread_mutex_unlock(&ctx->lock);
@@ -92,14 +100,46 @@ static int tx_st40p_next_frame(void* priv, uint16_t* next_frame_idx,
     meta->timestamp = framebuff->frame_info.timestamp;
   }
 
-  if (ctx->ops.flags & (ST40P_TX_FLAG_ACCURATE_FRAMEBUFF_STATISTICS)) {
-    ctx->stat_enable_verbose_framebuffers_status = true;
-  }
-
-  /* point to next */
-  ctx->framebuff_consumer_idx = tx_st40p_next_idx(ctx, framebuff->idx);
   mt_pthread_mutex_unlock(&ctx->lock);
   dbg("%s(%d), frame %u succ\n", __func__, ctx->idx, framebuff->idx);
+  MT_USDT_ST40P_TX_FRAME_NEXT(ctx->idx, framebuff->idx);
+  return 0;
+}
+
+int st40p_tx_late_frame_drop(void* handle, uint64_t epoch_skipped) {
+  struct st40p_tx_ctx* ctx = handle;
+  int cidx = ctx->idx;
+  struct st40p_tx_frame* framebuff;
+
+  if (ctx->type != MT_ST40_HANDLE_PIPELINE_TX) {
+    err("%s(%d), invalid type %d\n", __func__, cidx, ctx->type);
+    return 0;
+  }
+
+  if (!ctx->ready) return -EBUSY;
+
+  mt_pthread_mutex_lock(&ctx->lock);
+  framebuff = tx_st40p_newest_available(ctx, ST40P_TX_FRAME_READY);
+  if (!framebuff) {
+    mt_pthread_mutex_unlock(&ctx->lock);
+    return -EBUSY;
+  }
+
+  framebuff->stat = ST40P_TX_FRAME_FREE;
+  ctx->stat_drop_frame++;
+  dbg("%s(%d), drop frame %u succ\n", __func__, ctx->idx, framebuff->idx);
+  mt_pthread_mutex_unlock(&ctx->lock);
+
+  if (ctx->ops.notify_frame_late) {
+    ctx->ops.notify_frame_late(ctx->ops.priv, epoch_skipped);
+  } else if (ctx->ops.notify_frame_done) {
+    ctx->ops.notify_frame_done(ctx->ops.priv, &framebuff->frame_info);
+  }
+
+  tx_st40p_notify_frame_available(ctx);
+  MT_USDT_ST40P_TX_FRAME_DROP(ctx->idx, framebuff->idx,
+                              framebuff->frame_info.rtp_timestamp);
+
   return 0;
 }
 
@@ -137,6 +177,7 @@ static int tx_st40p_frame_done(void* priv, uint16_t frame_idx,
   /* notify app can get frame */
   tx_st40p_notify_frame_available(ctx);
 
+  MT_USDT_ST40P_TX_FRAME_DONE(ctx->idx, frame_idx, frame_info->rtp_timestamp);
   return ret;
 }
 static int tx_st40p_asign_anc_frames(struct st40p_tx_ctx* ctx) {
@@ -203,7 +244,11 @@ static int tx_st40p_create_transport(struct mtl_main_impl* impl, struct st40p_tx
     ops_tx.flags |= ST40_TX_FLAG_USER_TIMESTAMP;
 
   if (ops->flags & ST40P_TX_FLAG_USER_PACING) ops_tx.flags |= ST40_TX_FLAG_USER_PACING;
-
+  if (ops->flags & ST40P_TX_FLAG_DROP_WHEN_LATE) {
+    ops_tx.notify_frame_late = st40p_tx_late_frame_drop;
+  } else if (ops->notify_frame_late) {
+    ops_tx.notify_frame_late = ops->notify_frame_late;
+  }
   if (ops->flags & ST40P_TX_FLAG_ENABLE_RTCP) ops_tx.flags |= ST40_TX_FLAG_ENABLE_RTCP;
 
   ops_tx.interlaced = false;
@@ -285,41 +330,35 @@ static int tx_st40p_init_fbs(struct st40p_tx_ctx* ctx, struct st40p_tx_ops* ops)
 static int tx_st40p_stat(void* priv) {
   struct st40p_tx_ctx* ctx = priv;
   struct st40p_tx_frame* framebuff = ctx->framebuffs;
-  uint16_t producer_idx;
-  uint16_t consumer_idx;
   uint16_t status_counts[ST40P_TX_FRAME_STATUS_MAX] = {0};
-  enum st40p_tx_frame_status stat;
 
   if (!ctx->ready) return -EBUSY; /* not ready */
 
-  producer_idx = ctx->framebuff_producer_idx;
-  consumer_idx = ctx->framebuff_consumer_idx;
-
-  if (ctx->stat_enable_verbose_framebuffers_status) {
-    for (uint16_t j = 0; j < ctx->framebuff_cnt; j++) {
-      stat = framebuff[j].stat;
-
-      if (stat < ST40P_TX_FRAME_STATUS_MAX) {
-        status_counts[stat]++;
-      }
+  for (uint16_t j = 0; j < ctx->framebuff_cnt; j++) {
+    enum st40p_tx_frame_status stat = framebuff[j].stat;
+    if (stat < ST40P_TX_FRAME_STATUS_MAX) {
+      status_counts[stat]++;
     }
-
-    for (uint16_t i = 0; i < ST40P_TX_FRAME_STATUS_MAX; i++) {
-      notice("TX_st40p(%d,%s), framebuffer queue %s: %u\n", ctx->idx, ctx->ops_name,
-             tx_st40p_stat_name(i), status_counts[i]);
-    }
-  } else {
-    notice("TX_st40p(%d,%s), p(%d:%s) c(%d:%s)\n", ctx->idx, ctx->ops_name, producer_idx,
-           tx_st40p_stat_name(framebuff[producer_idx].stat), consumer_idx,
-           tx_st40p_stat_name(framebuff[consumer_idx].stat));
   }
 
-  notice("TX_st40p(%d), frame get try %d succ %d, put %d\n", ctx->idx,
-         ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame);
+  char status_str[256];
+  int offset = 0;
+  for (uint16_t i = 0; i < ST40P_TX_FRAME_STATUS_MAX; i++) {
+    if (status_counts[i] > 0) {
+      offset += snprintf(status_str + offset, sizeof(status_str) - offset, "%s:%u ",
+                         st40p_tx_frame_stat_name_short[i], status_counts[i]);
+    }
+  }
+  notice("TX_st40p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+
+  notice("TX_st40p(%d), frame get try %d succ %d, put %d, drop %d\n", ctx->idx,
+         ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame,
+         ctx->stat_drop_frame);
 
   ctx->stat_get_frame_try = 0;
   ctx->stat_get_frame_succ = 0;
   ctx->stat_put_frame = 0;
+  ctx->stat_drop_frame = 0;
 
   return 0;
 }
@@ -383,15 +422,13 @@ struct st40_frame_info* st40p_tx_get_frame(st40p_tx_handle handle) {
   ctx->stat_get_frame_try++;
 
   mt_pthread_mutex_lock(&ctx->lock);
-  framebuff =
-      tx_st40p_next_available(ctx, ctx->framebuff_producer_idx, ST40P_TX_FRAME_FREE);
+  framebuff = tx_st40p_next_available(ctx, ST40P_TX_FRAME_FREE);
   if (!framebuff && ctx->block_get) { /* wait here */
     mt_pthread_mutex_unlock(&ctx->lock);
     tx_st40p_get_block_wait(ctx);
     /* get again */
     mt_pthread_mutex_lock(&ctx->lock);
-    framebuff =
-        tx_st40p_next_available(ctx, ctx->framebuff_producer_idx, ST40P_TX_FRAME_FREE);
+    framebuff = tx_st40p_next_available(ctx, ST40P_TX_FRAME_FREE);
   }
 
   /* not any free frame */
@@ -401,12 +438,12 @@ struct st40_frame_info* st40p_tx_get_frame(st40p_tx_handle handle) {
   }
 
   framebuff->stat = ST40P_TX_FRAME_IN_USER;
-  /* point to next */
-  ctx->framebuff_producer_idx = tx_st40p_next_idx(ctx, framebuff->idx);
+  framebuff->seq_number = ctx->framebuff_seq_number++;
   mt_pthread_mutex_unlock(&ctx->lock);
 
   frame_info = &framebuff->frame_info;
   ctx->stat_get_frame_succ++;
+  MT_USDT_ST40P_TX_FRAME_GET(idx, framebuff->idx, frame_info->rtp_timestamp);
   dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, framebuff->idx, frame_info);
   return frame_info;
 }
@@ -441,6 +478,7 @@ int st40p_tx_put_frame(st40p_tx_handle handle, struct st40_frame_info* frame_inf
   framebuff->frame_info.udw_buffer_fill = 0;
   framebuff->stat = ST40P_TX_FRAME_READY;
   ctx->stat_put_frame++;
+  MT_USDT_ST40P_TX_FRAME_PUT(idx, framebuff->idx, framebuff->anc_frame->data);
   dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, producer_idx, framebuff->anc_frame);
   return 0;
 }
@@ -656,6 +694,25 @@ void* st40p_tx_get_fb_addr(st40p_tx_handle handle, uint16_t idx) {
 int st40p_tx_get_session_stats(st40p_tx_handle handle, struct st40_tx_user_stats* stats) {
   struct st40p_tx_ctx* ctx = handle;
   int cidx;
+  struct st40p_tx_frame* framebuff = ctx->framebuffs;
+  uint16_t status_counts[ST40P_TX_FRAME_STATUS_MAX] = {0};
+
+  for (uint16_t j = 0; j < ctx->framebuff_cnt; j++) {
+    enum st40p_tx_frame_status stat = framebuff[j].stat;
+    if (stat < ST40P_TX_FRAME_STATUS_MAX) {
+      status_counts[stat]++;
+    }
+  }
+
+  char status_str[256];
+  int offset = 0;
+  for (uint16_t i = 0; i < ST40P_TX_FRAME_STATUS_MAX; i++) {
+    if (status_counts[i] > 0) {
+      offset += snprintf(status_str + offset, sizeof(status_str) - offset, "%s:%u ",
+                         st40p_tx_frame_stat_name_short[i], status_counts[i]);
+    }
+  }
+  notice("TX_st40p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   if (!handle || !stats) {
     err("%s, invalid handle %p or stats %p\n", __func__, handle, stats);

--- a/lib/src/st2110/pipeline/st40_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st40_pipeline_tx.h
@@ -31,8 +31,7 @@ struct st40p_tx_ctx {
 
   st40_tx_handle transport;
   uint16_t framebuff_cnt;
-  uint16_t framebuff_producer_idx;
-  uint16_t framebuff_consumer_idx;
+  uint32_t framebuff_seq_number;
   struct st40p_tx_frame* framebuffs;
   pthread_mutex_t lock;
   bool ready;
@@ -46,10 +45,10 @@ struct st40p_tx_ctx {
   uint64_t block_timeout_ns;
 
   /* get frame stat */
-  bool stat_enable_verbose_framebuffers_status;
-  int stat_get_frame_try;
-  int stat_get_frame_succ;
-  int stat_put_frame;
+  uint32_t stat_get_frame_try;
+  uint32_t stat_get_frame_succ;
+  uint32_t stat_put_frame;
+  uint32_t stat_drop_frame;
 };
 
 struct st40p_tx_frame {
@@ -58,6 +57,7 @@ struct st40p_tx_frame {
   uint16_t idx;
   /** Pointer to the main ancillary frame buffer */
   struct st40_frame* anc_frame;
+  uint32_t seq_number;
 };
 
 #if defined(__cplusplus)

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -309,6 +309,10 @@ static int tx_ancillary_session_sync_pacing(struct mtl_main_impl* impl,
   if (epochs > next_epochs) {
     uint drop = (epochs - next_epochs);
     ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop, drop);
+
+    if (s->ops.notify_frame_late) {
+      s->ops.notify_frame_late(s->ops.priv, drop);
+    }
   }
 
   if (epochs < next_epochs) {

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -324,6 +324,10 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
   if (epochs > next_epochs) {
     ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
                         (epochs - next_epochs));
+
+    if (s->ops.notify_frame_late) {
+      s->ops.notify_frame_late(s->ops.priv, epochs - next_epochs);
+    }
   }
 
   if (epochs < next_epochs) {

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -571,6 +571,23 @@ static int tv_init_pacing_epoch(struct mtl_main_impl* impl,
   return 0;
 }
 
+static void validate_user_timestamp(struct st_tx_video_session_impl* s,
+                                    uint64_t requested_frame_count,
+                                    uint64_t current_frame_count) {
+  if (requested_frame_count < current_frame_count) {
+    ST_SESSION_STAT_INC(s, port_user_stats.common, stat_error_user_timestamp);
+    dbg("%s(%d), user requested transmission time in the past, required_tai %" PRIu64
+        ", cur_tai %" PRIu64 "\n",
+        __func__, s->idx, requested_frame_count, current_frame_count);
+  } else if (requested_frame_count >
+             current_frame_count + (NS_PER_S / s->pacing.frame_time)) {
+    dbg("%s(%d), requested frame count %" PRIu64
+        " too far in the future, current frame count %" PRIu64 "\n",
+        __func__, s->idx, requested_frame_count, current_frame_count);
+    ST_SESSION_STAT_INC(s, port_user_stats.common, stat_error_user_timestamp);
+  }
+}
+
 static inline uint64_t calc_frame_count_since_epoch(struct st_tx_video_session_impl* s,
                                                     uint64_t cur_tai,
                                                     uint64_t required_tai) {
@@ -580,50 +597,40 @@ static inline uint64_t calc_frame_count_since_epoch(struct st_tx_video_session_i
 
   if (required_tai) {
     frame_count = (required_tai + s->pacing.frame_time / 2) / s->pacing.frame_time;
-  } else {
-    if (frame_count_tai <= next_free_frame_slot) {
-      /* There is time buffer until the next available frame time window */
-      if (next_free_frame_slot - frame_count_tai > s->pacing.max_onward_epochs) {
-        /* current time is out of onward range, just note this and still move to next free
-         * slot */
-        dbg("%s(%d), onward range exceeded, next_free_frame_slot %" PRIu64
-            ", frame_count_tai %" PRIu64 "\n",
-            __func__, s->idx, next_free_frame_slot, frame_count_tai);
-        ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_onward,
-                            (next_free_frame_slot - frame_count_tai));
-      }
+    validate_user_timestamp(s, frame_count, frame_count_tai);
+  }
 
-      frame_count = next_free_frame_slot;
-
-    } else {
-      dbg("%s(%d), frame is late, frame_count_tai %" PRIu64
-          " next_free_frame_slot %" PRIu64 "\n",
-          __func__, s->idx, frame_count_tai, next_free_frame_slot);
-      ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
-                          (frame_count_tai - next_free_frame_slot));
-
-      frame_count = frame_count_tai;
+  if (frame_count_tai <= next_free_frame_slot) {
+    /* There is time buffer until the next available frame time window */
+    if (next_free_frame_slot - frame_count_tai > s->pacing.max_onward_epochs) {
+      /* current time is out of onward range, just note this and still move to next free
+       * slot */
+      dbg("%s(%d), onward range exceeded, next_free_frame_slot %" PRIu64
+          ", frame_count_tai %" PRIu64 "\n",
+          __func__, s->idx, next_free_frame_slot, frame_count_tai);
+      ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_onward,
+                          (next_free_frame_slot - frame_count_tai));
     }
+
+    if (!required_tai) {
+      frame_count = next_free_frame_slot;
+    }
+
+  } else {
+    dbg("%s(%d), frame is late, frame_count_tai %" PRIu64 " next_free_frame_slot %" PRIu64
+        "\n",
+        __func__, s->idx, frame_count_tai, next_free_frame_slot);
+    ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
+                        (frame_count_tai - next_free_frame_slot));
+
+    if (s->ops.notify_frame_late) {
+      s->ops.notify_frame_late(s->ops.priv, frame_count_tai - next_free_frame_slot);
+    }
+
+    frame_count = frame_count_tai;
   }
+
   return frame_count;
-}
-
-static inline uint64_t validate_and_adjust_user_timestamp(
-    struct st_tx_video_session_impl* s, uint64_t required_tai, uint64_t cur_tai) {
-  if (required_tai < cur_tai) {
-    ST_SESSION_STAT_INC(s, port_user_stats.common, stat_error_user_timestamp);
-    dbg("%s(%d), user requested transmission time in the past, required_tai %" PRIu64
-        ", cur_tai %" PRIu64 "\n",
-        __func__, s->idx, required_tai, cur_tai);
-    required_tai = cur_tai; /* send asap */
-
-  } else if (required_tai > cur_tai + NS_PER_S) {
-    dbg("%s(%d), required tai %" PRIu64 " too far in the future, cur_tai %" PRIu64 "\n",
-        __func__, s->idx, required_tai, cur_tai);
-    ST_SESSION_STAT_INC(s, port_user_stats.common, stat_error_user_timestamp);
-    required_tai = cur_tai + NS_PER_S;  // do our best to slow down
-  }
-  return required_tai;
 }
 
 static int tv_sync_pacing(struct mtl_main_impl* impl, struct st_tx_video_session_impl* s,
@@ -634,11 +641,8 @@ static int tv_sync_pacing(struct mtl_main_impl* impl, struct st_tx_video_session
   uint64_t start_time_tai;
   uint64_t time_to_tx_ns;
 
-  if (required_tai) {
-    required_tai = validate_and_adjust_user_timestamp(s, required_tai, cur_tai);
-  }
-
   pacing->cur_epochs = calc_frame_count_since_epoch(s, cur_tai, required_tai);
+
   if (s->ops.flags & ST20_TX_FLAG_EXACT_USER_PACING) {
     start_time_tai = required_tai;
   } else {


### PR DESCRIPTION
    Add: Ability to drop old frames
    
    Change the way pipeline TX handles the order of framebuffers. Track
    per-frame sequence numbers so transport can dequeue the newest converted
    frame instead of always taking the next one, needed as otherwise
    we cannot drop frames, as they will not be in order.
    
    Add a new flag to the TX pipeline to enable droping frames when we jump
    over epoch. Mostly will aid with user control pacing.
    
    Implemented in a way that only drops one frame in a scenario where late
    is detected. This creates limitation for extreamly high drops The stream
    will still not adjust immidiately instead doing
    send frame | drop frame | send frame | drop frame ...
    until we catch up.
    (Done mostly as big jumps over more than 2 frames could be undesirable
    and if you have that big of a drop ... well this is the leas of your
    troubles).
    
    All above done in pipeline as the purpose of the api pipeline is to
    smoothe the library tight timing requirements from the user
    applications.
    
    Fix the st20p wrong user timestamp reporting in frames snapped to
    the next frame.
    
    if times given by the application looks as follows
    ----|--frame-1--|--frame-2--|--frame-3--|--frame-4--|-...
    epoch-1--|--epoch-2--|--epoch-3--|--epoch-4--|...
    
    This causes frames to snap to the next epoch, resulting in incorrect
    timestamp reporting where every frame appears to have a "wrong user
    timestamp" due to the forward snapping behavior.
    
    Fixes: 88c3566987fd6e773d07d79b67e06391f3037cb2
    
    Add simple tests.
    Fix the usdt for st40p tx (only to add the spurn event).
    Fixes: 921fa0d0f21de48d385680c215365b55ca5f033d