### PR TITLE
Fix: eliminate false epoch drop reports on TX sessions

### DIFF
--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -278,14 +278,6 @@ static int tx_ancillary_session_init_pacing(struct st_tx_ancillary_session_impl*
   return 0;
 }
 
-static int tx_ancillary_session_init_pacing_epoch(
-    struct mtl_main_impl* impl, struct st_tx_ancillary_session_impl* s) {
-  uint64_t ptp_time = mt_get_ptp_time(impl, MTL_PORT_P);
-  struct st_tx_ancillary_session_pacing* pacing = &s->pacing;
-  pacing->cur_epochs = ptp_time / pacing->frame_time;
-  return 0;
-}
-
 static inline uint64_t tx_ancillary_pacing_time(
     struct st_tx_ancillary_session_pacing* pacing, uint64_t epochs) {
   return nextafter(epochs * pacing->frame_time, INFINITY);
@@ -344,7 +336,13 @@ static inline uint64_t tx_ancillary_calc_epoch(struct st_tx_ancillary_session_im
                                                uint64_t cur_tai, uint64_t required_tai) {
   struct st_tx_ancillary_session_pacing* pacing = &s->pacing;
   uint64_t current_epoch = cur_tai / pacing->frame_time;
-  uint64_t next_free_epoch = pacing->cur_epochs + 1;
+  /*
+   * cur_epochs is 0 before the first frame (zero-initialized struct).
+   * Real PTP-derived epochs are ~10^11, so 0 is a safe "uninitialized" sentinel.
+   * On first call, start from current_epoch to avoid a false epoch_drop.
+   */
+  uint64_t next_free_epoch =
+      likely(pacing->cur_epochs) ? pacing->cur_epochs + 1 : current_epoch;
   uint64_t epoch = next_free_epoch;
 
   if (required_tai) {
@@ -365,14 +363,16 @@ static inline uint64_t tx_ancillary_calc_epoch(struct st_tx_ancillary_session_im
   } else {
     dbg("%s(%d), frame is late, current_epoch %" PRIu64 " next_free_epoch %" PRIu64 "\n",
         __func__, s->idx, current_epoch, next_free_epoch);
-    ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
-                        (current_epoch - next_free_epoch));
-
-    if (s->ops.notify_frame_late) {
-      s->ops.notify_frame_late(s->ops.priv, current_epoch - next_free_epoch);
+    if (!required_tai) {
+      ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
+                          (current_epoch - next_free_epoch));
+      if (s->ops.notify_frame_late) {
+        s->ops.notify_frame_late(s->ops.priv, current_epoch - next_free_epoch);
+      }
+      epoch = current_epoch;
     }
-
-    epoch = current_epoch;
+    /* when required_tai is set, keep user-derived epoch — scheduler jitter
+     * does not mean the user dropped epochs */
   }
 
   return epoch;
@@ -445,22 +445,6 @@ static int tx_ancillary_session_init(struct st_tx_ancillary_sessions_mgr* mgr,
                                      struct st_tx_ancillary_session_impl* s, int idx) {
   MTL_MAY_UNUSED(mgr);
   s->idx = idx;
-  return 0;
-}
-
-static int tx_ancillary_sessions_tasklet_start(void* priv) {
-  struct st_tx_ancillary_sessions_mgr* mgr = priv;
-  struct mtl_main_impl* impl = mgr->parent;
-  struct st_tx_ancillary_session_impl* s;
-
-  for (int sidx = 0; sidx < mgr->max_idx; sidx++) {
-    s = tx_ancillary_session_get(mgr, sidx);
-    if (!s) continue;
-
-    tx_ancillary_session_init_pacing_epoch(impl, s);
-    tx_ancillary_session_put(mgr, sidx);
-  }
-
   return 0;
 }
 
@@ -1918,7 +1902,6 @@ static int tx_ancillary_sessions_mgr_init(struct mtl_main_impl* impl,
   memset(&ops, 0x0, sizeof(ops));
   ops.priv = mgr;
   ops.name = "tx_ancillary_sessions_mgr";
-  ops.start = tx_ancillary_sessions_tasklet_start;
   ops.handler = tx_ancillary_sessions_tasklet_handler;
 
   mgr->tasklet = mtl_sch_register_tasklet(sch, &ops);

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -219,14 +219,6 @@ static int tx_audio_session_init_pacing(struct st_tx_audio_session_impl* s) {
   return 0;
 }
 
-static int tx_audio_session_init_pacing_epoch(struct mtl_main_impl* impl,
-                                              struct st_tx_audio_session_impl* s) {
-  uint64_t ptp_time = mt_get_ptp_time(impl, MTL_PORT_P);
-  struct st_tx_audio_session_pacing* pacing = &s->pacing;
-  pacing->cur_epochs = ptp_time / pacing->trs;
-  return 0;
-}
-
 static inline double tx_audio_pacing_time(struct st_tx_audio_session_pacing* pacing,
                                           uint64_t epochs) {
   return epochs * pacing->trs;
@@ -268,7 +260,7 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
   long double pkt_time = pacing->trs;
   /* always use MTL_PORT_P for ptp now */
   uint64_t ptp_time = mt_get_ptp_time(impl, MTL_PORT_P);
-  uint64_t next_epochs = pacing->cur_epochs + 1;
+  uint64_t next_epochs;
   uint64_t epochs;
   double to_epoch;
   uint64_t ptp_epochs;
@@ -285,6 +277,13 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
   } else {
     epochs = ptp_time / pkt_time;
   }
+
+  /*
+   * cur_epochs is 0 before the first frame (zero-initialized struct).
+   * Real PTP-derived epochs are ~10^11, so 0 is a safe "uninitialized" sentinel.
+   * On first call, start from ptp-derived epoch to avoid a false epoch_drop.
+   */
+  next_epochs = likely(pacing->cur_epochs) ? pacing->cur_epochs + 1 : epochs;
 
   dbg("%s(%d), epochs %" PRIu64 " %" PRIu64 "\n", __func__, s->idx, epochs,
       pacing->cur_epochs);
@@ -325,8 +324,11 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
   }
 
   if (epochs > next_epochs) {
-    ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
-                        (epochs - next_epochs));
+    /* skip drop accounting when user controls pacing — epoch jumps are intentional */
+    if (!required_tai) {
+      ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
+                          (epochs - next_epochs));
+    }
   }
 
   if (epochs < next_epochs) {
@@ -392,22 +394,6 @@ static int tx_audio_session_init(struct st_tx_audio_sessions_mgr* mgr,
                                  struct st_tx_audio_session_impl* s, int idx) {
   MTL_MAY_UNUSED(mgr);
   s->idx = idx;
-  return 0;
-}
-
-static int tx_audio_sessions_tasklet_start(void* priv) {
-  struct st_tx_audio_sessions_mgr* mgr = priv;
-  struct mtl_main_impl* impl = mgr->parent;
-  struct st_tx_audio_session_impl* s;
-
-  for (int sidx = 0; sidx < mgr->max_idx; sidx++) {
-    s = tx_audio_session_get(mgr, sidx);
-    if (!s) continue;
-
-    tx_audio_session_init_pacing_epoch(impl, s);
-    tx_audio_session_put(mgr, sidx);
-  }
-
   return 0;
 }
 
@@ -2433,7 +2419,6 @@ static int tx_audio_sessions_mgr_init(struct mtl_main_impl* impl,
   memset(&ops, 0x0, sizeof(ops));
   ops.priv = mgr;
   ops.name = "tx_audio_sessions";
-  ops.start = tx_audio_sessions_tasklet_start;
   ops.handler = tx_audio_sessions_tasklet;
 
   mgr->tasklet = mtl_sch_register_tasklet(sch, &ops);

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -215,14 +215,6 @@ static int tx_fastmetadata_session_init_pacing(
   return 0;
 }
 
-static int tx_fastmetadata_session_init_pacing_epoch(
-    struct mtl_main_impl* impl, struct st_tx_fastmetadata_session_impl* s) {
-  uint64_t ptp_time = mt_get_ptp_time(impl, MTL_PORT_P);
-  struct st_tx_fastmetadata_session_pacing* pacing = &s->pacing;
-  pacing->cur_epochs = ptp_time / pacing->frame_time;
-  return 0;
-}
-
 static inline double tx_fastmetadata_pacing_time(
     struct st_tx_fastmetadata_session_pacing* pacing, uint64_t epochs) {
   return epochs * pacing->frame_time;
@@ -264,7 +256,7 @@ static int tx_fastmetadata_session_sync_pacing(struct mtl_main_impl* impl,
   double frame_time = pacing->frame_time;
   /* always use MTL_PORT_P for ptp now */
   uint64_t ptp_time = mt_get_ptp_time(impl, MTL_PORT_P);
-  uint64_t next_epochs = pacing->cur_epochs + 1;
+  uint64_t next_epochs;
   uint64_t epochs;
   double to_epoch;
   bool interlaced = s->ops.interlaced;
@@ -280,6 +272,13 @@ static int tx_fastmetadata_session_sync_pacing(struct mtl_main_impl* impl,
   } else {
     epochs = ptp_time / frame_time;
   }
+
+  /*
+   * cur_epochs is 0 before the first frame (zero-initialized struct).
+   * Real PTP-derived epochs are ~10^11, so 0 is a safe "uninitialized" sentinel.
+   * On first call, start from ptp-derived epoch to avoid a false epoch_drop.
+   */
+  next_epochs = likely(pacing->cur_epochs) ? pacing->cur_epochs + 1 : epochs;
 
   dbg("%s(%d), epochs %" PRIu64 " %" PRIu64 "\n", __func__, s->idx, epochs,
       pacing->cur_epochs);
@@ -306,7 +305,8 @@ static int tx_fastmetadata_session_sync_pacing(struct mtl_main_impl* impl,
     to_epoch = 0; /* send asap */
   }
 
-  if (epochs > next_epochs) s->stat_epoch_drop += (epochs - next_epochs);
+  /* skip drop accounting when user controls pacing — epoch jumps are intentional */
+  if (epochs > next_epochs && !required_tai) s->stat_epoch_drop += (epochs - next_epochs);
   if (epochs < next_epochs) {
     ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_onward,
                         (next_epochs - epochs));
@@ -352,22 +352,6 @@ static int tx_fastmetadata_session_init(struct st_tx_fastmetadata_sessions_mgr* 
                                         int idx) {
   MTL_MAY_UNUSED(mgr);
   s->idx = idx;
-  return 0;
-}
-
-static int tx_fastmetadata_sessions_tasklet_start(void* priv) {
-  struct st_tx_fastmetadata_sessions_mgr* mgr = priv;
-  struct mtl_main_impl* impl = mgr->parent;
-  struct st_tx_fastmetadata_session_impl* s;
-
-  for (int sidx = 0; sidx < mgr->max_idx; sidx++) {
-    s = tx_fastmetadata_session_get(mgr, sidx);
-    if (!s) continue;
-
-    tx_fastmetadata_session_init_pacing_epoch(impl, s);
-    tx_fastmetadata_session_put(mgr, sidx);
-  }
-
   return 0;
 }
 
@@ -1678,7 +1662,6 @@ static int tx_fastmetadata_sessions_mgr_init(
   memset(&ops, 0x0, sizeof(ops));
   ops.priv = mgr;
   ops.name = "tx_fastmetadata_sessions_mgr";
-  ops.start = tx_fastmetadata_sessions_tasklet_start;
   ops.handler = tx_fastmetadata_sessions_tasklet_handler;
 
   mgr->tasklet = mtl_sch_register_tasklet(sch, &ops);

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -604,14 +604,6 @@ static int tv_init_pacing(struct mtl_main_impl* impl,
   return 0;
 }
 
-static int tv_init_pacing_epoch(struct mtl_main_impl* impl,
-                                struct st_tx_video_session_impl* s) {
-  uint64_t ptp_time = mt_get_ptp_time(impl, MTL_PORT_P);
-  struct st_tx_video_pacing* pacing = &s->pacing;
-  pacing->cur_epochs = ptp_time / pacing->frame_time;
-  return 0;
-}
-
 static void validate_user_timestamp(struct st_tx_video_session_impl* s,
                                     uint64_t requested_frame_count,
                                     uint64_t current_frame_count) {
@@ -633,7 +625,13 @@ static inline uint64_t calc_frame_count_since_epoch(struct st_tx_video_session_i
                                                     uint64_t cur_tai,
                                                     uint64_t required_tai) {
   uint64_t frame_count_tai = cur_tai / s->pacing.frame_time;
-  uint64_t next_free_frame_slot = s->pacing.cur_epochs + 1;
+  /*
+   * cur_epochs is 0 before the first frame (zero-initialized struct).
+   * Real PTP-derived epochs are ~10^11, so 0 is a safe "uninitialized" sentinel.
+   * On first call, start from frame_count_tai to avoid a false epoch_drop.
+   */
+  uint64_t next_free_frame_slot =
+      likely(s->pacing.cur_epochs) ? s->pacing.cur_epochs + 1 : frame_count_tai;
   uint64_t frame_count;
 
   if (required_tai) {
@@ -661,14 +659,16 @@ static inline uint64_t calc_frame_count_since_epoch(struct st_tx_video_session_i
     dbg("%s(%d), frame is late, frame_count_tai %" PRIu64 " next_free_frame_slot %" PRIu64
         "\n",
         __func__, s->idx, frame_count_tai, next_free_frame_slot);
-    ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
-                        (frame_count_tai - next_free_frame_slot));
-
-    if (s->ops.notify_frame_late) {
-      s->ops.notify_frame_late(s->ops.priv, frame_count_tai - next_free_frame_slot);
+    if (!required_tai) {
+      ST_SESSION_STAT_ADD(s, port_user_stats.common, stat_epoch_drop,
+                          (frame_count_tai - next_free_frame_slot));
+      if (s->ops.notify_frame_late) {
+        s->ops.notify_frame_late(s->ops.priv, frame_count_tai - next_free_frame_slot);
+      }
+      frame_count = frame_count_tai;
     }
-
-    frame_count = frame_count_tai;
+    /* when required_tai is set, keep user-derived frame_count — scheduler jitter
+     * does not mean the user dropped epochs */
   }
 
   return frame_count;
@@ -1746,8 +1746,6 @@ static int tv_tasklet_start(void* priv) {
     for (int i = 0; i < s->ops.num_port; i++) {
       s->last_burst_succ_time_tsc[i] = mt_get_tsc(impl);
     }
-    /* calculate the pacing epoch */
-    tv_init_pacing_epoch(impl, s);
     tx_video_session_put(mgr, sidx);
   }
 
@@ -3359,7 +3357,6 @@ static int tv_attach(struct mtl_main_impl* impl, struct st_tx_video_sessions_mgr
     s->last_burst_succ_time_tsc[i] = mt_get_tsc(impl);
   }
 
-  tv_init_pacing_epoch(impl, s);
   s->active = true;
 
   info("%s(%d), len %d(%d) total %d each line %d type %d flags 0x%x, %s\n", __func__, idx,

--- a/tests/integration_tests/st20p_test.cpp
+++ b/tests/integration_tests/st20p_test.cpp
@@ -1842,3 +1842,96 @@ TEST(St20p, frame_is_late) {
 
   info("%s, st_frame_is_late tests passed\n", __func__);
 }
+
+#define EPOCH_DROP_TEST_UDP_PORT_ST20P (20100)
+
+static void st20p_tx_epoch_drop_test(bool user_pacing) {
+  auto ctx = (struct st_tests_context*)st_test_ctx();
+  auto st = ctx->handle;
+  int ret;
+  struct st20p_tx_ops ops_tx;
+
+  auto test_ctx = new tests_context();
+  ASSERT_TRUE(test_ctx != NULL);
+  test_ctx->idx = 0;
+  test_ctx->ctx = ctx;
+  test_ctx->fb_cnt = 3;
+
+  memset(&ops_tx, 0, sizeof(ops_tx));
+  ops_tx.name = "st20p_epoch_drop_test";
+  ops_tx.priv = test_ctx;
+  ops_tx.port.num_port = 1;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  snprintf(ops_tx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
+           ctx->para.port[MTL_PORT_P]);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = EPOCH_DROP_TEST_UDP_PORT_ST20P;
+  ops_tx.port.payload_type = 112;
+  ops_tx.width = 1920;
+  ops_tx.height = 1080;
+  ops_tx.fps = ST_FPS_P59_94;
+  ops_tx.input_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
+  ops_tx.transport_fmt = ST20_FMT_YUV_422_10BIT;
+  ops_tx.device = ST_PLUGIN_DEVICE_TEST;
+  ops_tx.framebuff_cnt = test_ctx->fb_cnt;
+  ops_tx.flags |= ST20P_TX_FLAG_BLOCK_GET;
+  if (user_pacing) {
+    ops_tx.flags |= ST20P_TX_FLAG_USER_PACING;
+    ops_tx.flags |= ST20P_TX_FLAG_USER_TIMESTAMP;
+  }
+
+  auto tx_handle = st20p_tx_create(st, &ops_tx);
+  ASSERT_TRUE(tx_handle != NULL);
+  ret = st20p_tx_set_block_timeout(tx_handle, NS_PER_S);
+  EXPECT_EQ(ret, 0);
+
+  test_ctx->handle = tx_handle;
+  test_ctx->stop = false;
+
+  ret = mtl_start(st);
+  EXPECT_GE(ret, 0);
+
+  auto tx_thread = std::thread(
+      [user_pacing](tests_context* s) {
+        auto handle = (st20p_tx_handle)s->handle;
+        auto st = s->ctx->handle;
+        while (!s->stop) {
+          auto frame = st20p_tx_get_frame(handle);
+          if (!frame) continue;
+          if (user_pacing) {
+            frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+            frame->timestamp = mtl_ptp_read_time(st) + 20 * 1000 * 1000; /* +20ms */
+          }
+          st20p_tx_put_frame(handle, frame);
+          s->fb_send++;
+        }
+      },
+      test_ctx);
+  sleep(5);
+
+  test_ctx->stop = true;
+  st20p_tx_wake_block(tx_handle);
+  tx_thread.join();
+
+  struct st20_tx_user_stats stats;
+  ret = st20p_tx_get_session_stats(tx_handle, &stats);
+  EXPECT_GE(ret, 0);
+  EXPECT_GT(test_ctx->fb_send, 0);
+  info("%s, user_pacing %d, fb_send %d, epoch_drop %" PRIu64 "\n", __func__, user_pacing,
+       test_ctx->fb_send, stats.common.stat_epoch_drop);
+  EXPECT_EQ(stats.common.stat_epoch_drop, 0);
+
+  ret = mtl_stop(st);
+  EXPECT_GE(ret, 0);
+  ret = st20p_tx_free(tx_handle);
+  EXPECT_GE(ret, 0);
+  delete test_ctx;
+}
+
+TEST(St20p, tx_no_epoch_drop) {
+  st20p_tx_epoch_drop_test(false);
+}
+
+TEST(St20p, tx_user_pacing_no_epoch_drop) {
+  st20p_tx_epoch_drop_test(true);
+}

--- a/tests/integration_tests/st30p_test.cpp
+++ b/tests/integration_tests/st30p_test.cpp
@@ -713,3 +713,95 @@ TEST(St30p, frame_is_late) {
 
   info("%s, st30_frame_is_late tests passed\n", __func__);
 }
+
+#define EPOCH_DROP_TEST_UDP_PORT_ST30P (50100)
+
+static void st30p_tx_epoch_drop_test(bool user_pacing) {
+  auto ctx = (struct st_tests_context*)st_test_ctx();
+  auto st = ctx->handle;
+  int ret;
+  struct st30p_tx_ops ops_tx;
+
+  auto test_ctx = new tests_context();
+  ASSERT_TRUE(test_ctx != NULL);
+  test_ctx->idx = 0;
+  test_ctx->ctx = ctx;
+  test_ctx->fb_cnt = 3;
+
+  memset(&ops_tx, 0, sizeof(ops_tx));
+  ops_tx.name = "st30p_epoch_drop_test";
+  ops_tx.priv = test_ctx;
+  ops_tx.port.num_port = 1;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  snprintf(ops_tx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
+           ctx->para.port[MTL_PORT_P]);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = EPOCH_DROP_TEST_UDP_PORT_ST30P;
+  ops_tx.port.payload_type = 111;
+  ops_tx.fmt = ST30_FMT_PCM24;
+  ops_tx.channel = 2;
+  ops_tx.sampling = ST30_SAMPLING_48K;
+  ops_tx.ptime = ST30_PTIME_1MS;
+  ops_tx.framebuff_size = st30_calculate_framebuff_size(
+      ops_tx.fmt, ops_tx.ptime, ops_tx.sampling, ops_tx.channel, 10 * NS_PER_MS, NULL);
+  ops_tx.framebuff_cnt = test_ctx->fb_cnt;
+  ops_tx.flags |= ST30P_TX_FLAG_BLOCK_GET;
+  if (user_pacing) {
+    ops_tx.flags |= ST30P_TX_FLAG_USER_PACING;
+  }
+
+  auto tx_handle = st30p_tx_create(st, &ops_tx);
+  ASSERT_TRUE(tx_handle != NULL);
+  ret = st30p_tx_set_block_timeout(tx_handle, NS_PER_S);
+  EXPECT_EQ(ret, 0);
+
+  test_ctx->handle = tx_handle;
+  test_ctx->stop = false;
+
+  ret = mtl_start(st);
+  EXPECT_GE(ret, 0);
+
+  auto tx_thread = std::thread(
+      [user_pacing](tests_context* s) {
+        auto handle = (st30p_tx_handle)s->handle;
+        auto st = s->ctx->handle;
+        while (!s->stop) {
+          auto frame = st30p_tx_get_frame(handle);
+          if (!frame) continue;
+          if (user_pacing) {
+            frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+            frame->timestamp = mtl_ptp_read_time(st) + 20 * 1000 * 1000; /* +20ms */
+          }
+          st30p_tx_put_frame(handle, frame);
+          s->fb_send++;
+        }
+      },
+      test_ctx);
+  sleep(5);
+
+  test_ctx->stop = true;
+  st30p_tx_wake_block(tx_handle);
+  tx_thread.join();
+
+  struct st30_tx_user_stats stats;
+  ret = st30p_tx_get_session_stats(tx_handle, &stats);
+  EXPECT_GE(ret, 0);
+  EXPECT_GT(test_ctx->fb_send, 0);
+  info("%s, user_pacing %d, fb_send %d, epoch_drop %" PRIu64 "\n", __func__, user_pacing,
+       test_ctx->fb_send, stats.common.stat_epoch_drop);
+  EXPECT_EQ(stats.common.stat_epoch_drop, 0);
+
+  ret = mtl_stop(st);
+  EXPECT_GE(ret, 0);
+  ret = st30p_tx_free(tx_handle);
+  EXPECT_GE(ret, 0);
+  delete test_ctx;
+}
+
+TEST(St30p, tx_no_epoch_drop) {
+  st30p_tx_epoch_drop_test(false);
+}
+
+TEST(St30p, tx_user_pacing_no_epoch_drop) {
+  st30p_tx_epoch_drop_test(true);
+}

--- a/tests/integration_tests/st40p_test.cpp
+++ b/tests/integration_tests/st40p_test.cpp
@@ -188,3 +188,99 @@ TEST(St40p, frame_is_late) {
 
   info("%s, st40_frame_is_late tests passed\n", __func__);
 }
+
+#define EPOCH_DROP_TEST_UDP_PORT (40100)
+
+static void st40p_tx_epoch_drop_test(bool user_pacing) {
+  auto ctx = (struct st_tests_context*)st_test_ctx();
+  auto st = ctx->handle;
+  int ret;
+  struct st40p_tx_ops ops_tx;
+
+  auto test_ctx = new tests_context();
+  ASSERT_TRUE(test_ctx != NULL);
+  test_ctx->idx = 0;
+  test_ctx->ctx = ctx;
+  test_ctx->fb_cnt = 3;
+
+  memset(&ops_tx, 0, sizeof(ops_tx));
+  ops_tx.name = "st40p_epoch_drop_test";
+  ops_tx.priv = test_ctx;
+  ops_tx.port.num_port = 1;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  snprintf(ops_tx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
+           ctx->para.port[MTL_PORT_P]);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = EPOCH_DROP_TEST_UDP_PORT;
+  ops_tx.port.payload_type = 113;
+  ops_tx.fps = ST_FPS_P59_94;
+  ops_tx.interlaced = false;
+  ops_tx.framebuff_cnt = test_ctx->fb_cnt;
+  ops_tx.max_udw_buff_size = 1024;
+  ops_tx.flags |= ST40P_TX_FLAG_BLOCK_GET;
+  if (user_pacing) {
+    ops_tx.flags |= ST40P_TX_FLAG_USER_PACING;
+    ops_tx.flags |= ST40P_TX_FLAG_USER_TIMESTAMP;
+  }
+
+  auto tx_handle = st40p_tx_create(st, &ops_tx);
+  ASSERT_TRUE(tx_handle != NULL);
+  ret = st40p_tx_set_block_timeout(tx_handle, NS_PER_S);
+  EXPECT_EQ(ret, 0);
+
+  test_ctx->handle = tx_handle;
+  test_ctx->stop = false;
+
+  ret = mtl_start(st);
+  EXPECT_GE(ret, 0);
+
+  auto tx_thread = std::thread(
+      [user_pacing](tests_context* s) {
+        auto handle = (st40p_tx_handle)s->handle;
+        auto st = s->ctx->handle;
+        while (!s->stop) {
+          auto frame_info = st40p_tx_get_frame(handle);
+          if (!frame_info) continue;
+          /* fill minimal ANC metadata */
+          frame_info->meta_num = 0;
+          frame_info->udw_buffer_fill = 0;
+          if (user_pacing) {
+            frame_info->tfmt = ST10_TIMESTAMP_FMT_TAI;
+            frame_info->timestamp = mtl_ptp_read_time(st) + 20 * 1000 * 1000; /* +20ms */
+          }
+          st40p_tx_put_frame(handle, frame_info);
+          s->fb_send++;
+        }
+      },
+      test_ctx);
+  sleep(5);
+
+  test_ctx->stop = true;
+  st40p_tx_wake_block(tx_handle);
+  tx_thread.join();
+
+  /* check stats before free */
+  struct st40_tx_user_stats stats;
+  ret = st40p_tx_get_session_stats(tx_handle, &stats);
+  EXPECT_GE(ret, 0);
+  EXPECT_GT(test_ctx->fb_send, 0);
+  info("%s, user_pacing %d, fb_send %d, epoch_drop %" PRIu64 ", epoch_mismatch %" PRIu64
+       "\n",
+       __func__, user_pacing, test_ctx->fb_send, stats.common.stat_epoch_drop,
+       stats.stat_epoch_mismatch);
+  EXPECT_EQ(stats.common.stat_epoch_drop, 0);
+
+  ret = mtl_stop(st);
+  EXPECT_GE(ret, 0);
+  ret = st40p_tx_free(tx_handle);
+  EXPECT_GE(ret, 0);
+  delete test_ctx;
+}
+
+TEST(St40p, tx_no_epoch_drop) {
+  st40p_tx_epoch_drop_test(false);
+}
+
+TEST(St40p, tx_user_pacing_no_epoch_drop) {
+  st40p_tx_epoch_drop_test(true);
+}

--- a/tests/tools/RxTxApp/src/rxtx_app.c
+++ b/tests/tools/RxTxApp/src/rxtx_app.c
@@ -478,6 +478,10 @@ int main(int argc, char** argv) {
       st_app_ctx_free(ctx);
       return -EIO;
     }
+    /* Initialize base_tai_time so frame threads start providing user timestamps.
+     * Before this, base_tai_time is 0 and frame threads skip user timestamps
+     * to avoid queuing stale-timestamped frames before the scheduler runs. */
+    ctx->user_time.base_tai_time = app_ptp_from_tai_time(ctx);
   }
 
   if (ctx->json_ctx->user_time_offset) {
@@ -617,6 +621,7 @@ int main(int argc, char** argv) {
       st_app_ctx_free(ctx);
       return -EIO;
     }
+    ctx->user_time.base_tai_time = app_ptp_from_tai_time(ctx);
   }
 
   test_time_s = ctx->test_time_s;

--- a/tests/tools/RxTxApp/src/tx_st20p_app.c
+++ b/tests/tools/RxTxApp/src/tx_st20p_app.c
@@ -93,8 +93,9 @@ static void* app_tx_st20p_frame_thread(void* arg) {
       frame->user_meta_size = sizeof(shas);
     }
 
-    if (s->user_time) {
-      bool restart_base_time = !s->local_tai_base_time;
+    if (s->user_time && s->user_time->base_tai_time) {
+      bool restart_base_time = (s->local_tai_base_time != s->user_time->base_tai_time);
+      if (restart_base_time) s->frame_num = 0;
       frame->timestamp = st_app_user_time(s->ctx, s->user_time, s->frame_num, frame_time,
                                           restart_base_time);
       frame->tfmt = ST10_TIMESTAMP_FMT_TAI;

--- a/tests/tools/RxTxApp/src/tx_st30p_app.c
+++ b/tests/tools/RxTxApp/src/tx_st30p_app.c
@@ -36,8 +36,9 @@ static void* app_tx_st30p_frame_thread(void* arg) {
     }
     app_tx_st30p_build_frame(s, frame, s->st30p_frame_size);
 
-    if (s->user_time) {
-      bool restart_base_time = !s->local_tai_base_time;
+    if (s->user_time && s->user_time->base_tai_time) {
+      bool restart_base_time = (s->local_tai_base_time != s->user_time->base_tai_time);
+      if (restart_base_time) s->frame_num = 0;
 
       frame->timestamp = st_app_user_time(s->ctx, s->user_time, s->frame_num, frame_time,
                                           restart_base_time);

--- a/tests/tools/RxTxApp/src/tx_st40p_app.c
+++ b/tests/tools/RxTxApp/src/tx_st40p_app.c
@@ -137,8 +137,9 @@ static void* app_tx_st40p_frame_thread(void* arg) {
 
     app_tx_st40p_fill_payload(s, frame_info);
 
-    if (s->user_time && s->frame_time > 0) {
-      bool restart_base_time = !s->local_tai_base_time;
+    if (s->user_time && s->frame_time > 0 && s->user_time->base_tai_time) {
+      bool restart_base_time = (s->local_tai_base_time != s->user_time->base_tai_time);
+      if (restart_base_time) s->frame_num = 0;
       frame_info->timestamp = st_app_user_time(s->ctx, s->user_time, s->frame_num,
                                                s->frame_time, restart_base_time);
       frame_info->tfmt = ST10_TIMESTAMP_FMT_TAI;


### PR DESCRIPTION
Problem: TX sessions (st20/st30/st40/st41) falsely reported epoch drops in two scenarios:

First frame after session creation pacing state was uninitialized (stale zero values vs PTP time ~10^11)
User-pacing mode library compared current PTP wall-clock against the next free slot, penalizing scheduler jitter as dropped epochs even though the user's timestamp was valid
Fix:

Use cur_epochs == 0 as uninitialized sentinel; on first frame, start from current PTP epoch
When required_tai is set (user controls pacing), skip epoch drop accounting — video/ancillary keep user-derived frame_count, audio/fastmetadata skip the epochs > next_epochs counter
In RxTxApp, initialize base_tai_time from PTP after [mtl_start()](vscode-file://vscode-app/c:/Users/mkasiewi/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so frame threads don't stamp frames before the scheduler is running
Tests: Added TX-only epoch drop tests for st20p, st30p, st40p  both with and without user_pacing (6 tests total, all pass with 0 drops).

Fixes #1378