### PR TITLE
Fix: prevent use-after-free in st20p TX zero-copy and frame_done

### DIFF
--- a/app/sample/ext_frame/tx_st20_pipeline_ext_frame_sample.c
+++ b/app/sample/ext_frame/tx_st20_pipeline_ext_frame_sample.c
@@ -237,6 +237,7 @@ int main(int argc, char** argv) {
     ops_tx.notify_frame_available = tx_st20p_frame_available;
     ops_tx.notify_frame_done = tx_st20p_frame_done;
     ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
+    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
 
     st20p_tx_handle tx_handle = st20p_tx_create(ctx.st, &ops_tx);
     if (!tx_handle) {

--- a/app/sample/ext_frame/tx_st20_pipeline_ext_frame_sample.c
+++ b/app/sample/ext_frame/tx_st20_pipeline_ext_frame_sample.c
@@ -123,8 +123,9 @@ static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
   /* free or return the ext memory here if necessary */
   /* then clear the frame buffer */
 
-  /* release the frame slot back to the pipeline */
-  st20p_tx_notify_ext_frame_done(s->handle, frame);
+  /* Required only when ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE is set:
+   * release the frame slot back to the pipeline so it can be reused. */
+  st20p_tx_notify_ext_frame_free(s->handle, frame);
 
   return 0;
 }
@@ -237,7 +238,7 @@ int main(int argc, char** argv) {
     ops_tx.notify_frame_available = tx_st20p_frame_available;
     ops_tx.notify_frame_done = tx_st20p_frame_done;
     ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
-    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
 
     st20p_tx_handle tx_handle = st20p_tx_create(ctx.st, &ops_tx);
     if (!tx_handle) {

--- a/app/sample/ext_frame/tx_st20_pipeline_ext_frame_sample.c
+++ b/app/sample/ext_frame/tx_st20_pipeline_ext_frame_sample.c
@@ -118,11 +118,13 @@ static int tx_st20p_frame_available(void* priv) {
 }
 
 static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
-  MTL_MAY_UNUSED(priv);
-  MTL_MAY_UNUSED(frame);
+  struct tx_st20p_sample_ctx* s = priv;
 
   /* free or return the ext memory here if necessary */
   /* then clear the frame buffer */
+
+  /* release the frame slot back to the pipeline */
+  st20p_tx_notify_ext_frame_done(s->handle, frame);
 
   return 0;
 }

--- a/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
@@ -310,6 +310,7 @@ int main(int argc, char** argv) {
   if (app.zero_copy) {
     ops_tx.notify_frame_done = tx_st20p_frame_done;
     ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
+    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
   }
 
   st20p_tx_handle tx_handle = st20p_tx_create(ctx.st, &ops_tx);

--- a/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
@@ -103,9 +103,11 @@ static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
   struct st_frame* rx_frame = rx_st20p_dequeue_frame(s);
   if (frame->addr[0] != rx_frame->addr[0]) {
     err("%s, frame ooo, should not happen!\n", __func__);
+    st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
     return -EIO;
   }
   st20p_rx_put_frame(rx_handle, rx_frame);
+  st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
   return 0;
 }
 

--- a/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
+++ b/app/sample/fwd/rx_st20p_tx_st20p_fwd.c
@@ -103,11 +103,11 @@ static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
   struct st_frame* rx_frame = rx_st20p_dequeue_frame(s);
   if (frame->addr[0] != rx_frame->addr[0]) {
     err("%s, frame ooo, should not happen!\n", __func__);
-    st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
+    st20p_tx_notify_ext_frame_free(s->tx_handle, frame);
     return -EIO;
   }
   st20p_rx_put_frame(rx_handle, rx_frame);
-  st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
+  st20p_tx_notify_ext_frame_free(s->tx_handle, frame);
   return 0;
 }
 
@@ -310,7 +310,7 @@ int main(int argc, char** argv) {
   if (app.zero_copy) {
     ops_tx.notify_frame_done = tx_st20p_frame_done;
     ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
-    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
   }
 
   st20p_tx_handle tx_handle = st20p_tx_create(ctx.st, &ops_tx);

--- a/doc/design.md
+++ b/doc/design.md
@@ -302,7 +302,7 @@ There are 3 different types of API between MTL and application:
 MTL orchestrates the packet processing from the frame level to L2 network packets and vice versa, with the frame buffer serving as the interface for video context exchange between MTL and the application.
 
 For transmission, the MTL TX session will get the index of the next available frame buffer via the `get_next_frame` callback function. Once transmission of the entire frame to the network is complete, the application will be notified through the `notify_frame_done` callback.
-It is crucial for the application to manage the lifecycle of the frame buffers, ensuring that no modifications are made to a frame while it is in the midst of being transmitted.
+It is crucial for the application to manage the lifecycle of the frame buffers, ensuring that no modifications are made to a frame while it is in the midst of being transmitted. For pipeline TX sessions using external frames, see section 6.9 for additional lifecycle requirements.
 
 For reception, the MTL RX session will process packets received from the network. Once a complete frame is assembled, the application will be alerted via the `notify_frame_ready` callback. However, it is important to note that the application must return the frame to MTL using the `st**_rx_put_framebuff` function after video frame processing is complete.
 
@@ -471,6 +471,8 @@ For more details, please refer to [RTCP doc](rtcp.md).
 
 By default, the frame buffer is allocated by MTL using huge page memory, however, some advanced use cases may require managing the frame buffers themselves — especially applications that utilize GPU-based memory for additional video frame processing. MTL offers an external frame mode, allowing applications to supply frame information at runtime for increased flexibility.
 MTL TX and RX will interact with the NIC using these user-defined frames directly. It is the application's responsibility to manage the frame lifecycle because MTL only recognizes the frame address.
+For st20p TX external frames, after transmission completes the library parks the frame in an intermediate state and notifies the application via the `notify_frame_done` callback. The application must free its resources and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library.
+This two-phase release prevents the library from reusing the frame slot while the application still holds references to the external memory.
 Additionally, it's important to note that if a DPDK-based PMD backend is utilized, the external frame must provide an IOVA address, which can be conveniently obtained using the `mtl_dma_map` API, thanks to IOMMU/VFIO support.
 
 For more comprehensive information and instructions on using these converters, please refer to the [External Frame API Guide](external_frame.md).

--- a/doc/design.md
+++ b/doc/design.md
@@ -12,7 +12,7 @@ Similar to other network processing libraries, it consists of a control plane an
 
 MTL default uses busy polling, also known as busy-waiting or spinning, to achieve high data packet throughput and low latency. This technique constantly checks for new data packets to process rather than waiting for an interrupt. The polling thread is pinned to a single CPU core to prevent the thread from migrating between CPU cores.
 
-Busy polling allows t he application to detect and process packets as soon as they arrive, minimizing latency. It provides consistent and predictable packet processing times because there's no waiting time introduced by other scheduling mechanisms. It also avoids context switches between the kernel and user space, which can be costly in terms of CPU cycles.
+Busy polling allows the application to detect and process packets as soon as they arrive, minimizing latency. It provides consistent and predictable packet processing times because there's no waiting time introduced by other scheduling mechanisms. It also avoids context switches between the kernel and user space, which can be costly in terms of CPU cycles.
 
 The drawbacks is it can lead to 100% CPU usage because the cores are always active, checking for new work.
 
@@ -471,8 +471,8 @@ For more details, please refer to [RTCP doc](rtcp.md).
 
 By default, the frame buffer is allocated by MTL using huge page memory, however, some advanced use cases may require managing the frame buffers themselves — especially applications that utilize GPU-based memory for additional video frame processing. MTL offers an external frame mode, allowing applications to supply frame information at runtime for increased flexibility.
 MTL TX and RX will interact with the NIC using these user-defined frames directly. It is the application's responsibility to manage the frame lifecycle because MTL only recognizes the frame address.
-For st20p TX external frames, an optional two-phase release mode is available via `ST20P_TX_FLAG_EXT_FRAME_USER_DONE`.
-When enabled, after transmission completes the library parks the frame in an intermediate state and notifies the application via the `notify_frame_done` callback. The application must free its resources and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library.
+For st20p TX external frames, an optional two-phase release mode is available via `ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE`.
+When enabled, after transmission completes the library parks the frame in an intermediate state and notifies the application via the `notify_frame_done` callback. The application must free its resources and then call `st20p_tx_notify_ext_frame_free` to release the frame buffer back to the library.
 This two-phase release prevents the library from reusing the frame slot while the application still holds references to the external memory. Without this flag, the legacy behavior is preserved and the frame slot is released immediately.
 Additionally, it's important to note that if a DPDK-based PMD backend is utilized, the external frame must provide an IOVA address, which can be conveniently obtained using the `mtl_dma_map` API, thanks to IOMMU/VFIO support.
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -12,7 +12,7 @@ Similar to other network processing libraries, it consists of a control plane an
 
 MTL default uses busy polling, also known as busy-waiting or spinning, to achieve high data packet throughput and low latency. This technique constantly checks for new data packets to process rather than waiting for an interrupt. The polling thread is pinned to a single CPU core to prevent the thread from migrating between CPU cores.
 
-Busy polling allows the application to detect and process packets as soon as they arrive, minimizing latency. It provides consistent and predictable packet processing times because there's no waiting time introduced by other scheduling mechanisms. It also avoids context switches between the kernel and user space, which can be costly in terms of CPU cycles.
+Busy polling allows t he application to detect and process packets as soon as they arrive, minimizing latency. It provides consistent and predictable packet processing times because there's no waiting time introduced by other scheduling mechanisms. It also avoids context switches between the kernel and user space, which can be costly in terms of CPU cycles.
 
 The drawbacks is it can lead to 100% CPU usage because the cores are always active, checking for new work.
 
@@ -471,8 +471,9 @@ For more details, please refer to [RTCP doc](rtcp.md).
 
 By default, the frame buffer is allocated by MTL using huge page memory, however, some advanced use cases may require managing the frame buffers themselves — especially applications that utilize GPU-based memory for additional video frame processing. MTL offers an external frame mode, allowing applications to supply frame information at runtime for increased flexibility.
 MTL TX and RX will interact with the NIC using these user-defined frames directly. It is the application's responsibility to manage the frame lifecycle because MTL only recognizes the frame address.
-For st20p TX external frames, after transmission completes the library parks the frame in an intermediate state and notifies the application via the `notify_frame_done` callback. The application must free its resources and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library.
-This two-phase release prevents the library from reusing the frame slot while the application still holds references to the external memory.
+For st20p TX external frames, an optional two-phase release mode is available via `ST20P_TX_FLAG_EXT_FRAME_USER_DONE`.
+When enabled, after transmission completes the library parks the frame in an intermediate state and notifies the application via the `notify_frame_done` callback. The application must free its resources and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library.
+This two-phase release prevents the library from reusing the frame slot while the application still holds references to the external memory. Without this flag, the legacy behavior is preserved and the frame slot is released immediately.
 Additionally, it's important to note that if a DPDK-based PMD backend is utilized, the external frame must provide an IOVA address, which can be conveniently obtained using the `mtl_dma_map` API, thanks to IOMMU/VFIO support.
 
 For more comprehensive information and instructions on using these converters, please refer to the [External Frame API Guide](external_frame.md).

--- a/doc/external_frame.md
+++ b/doc/external_frame.md
@@ -40,10 +40,10 @@ ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
 Optionally, to enable the two-phase external frame release (where the application explicitly releases the frame slot after cleanup), also set:
 
 ```c
-ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
 ```
 
-Without `ST20P_TX_FLAG_EXT_FRAME_USER_DONE`, the frame slot is released immediately after `notify_frame_done` (legacy behavior).
+Without `ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE`, the frame slot is released immediately after `notify_frame_done` (legacy behavior).
 
 when sending a frame, get the frame and put with ext_frame info
 
@@ -61,12 +61,12 @@ ext_frame.opaque = your_frame_handle;
 st20p_tx_put_ext_frame(tx_handle, frame, &ext_frame);
 ```
 
-when the library finished transmitting the frame, it will notify by callback. When `ST20P_TX_FLAG_EXT_FRAME_USER_DONE` is set, free your resources in the callback and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library. This two-phase release ensures the application can safely clean up external memory before the library reuses the frame slot.
+when the library finished transmitting the frame, it will notify by callback. When `ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE` is set, free your resources in the callback and then call `st20p_tx_notify_ext_frame_free` to release the frame buffer back to the library. This two-phase release ensures the application can safely clean up external memory before the library reuses the frame slot.
 
-**Important:** The `notify_frame_done` callback is invoked from the library's internal tasklet — the same critical path that drives packet transmission and frame scheduling. When `ST20P_TX_FLAG_EXT_FRAME_USER_DONE` is enabled, the frame buffer remains occupied (not returned to the free pool) until `st20p_tx_notify_ext_frame_done` is called.
+**Important:** The `notify_frame_done` callback is invoked from the library's internal tasklet — the same critical path that drives packet transmission and frame scheduling. When `ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE` is enabled, the frame buffer remains occupied (not returned to the free pool) until `st20p_tx_notify_ext_frame_free` is called.
 With short frame queues this can stall the pipeline if cleanup takes too long.
 
-For production use, the recommended pattern is to **signal** a separate application thread from the callback and perform the actual resource cleanup and `st20p_tx_notify_ext_frame_done` call from that thread:
+For production use, the recommended pattern is to **signal** a separate application thread from the callback and perform the actual resource cleanup and `st20p_tx_notify_ext_frame_free` call from that thread:
 
 ```c
 // set the callback and priv in ops
@@ -91,7 +91,7 @@ static void* cleanup_thread(void* arg) {
         while ((frame = dequeue(&s->done_queue))) {
             your_frame_handle = frame->opaque;
             your_frame_free(your_frame_handle);
-            st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
+            st20p_tx_notify_ext_frame_free(s->tx_handle, frame);
         }
     }
     return NULL;
@@ -105,12 +105,12 @@ static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
     ctx* s = priv;
     your_frame_handle = frame->opaque;
     your_frame_free(your_frame_handle);
-    st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
+    st20p_tx_notify_ext_frame_free(s->tx_handle, frame);
     return 0;
 }
 ```
 
-Note: `st20p_tx_notify_ext_frame_done` is safe to call unconditionally — when the library uses an internal converter (input format differs from transport format), the frame buffer is already released before the callback, and the call is a silent no-op.
+Note: `st20p_tx_notify_ext_frame_free` is safe to call unconditionally — when the library uses an internal converter (input format differs from transport format), the frame buffer is already released before the callback, and the call is a silent no-op.
 
 Others follow the general API flow.
 

--- a/doc/external_frame.md
+++ b/doc/external_frame.md
@@ -53,20 +53,55 @@ ext_frame.opaque = your_frame_handle;
 st20p_tx_put_ext_frame(tx_handle, frame, &ext_frame);
 ```
 
-when the library finished handling the frame, it will notify by callback, you can return the frame buffer here
+when the library finished transmitting the frame, it will notify by callback. In the callback, free your resources and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library. This two-phase release ensures the application can safely clean up external memory before the library reuses the frame slot.
+
+**Important:** The `notify_frame_done` callback is invoked from the library's internal tasklet — the same critical path that drives packet transmission and frame scheduling. The frame buffer remains occupied (not returned to the free pool) until `st20p_tx_notify_ext_frame_done` is called. With short frame queues this can stall the pipeline if cleanup takes too long.
+
+For production use, the recommended pattern is to **signal** a separate application thread from the callback and perform the actual resource cleanup and `st20p_tx_notify_ext_frame_done` call from that thread:
 
 ```c
-// set the callback in ops
+// set the callback and priv in ops
 ops_tx.notify_frame_done = tx_st20p_frame_done;
+ops_tx.priv = your_ctx;
 // ...
-// implement the callback
-static int tx_st20p_frame_done(void* priv, struct st_frame*frame) {
+// callback — runs on the library critical path, keep it minimal
+static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
+    ctx* s = priv;
+    /* enqueue the done frame and wake the cleanup thread */
+    enqueue(&s->done_queue, frame);
+    signal(&s->done_signal);
+    return 0;
+}
+
+// cleanup thread — runs outside the library critical path
+static void* cleanup_thread(void* arg) {
+    ctx* s = arg;
+    while (s->running) {
+        wait(&s->done_signal);
+        struct st_frame* frame;
+        while ((frame = dequeue(&s->done_queue))) {
+            your_frame_handle = frame->opaque;
+            your_frame_free(your_frame_handle);
+            st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
+        }
+    }
+    return NULL;
+}
+```
+
+For simple cases where cleanup is trivial (e.g. decrementing a refcount), calling directly from the callback is acceptable:
+
+```c
+static int tx_st20p_frame_done(void* priv, struct st_frame* frame) {
     ctx* s = priv;
     your_frame_handle = frame->opaque;
     your_frame_free(your_frame_handle);
+    st20p_tx_notify_ext_frame_done(s->tx_handle, frame);
     return 0;
 }
 ```
+
+Note: `st20p_tx_notify_ext_frame_done` is safe to call unconditionally — when the library uses an internal converter (input format differs from transport format), the frame buffer is already released before the callback, and the call is a silent no-op.
 
 Others follow the general API flow.
 

--- a/doc/external_frame.md
+++ b/doc/external_frame.md
@@ -37,6 +37,14 @@ in ops, set the flag
 ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
 ```
 
+Optionally, to enable the two-phase external frame release (where the application explicitly releases the frame slot after cleanup), also set:
+
+```c
+ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+```
+
+Without `ST20P_TX_FLAG_EXT_FRAME_USER_DONE`, the frame slot is released immediately after `notify_frame_done` (legacy behavior).
+
 when sending a frame, get the frame and put with ext_frame info
 
 ```c
@@ -53,9 +61,10 @@ ext_frame.opaque = your_frame_handle;
 st20p_tx_put_ext_frame(tx_handle, frame, &ext_frame);
 ```
 
-when the library finished transmitting the frame, it will notify by callback. In the callback, free your resources and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library. This two-phase release ensures the application can safely clean up external memory before the library reuses the frame slot.
+when the library finished transmitting the frame, it will notify by callback. When `ST20P_TX_FLAG_EXT_FRAME_USER_DONE` is set, free your resources in the callback and then call `st20p_tx_notify_ext_frame_done` to release the frame buffer back to the library. This two-phase release ensures the application can safely clean up external memory before the library reuses the frame slot.
 
-**Important:** The `notify_frame_done` callback is invoked from the library's internal tasklet — the same critical path that drives packet transmission and frame scheduling. The frame buffer remains occupied (not returned to the free pool) until `st20p_tx_notify_ext_frame_done` is called. With short frame queues this can stall the pipeline if cleanup takes too long.
+**Important:** The `notify_frame_done` callback is invoked from the library's internal tasklet — the same critical path that drives packet transmission and frame scheduling. When `ST20P_TX_FLAG_EXT_FRAME_USER_DONE` is enabled, the frame buffer remains occupied (not returned to the free pool) until `st20p_tx_notify_ext_frame_done` is called.
+With short frame queues this can stall the pipeline if cleanup takes too long.
 
 For production use, the recommended pattern is to **signal** a separate application thread from the callback and perform the actual resource cleanup and `st20p_tx_notify_ext_frame_done` call from that thread:
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -115,6 +115,7 @@ typedef struct {
   GstSt20pTxExternalDataParent* parent;
   GstMemory* gst_buffer_memory;
   GstMapInfo map_info;
+  gint cleaned_up;
 } GstSt20pTxExternalDataChild;
 
 /* pad template */
@@ -544,9 +545,33 @@ GST_PLUGIN_DEFINE(GST_VERSION_MAJOR, GST_VERSION_MINOR, mtl_st20p_tx,
 
 static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
   GstSt20pTxExternalDataChild* child = frame->opaque;
+
+  if (!child) {
+    GST_WARNING("frame_done called with NULL opaque (frame %p)", frame);
+    return -1;
+  }
+
+  /* Atomically guard against double invocation from DPDK lcore */
+  if (!g_atomic_int_compare_and_exchange(&child->cleaned_up, FALSE, TRUE)) {
+    GST_ERROR("frame_done: double cleanup detected (frame %p, child %p)",
+              frame, child);
+    return -1;
+  }
+
+  frame->opaque = NULL;
+
   GstSt20pTxExternalDataParent* parent = child->parent;
 
-  gst_memory_unmap(child->gst_buffer_memory, &child->map_info);
+  GST_LOG("frame_done: unmapping child %p, mem %p",
+          child, child->gst_buffer_memory);
+
+  if (child->gst_buffer_memory) {
+    gst_memory_unmap(child->gst_buffer_memory, &child->map_info);
+    child->gst_buffer_memory = NULL;
+  } else {
+    GST_ERROR("frame_done: gst_buffer_memory already NULL (child %p)", child);
+  }
+
   free(child);
 
   pthread_mutex_lock(&parent->parent_mutex);
@@ -587,6 +612,7 @@ static GstFlowReturn gst_mtl_st20p_tx_zero_copy(Gst_Mtl_St20p_Tx* sink, GstBuffe
       GST_ERROR("Failed to allocate memory for child structure");
       free(parent);
     }
+    memset(child, 0, sizeof(GstSt20pTxExternalDataChild));
     child->parent = parent;
     child->gst_buffer_memory = gst_buffer_peek_memory(buf, i);
 

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -371,6 +371,7 @@ static gboolean gst_mtl_st20p_tx_session_create(Gst_Mtl_St20p_Tx* sink, GstCaps*
   sink->zero_copy = (ops_tx.transport_fmt != st_frame_fmt_to_transport(ops_tx.input_fmt));
   if (sink->zero_copy) {
     ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
+    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
     ops_tx.notify_frame_done = gst_mtl_st20p_tx_frame_done;
     ops_tx.priv = sink;
   } else {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -553,8 +553,7 @@ static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
 
   /* Atomically guard against double invocation from DPDK lcore */
   if (!g_atomic_int_compare_and_exchange(&child->cleaned_up, FALSE, TRUE)) {
-    GST_ERROR("frame_done: double cleanup detected (frame %p, child %p)",
-              frame, child);
+    GST_ERROR("frame_done: double cleanup detected (frame %p, child %p)", frame, child);
     return -1;
   }
 
@@ -562,8 +561,7 @@ static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
 
   GstSt20pTxExternalDataParent* parent = child->parent;
 
-  GST_LOG("frame_done: unmapping child %p, mem %p",
-          child, child->gst_buffer_memory);
+  GST_LOG("frame_done: unmapping child %p, mem %p", child, child->gst_buffer_memory);
 
   if (child->gst_buffer_memory) {
     gst_memory_unmap(child->gst_buffer_memory, &child->map_info);

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -371,7 +371,7 @@ static gboolean gst_mtl_st20p_tx_session_create(Gst_Mtl_St20p_Tx* sink, GstCaps*
   sink->zero_copy = (ops_tx.transport_fmt != st_frame_fmt_to_transport(ops_tx.input_fmt));
   if (sink->zero_copy) {
     ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
-    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+    ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
     ops_tx.notify_frame_done = gst_mtl_st20p_tx_frame_done;
     ops_tx.priv = sink;
   } else {
@@ -551,14 +551,14 @@ static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
 
   if (!child) {
     GST_WARNING("frame_done called with NULL opaque (frame %p)", frame);
-    st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
+    st20p_tx_notify_ext_frame_free(sink->tx_handle, frame);
     return -1;
   }
 
   /* Atomically guard against double invocation from DPDK lcore */
   if (!g_atomic_int_compare_and_exchange(&child->cleaned_up, FALSE, TRUE)) {
     GST_ERROR("frame_done: double cleanup detected (frame %p, child %p)", frame, child);
-    st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
+    st20p_tx_notify_ext_frame_free(sink->tx_handle, frame);
     return -1;
   }
 
@@ -582,7 +582,7 @@ static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
   if (parent->child_count > 0) {
     pthread_mutex_unlock(&parent->parent_mutex);
     /* Not the last child - release this frame slot but keep the GstBuffer alive */
-    st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
+    st20p_tx_notify_ext_frame_free(sink->tx_handle, frame);
     return 0;
   }
 
@@ -592,7 +592,7 @@ static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
   free(parent);
 
   /* Last child done - release the frame slot */
-  st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
+  st20p_tx_notify_ext_frame_free(sink->tx_handle, frame);
 
   return 0;
 }

--- a/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st20p_tx.c
@@ -372,6 +372,7 @@ static gboolean gst_mtl_st20p_tx_session_create(Gst_Mtl_St20p_Tx* sink, GstCaps*
   if (sink->zero_copy) {
     ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
     ops_tx.notify_frame_done = gst_mtl_st20p_tx_frame_done;
+    ops_tx.priv = sink;
   } else {
     GST_WARNING("Using memcpy path");
   }
@@ -544,16 +545,19 @@ GST_PLUGIN_DEFINE(GST_VERSION_MAJOR, GST_VERSION_MINOR, mtl_st20p_tx,
                   GST_PACKAGE_ORIGIN)
 
 static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
+  Gst_Mtl_St20p_Tx* sink = (Gst_Mtl_St20p_Tx*)priv;
   GstSt20pTxExternalDataChild* child = frame->opaque;
 
   if (!child) {
     GST_WARNING("frame_done called with NULL opaque (frame %p)", frame);
+    st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
     return -1;
   }
 
   /* Atomically guard against double invocation from DPDK lcore */
   if (!g_atomic_int_compare_and_exchange(&child->cleaned_up, FALSE, TRUE)) {
     GST_ERROR("frame_done: double cleanup detected (frame %p, child %p)", frame, child);
+    st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
     return -1;
   }
 
@@ -576,6 +580,8 @@ static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
   parent->child_count--;
   if (parent->child_count > 0) {
     pthread_mutex_unlock(&parent->parent_mutex);
+    /* Not the last child - release this frame slot but keep the GstBuffer alive */
+    st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
     return 0;
   }
 
@@ -583,6 +589,9 @@ static int gst_mtl_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
   gst_buffer_unref(parent->buf);
   pthread_mutex_destroy(&parent->parent_mutex);
   free(parent);
+
+  /* Last child done - release the frame slot */
+  st20p_tx_notify_ext_frame_done(sink->tx_handle, frame);
 
   return 0;
 }

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -493,11 +493,11 @@ enum st20p_tx_flag {
    * Enable two-phase external frame release for EXT_FRAME mode.
    * When set together with ST20P_TX_FLAG_EXT_FRAME, the library parks the frame
    * in an intermediate state after notify_frame_done; the application must call
-   * st20p_tx_notify_ext_frame_done() to release the slot back to the free pool.
+   * st20p_tx_notify_ext_frame_free() to release the slot back to the free pool.
    * Without this flag the legacy behavior is preserved (frame goes to FREE
    * immediately after notify_frame_done).
    */
-  ST20P_TX_FLAG_EXT_FRAME_USER_DONE = (MTL_BIT32(13)),
+  ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE = (MTL_BIT32(13)),
   /** Enable the st20p_tx_get_frame block behavior to wait until a frame becomes
      available or (default: 1s, use st20p_tx_set_block_timeout to customize) */
   ST20P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
@@ -1816,11 +1816,11 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
  * Notify the tx st2110-20 pipeline session that the application has finished
  * processing an external frame previously signalled via notify_frame_done.
  *
- * Only effective when ST20P_TX_FLAG_EXT_FRAME_USER_DONE is set.
+ * Only effective when ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE is set.
  * In that mode, after notify_frame_done fires, the frame slot is held in
  * IN_USER state so the application can safely unmap / release external buffers.
  * Call this function once cleanup is complete to release the slot back to FREE.
- * When ST20P_TX_FLAG_EXT_FRAME_USER_DONE is not set this is a silent no-op.
+ * When ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE is not set this is a silent no-op.
  *
  * @param handle
  *   The handle to the tx st2110-20 pipeline session.
@@ -1830,7 +1830,7 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
  *   - 0 if successful.
  *   - <0: Error code if the frame is not in IN_USER state.
  */
-int st20p_tx_notify_ext_frame_done(st20p_tx_handle handle, struct st_frame* frame);
+int st20p_tx_notify_ext_frame_free(st20p_tx_handle handle, struct st_frame* frame);
 
 /**
  * Get the framebuffer pointer from the tx st2110-20 pipeline session.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -489,6 +489,15 @@ enum st20p_tx_flag {
   ST20P_TX_FLAG_DISABLE_BULK = (MTL_BIT32(10)),
   /** Force the numa of the created session, both CPU and memory */
   ST20P_TX_FLAG_FORCE_NUMA = (MTL_BIT32(11)),
+  /**
+   * Enable two-phase external frame release for EXT_FRAME mode.
+   * When set together with ST20P_TX_FLAG_EXT_FRAME, the library parks the frame
+   * in an intermediate state after notify_frame_done; the application must call
+   * st20p_tx_notify_ext_frame_done() to release the slot back to the free pool.
+   * Without this flag the legacy behavior is preserved (frame goes to FREE
+   * immediately after notify_frame_done).
+   */
+  ST20P_TX_FLAG_EXT_FRAME_USER_DONE = (MTL_BIT32(13)),
   /** Enable the st20p_tx_get_frame block behavior to wait until a frame becomes
      available or (default: 1s, use st20p_tx_set_block_timeout to customize) */
   ST20P_TX_FLAG_BLOCK_GET = (MTL_BIT32(15)),
@@ -1807,9 +1816,11 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
  * Notify the tx st2110-20 pipeline session that the application has finished
  * processing an external frame previously signalled via notify_frame_done.
  *
- * In EXT_FRAME mode, after notify_frame_done fires, the frame slot is held in
+ * Only effective when ST20P_TX_FLAG_EXT_FRAME_USER_DONE is set.
+ * In that mode, after notify_frame_done fires, the frame slot is held in
  * IN_USER state so the application can safely unmap / release external buffers.
  * Call this function once cleanup is complete to release the slot back to FREE.
+ * When ST20P_TX_FLAG_EXT_FRAME_USER_DONE is not set this is a silent no-op.
  *
  * @param handle
  *   The handle to the tx st2110-20 pipeline session.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -1804,6 +1804,24 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
                            struct st_ext_frame* ext_frame);
 
 /**
+ * Notify the tx st2110-20 pipeline session that the application has finished
+ * processing an external frame previously signalled via notify_frame_done.
+ *
+ * In EXT_FRAME mode, after notify_frame_done fires, the frame slot is held in
+ * IN_USER state so the application can safely unmap / release external buffers.
+ * Call this function once cleanup is complete to release the slot back to FREE.
+ *
+ * @param handle
+ *   The handle to the tx st2110-20 pipeline session.
+ * @param frame
+ *   The frame pointer received in the notify_frame_done callback.
+ * @return
+ *   - 0 if successful.
+ *   - <0: Error code if the frame is not in IN_USER state.
+ */
+int st20p_tx_notify_ext_frame_done(st20p_tx_handle handle, struct st_frame* frame);
+
+/**
  * Get the framebuffer pointer from the tx st2110-20 pipeline session.
  *
  * @param handle

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -87,7 +87,7 @@ static struct st20p_tx_frame* tx_st20p_newest_available(
  *   5. Re-acquire lock, clear ext-buffer pointers on the framebuff so the next
  *      get_frame call receives a clean slot with no stale external pointers.
  *   6. If EXT_FRAME_USER_DONE: advance to IN_USER — app must call
- *      st20p_tx_notify_ext_frame_done to release the slot to FREE.
+ *      st20p_tx_notify_ext_frame_free to release the slot to FREE.
  *      Otherwise: advance to FREE, unlock, then notify_frame_available —
  *      the slot is immediately visible to get_frame callers.
  *   7. Re-acquire for the caller's do-while loop and return true.
@@ -97,7 +97,7 @@ static bool tx_st20p_if_frame_late(struct st20p_tx_ctx* ctx,
                                    struct st20p_tx_frame* framebuff) {
   struct st_frame* frame = tx_st20p_user_frame(ctx, framebuff);
   uint32_t rtp_ts; /* captured under lock for use in USDT after unlock */
-  bool user_done = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+  bool user_done = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
   /* Park in IN_USER only when user_done flag is set and derive path */
   bool need_in_user = user_done && !framebuff->frame_done_cb_called;
 
@@ -146,7 +146,7 @@ static bool tx_st20p_if_frame_late(struct st20p_tx_ctx* ctx,
   mt_pthread_mutex_lock(&ctx->lock);
 
   /* ext_frame derive: park in IN_USER until app calls
-   * st20p_tx_notify_ext_frame_done */
+   * st20p_tx_notify_ext_frame_free */
   framebuff->stat = need_in_user ? ST20P_TX_FRAME_IN_USER : ST20P_TX_FRAME_FREE;
   mt_pthread_mutex_unlock(&ctx->lock);
 
@@ -217,7 +217,7 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   struct st20p_tx_ctx* ctx = priv;
   int ret;
   struct st20p_tx_frame* framebuff = &ctx->framebuffs[frame_idx];
-  bool user_done = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+  bool user_done = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
   /* Park in IN_USER only when user_done flag is set and the app has not yet
    * been notified (derive path).  When an internal converter is used,
    * notify_frame_done fires early during put_ext_frame so the app already
@@ -231,7 +231,7 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   frame->rtp_timestamp = meta->rtp_timestamp;
 
   /* Transition state BEFORE the callback so the app can call
-   * st20p_tx_notify_ext_frame_done from within notify_frame_done. */
+   * st20p_tx_notify_ext_frame_free from within notify_frame_done. */
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST20P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
@@ -936,7 +936,7 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
   return 0;
 }
 
-int st20p_tx_notify_ext_frame_done(st20p_tx_handle handle, struct st_frame* frame) {
+int st20p_tx_notify_ext_frame_free(st20p_tx_handle handle, struct st_frame* frame) {
   struct st20p_tx_ctx* ctx = handle;
   int idx = ctx->idx;
   struct st20p_tx_frame* framebuff = frame->priv;
@@ -946,7 +946,7 @@ int st20p_tx_notify_ext_frame_done(st20p_tx_handle handle, struct st_frame* fram
     return -EIO;
   }
 
-  if (!(ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_USER_DONE)) {
+  if (!(ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE)) {
     /* Two-phase release not enabled — silently succeed for unconditional callers. */
     return 0;
   }

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -214,6 +214,14 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   frame->timestamp = meta->timestamp;
   frame->epoch = meta->epoch;
   frame->rtp_timestamp = meta->rtp_timestamp;
+
+  if (ctx->ops.notify_frame_done &&
+      !framebuff->frame_done_cb_called) { /* notify app which frame done */
+    frame->status = ST_FRAME_STATUS_COMPLETE;
+    ctx->ops.notify_frame_done(ctx->ops.priv, frame);
+    framebuff->frame_done_cb_called = true;
+  }
+
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST20P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
@@ -225,13 +233,6 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
         frame_idx);
   }
   mt_pthread_mutex_unlock(&ctx->lock);
-
-  if (ctx->ops.notify_frame_done &&
-      !framebuff->frame_done_cb_called) { /* notify app which frame done */
-    frame->status = ST_FRAME_STATUS_COMPLETE;
-    ctx->ops.notify_frame_done(ctx->ops.priv, frame);
-    framebuff->frame_done_cb_called = true;
-  }
 
   /* notify app can get frame */
   tx_st20p_notify_frame_available(ctx);

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -86,8 +86,10 @@ static struct st20p_tx_frame* tx_st20p_newest_available(
  *   4. Fire notify_frame_late + USDT probe.
  *   5. Re-acquire lock, clear ext-buffer pointers on the framebuff so the next
  *      get_frame call receives a clean slot with no stale external pointers.
- *   6. Advance to FREE, unlock, then notify_frame_available — only at this point
- *      is the slot visible to get_frame callers.
+ *   6. If EXT_FRAME: advance to IN_USER — app must call
+ *      st20p_tx_notify_ext_frame_done to release the slot to FREE.
+ *      Otherwise: advance to FREE, unlock, then notify_frame_available —
+ *      the slot is immediately visible to get_frame callers.
  *   7. Re-acquire for the caller's do-while loop and return true.
  *
  * Must be called with ctx->lock held. Returns with ctx->lock held. */
@@ -95,6 +97,9 @@ static bool tx_st20p_if_frame_late(struct st20p_tx_ctx* ctx,
                                    struct st20p_tx_frame* framebuff) {
   struct st_frame* frame = tx_st20p_user_frame(ctx, framebuff);
   uint32_t rtp_ts; /* captured under lock for use in USDT after unlock */
+  bool ext_frame = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME;
+  /* Park in IN_USER only for derive path (converter already released the ext buf) */
+  bool need_in_user = ext_frame && !framebuff->frame_done_cb_called;
 
   /* prerequisite: both flags must be set */
   if (!(ctx->ops.flags & ST20P_TX_FLAG_DROP_WHEN_LATE) ||
@@ -140,10 +145,14 @@ static bool tx_st20p_if_frame_late(struct st20p_tx_ctx* ctx,
 
   mt_pthread_mutex_lock(&ctx->lock);
 
-  framebuff->stat = ST20P_TX_FRAME_FREE;
+  /* ext_frame derive: park in IN_USER until app calls
+   * st20p_tx_notify_ext_frame_done */
+  framebuff->stat = need_in_user ? ST20P_TX_FRAME_IN_USER : ST20P_TX_FRAME_FREE;
   mt_pthread_mutex_unlock(&ctx->lock);
 
-  tx_st20p_notify_frame_available(ctx);
+  if (!need_in_user) {
+    tx_st20p_notify_frame_available(ctx);
+  }
 
   mt_pthread_mutex_lock(&ctx->lock);
   return true; /* frame was dropped, caller should retry */
@@ -208,6 +217,11 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   struct st20p_tx_ctx* ctx = priv;
   int ret;
   struct st20p_tx_frame* framebuff = &ctx->framebuffs[frame_idx];
+  bool ext_frame = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME;
+  /* Park in IN_USER only when the app has not yet been notified (derive path).
+   * When an internal converter is used, notify_frame_done fires early during
+   * put_ext_frame so the app already released the ext buffer — go to FREE. */
+  bool need_in_user = ext_frame && !framebuff->frame_done_cb_called;
 
   struct st_frame* frame = tx_st20p_user_frame(ctx, framebuff);
   frame->tfmt = meta->tfmt;
@@ -215,17 +229,12 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   frame->epoch = meta->epoch;
   frame->rtp_timestamp = meta->rtp_timestamp;
 
-  if (ctx->ops.notify_frame_done &&
-      !framebuff->frame_done_cb_called) { /* notify app which frame done */
-    frame->status = ST_FRAME_STATUS_COMPLETE;
-    ctx->ops.notify_frame_done(ctx->ops.priv, frame);
-    framebuff->frame_done_cb_called = true;
-  }
-
+  /* Transition state BEFORE the callback so the app can call
+   * st20p_tx_notify_ext_frame_done from within notify_frame_done. */
   mt_pthread_mutex_lock(&ctx->lock);
   if (ST20P_TX_FRAME_IN_TRANSMITTING == framebuff->stat) {
     ret = 0;
-    framebuff->stat = ST20P_TX_FRAME_FREE;
+    framebuff->stat = need_in_user ? ST20P_TX_FRAME_IN_USER : ST20P_TX_FRAME_FREE;
     dbg("%s(%d), frame_idx: %u\n", __func__, ctx->idx, frame_idx);
   } else {
     ret = -EIO;
@@ -234,8 +243,17 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   }
   mt_pthread_mutex_unlock(&ctx->lock);
 
-  /* notify app can get frame */
-  tx_st20p_notify_frame_available(ctx);
+  if (ctx->ops.notify_frame_done &&
+      !framebuff->frame_done_cb_called) { /* notify app which frame done */
+    frame->status = ST_FRAME_STATUS_COMPLETE;
+    ctx->ops.notify_frame_done(ctx->ops.priv, frame);
+    framebuff->frame_done_cb_called = true;
+  }
+
+  if (!need_in_user) {
+    /* notify app can get frame */
+    tx_st20p_notify_frame_available(ctx);
+  }
 
   MT_USDT_ST20P_TX_FRAME_DONE(ctx->idx, frame_idx, frame->rtp_timestamp);
 
@@ -914,6 +932,41 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
   }
 
   dbg("%s(%d), frame %u succ\n", __func__, idx, producer_idx);
+  return 0;
+}
+
+int st20p_tx_notify_ext_frame_done(st20p_tx_handle handle, struct st_frame* frame) {
+  struct st20p_tx_ctx* ctx = handle;
+  int idx = ctx->idx;
+  struct st20p_tx_frame* framebuff = frame->priv;
+
+  if (ctx->type != MT_ST20_HANDLE_PIPELINE_TX) {
+    err("%s(%d), invalid type %d\n", __func__, idx, ctx->type);
+    return -EIO;
+  }
+
+  if (!(ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME)) {
+    err("%s(%d), EXT_FRAME flag not enabled\n", __func__, idx);
+    return -EIO;
+  }
+
+  mt_pthread_mutex_lock(&ctx->lock);
+  if (ST20P_TX_FRAME_IN_USER != framebuff->stat) {
+    /* Frame is not in IN_USER — this happens when the converter already released
+     * the ext buffer during put_ext_frame and the frame went CONVERTED → FREE
+     * without the IN_USER step.  Silently succeed so callers can always call
+     * this unconditionally from notify_frame_done. */
+    mt_pthread_mutex_unlock(&ctx->lock);
+    dbg("%s(%d), frame %u not in_user (stat %d), skip\n", __func__, idx, framebuff->idx,
+        framebuff->stat);
+    return 0;
+  }
+  framebuff->stat = ST20P_TX_FRAME_FREE;
+  mt_pthread_mutex_unlock(&ctx->lock);
+
+  tx_st20p_notify_frame_available(ctx);
+
+  dbg("%s(%d), frame %u succ\n", __func__, idx, framebuff->idx);
   return 0;
 }
 

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -86,7 +86,7 @@ static struct st20p_tx_frame* tx_st20p_newest_available(
  *   4. Fire notify_frame_late + USDT probe.
  *   5. Re-acquire lock, clear ext-buffer pointers on the framebuff so the next
  *      get_frame call receives a clean slot with no stale external pointers.
- *   6. If EXT_FRAME: advance to IN_USER — app must call
+ *   6. If EXT_FRAME_USER_DONE: advance to IN_USER — app must call
  *      st20p_tx_notify_ext_frame_done to release the slot to FREE.
  *      Otherwise: advance to FREE, unlock, then notify_frame_available —
  *      the slot is immediately visible to get_frame callers.
@@ -97,9 +97,9 @@ static bool tx_st20p_if_frame_late(struct st20p_tx_ctx* ctx,
                                    struct st20p_tx_frame* framebuff) {
   struct st_frame* frame = tx_st20p_user_frame(ctx, framebuff);
   uint32_t rtp_ts; /* captured under lock for use in USDT after unlock */
-  bool ext_frame = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME;
-  /* Park in IN_USER only for derive path (converter already released the ext buf) */
-  bool need_in_user = ext_frame && !framebuff->frame_done_cb_called;
+  bool user_done = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+  /* Park in IN_USER only when user_done flag is set and derive path */
+  bool need_in_user = user_done && !framebuff->frame_done_cb_called;
 
   /* prerequisite: both flags must be set */
   if (!(ctx->ops.flags & ST20P_TX_FLAG_DROP_WHEN_LATE) ||
@@ -217,11 +217,12 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
   struct st20p_tx_ctx* ctx = priv;
   int ret;
   struct st20p_tx_frame* framebuff = &ctx->framebuffs[frame_idx];
-  bool ext_frame = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME;
-  /* Park in IN_USER only when the app has not yet been notified (derive path).
-   * When an internal converter is used, notify_frame_done fires early during
-   * put_ext_frame so the app already released the ext buffer — go to FREE. */
-  bool need_in_user = ext_frame && !framebuff->frame_done_cb_called;
+  bool user_done = ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+  /* Park in IN_USER only when user_done flag is set and the app has not yet
+   * been notified (derive path).  When an internal converter is used,
+   * notify_frame_done fires early during put_ext_frame so the app already
+   * released the ext buffer — go to FREE. */
+  bool need_in_user = user_done && !framebuff->frame_done_cb_called;
 
   struct st_frame* frame = tx_st20p_user_frame(ctx, framebuff);
   frame->tfmt = meta->tfmt;
@@ -945,9 +946,9 @@ int st20p_tx_notify_ext_frame_done(st20p_tx_handle handle, struct st_frame* fram
     return -EIO;
   }
 
-  if (!(ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME)) {
-    err("%s(%d), EXT_FRAME flag not enabled\n", __func__, idx);
-    return -EIO;
+  if (!(ctx->ops.flags & ST20P_TX_FLAG_EXT_FRAME_USER_DONE)) {
+    /* Two-phase release not enabled — silently succeed for unconditional callers. */
+    return 0;
   }
 
   mt_pthread_mutex_lock(&ctx->lock);

--- a/tests/integration_tests/st20p_test.cpp
+++ b/tests/integration_tests/st20p_test.cpp
@@ -226,13 +226,13 @@ static int test_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
     if (frame->addr[0] == s->ext_fb + i * s->frame_size) {
       s->ext_fb_in_use[i] = false;
       dbg("%s(%d), frame done at %d\n", __func__, i, s->idx);
-      st20p_tx_notify_ext_frame_done((st20p_tx_handle)s->handle, frame);
+      st20p_tx_notify_ext_frame_free((st20p_tx_handle)s->handle, frame);
       return 0;
     }
   }
 
   err("%s(%d), unknown frame_addr %p\n", __func__, s->idx, frame->addr[0]);
-  st20p_tx_notify_ext_frame_done((st20p_tx_handle)s->handle, frame);
+  st20p_tx_notify_ext_frame_free((st20p_tx_handle)s->handle, frame);
   return 0;
 }
 
@@ -828,7 +828,7 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_tx.notify_frame_done = test_st20p_tx_frame_done;
     if (para->tx_ext) {
       ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
-      ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
+      ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
     }
     if (para->user_timestamp) ops_tx.flags |= ST20P_TX_FLAG_USER_TIMESTAMP;
     if (para->vsync) ops_tx.flags |= ST20P_TX_FLAG_ENABLE_VSYNC;

--- a/tests/integration_tests/st20p_test.cpp
+++ b/tests/integration_tests/st20p_test.cpp
@@ -226,11 +226,13 @@ static int test_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
     if (frame->addr[0] == s->ext_fb + i * s->frame_size) {
       s->ext_fb_in_use[i] = false;
       dbg("%s(%d), frame done at %d\n", __func__, i, s->idx);
+      st20p_tx_notify_ext_frame_done((st20p_tx_handle)s->handle, frame);
       return 0;
     }
   }
 
   err("%s(%d), unknown frame_addr %p\n", __func__, s->idx, frame->addr[0]);
+  st20p_tx_notify_ext_frame_done((st20p_tx_handle)s->handle, frame);
   return 0;
 }
 

--- a/tests/integration_tests/st20p_test.cpp
+++ b/tests/integration_tests/st20p_test.cpp
@@ -828,6 +828,7 @@ static void st20p_rx_digest_test(enum st_fps fps[], int width[], int height[],
     ops_tx.notify_frame_done = test_st20p_tx_frame_done;
     if (para->tx_ext) {
       ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME;
+      ops_tx.flags |= ST20P_TX_FLAG_EXT_FRAME_USER_DONE;
     }
     if (para->user_timestamp) ops_tx.flags |= ST20P_TX_FLAG_USER_TIMESTAMP;
     if (para->vsync) ops_tx.flags |= ST20P_TX_FLAG_ENABLE_VSYNC;


### PR DESCRIPTION
Move notify_frame_done callback before the mutex-locked state transition in st20_pipeline_tx so the application is notified while the ext_frame resources are still valid. Previously the frame could be recycled by the pipeline before the callback had a chance to release GStreamer buffers, causing use-after-free crashes.

In the GStreamer plugin zero-copy path:
- Add atomic cleaned_up guard to prevent double cleanup from DPDK lcore racing on the same frame_done callback.
- Null-check frame->opaque and clear it after use.
- Null-check gst_buffer_memory before unmapping.
- Zero-initialize child struct via memset so cleaned_up starts FALSE.