### PR TITLE
Add: ST40_TX_FLAG_EXACT_USER_PACING

### DIFF
--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -59,6 +59,12 @@ typedef struct st_rx_ancillary_session_handle_impl* st40_rx_handle;
  * If use dedicated queue for TX.
  */
 #define ST40_TX_FLAG_DEDICATE_QUEUE (MTL_BIT32(6))
+/**
+ * Flag bit in flags of struct st40_tx_ops.
+ * Works together with ST40_TX_FLAG_USER_PACING and makes the sender transmit at the
+ * exact timestamp provided by the user instead of aligning to the internal epoch.
+ */
+#define ST40_TX_FLAG_EXACT_USER_PACING (MTL_BIT32(7))
 
 /**
  * Flag bit in flags of struct st30_rx_ops, for non MTL_PMD_DPDK_USER.

--- a/include/st40_pipeline_api.h
+++ b/include/st40_pipeline_api.h
@@ -71,12 +71,6 @@ enum st40p_tx_flag {
    */
   ST40P_TX_FLAG_USER_PACING = (MTL_BIT32(3)),
   /**
-   * Drop frames when the mtl reports late frames (transport can't keep up).
-   * When late frame is detected, next frame from pipeline is ommited.
-   * Untill we resume normal frame sending.
-   */
-  ST40P_TX_FLAG_DROP_WHEN_LATE = (MTL_BIT32(7)),
-  /**
    * Flag bit in flags of struct st40_tx_ops.
    * If enabled, lib will assign the rtp timestamp to the value in
    * st40_tx_frame_meta(ST10_TIMESTAMP_FMT_MEDIA_CLK is used)
@@ -93,10 +87,21 @@ enum st40p_tx_flag {
    */
   ST40P_TX_FLAG_DEDICATE_QUEUE = (MTL_BIT32(6)),
   /**
+   * Drop frames when the mtl reports late frames (transport can't keep up).
+   * When late frame is detected, next frame from pipeline is ommited.
+   * Untill we resume normal frame sending.
+   */
+  ST40P_TX_FLAG_DROP_WHEN_LATE = (MTL_BIT32(7)),
+  /**
    * NOT SUPPORTED YET
    * Force the numa of the created session, both CPU and memory
    */
   ST40P_TX_FLAG_FORCE_NUMA = (MTL_BIT32(8)),
+  /**
+   * Works together with ST40P_TX_FLAG_USER_PACING and makes the first packet of the
+   * frame leave exactly at the user provided timestamp instead of aligning to epochs.
+   */
+  ST40P_TX_FLAG_EXACT_USER_PACING = (MTL_BIT32(9)),
   /** Enable the st40p_tx_get_frame block behavior to wait until a frame becomes
    available or timeout(default: 1s, use st40p_tx_set_block_timeout to customize)*/
   ST40P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),

