### PR TITLE
Test: Fix PF pci address in InterfaceSetup collecion list

### DIFF
--- a/tests/validation/common/nicctl.py
+++ b/tests/validation/common/nicctl.py
@@ -137,7 +137,7 @@ class InterfaceSetup:
                                 host.network_interfaces[i].pci_address.lspci
                             )
                             selected_interfaces[host.name].append(
-                                str(host.network_interfaces[i])
+                                str(host.network_interfaces[i].pci_address.lspci)
                             )
                             self.register_cleanup(
                                 self.nicctl_objs[host.name],


### PR DESCRIPTION
When PF interface type was choosen get_test_interfaces setup returned list of objects instead of strings.