### PR TITLE
Ci: combine dependabot dependency updates

### DIFF
--- a/.github/workflows/base_build.yml
+++ b/.github/workflows/base_build.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: 'upload release build artifacts'
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: mtl-release-bin
           path: '${{ github.workspace }}/build/'

--- a/.github/workflows/base_build.yml
+++ b/.github/workflows/base_build.yml
@@ -43,7 +43,7 @@ jobs:
       manager_build: ${{ steps.filter.outputs.manager_build == 'true' }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
@@ -61,7 +61,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build Release
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
@@ -85,7 +85,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: ebpf-xdp build
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
           ref: main
       

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -57,7 +57,7 @@ jobs:
         build_platform: 'linux64'
         working-directory: '${{ github.workspace }}'
         command: ./build.sh 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: coverity-reports
         path: '${{ github.workspace }}/cov-int'

--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -90,7 +90,7 @@ jobs:
             "./${{ inputs.dir }}"
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: "custom-test-report-${{ env.CURRENT_DATE }}"
           path: ./tests/validation/report.html

--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set current date
         run: echo "CURRENT_DATE=$(date '+%y%m%d-%H%M%S')" >> "$GITHUB_ENV"
       - name: Checkout MTL
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{ github.ref }}"
       - uses: ./.github/actions/build

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,6 @@ jobs:
           egress-policy: audit
 
       - name: 'Checkout Repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,4 +24,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -60,7 +60,7 @@ jobs:
           driver-opts: memory=14Gib,memory-swap=25Gib,env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000,env.BUILDKIT_STEP_LOG_MAX_SPEED=10000000
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: ${{ env.DOCKER_REGISTRY_LOGIN == 'true' }}
         id: dockerLoginStep
         continue-on-error: true
@@ -112,7 +112,7 @@ jobs:
         run: echo "VERSION=$(cat VERSION)">> "$GITHUB_OUTPUT"
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: ${{ env.DOCKER_REGISTRY_LOGIN == 'true' }}
         id: dockerLoginStep
         continue-on-error: true

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -30,7 +30,7 @@ jobs:
       ubuntu_build: ${{ steps.filter.outputs.ubuntu_build == 'true' }}
       manager_build: ${{ steps.filter.outputs.manager_build == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
@@ -50,7 +50,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -97,7 +97,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/github_pages_update.yml
+++ b/.github/workflows/github_pages_update.yml
@@ -34,7 +34,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare operating system for documentation build
         run: |

--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.linux_tests == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
@@ -60,7 +60,7 @@ jobs:
 
       - name: Checkout MTL
         if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ inputs.branch-to-checkout || github.sha || github.ref }}'
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full git history is needed to get a proper
           # list of changed files within `super-linter`

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.msys2_build == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
@@ -76,10 +76,10 @@ jobs:
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 
       - name: Checkout IMTL code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout mman-win32 code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: 'alitrack/mman-win32'
           ref: master
@@ -113,7 +113,7 @@ jobs:
 
       - name: Checkout DPDK code
         if: ${{ steps.cache-dpdk.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: 'DPDK/dpdk'
           ref: v${{matrix.dpdk}}

--- a/.github/workflows/nightly-combined-report.yml
+++ b/.github/workflows/nightly-combined-report.yml
@@ -454,14 +454,14 @@ jobs:
 
       - name: Upload combined Excel report
         if: steps.combine.outputs.reports_generated == 'true'
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-combined-report-excel
           path: combined_nightly_report.xlsx
 
       - name: Upload combined HTML report
         if: steps.combine.outputs.reports_generated == 'true'
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-combined-report-html
           path: combined_nightly_report.html

--- a/.github/workflows/nightly-combined-report.yml
+++ b/.github/workflows/nightly-combined-report.yml
@@ -206,7 +206,7 @@ jobs:
           egress-policy: audit
 
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get pytest run metadata
         id: pytest-metadata

--- a/.github/workflows/nightly-gtest.yml
+++ b/.github/workflows/nightly-gtest.yml
@@ -63,7 +63,7 @@ jobs:
       - name: "upload report gtest"
         if: always()
         id: upload-report-gtest
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-gtest-report-${{ matrix.nic }}
           path: |
@@ -71,7 +71,7 @@ jobs:
       
       - name: "upload system info"
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: system-info-${{ matrix.nic }}
           path: system-info-${{ matrix.nic }}/

--- a/.github/workflows/nightly-gtest.yml
+++ b/.github/workflows/nightly-gtest.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ github.ref }}'
       - uses: ./.github/actions/build

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -107,14 +107,14 @@ jobs:
       - name: "upload report python"
         if: always()
         id: upload-report
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-test-report-${{ matrix.nic }}-${{ matrix.dir }}
           path: ./tests/validation/report.html
 
       - name: "upload system info"
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: system-info-${{ matrix.nic }}-${{ matrix.dir }}
           path: ./system-info-${{ matrix.nic }}-${{ matrix.dir }}
