### PR TITLE
Fix: Changed maximum allowed number of DMA devices supported by MTL

### DIFF
--- a/include/mtl_api.h
+++ b/include/mtl_api.h
@@ -91,7 +91,7 @@ extern "C" {
 /**
  * Max allowed number of dma devs
  */
-#define MTL_DMA_DEV_MAX (8)
+#define MTL_DMA_DEV_MAX (32)
 
 /**
  * Max length of a pcap dump filename


### PR DESCRIPTION
Changed maximum allowed number of DMA devices supported by MTL to avoid deadlock on newer platforms with more than 8 DMA devices available. This is a temporary solution for a quick fix of the issue. Dynamic device allocation will be available soon.