--- a/lib/src/st2110/pipeline/st40_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_tx.c
@@ -244,6 +244,8 @@ static int tx_st40p_create_transport(struct mtl_main_impl* impl, struct st40p_tx
     ops_tx.flags |= ST40_TX_FLAG_USER_TIMESTAMP;
 
   if (ops->flags & ST40P_TX_FLAG_USER_PACING) ops_tx.flags |= ST40_TX_FLAG_USER_PACING;
+  if (ops->flags & ST40P_TX_FLAG_EXACT_USER_PACING)
+    ops_tx.flags |= ST40_TX_FLAG_EXACT_USER_PACING;
   if (ops->flags & ST40P_TX_FLAG_DROP_WHEN_LATE) {
     ops_tx.notify_frame_late = st40p_tx_late_frame_drop;
   } else if (ops->notify_frame_late) {

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -763,7 +763,7 @@ struct st_tx_audio_session_pacing {
   uint64_t cur_epochs;      /* epoch of current pkt */
   /* timestamp for rtp header */
   uint32_t rtp_time_stamp;
-  uint64_t cur_epoch_time;
+  uint64_t ptp_time_cursor;
   /* in ns, tsc time cursor for packet pacing */
   uint64_t tsc_time_cursor;
   /* ptp time may onward */
@@ -1079,9 +1079,7 @@ struct st_tx_ancillary_session_pacing {
   uint64_t cur_epochs;        /* epoch of current frame */
   /* timestamp for rtp header */
   uint32_t rtp_time_stamp;
-  /* timestamp for pacing */
-  uint32_t pacing_time_stamp;
-  uint64_t cur_epoch_time;
+  uint64_t ptp_time_cursor;
   double tsc_time_cursor; /* in ns, tsc time cursor for packet pacing */
   /* ptp time may onward */
   uint32_t max_onward_epochs;
@@ -1260,7 +1258,7 @@ struct st_tx_fastmetadata_session_pacing {
   uint32_t rtp_time_stamp;
   /* timestamp for pacing */
   uint32_t pacing_time_stamp;
-  uint64_t cur_epoch_time;
+  uint64_t ptp_time_cursor;
   double tsc_time_cursor; /* in ns, tsc time cursor for packet pacing */
   /* ptp time may onward */
   uint32_t max_onward_epochs;

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -338,7 +338,7 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
   pacing->cur_epochs = epochs;
 
   if (required_tai) {
-    pacing->cur_epoch_time = required_tai + pkt_time;  // prepare next packet
+    pacing->ptp_time_cursor = required_tai + pkt_time;  // prepare next packet
     /*
      * Cast [double] to intermediate [uint64_t] to extract 32 least significant bits.
      * If calculated time stored in [double] is larger than max uint32_t,
@@ -349,7 +349,7 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
     pacing->rtp_time_stamp =
         ((uint64_t)((required_tai / pkt_time) * pacing->pkt_time_sampling) & 0xffffffff);
   } else {
-    pacing->cur_epoch_time = tx_audio_pacing_time(pacing, epochs);
+    pacing->ptp_time_cursor = tx_audio_pacing_time(pacing, epochs);
     pacing->rtp_time_stamp = tx_audio_pacing_time_stamp(pacing, epochs);
   }
 
@@ -783,7 +783,7 @@ static int tx_audio_session_tasklet_frame(struct mtl_main_impl* impl,
       pacing->rtp_time_stamp = (uint32_t)frame->ta_meta.timestamp;
     }
     frame->ta_meta.tfmt = ST10_TIMESTAMP_FMT_TAI;
-    frame->ta_meta.timestamp = pacing->cur_epoch_time;
+    frame->ta_meta.timestamp = pacing->ptp_time_cursor;
     frame->ta_meta.rtp_timestamp = pacing->rtp_time_stamp;
     s->calculate_time_cursor = false; /* clear */
   }

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -313,7 +313,7 @@ static int tx_fastmetadata_session_sync_pacing(struct mtl_main_impl* impl,
   }
 
   pacing->cur_epochs = epochs;
-  pacing->cur_epoch_time = tx_fastmetadata_pacing_time(pacing, epochs);
+  pacing->ptp_time_cursor = tx_fastmetadata_pacing_time(pacing, epochs);
   pacing->pacing_time_stamp = tx_fastmetadata_pacing_time_stamp(pacing, epochs);
   pacing->rtp_time_stamp = pacing->pacing_time_stamp;
   pacing->tsc_time_cursor = (double)mt_get_tsc(impl) + to_epoch;
@@ -769,7 +769,7 @@ static int tx_fastmetadata_session_tasklet_frame(
       pacing->rtp_time_stamp = (uint32_t)frame->tf_meta.timestamp;
     }
     frame->tf_meta.tfmt = ST10_TIMESTAMP_FMT_TAI;
-    frame->tf_meta.timestamp = pacing->cur_epoch_time;
+    frame->tf_meta.timestamp = pacing->ptp_time_cursor;
     frame->tf_meta.rtp_timestamp = pacing->rtp_time_stamp;
     /* init to next field */
     if (ops->interlaced) {

--- a/tests/integration_tests/noctx/strategies/st20p_strategies.hpp
+++ b/tests/integration_tests/noctx/strategies/st20p_strategies.hpp
@@ -36,14 +36,14 @@ class St20pUserTimestamp : public FrameTestStrategy {
  protected:
   void initializeTiming(St20pHandler* handler);
   uint64_t plannedTimestampNs(uint64_t frame_idx) const;
-  double plannedTimestampBaseNs(uint64_t frame_idx) const;
+  uint64_t plannedTimestampBaseNs(uint64_t frame_idx) const;
   double offsetMultiplierForFrame(uint64_t frame_idx) const;
-  uint64_t expectedTransmitTimeNs(uint64_t frame_idx) const;
-  void verifyReceiveTiming(uint64_t frame_idx, uint64_t receive_time_ns,
-                           uint64_t expected_transmit_time_ns) const;
+  virtual uint64_t expectedTransmitTimeNs(uint64_t frame_idx) const;
+  virtual void verifyReceiveTiming(uint64_t frame_idx, uint64_t receive_time_ns,
+                                   uint64_t expected_transmit_time_ns) const;
   void verifyMediaClock(uint64_t frame_idx, uint64_t timestamp_media_clk,
                         uint64_t expected_media_clk) const;
-  void verifyTimestampStep(uint64_t frame_idx, uint64_t current_timestamp);
+  virtual void verifyTimestampStep(uint64_t frame_idx, uint64_t current_timestamp);
 
   double frameTimeNs = 0.0;
   uint64_t startingTime = 0;
@@ -65,4 +65,16 @@ class St20pRedundantLatency : public St20pUserTimestamp {
 
  private:
   unsigned int latencyInMs;
+};
+
+class St20pExactUserPacing : public St20pUserTimestamp {
+ public:
+  explicit St20pExactUserPacing(St20pHandler* parentHandler = nullptr,
+                                std::vector<double> offsetMultipliers = {});
+
+ protected:
+  uint64_t expectedTransmitTimeNs(uint64_t frame_idx) const override;
+  void verifyReceiveTiming(uint64_t frame_idx, uint64_t receive_time_ns,
+                           uint64_t expected_transmit_time_ns) const override;
+  void verifyTimestampStep(uint64_t frame_idx, uint64_t current_timestamp) override;
 };

--- a/tests/integration_tests/noctx/strategies/st40p_strategies.hpp
+++ b/tests/integration_tests/noctx/strategies/st40p_strategies.hpp
@@ -25,20 +25,30 @@ class St40pUserTimestamp : public FrameTestStrategy {
   double pacing_trs_ns = 0.0;
   uint32_t pacing_vrx_pkts = 0;
 
- private:
+ protected:
   void initializeTiming(St40pHandler* handler);
   uint64_t plannedTimestampNs(uint64_t frame_idx) const;
   double plannedTimestampBaseNs(uint64_t frame_idx) const;
   double offsetMultiplierForFrame(uint64_t frame_idx) const;
-  uint64_t expectedTransmitTimeNs(uint64_t frame_idx) const;
-  void verifyReceiveTiming(uint64_t frame_idx, uint64_t receive_time_ns,
-                           uint64_t expected_transmit_time_ns) const;
+  virtual uint64_t expectedTransmitTimeNs(uint64_t frame_idx) const;
+  virtual void verifyReceiveTiming(uint64_t frame_idx, uint64_t receive_time_ns,
+                                   uint64_t expected_transmit_time_ns) const;
   void verifyMediaClock(uint64_t frame_idx, uint64_t timestamp_media_clk,
                         uint64_t expected_media_clk) const;
-  void verifyTimestampStep(uint64_t frame_idx, uint64_t current_timestamp);
+  virtual void verifyTimestampStep(uint64_t frame_idx, uint64_t current_timestamp);
 
   long double frameTimeNs = 0.0;
   long double startingTime = 0;
   uint64_t lastTimestamp = 0;
   std::vector<double> timestampOffsetMultipliers;
+};
+
+class St40pExactUserPacing : public St40pUserTimestamp {
+ public:
+  explicit St40pExactUserPacing(St40pHandler* parentHandler = nullptr,
+                                std::vector<double> offsetMultipliers = {});
+
+ protected:
+  uint64_t expectedTransmitTimeNs(uint64_t frame_idx) const override;
+  void verifyTimestampStep(uint64_t frame_idx, uint64_t current_timestamp) override;
 };

--- a/tests/integration_tests/noctx/testcases/st20p_user_pacing_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st20p_user_pacing_tests.cpp
@@ -62,8 +62,9 @@ TEST_F(NoCtxTest, st20p_user_pacing) {
 TEST_F(NoCtxTest, st20p_user_pacing_offset_jitter) {
   initDefaultContext();
 
-  std::vector<double> jitterMultipliers = {-0.00005, 0.0,      0.0000875, -0.00003,
-                                           0.00012,  -0.00001, 0.0,       0.00006};
+  /* everything that does not cross the half-frame boundary should be snapped to correct
+   * epochs */
+  std::vector<double> jitterMultipliers = {0, 0.3, 0.1, -0.49, 0.37, -0.14, 0.0, 0.44};
   auto bundle = createSt20pHandlerBundle(
       /*createTx=*/true, /*createRx=*/true,
       [jitterMultipliers](St20pHandler* handler) {
@@ -90,4 +91,61 @@ TEST_F(NoCtxTest, st20p_user_pacing_offset_jitter) {
   ASSERT_GE(strategy->idx_tx, jitterMultipliers.size()) << "TX frames below expectation";
   ASSERT_GE(strategy->idx_rx, jitterMultipliers.size()) << "RX frames below expectation";
   ASSERT_EQ(strategy->idx_tx, strategy->idx_rx) << "TX/RX frame count mismatch";
+}
+
+TEST_F(NoCtxTest, st20p_exact_user_pacing) {
+  initDefaultContext();
+
+  /* Offset values must remain smaller than in standard user pacing, since exact mode
+     lacks epoch snapping and only minimal timing slack exists between consecutive frames.
+     ~(tr_offset - processing time) */
+  std::vector<double> exactOffsets = {0.002,   0.007,  -0.002,  0.008,
+                                      -0.0005, 0.0033, -0.0025, 0.0051};
+
+  auto bundle = createSt20pHandlerBundle(
+      /*createTx=*/true, /*createRx=*/true,
+      [exactOffsets](St20pHandler* handler) {
+        return new St20pExactUserPacing(handler, exactOffsets);
+      },
+      [](St20pHandler* handler) {
+        handler->sessionsOpsTx.flags |= ST20P_TX_FLAG_USER_PACING;
+        handler->sessionsOpsTx.flags |= ST20P_TX_FLAG_EXACT_USER_PACING;
+      });
+
+  auto* handler = bundle.handler;
+  auto* strategy = static_cast<St20pExactUserPacing*>(bundle.strategy);
+  ASSERT_NE(handler, nullptr);
+  ASSERT_NE(strategy, nullptr);
+
+  StartFakePtpClock();
+  handler->startSession();
+
+  const int pacing_status = strategy->getPacingParameters();
+  if (pacing_status == 0) {
+    EXPECT_GT(strategy->pacing_tr_offset_ns, 0.0);
+    EXPECT_GT(strategy->pacing_trs_ns, 0.0);
+    EXPECT_GT(strategy->pacing_vrx_pkts, 0u);
+
+  } else {
+    EXPECT_EQ(pacing_status, -ENOTSUP) << "Unexpected pacing query result";
+  }
+
+  mtl_start(ctx->handle);
+
+  sleepUntilFailure();
+
+  handler->stopSession();
+
+  ASSERT_GE(handler->txFrames(), exactOffsets.size())
+      << "st20p_exact_user_pacing transmitted too few frames for offset coverage";
+  ASSERT_GE(handler->rxFrames(), exactOffsets.size())
+      << "st20p_exact_user_pacing received too few frames for offset coverage";
+  EXPECT_EQ(handler->txFrames(), handler->rxFrames())
+      << "st20p_exact_user_pacing TX/RX frame count mismatch";
+  ASSERT_GE(strategy->idx_tx, exactOffsets.size())
+      << "st20p_exact_user_pacing strategy TX frames below expectation";
+  ASSERT_GE(strategy->idx_rx, exactOffsets.size())
+      << "st20p_exact_user_pacing strategy RX frames below expectation";
+  EXPECT_EQ(strategy->idx_tx, strategy->idx_rx)
+      << "st20p_exact_user_pacing strategy TX/RX mismatch";
 }

--- a/tests/integration_tests/noctx/testcases/st40p_user_pacing_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st40p_user_pacing_tests.cpp
@@ -92,8 +92,9 @@ TEST_F(NoCtxTest, st40p_user_pacing_59fps) {
 TEST_F(NoCtxTest, st40p_user_pacing_offset_jitter) {
   initDefaultContext();
 
-  std::vector<double> jitterMultipliers = {-0.00005, 0.0,      0.0000875, -0.00003,
-                                           0.00012,  -0.00001, 0.0,       0.00006};
+  /* everything that does not cross the half-frame boundary should be snapped to correct
+   * epochs */
+  std::vector<double> jitterMultipliers = {0, 0.3, 0.1, -0.49, 0.37, -0.14, 0.0, 0.44};
 
   auto bundle = createSt40pHandlerBundle(
       /*createTx=*/true, /*createRx=*/true,
@@ -138,4 +139,57 @@ TEST_F(NoCtxTest, st40p_user_pacing_offset_jitter) {
       << "st40p_user_pacing_offset_jitter strategy RX frames below expectation";
   EXPECT_EQ(strategy->idx_tx, strategy->idx_rx)
       << "st40p_user_pacing_offset_jitter strategy TX/RX mismatch";
+}
+
+TEST_F(NoCtxTest, st40p_exact_user_pacing) {
+  initDefaultContext();
+
+  /* Ancillary frame transmission time is minimal relative to the inter-frame interval at
+  60 fps, allowing large offsets while maintaining successful transmission. */
+  std::vector<double> exactOffsets = {0.2, 0.7, -0.1, 0.8, -0.05, 0.33, -0.25, 0.51};
+
+  auto bundle = createSt40pHandlerBundle(
+      /*createTx=*/true, /*createRx=*/true,
+      [exactOffsets](St40pHandler* handler) {
+        return new St40pExactUserPacing(handler, exactOffsets);
+      },
+      [](St40pHandler* handler) {
+        handler->sessionsOpsTx.flags |= ST40P_TX_FLAG_USER_PACING;
+        handler->sessionsOpsTx.flags |= ST40P_TX_FLAG_EXACT_USER_PACING;
+      });
+
+  auto* handler = bundle.handler;
+  auto* strategy = static_cast<St40pExactUserPacing*>(bundle.strategy);
+  ASSERT_NE(handler, nullptr);
+  ASSERT_NE(strategy, nullptr);
+
+  StartFakePtpClock();
+  handler->startSession();
+  mtl_start(ctx->handle);
+
+  const int pacing_status = strategy->getPacingParameters();
+  if (pacing_status == 0) {
+    EXPECT_GT(strategy->pacing_tr_offset_ns, 0.0);
+    EXPECT_GT(strategy->pacing_trs_ns, 0.0);
+    EXPECT_GT(strategy->pacing_vrx_pkts, 0u);
+  } else {
+    EXPECT_EQ(pacing_status, -ENOTSUP) << "Unexpected pacing query result";
+  }
+
+  sleepUntilFailure();
+
+  handler->stopSession();
+
+  ASSERT_GE(handler->txFrames(), exactOffsets.size())
+      << "st40p_exact_user_pacing transmitted too few frames for offset coverage";
+  ASSERT_GE(handler->rxFrames(), exactOffsets.size())
+      << "st40p_exact_user_pacing received too few frames for offset coverage";
+  EXPECT_EQ(handler->txFrames(), handler->rxFrames())
+      << "st40p_exact_user_pacing TX/RX frame count mismatch";
+  ASSERT_GE(strategy->idx_tx, exactOffsets.size())
+      << "st40p_exact_user_pacing strategy TX frames below expectation";
+  ASSERT_GE(strategy->idx_rx, exactOffsets.size())
+      << "st40p_exact_user_pacing strategy RX frames below expectation";
+  EXPECT_EQ(strategy->idx_tx, strategy->idx_rx)
+      << "st40p_exact_user_pacing strategy TX/RX mismatch";
 }

--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -1182,6 +1182,14 @@ static int st_json_parse_tx_anc(int idx, json_object* anc_obj,
   ret = parse_url(anc_obj, "ancillary_url", anc->info.anc_url);
   if (ret < 0) return ret;
 
+  anc->user_pacing =
+      json_object_get_boolean(st_json_object_object_get(anc_obj, "user_pacing"));
+
+  anc->exact_user_pacing =
+      json_object_get_boolean(st_json_object_object_get(anc_obj, "exact_user_pacing"));
+
+  if (anc->exact_user_pacing) anc->user_pacing = true;
+
   /* parse enable rtcp */
   anc->enable_rtcp =
       json_object_get_boolean(st_json_object_object_get(anc_obj, "enable_rtcp"));

--- a/tests/tools/RxTxApp/src/parse_json.h
+++ b/tests/tools/RxTxApp/src/parse_json.h
@@ -249,6 +249,8 @@ typedef struct st_json_ancillary_session {
   st_json_session_base_t base;
   st_json_ancillary_info_t info;
 
+  bool user_pacing;
+  bool exact_user_pacing;
   bool enable_rtcp;
 } st_json_ancillary_session_t;
 

--- a/tests/tools/RxTxApp/src/tx_ancillary_app.c
+++ b/tests/tools/RxTxApp/src/tx_ancillary_app.c
@@ -479,6 +479,8 @@ static int app_tx_anc_init(struct st_app_context* ctx, st_json_ancillary_session
     else
       ops.rtp_ring_size = 16;
   }
+  if (anc && anc->user_pacing) ops.flags |= ST40_TX_FLAG_USER_PACING;
+  if (anc && anc->exact_user_pacing) ops.flags |= ST40_TX_FLAG_EXACT_USER_PACING;
   if (anc && anc->enable_rtcp) ops.flags |= ST40_TX_FLAG_ENABLE_RTCP;
   if (ctx->tx_anc_dedicate_queue) ops.flags |= ST40_TX_FLAG_DEDICATE_QUEUE;
 


### PR DESCRIPTION
The flag works the same as ST20_TX_FLAG_EXACT_USER_PACING:
It works together with ST40P_TX_FLAG_USER_PACING and makes the first packet of the
frame leave exactly at the user provided timestamp instead of aligning to epochs.

Other changes:
- Align ancillary pacing with how it is done in video session.
- Add exact user pacing noctx tests

Addresses: https://github.com/OpenVisualCloud/Media-Transport-Library/issues/1318