@@ -169,7 +169,7 @@ jobs:
           printf 'report_path=%s\n' "$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
       - name: Upload combined python report
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-pytest-combined-report
           path: ${{ steps.combine.outputs.report_path }}

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ github.ref }}'
       - uses: ./.github/actions/build
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download python report artifacts
         uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
         with:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -37,7 +37,7 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -107,7 +107,7 @@ jobs:
       - name: "upload report"
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
         id: upload-report
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: smoke-test-report-${{ matrix.nic }}
           path: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.linux_tests == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
         id: filter
@@ -49,7 +49,7 @@ jobs:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ github.ref }}'
       - uses: ./.github/actions/build

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,18 +36,18 @@ jobs:
     steps:
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 23 * * *'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: maint-25.02 # tmp branch
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * *'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Checkout code
         if: github.event_name != 'schedule'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -75,18 +75,18 @@ jobs:
     steps:
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 23 * * *'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: maint-25.02 # tmp branch
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * *'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Checkout code
         if: github.event_name != 'schedule'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -111,18 +111,18 @@ jobs:
     steps:
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 23 * * *'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: maint-25.02 # tmp branch
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * *'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Checkout code
         if: github.event_name != 'schedule'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Sync upstream changes
         id: sync

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -131,12 +131,12 @@ jobs:
           env | grep TEST_ || true
 
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ inputs.branch-to-checkout }}'
 
       - name: 'preparation: Checkout DPDK'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: env.DPDK_REBUILD == 'true'
         with:
           repository: 'DPDK/dpdk'

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: 'cleanup: Validation execution logs'
         if: always()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: 'validation-execution-logs.tar.gz'
           path: '${{ github.workspace }}/tests/validation/validation-execution-logs.tar.gz'

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -6,7 +6,7 @@
 # Please review and modify as necessary before using in a production environment.
 
 # Build stage, ubuntu 22.04
-FROM ubuntu@sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7ca37 AS builder
+FROM ubuntu@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b AS builder
 
 LABEL maintainer="andrzej.wilczynski@intel.com,dawid.wesierski@intel.com,marek.kasiewicz@intel.com"
 
@@ -41,7 +41,7 @@ RUN meson setup build && \
     DESTDIR=/install meson install -C build
 
 # Runtime stage, ubuntu 22.04
-FROM ubuntu@sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7ca37
+FROM ubuntu@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 
 # Install runtime dependencies
 RUN apt-get update -y && \

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,4 +21,4 @@ version = "^0.1.0"
 ctrlc = "3.4.4"
 memmap2 = "0.9.4"
 clap = { version = "4.5.4", features = ["derive"] }
-sdl2 = "0.36.0"
+sdl2 = "0.38.0"

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -15,7 +15,7 @@ exceptiongroup==1.3.0
 Flask==3.1.3
 funcy==1.18
 htmlmin2==0.1.13
-idna==3.10
+idna==3.11
 iniconfig==2.1.0
 itsdangerous==2.2.0
 Jinja2==3.1.6

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -57,7 +57,7 @@ netaddr==0.8.0
 netmiko==4.6.0
 ntc_templates==7.9.0
 packaging==25.0
-paramiko==3.4.0
+paramiko==4.0.0
 pexpect==4.8.0
 pluggy==1.6.0
 plumbum==1.9.0

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -7,7 +7,7 @@ blinker==1.9.0
 certifi==2025.7.14
 cffi==2.0.0
 charset-normalizer==3.4.2
-click==8.3.1
+click==8.3.2
 cryptography==46.0.7
 dlipower==1.0.176
 docutils==0.21.2

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -60,7 +60,7 @@ packaging==25.0
 paramiko==4.0.0
 pexpect==4.8.0
 pluggy==1.6.0
-plumbum==1.9.0
+plumbum==1.10.0
 psutil==5.9.8
 ptyprocess==0.7.0
 pyasn1==0.6.3


### PR DESCRIPTION
Combined dependabot dependency updates:

- #1503 Ci: Update sdl2 requirement from 0.36.0 to 0.38.0 in /rust
- #1502 Ci: Bump ubuntu from `149d67e` to `84e77de` in /manager
- #1501 Ci: Bump paramiko from 3.4.0 to 4.0.0 in /tests
- #1500 Ci: Bump click from 8.3.1 to 8.3.2 in /tests
- #1498 Ci: Bump idna from 3.10 to 3.11 in /tests
- #1497 Ci: Bump plumbum from 1.9.0 to 1.10.0 in /tests
- #1496 Ci: Bump ossf/scorecard-action from 2.4.2 to 2.4.3
- #1495 Ci: Bump docker/login-action from 3.5.0 to 4.1.0
- #1494 Ci: Bump actions/upload-artifact from 4 to 7
- #1493 Ci: Bump actions/dependency-review-action from 4.7.3 to 4.9.0
- #1483 Ci: Bump actions/checkout from 4 to 6

Skipped due to conflicts:
- #1499 Ci: Bump pexpect from 4.8.0 to 4.9.0 in /tests

