### PR TITLE
Refactor: unify and fix session statistics counters

### DIFF
--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -1,0 +1,193 @@
+# Session Statistics Guide
+
+How to interpret the statistics counters exposed by MTL session APIs. For the full list of
+fields and their descriptions, see the doxygen comments in the header files (`st_api.h`,
+`st20_api.h`, `st30_api.h`, `st40_api.h`, `st41_api.h`).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [RX Packet Processing Pipeline](#rx-packet-processing-pipeline)
+- [Understanding OOO and Loss Counters](#understanding-ooo-and-loss-counters)
+- [Cross-Session Differences](#cross-session-differences)
+- [Troubleshooting with Stats](#troubleshooting-with-stats)
+
+## Overview
+
+Each RX/TX session exposes statistics via a pair of functions:
+
+- `st*_get_session_stats()` — copies the current counters to a user-provided struct
+- `st*_reset_session_stats()` — zeros all counters
+
+All counters are `uint64_t` and monotonically increase until reset. The library never
+decreases a counter.
+
+| Session type | Get stats | Reset stats |
+|---|---|---|
+| Video TX (ST20) | `st20_tx_get_session_stats()` | `st20_tx_reset_session_stats()` |
+| Video RX (ST20) | `st20_rx_get_session_stats()` | `st20_rx_reset_session_stats()` |
+| Audio TX (ST30) | `st30_tx_get_session_stats()` | `st30_tx_reset_session_stats()` |
+| Audio RX (ST30) | `st30_rx_get_session_stats()` | `st30_rx_reset_session_stats()` |
+| Ancillary TX (ST40) | `st40_tx_get_session_stats()` | `st40_tx_reset_session_stats()` |
+| Ancillary RX (ST40) | `st40_rx_get_session_stats()` | `st40_rx_reset_session_stats()` |
+| Metadata TX (ST41) | `st41_tx_get_session_stats()` | `st41_tx_reset_session_stats()` |
+| Metadata RX (ST41) | `st41_rx_get_session_stats()` | `st41_rx_reset_session_stats()` |
+
+## RX Packet Processing Pipeline
+
+Every incoming packet goes through the following stages. Understanding this order is key to
+interpreting which counters are "pre-redundancy" (counted early) vs "post-redundancy"
+(counted after merging redundant streams).
+
+```
+NIC queue
+  │
+  ├─① Early validation (payload type, SSRC, packet length, interlace F-bits)
+  │     └── FAIL → err_packets++
+  │                 stat_pkts_wrong_pt_dropped++ or stat_pkts_wrong_ssrc_dropped++
+  │                 (packet discarded)
+  │
+  ├─② Per-port sequence check
+  │     └── GAP  → port[].out_of_order_packets++
+  │                 stat_pkts_out_of_order++
+  │
+  ├─③ port[].packets++, port[].bytes++          ← "pre-redundancy" counters
+  │
+  ├─④ Redundancy filter (is this packet's timestamp already seen?)
+  │     └── STALE → stat_pkts_redundant++
+  │                  (packet discarded)
+  │
+  ├─⑤ Post-redundancy loss detection
+  │     Audio/anc/fmd: session_seq_id gap → stat_pkts_unrecovered += gap_size
+  │     Video: frame completion check     → stat_pkts_unrecovered += (total - received)
+  │
+  ├─⑥ stat_pkts_received++                      ← "post-redundancy" counter
+  │
+  └─⑦ Deliver to frame buffer / RTP ring
+```
+
+**Key insight**: `port[].packets` counts everything that passes validation (step ③),
+including packets that the redundancy filter will later discard (step ④).
+`stat_pkts_received` counts only the packets that make it through all filters (step ⑥).
+
+**Video note**: Video (ST20) performs step ⑤ at frame completion time rather than per-packet.
+It compares expected total packets to received packets and adds the difference to
+`stat_pkts_unrecovered`. See [Video-Specific OOO Behavior](#video-specific-ooo-behavior).
+
+### `port[].frames` Semantics
+
+The `frames` counter means different things depending on the session type:
+
+| Session type | What `frames` counts | When it increments |
+|---|---|---|
+| Video (ST20) | Frame completions | When a frame is notified to app (complete or incomplete) |
+| Audio (ST30) | Frame completions | When a frame buffer is filled and delivered to app |
+| Ancillary (ST40) | New RTP timestamps | When a new timestamp is first seen (frame **start**, not completion) |
+| Metadata (ST41) | New RTP timestamps | When a new timestamp is first seen (frame **start**, not completion) |
+
+**Example**: If an ancillary stream sends 100 frames and you see `port[0].frames = 100`,
+that means 100 distinct timestamps were detected — but some of those frames could be
+incomplete if packets were lost.
+
+## Understanding OOO and Loss Counters
+
+The library provides three levels of out-of-order / loss tracking:
+
+### The Three Counters
+
+| Counter | Scope | Stage | What it detects |
+|---|---|---|---|
+| `port[i].out_of_order_packets` | Per-port | Pre-redundancy | Gaps in RTP sequence on a single port |
+| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of all per-port gaps |
+| `stat_pkts_unrecovered` | Session | Post-redundancy | Actual missing packets that redundancy could not cover |
+
+**Invariants** (always true):
+
+```
+stat_pkts_out_of_order == port[0].out_of_order_packets + port[1].out_of_order_packets
+stat_pkts_unrecovered <= stat_pkts_out_of_order
+```
+
+### Interpreting OOO Scenarios
+
+| Scenario | `port[P].ooo` | `port[R].ooo` | `stat_pkts_out_of_order` | `stat_pkts_unrecovered` | Interpretation |
+|---|---:|---:|---:|---:|---|
+| Perfect stream | 0 | 0 | 0 | 0 | All good |
+| Port P lossy, R covers | 50 | 0 | 50 | 0 | Redundancy working |
+| Both ports lossy, some gaps | 50 | 30 | 80 | 5 | 5 uncoverable gaps — real data loss |
+| Single port, some loss | 10 | n/a | 10 | 10 | No redundancy to help |
+| Network reordering | 3 | 2 | 5 | 0 | Packets reordered but none lost |
+
+Key takeaways:
+- `stat_pkts_out_of_order > 0` with `stat_pkts_unrecovered == 0` → redundancy is
+  covering the gaps, the stream is healthy at session level.
+- `stat_pkts_unrecovered > 0` → real data loss that redundancy could not cover. Check
+  network path diversity.
+- With a single port, `stat_pkts_unrecovered` always equals `stat_pkts_out_of_order`
+  because there is no redundant port to fill gaps.
+
+### Video-Specific OOO Behavior
+
+Video (ST20) works differently from audio/anc/fmd:
+
+- Video detects OOO using **frame-internal `pkt_idx`** (packet index within the current
+  frame), not RTP sequence numbers
+- When a packet arrives with `pkt_idx != last_pkt_idx + 1`, both
+  `port[].out_of_order_packets` and `stat_pkts_out_of_order` are incremented together
+- Video has **no `session_seq_id`** — frames are identified by RTP timestamp, and each
+  frame resets the packet index tracking
+- `stat_pkts_unrecovered` for video counts exact missing packets in corrupted frames
+  (`st20_total_pkts - pkts_received`)
+
+**Practical implication**: For video, `stat_pkts_unrecovered` and `stat_frames_dropped`
+are the primary loss indicators. `common.port[].incomplete_frames` shows per-port
+contribution.
+
+---
+
+## Cross-Session Differences
+
+### Redundancy Counter Names
+
+Different session types use different counter names for the redundancy concept:
+
+| Session | Counter name | Detection mechanism |
+|---|---|---|
+| Video (ST20) | `stat_pkts_redundant_dropped` | Same-frame packet already seen at slot level |
+| Audio (ST30) | `stat_pkts_redundant` | Stale RTP timestamp |
+| Ancillary (ST40) | `stat_pkts_redundant` | Stale timestamp or stale seq_id |
+| Metadata (ST41) | `stat_pkts_redundant` | Stale timestamp or stale seq_id |
+
+### OOO Counters at a Glance
+
+| Counter | Scope | Stage | Video (ST20) | Audio/Anc/FMD |
+|---|---|---|---|---|
+| `port[].out_of_order_packets` | Per-port | Pre-redundancy | `pkt_idx` gap in frame | RTP `seq_number` gap |
+| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of port OOO | Sum of port OOO |
+| `stat_pkts_unrecovered` | Session | Post-redundancy | Missing pkts in corrupted frames | Missing pkts from `session_seq_id` gaps |
+
+### How `stat_pkts_unrecovered` Is Computed
+
+| Session type | Source | Computation | Exact? |
+|---|---|---|---|
+| Video (ST20) | Corrupted frame at slot completion | `(frame_size - recv_size) / avg_pkt_size` | Estimated |
+| Video (ST22) | Corrupted frame at slot completion | `(expect_size - recv_size) / avg_pkt_size` | Estimated |
+| Audio (ST30) | Post-redundancy `session_seq_id` gap | `(uint16_t)(seq_id - session_seq_id - 1)` per gap | Exact |
+| Ancillary (ST40) | Post-redundancy `session_seq_id` gap | `(uint16_t)(seq_id - session_seq_id - 1)` per gap | Exact |
+| Metadata (ST41) | Post-redundancy `session_seq_id` gap | `(uint16_t)(seq_id - session_seq_id - 1)` per gap | Exact |
+
+---
+
+## Troubleshooting with Stats
+
+| Symptom | Counter to check | Likely cause |
+|---|---|---|
+| No packets at all | `port[0].packets == 0` | Wrong IP/port, multicast not joined, NIC link down |
+| Packets arrive but `stat_pkts_received` is 0 | `stat_pkts_wrong_pt_dropped`, `stat_pkts_wrong_ssrc_dropped`, `port[].err_packets` | PT or SSRC mismatch between sender and receiver |
+| `stat_pkts_out_of_order` increasing | `port[P].out_of_order_packets`, `port[R].out_of_order_packets` | Network congestion, packet loss, or RSS misconfiguration |
+| `stat_pkts_unrecovered` increasing | Compare with `stat_pkts_out_of_order` | Real data loss — redundancy could not cover; check path diversity |
+| `stat_pkts_redundant` is 0 on 2-port session | `port[1].packets` | Redundant port not receiving data |
+| `stat_pkts_redundant ≈ stat_pkts_received` on 2-port session | — | Normal — each packet arrives on both ports, one copy filtered |
+| Video `stat_frames_dropped` increasing | `stat_pkts_unrecovered`, `stat_pkts_no_slot` | Incomplete frames due to packet loss or frame buffers exhausted |
+| TX `stat_epoch_drop` increasing | `stat_epoch_onward` | Application providing frames too late; callback blocking |
+| `stat_slot_get_frame_fail` / `stat_pkts_enqueue_fail` increasing | — | Receiver too slow: return frame buffers faster or increase ring size |

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -136,8 +136,8 @@ Video (ST20) works differently from audio/anc/fmd:
   `port[].out_of_order_packets` and `stat_pkts_out_of_order` are incremented together
 - Video has **no `session_seq_id`** — frames are identified by RTP timestamp, and each
   frame resets the packet index tracking
-- `stat_pkts_unrecovered` for video counts exact missing packets in corrupted frames
-  (`st20_total_pkts - pkts_received`)
+- `stat_pkts_unrecovered` for video counts missing packets in corrupted frames
+  (estimated from `(frame_size - recv_size) / avg_pkt_size`)
 
 **Practical implication**: For video, `stat_pkts_unrecovered` and `stat_frames_dropped`
 are the primary loss indicators. `common.port[].incomplete_frames` shows per-port
@@ -146,17 +146,6 @@ contribution.
 ---
 
 ## Cross-Session Differences
-
-### Redundancy Counter Names
-
-Different session types use different counter names for the redundancy concept:
-
-| Session | Counter name | Detection mechanism |
-|---|---|---|
-| Video (ST20) | `stat_pkts_redundant_dropped` | Same-frame packet already seen at slot level |
-| Audio (ST30) | `stat_pkts_redundant` | Stale RTP timestamp |
-| Ancillary (ST40) | `stat_pkts_redundant` | Stale timestamp or stale seq_id |
-| Metadata (ST41) | `stat_pkts_redundant` | Stale timestamp or stale seq_id |
 
 ### OOO Counters at a Glance
 

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -22,6 +22,18 @@ Each RX/TX session exposes statistics via a pair of functions:
 All counters are `uint64_t` and monotonically increase until reset. The library never
 decreases a counter.
 
+### Thread Safety
+
+Both `get` and `reset` acquire the per-session spinlock internally, making them safe to
+call from any thread while the session is active.
+
+**Data-path impact**: the data-path tasklet holds the same spinlock during packet
+processing. A concurrent `get` or `reset` may cause the tasklet to skip one poll cycle
+(trylock failure). The lock is held only for a struct memcpy/memset (~200-400 bytes, tens
+of nanoseconds), which is negligible compared to the microsecond-scale poll interval.
+
+**Recommended pattern**: call `get` followed by `reset` for interval-based monitoring.
+
 | Session type | Get stats | Reset stats |
 |---|---|---|
 | Video TX (ST20) | `st20_tx_get_session_stats()` | `st20_tx_reset_session_stats()` |
@@ -39,38 +51,38 @@ Every incoming packet goes through the following stages. Understanding this orde
 interpreting which counters are "pre-redundancy" (counted early) vs "post-redundancy"
 (counted after merging redundant streams).
 
-```
+```text
 NIC queue
   │
-  ├─① Early validation (payload type, SSRC, packet length, interlace F-bits)
+  ├─1. Early validation (payload type, SSRC, packet length, interlace F-bits)
   │     └── FAIL → err_packets++
   │                 stat_pkts_wrong_pt_dropped++ or stat_pkts_wrong_ssrc_dropped++
   │                 (packet discarded)
   │
-  ├─② Per-port sequence check
-  │     └── GAP  → port[].out_of_order_packets++
-  │                 stat_pkts_out_of_order++
+  ├─2. Per-port sequence check
+  │     └── GAP  → port[].out_of_order_packets += gap_size
+  │                 stat_pkts_out_of_order += gap_size
   │
-  ├─③ port[].packets++, port[].bytes++          ← "pre-redundancy" counters
+  ├─3. port[].packets++, port[].bytes++          ← "pre-redundancy" counters
   │
-  ├─④ Redundancy filter (is this packet's timestamp already seen?)
+  ├─4. Redundancy filter (is this packet's timestamp already seen?)
   │     └── STALE → stat_pkts_redundant++
   │                  (packet discarded)
   │
-  ├─⑤ Post-redundancy loss detection
+  ├─5. Post-redundancy loss detection
   │     Audio/anc/fmd: session_seq_id gap → stat_pkts_unrecovered += gap_size
   │     Video: frame completion check     → stat_pkts_unrecovered += (total - received)
   │
-  ├─⑥ stat_pkts_received++                      ← "post-redundancy" counter
+  ├─6. stat_pkts_received++                      ← "post-redundancy" counter
   │
-  └─⑦ Deliver to frame buffer / RTP ring
+  └─7. Deliver to frame buffer / RTP ring
 ```
 
-**Key insight**: `port[].packets` counts everything that passes validation (step ③),
-including packets that the redundancy filter will later discard (step ④).
-`stat_pkts_received` counts only the packets that make it through all filters (step ⑥).
+**Key insight**: `port[].packets` counts everything that passes validation (step 3),
+including packets that the redundancy filter will later discard (step 4).
+`stat_pkts_received` counts only the packets that make it through all filters (step 6).
 
-**Video note**: Video (ST20) performs step ⑤ at frame completion time rather than per-packet.
+**Video note**: Video (ST20) performs step 5 at frame completion time rather than per-packet.
 It compares expected total packets to received packets and adds the difference to
 `stat_pkts_unrecovered`. See [Video-Specific OOO Behavior](#video-specific-ooo-behavior).
 
@@ -97,13 +109,13 @@ The library provides three levels of out-of-order / loss tracking:
 
 | Counter | Scope | Stage | What it detects |
 |---|---|---|---|
-| `port[i].out_of_order_packets` | Per-port | Pre-redundancy | Gaps in RTP sequence on a single port |
-| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of all per-port gaps |
+| `port[i].out_of_order_packets` | Per-port | Pre-redundancy | Missing packets on a single port (gap size, not gap count) |
+| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of per-port missing packets |
 | `stat_pkts_unrecovered` | Session | Post-redundancy | Actual missing packets that redundancy could not cover |
 
 **Invariants** (always true):
 
-```
+```text
 stat_pkts_out_of_order == port[0].out_of_order_packets + port[1].out_of_order_packets
 stat_pkts_unrecovered <= stat_pkts_out_of_order
 ```
@@ -114,7 +126,7 @@ stat_pkts_unrecovered <= stat_pkts_out_of_order
 |---|---:|---:|---:|---:|---|
 | Perfect stream | 0 | 0 | 0 | 0 | All good |
 | Port P lossy, R covers | 50 | 0 | 50 | 0 | Redundancy working |
-| Both ports lossy, some gaps | 50 | 30 | 80 | 5 | 5 uncoverable gaps — real data loss |
+| Both ports lossy, some overlap | 50 | 30 | 80 | 5 | 5 packets unrecoverable — real data loss |
 | Single port, some loss | 10 | n/a | 10 | 10 | No redundancy to help |
 | Network reordering | 3 | 2 | 5 | 0 | Packets reordered but none lost |
 
@@ -123,8 +135,9 @@ Key takeaways:
   covering the gaps, the stream is healthy at session level.
 - `stat_pkts_unrecovered > 0` → real data loss that redundancy could not cover. Check
   network path diversity.
-- With a single port, `stat_pkts_unrecovered` always equals `stat_pkts_out_of_order`
+- With a single port, `stat_pkts_unrecovered` equals `stat_pkts_out_of_order`
   because there is no redundant port to fill gaps.
+- Redundancy recovery rate: `(ooo - unrecovered) / ooo`.
 
 ### Video-Specific OOO Behavior
 
@@ -132,8 +145,9 @@ Video (ST20) works differently from audio/anc/fmd:
 
 - Video detects OOO using **frame-internal `pkt_idx`** (packet index within the current
   frame), not RTP sequence numbers
-- When a packet arrives with `pkt_idx != last_pkt_idx + 1`, both
-  `port[].out_of_order_packets` and `stat_pkts_out_of_order` are incremented together
+- When a packet arrives with `pkt_idx != last_pkt_idx + 1`, the gap size
+  (`pkt_idx - last_pkt_idx - 1`) is added to both `port[].out_of_order_packets`
+  and `stat_pkts_out_of_order`
 - Video has **no `session_seq_id`** — frames are identified by RTP timestamp, and each
   frame resets the packet index tracking
 - `stat_pkts_unrecovered` for video counts missing packets in corrupted frames
@@ -151,8 +165,8 @@ contribution.
 
 | Counter | Scope | Stage | Video (ST20) | Audio/Anc/FMD |
 |---|---|---|---|---|
-| `port[].out_of_order_packets` | Per-port | Pre-redundancy | `pkt_idx` gap in frame | RTP `seq_number` gap |
-| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of port OOO | Sum of port OOO |
+| `port[].out_of_order_packets` | Per-port | Pre-redundancy | Missing pkts from `pkt_idx` gaps | Missing pkts from RTP `seq_number` gaps |
+| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of port missing pkts | Sum of port missing pkts |
 | `stat_pkts_unrecovered` | Session | Post-redundancy | Missing pkts in corrupted frames | Missing pkts from `session_seq_id` gaps |
 
 ### How `stat_pkts_unrecovered` Is Computed

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1910,6 +1910,7 @@ int st20_tx_get_pacing_params(st20_tx_handle handle, double* tr_offset_ns, doubl
 /**
  * Retrieve the general statistics(I/O) for one tx st2110-20(video) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-20(video) session.
  * @param port
@@ -1925,6 +1926,7 @@ int st20_tx_get_session_stats(st20_tx_handle handle, struct st20_tx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one tx st2110-20(video) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-20(video) session.
  * @param port
@@ -2259,6 +2261,7 @@ int st20_rx_timing_parser_critical(st20_rx_handle handle, struct st20_rx_tp_pass
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-20(video) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-20(video) session.
  * @param port
@@ -2274,6 +2277,7 @@ int st20_rx_get_session_stats(st20_rx_handle handle, struct st20_rx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one rx st2110-20(video) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-20(video) session.
  * @param port

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1731,7 +1731,6 @@ struct st20_rx_user_stats {
   uint64_t stat_pkts_offset_dropped;
   uint64_t stat_frames_dropped;
   uint64_t stat_pkts_idx_oo_bitmap;
-  uint64_t stat_frames_pks_missed;
   uint64_t stat_pkts_rtp_ring_full;
   uint64_t stat_pkts_no_slot;
   uint64_t stat_pkts_redundant_dropped;

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1714,8 +1714,6 @@ struct st20_tx_user_stats {
   uint64_t stat_pkts_chain_realloc_fail;
   uint64_t stat_user_meta_cnt;
   uint64_t stat_user_meta_pkt_cnt;
-  uint64_t stat_recoverable_error;
-  uint64_t stat_unrecoverable_error;
   uint64_t stat_interlace_first_field;
   uint64_t stat_interlace_second_field;
 };
@@ -1733,7 +1731,6 @@ struct st20_rx_user_stats {
   uint64_t stat_pkts_idx_oo_bitmap;
   uint64_t stat_pkts_rtp_ring_full;
   uint64_t stat_pkts_no_slot;
-  uint64_t stat_pkts_redundant_dropped;
   uint64_t stat_pkts_wrong_interlace_dropped;
   uint64_t stat_pkts_wrong_len_dropped;
   uint64_t stat_pkts_enqueue_fallback;

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -543,10 +543,7 @@ struct st30_rx_ops {
  */
 struct st30_tx_user_stats {
   struct st_tx_user_stats common;
-  uint64_t stat_epoch_mismatch;
   uint64_t stat_epoch_late;
-  uint64_t stat_recoverable_error;
-  uint64_t stat_unrecoverable_error;
   uint64_t stat_pkts_burst;
   uint64_t stat_pad_pkts_burst;
   uint64_t stat_warmup_pkts_burst;
@@ -560,7 +557,6 @@ struct st30_tx_user_stats {
  */
 struct st30_rx_user_stats {
   struct st_rx_user_stats common;
-  uint64_t stat_pkts_redundant;
   uint64_t stat_pkts_dropped;
   uint64_t stat_pkts_len_mismatch_dropped;
   uint64_t stat_slot_get_frame_fail;

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -565,6 +565,7 @@ struct st30_rx_user_stats {
 /**
  * Retrieve the general statistics(I/O) for one tx st2110-30(audio) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-30(audio) session.
  * @param port
@@ -580,6 +581,7 @@ int st30_tx_get_session_stats(st30_tx_handle handle, struct st30_tx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one tx st2110-30(audio) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-30(audio) session.
  * @param port
@@ -593,6 +595,7 @@ int st30_tx_reset_session_stats(st30_tx_handle handle);
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-30(audio) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-30(audio) session.
  * @param port
@@ -608,6 +611,7 @@ int st30_rx_get_session_stats(st30_rx_handle handle, struct st30_rx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one rx st2110-30(audio) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-30(audio) session.
  * @param port

--- a/include/st30_pipeline_api.h
+++ b/include/st30_pipeline_api.h
@@ -182,6 +182,7 @@ struct st30p_tx_ops {
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-30(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-30(pipeline) session.
  * @param port
@@ -197,6 +198,7 @@ int st30p_tx_get_session_stats(st30p_tx_handle handle, struct st30_tx_user_stats
 /**
  * Reset the general statistics(I/O) for one rx st2110-30(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-30(pipeline) session.
  * @param port
@@ -290,6 +292,7 @@ struct st30p_rx_ops {
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-30(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-30(pipeline) session.
  * @param port
@@ -305,6 +308,7 @@ int st30p_rx_get_session_stats(st30p_rx_handle handle, struct st30_rx_user_stats
 /**
  * Reset the general statistics(I/O) for one rx st2110-30(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-30(pipeline) session.
  * @param port

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -462,7 +462,6 @@ struct st40_rx_ops {
  */
 struct st40_tx_user_stats {
   struct st_tx_user_stats common;
-  uint64_t stat_epoch_mismatch;
   uint64_t stat_interlace_first_field;
   uint64_t stat_interlace_second_field;
 };
@@ -473,7 +472,6 @@ struct st40_tx_user_stats {
 struct st40_rx_user_stats {
   struct st_rx_user_stats common;
   uint64_t stat_pkts_dropped;
-  uint64_t stat_pkts_redundant;
   uint64_t stat_pkts_enqueue_fail;
   uint64_t stat_interlace_first_field;
   uint64_t stat_interlace_second_field;

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -481,6 +481,7 @@ struct st40_rx_user_stats {
 /**
  * Retrieve the general statistics(I/O) for one tx st2110-40(ancillary) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-40(ancillary) session.
  * @param port
@@ -496,6 +497,7 @@ int st40_tx_get_session_stats(st40_tx_handle handle, struct st40_tx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one tx st2110-40(ancillary) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-40(ancillary) session.
  * @param port
@@ -561,6 +563,7 @@ void* st40_tx_get_framebuffer(st40_tx_handle handle, uint16_t idx);
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-40(ancillary) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-40(ancillary) session.
  * @param port
@@ -576,6 +579,7 @@ int st40_rx_get_session_stats(st40_rx_handle handle, struct st40_rx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one rx st2110-40(ancillary) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-40(ancillary) session.
  * @param port

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -477,7 +477,7 @@ struct st40_rx_user_stats {
   uint64_t stat_pkts_enqueue_fail;
   uint64_t stat_interlace_first_field;
   uint64_t stat_interlace_second_field;
-  int stat_pkts_wrong_interlace_dropped;
+  uint64_t stat_pkts_wrong_interlace_dropped;
 };
 
 /**

--- a/include/st40_pipeline_api.h
+++ b/include/st40_pipeline_api.h
@@ -247,6 +247,7 @@ struct st40p_rx_ops {
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-40(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-40(pipeline) session.
  * @param port
@@ -262,6 +263,7 @@ int st40p_tx_get_session_stats(st40p_tx_handle handle, struct st40_tx_user_stats
 /**
  * Reset the general statistics(I/O) for one rx st2110-40(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-40(pipeline) session.
  * @param port
@@ -344,6 +346,7 @@ int st40p_rx_get_queue_meta(st40p_rx_handle handle, struct st_queue_meta* meta);
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-40(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-40(pipeline) session.
  * @param stats
@@ -357,6 +360,7 @@ int st40p_rx_get_session_stats(st40p_rx_handle handle, struct st40_rx_user_stats
 /**
  * Reset the general statistics(I/O) for one rx st2110-40(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-40(pipeline) session.
  * @return

--- a/include/st41_api.h
+++ b/include/st41_api.h
@@ -305,6 +305,7 @@ struct st41_rx_user_stats {
 /**
  * Retrieve the general statistics(I/O) for one tx st2110-41(fastmetadata) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-41(fastmetadata) session.
  * @param port
@@ -320,6 +321,7 @@ int st41_tx_get_session_stats(st41_tx_handle handle, struct st41_tx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one tx st2110-41(fastmetadata) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-41(fastmetadata) session.
  * @param port
@@ -333,6 +335,7 @@ int st41_tx_reset_session_stats(st41_tx_handle handle);
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-40(fastmetadata) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-40(fastmetadata) session.
  * @param port
@@ -348,6 +351,7 @@ int st41_rx_get_session_stats(st41_rx_handle handle, struct st41_rx_user_stats* 
 /**
  * Reset the general statistics(I/O) for one rx st2110-41(fastmetadata) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-41(fastmetadata) session.
  * @param port

--- a/include/st41_api.h
+++ b/include/st41_api.h
@@ -296,8 +296,11 @@ struct st41_rx_user_stats {
   uint64_t stat_pkts_enqueue_fail;
   uint64_t stat_last_time;
   uint64_t stat_max_notify_rtp_us;
+  /** @note Always 0 for ST2110-41 (no interlace F-bits in RTP header). */
   uint64_t stat_interlace_first_field;
+  /** @note Always 0 for ST2110-41 (no interlace F-bits in RTP header). */
   uint64_t stat_interlace_second_field;
+  /** @note Always 0 for ST2110-41 (no interlace F-bits in RTP header). */
   uint64_t stat_pkts_wrong_interlace_dropped;
 };
 

--- a/include/st41_api.h
+++ b/include/st41_api.h
@@ -282,18 +282,9 @@ struct st41_rx_ops {
  */
 struct st41_tx_user_stats {
   struct st_tx_user_stats common;
-  uint64_t stat_pkts_redundant;
-  uint64_t stat_pkts_out_of_order;
-  uint64_t stat_pkts_enqueue_fail;
-  uint64_t stat_pkts_wrong_pt_dropped;
-  uint64_t stat_pkts_wrong_ssrc_dropped;
-  uint64_t stat_pkts_received;
-  uint64_t stat_last_time;
-  uint64_t stat_max_notify_rtp_us;
+  uint64_t stat_epoch_mismatch;
   uint64_t stat_interlace_first_field;
   uint64_t stat_interlace_second_field;
-  uint64_t stat_pkts_wrong_interlace_dropped;
-  uint64_t stat_epoch_mismatch;
 };
 
 /**
@@ -304,10 +295,10 @@ struct st41_rx_user_stats {
   uint64_t stat_pkts_redundant;
   uint64_t stat_pkts_enqueue_fail;
   uint64_t stat_last_time;
-  uint32_t stat_max_notify_rtp_us;
-  uint32_t stat_interlace_first_field;
-  uint32_t stat_interlace_second_field;
-  int stat_pkts_wrong_interlace_dropped;
+  uint64_t stat_max_notify_rtp_us;
+  uint64_t stat_interlace_first_field;
+  uint64_t stat_interlace_second_field;
+  uint64_t stat_pkts_wrong_interlace_dropped;
 };
 
 /**

--- a/include/st41_api.h
+++ b/include/st41_api.h
@@ -282,7 +282,6 @@ struct st41_rx_ops {
  */
 struct st41_tx_user_stats {
   struct st_tx_user_stats common;
-  uint64_t stat_epoch_mismatch;
   uint64_t stat_interlace_first_field;
   uint64_t stat_interlace_second_field;
 };
@@ -292,7 +291,6 @@ struct st41_tx_user_stats {
  */
 struct st41_rx_user_stats {
   struct st_rx_user_stats common;
-  uint64_t stat_pkts_redundant;
   uint64_t stat_pkts_enqueue_fail;
   uint64_t stat_last_time;
   uint64_t stat_max_notify_rtp_us;

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -261,19 +261,20 @@ struct st_tx_port_stats {
 
 /**
  * A structure used to retrieve general statistics(I/O) for a session rx port.
+ * All counters are pre-redundancy (counted before redundancy filtering).
  */
 struct st_rx_port_stats {
-  /** Total number of received packets. */
+  /** Total number of received packets (pre-redundancy). */
   uint64_t packets;
-  /** Total number of received bytes. */
+  /** Total number of received bytes (pre-redundancy). */
   uint64_t bytes;
   /** Total number of received frames / memory buffers. */
   uint64_t frames;
   /** Total number of incomplete frames */
   uint64_t incomplete_frames;
-  /** Total number of received packets which are not valid. */
+  /** Total number of received packets rejected by handler. */
   uint64_t err_packets;
-  /** Total number of out-of-order packets received */
+  /** Total number of out-of-order packets received on this port (pre-redundancy). */
   uint64_t out_of_order_packets;
 };
 
@@ -299,10 +300,21 @@ struct st_tx_user_stats {
  */
 struct st_rx_user_stats {
   struct st_rx_port_stats port[MTL_SESSION_PORT_MAX]; /**< Per-port RX statistics */
-  /** Total number of received packets */
+  /** Total number of accepted packets (post-redundancy). */
   uint64_t stat_pkts_received;
-  /** Total number of out-of-order packets received */
+  /**
+   * Aggregate of per-port out-of-order packets: sum(port[].out_of_order_packets).
+   * For video: frame-internal pkt_idx gaps.
+   * For audio/anc/fmd: per-port RTP seq gaps (pre-redundancy).
+   */
   uint64_t stat_pkts_out_of_order;
+  /**
+   * Total packets lost post-redundancy (unrecoverable by redundancy).
+   * For audio/anc/fmd: number of missing packets inferred from RTP sequence gaps.
+   * For video: number of missing packets in corrupted/incomplete frames.
+   * Invariant: stat_pkts_unrecovered <= stat_pkts_out_of_order.
+   */
+  uint64_t stat_pkts_unrecovered;
   /** Total number of packets dropped due to wrong SSRC */
   uint64_t stat_pkts_wrong_ssrc_dropped;
   /** Total number of packets dropped due to wrong payload type */

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -292,6 +292,12 @@ struct st_tx_user_stats {
   uint64_t stat_exceed_frame_time;
   /** Total number of errors due to user timestamp issues */
   uint64_t stat_error_user_timestamp;
+  /** Total number of epoch mismatch events */
+  uint64_t stat_epoch_mismatch;
+  /** Total number of recoverable transmission errors (session auto-recovered) */
+  uint64_t stat_recoverable_error;
+  /** Total number of unrecoverable transmission errors (session needed restart) */
+  uint64_t stat_unrecoverable_error;
 };
 
 /**
@@ -319,6 +325,8 @@ struct st_rx_user_stats {
   uint64_t stat_pkts_wrong_ssrc_dropped;
   /** Total number of packets dropped due to wrong payload type */
   uint64_t stat_pkts_wrong_pt_dropped;
+  /** Total number of redundant packets filtered (post-redundancy duplicates). */
+  uint64_t stat_pkts_redundant;
 };
 
 /**

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -274,7 +274,12 @@ struct st_rx_port_stats {
   uint64_t incomplete_frames;
   /** Total number of received packets rejected by handler. */
   uint64_t err_packets;
-  /** Total number of out-of-order packets received on this port (pre-redundancy). */
+  /**
+   * Total number of missing packets detected on this port (pre-redundancy).
+   * Counts actual missing packets, not gap events.
+   * For video: sum of pkt_idx gaps within frames.
+   * For audio/anc/fmd: sum of RTP sequence number gaps.
+   */
   uint64_t out_of_order_packets;
 };
 
@@ -309,9 +314,9 @@ struct st_rx_user_stats {
   /** Total number of accepted packets (post-redundancy). */
   uint64_t stat_pkts_received;
   /**
-   * Aggregate of per-port out-of-order packets: sum(port[].out_of_order_packets).
-   * For video: frame-internal pkt_idx gaps.
-   * For audio/anc/fmd: per-port RTP seq gaps (pre-redundancy).
+   * Total missing packets detected pre-redundancy: sum(port[].out_of_order_packets).
+   * For video: sum of pkt_idx gaps within frames.
+   * For audio/anc/fmd: sum of RTP sequence number gaps.
    */
   uint64_t stat_pkts_out_of_order;
   /**

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -1886,6 +1886,7 @@ int st20p_tx_get_pacing_params(st20p_tx_handle handle, double* tr_offset_ns,
 /**
  * Retrieve the general statistics(I/O) for one tx st2110-20(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-20(pipeline) session.
  * @param port
@@ -1901,6 +1902,7 @@ int st20p_tx_get_session_stats(st20p_tx_handle handle, struct st20_tx_user_stats
 /**
  * Reset the general statistics(I/O) for one tx st2110-20(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the tx st2110-20(pipeline) session.
  * @param port
@@ -2082,6 +2084,7 @@ int st20p_rx_get_sch_idx(st20p_rx_handle handle);
 /**
  * Retrieve the general statistics(I/O) for one rx st2110-20(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-20(pipeline) session.
  * @param port
@@ -2097,6 +2100,7 @@ int st20p_rx_get_session_stats(st20p_rx_handle handle, struct st20_rx_user_stats
 /**
  * Reset the general statistics(I/O) for one rx st2110-20(pipeline) session.
  *
+ * @note Thread-safe. Briefly acquires the per-session spinlock.
  * @param handle
  *   The handle to the rx st2110-20(pipeline) session.
  * @param port

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -663,7 +663,6 @@ struct st_rx_video_session_impl {
   struct st20_rx_user_stats stat_snapshot; /* for delta computation in stat dump */
   /* internal-only stats */
   rte_atomic32_t stat_frames_received; /* session-total atomic for cross-thread */
-  int stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_MAX];
   uint64_t stat_last_time;
   uint32_t stat_max_notify_frame_us;
   double stat_cpu_busy_score;
@@ -963,7 +962,6 @@ struct st_rx_audio_session_impl {
   struct st30_rx_user_stats stat_snapshot; /* for delta computation in stat dump */
   /* internal-only stats */
   rte_atomic32_t stat_frames_received; /* session-total atomic for cross-thread */
-  int stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_MAX];
   uint64_t stat_last_time;
   uint32_t stat_max_notify_frame_us;
   struct mt_stat_u64 stat_time;
@@ -1128,7 +1126,6 @@ struct st_rx_ancillary_session_impl {
   struct st40_rx_user_stats stat_snapshot; /* for delta computation in stat dump */
   /* internal-only stats */
   rte_atomic32_t stat_frames_received; /* session-total atomic for cross-thread */
-  int stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_MAX];
   uint64_t stat_last_time;
   uint32_t stat_max_notify_rtp_us;
   struct mt_stat_u64 stat_time;
@@ -1287,7 +1284,6 @@ struct st_rx_fastmetadata_session_impl {
   struct st41_rx_user_stats stat_snapshot; /* for delta computation in stat dump */
   /* internal-only stats */
   rte_atomic32_t stat_frames_received; /* session-total atomic for cross-thread */
-  int stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_MAX];
   uint64_t stat_last_time;
   uint32_t stat_max_notify_rtp_us;
   struct mt_stat_u64 stat_time;

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -166,7 +166,6 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->stat_pkts_out_of_order_per_port[s_port]++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -269,8 +268,6 @@ static void rx_ancillary_session_reset(struct st_rx_ancillary_session_impl* s,
   mt_stat_u64_init(&s->stat_time);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
-  memset(s->stat_pkts_out_of_order_per_port, 0,
-         sizeof(s->stat_pkts_out_of_order_per_port));
 
   /* Reset interlace detection state */
   s->interlace_detected = !s->interlace_auto;
@@ -592,11 +589,12 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
     notice("RX_ANC_SESSION(%d): dropped pkts %" PRIu64 "\n", idx, pkts_dropped);
   }
   if (pkts_out_of_order) {
-    warn("RX_ANC_SESSION(%d): out of order pkts %" PRIu64 " (%d:%d)\n", idx,
-         pkts_out_of_order, s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_P],
-         s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_R]);
-    s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_P] = 0;
-    s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_R] = 0;
+    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
+    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
+    warn("RX_ANC_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64 ")\n",
+         idx, pkts_out_of_order, d_p, d_r);
   }
 
   if (pkts_wrong_pt_dropped) {

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -191,7 +191,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     }
 
     s->redundant_error_cnt[s_port]++;
-    s->port_user_stats.stat_pkts_redundant++;
+    s->port_user_stats.common.stat_pkts_redundant++;
 
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
@@ -563,7 +563,8 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
 
   uint64_t pkts_received =
       us->common.stat_pkts_received - snap->common.stat_pkts_received;
-  uint64_t pkts_redundant = us->stat_pkts_redundant - snap->stat_pkts_redundant;
+  uint64_t pkts_redundant =
+      us->common.stat_pkts_redundant - snap->common.stat_pkts_redundant;
   uint64_t pkts_out_of_order =
       us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
   uint64_t pkts_unrecovered =

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -163,10 +163,11 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
 
   /* not a big deal as long as stream is continous */
   if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+    uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+    s->port_user_stats.common.stat_pkts_out_of_order += gap;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -1209,7 +1210,9 @@ int st40_rx_get_session_stats(st40_rx_handle handle, struct st40_rx_user_stats* 
   }
   struct st_rx_ancillary_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 
@@ -1227,8 +1230,10 @@ int st40_rx_reset_session_stats(st40_rx_handle handle) {
   }
   struct st_rx_ancillary_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
   rte_atomic32_set(&s->stat_frames_received, 0);
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -166,6 +166,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
+    s->port_user_stats.common.stat_pkts_out_of_order++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -214,7 +215,8 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     }
     dbg("%s(%d,%d), session seq_id %u out of order %d\n", __func__, s->idx, s_port,
         seq_id, s->session_seq_id);
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.stat_pkts_unrecovered +=
+        (uint16_t)(seq_id - s->session_seq_id - 1);
   }
 
   /* update seq id */
@@ -304,8 +306,10 @@ static int rx_ancillary_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf,
     return -EIO;
   }
 
-  for (uint16_t i = 0; i < nb; i++)
-    rx_ancillary_session_handle_pkt(impl, s, mbuf[i], s_port);
+  for (uint16_t i = 0; i < nb; i++) {
+    if (rx_ancillary_session_handle_pkt(impl, s, mbuf[i], s_port) < 0)
+      s->port_user_stats.common.port[s_port].err_packets++;
+  }
 
   return 0;
 }
@@ -562,6 +566,8 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
   uint64_t pkts_redundant = us->stat_pkts_redundant - snap->stat_pkts_redundant;
   uint64_t pkts_out_of_order =
       us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
+  uint64_t pkts_unrecovered =
+      us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
   uint64_t pkts_dropped = us->stat_pkts_dropped - snap->stat_pkts_dropped;
   uint64_t pkts_wrong_pt_dropped =
       us->common.stat_pkts_wrong_pt_dropped - snap->common.stat_pkts_wrong_pt_dropped;
@@ -595,6 +601,9 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
                    snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
     warn("RX_ANC_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64 ")\n",
          idx, pkts_out_of_order, d_p, d_r);
+  }
+  if (pkts_unrecovered) {
+    warn("RX_ANC_SESSION(%d): unrecovered pkts %" PRIu64 "\n", idx, pkts_unrecovered);
   }
 
   if (pkts_wrong_pt_dropped) {

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -305,6 +305,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
+    s->port_user_stats.common.stat_pkts_out_of_order++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -333,7 +334,8 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   if (seq_id != (uint16_t)(s->session_seq_id + 1)) {
     dbg("%s(%d,%d), session seq_id %u out of order %d\n", __func__, s->idx, s_port,
         seq_id, s->session_seq_id);
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.stat_pkts_unrecovered +=
+        (uint16_t)(seq_id - s->session_seq_id - 1);
   }
 
   /* The package is accepted and goes into the frame */
@@ -471,6 +473,7 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
+    s->port_user_stats.common.stat_pkts_out_of_order++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -501,7 +504,8 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   if (seq_id != (uint16_t)(s->session_seq_id + 1)) {
     dbg("%s(%d,%d), session seq_id %u out of order %d\n", __func__, s->idx, s_port,
         seq_id, s->session_seq_id);
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.stat_pkts_unrecovered +=
+        (uint16_t)(seq_id - s->session_seq_id - 1);
   }
 
   /* The package is accepted and goes into the frame */
@@ -653,11 +657,14 @@ static int rx_audio_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf, uint
   }
 
   if (ST30_TYPE_FRAME_LEVEL == st30_type) {
-    for (uint16_t i = 0; i < nb; i++)
-      rx_audio_session_handle_frame_pkt(impl, s, mbuf[i], s_port);
+    for (uint16_t i = 0; i < nb; i++) {
+      if (rx_audio_session_handle_frame_pkt(impl, s, mbuf[i], s_port) < 0)
+        s->port_user_stats.common.port[s_port].err_packets++;
+    }
   } else {
     for (uint16_t i = 0; i < nb; i++) {
-      rx_audio_session_handle_rtp_pkt(impl, s, mbuf[i], s_port);
+      if (rx_audio_session_handle_rtp_pkt(impl, s, mbuf[i], s_port) < 0)
+        s->port_user_stats.common.port[s_port].err_packets++;
     }
   }
 
@@ -979,6 +986,8 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
   uint64_t pkts_redundant = us->stat_pkts_redundant - snap->stat_pkts_redundant;
   uint64_t pkts_out_of_order =
       us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
+  uint64_t pkts_unrecovered =
+      us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
   uint64_t pkts_dropped = us->stat_pkts_dropped - snap->stat_pkts_dropped;
   uint64_t pkts_wrong_pt_dropped =
       us->common.stat_pkts_wrong_pt_dropped - snap->common.stat_pkts_wrong_pt_dropped;
@@ -1008,6 +1017,9 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
     warn("RX_AUDIO_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64
          ")\n",
          idx, pkts_out_of_order, d_p, d_r);
+  }
+  if (pkts_unrecovered) {
+    warn("RX_AUDIO_SESSION(%d): unrecovered pkts %" PRIu64 "\n", idx, pkts_unrecovered);
   }
 
   if (pkts_dropped) {

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -317,7 +317,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   if (!mt_seq32_greater(tmstamp, s->tmstamp)) {
     dbg("%s(%d,%d), drop as pkt seq_id %u (%u) or tmstamp %u (%ld) is old\n", __func__,
         s->idx, s_port, seq_id, s->latest_seq_id[s_port], tmstamp, s->tmstamp);
-    s->port_user_stats.stat_pkts_redundant++;
+    s->port_user_stats.common.stat_pkts_redundant++;
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
         return -EIO;
@@ -485,7 +485,7 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   if (!mt_seq32_greater(tmstamp, s->tmstamp)) {
     dbg("%s(%d,%d), drop as pkt seq_id %u (%u) or tmstamp %u (%ld) is old\n", __func__,
         s->idx, s_port, seq_id, s->latest_seq_id[s_port], tmstamp, s->tmstamp);
-    s->port_user_stats.stat_pkts_redundant++;
+    s->port_user_stats.common.stat_pkts_redundant++;
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
         return -EIO;
@@ -983,7 +983,8 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
 
   uint64_t pkts_received =
       us->common.stat_pkts_received - snap->common.stat_pkts_received;
-  uint64_t pkts_redundant = us->stat_pkts_redundant - snap->stat_pkts_redundant;
+  uint64_t pkts_redundant =
+      us->common.stat_pkts_redundant - snap->common.stat_pkts_redundant;
   uint64_t pkts_out_of_order =
       us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
   uint64_t pkts_unrecovered =

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -302,10 +302,11 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   /* redundant stream seq_id out of order is not a big deal as long as stream is continous
    */
   if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+    uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+    s->port_user_stats.common.stat_pkts_out_of_order += gap;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -470,10 +471,11 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   /* redundant stream seq_id out of order is not a big deal as long as stream is continous
    */
   if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+    uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+    s->port_user_stats.common.stat_pkts_out_of_order += gap;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -1672,7 +1674,9 @@ int st30_rx_get_session_stats(st30_rx_handle handle, struct st30_rx_user_stats* 
   }
   struct st_rx_audio_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 
@@ -1690,8 +1694,10 @@ int st30_rx_reset_session_stats(st30_rx_handle handle) {
   }
   struct st_rx_audio_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
   rte_atomic32_set(&s->stat_frames_received, 0);
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -305,7 +305,6 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->stat_pkts_out_of_order_per_port[s_port]++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -472,7 +471,6 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->stat_pkts_out_of_order_per_port[s_port]++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -536,8 +534,6 @@ static void rx_audio_session_reset(struct st_rx_audio_session_impl* s,
   s->st30_pkt_idx = 0;
   s->st30_cur_frame = NULL;
   s->first_pkt_rtp_ts = 0;
-  s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_P] = 0;
-  s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_R] = 0;
   s->stat_last_time = init_stat_time_now ? mt_get_monotonic_time() : 0;
   s->stat_max_notify_frame_us = 0;
   rte_atomic32_set(&s->stat_frames_received, 0);
@@ -1005,11 +1001,13 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
 
   s->stat_last_time = cur_time_ns;
   if (pkts_out_of_order) {
-    warn("RX_AUDIO_SESSION(%d): out of order pkts %" PRIu64 " (%d:%d)\n", idx,
-         pkts_out_of_order, s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_P],
-         s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_R]);
-    s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_P] = 0;
-    s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_R] = 0;
+    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
+    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
+    warn("RX_AUDIO_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64
+         ")\n",
+         idx, pkts_out_of_order, d_p, d_r);
   }
 
   if (pkts_dropped) {

--- a/lib/src/st2110/st_rx_fastmetadata_session.c
+++ b/lib/src/st2110/st_rx_fastmetadata_session.c
@@ -143,7 +143,7 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
           s_port, tmstamp, s->tmstamp);
     }
 
-    s->port_user_stats.stat_pkts_redundant++;
+    s->port_user_stats.common.stat_pkts_redundant++;
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
         return -EIO;
@@ -480,7 +480,8 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
 
   uint64_t pkts_received =
       us->common.stat_pkts_received - snap->common.stat_pkts_received;
-  uint64_t pkts_redundant = us->stat_pkts_redundant - snap->stat_pkts_redundant;
+  uint64_t pkts_redundant =
+      us->common.stat_pkts_redundant - snap->common.stat_pkts_redundant;
   uint64_t pkts_out_of_order =
       us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
   uint64_t pkts_unrecovered =

--- a/lib/src/st2110/st_rx_fastmetadata_session.c
+++ b/lib/src/st2110/st_rx_fastmetadata_session.c
@@ -120,10 +120,11 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
 
   /* not a big deal as long as stream is continous */
   if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+    uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+    s->port_user_stats.common.stat_pkts_out_of_order += gap;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -1115,7 +1116,9 @@ int st41_rx_get_session_stats(st41_rx_handle handle, struct st41_rx_user_stats* 
   }
   struct st_rx_fastmetadata_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 
@@ -1133,8 +1136,10 @@ int st41_rx_reset_session_stats(st41_rx_handle handle) {
   }
   struct st_rx_fastmetadata_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
   rte_atomic32_set(&s->stat_frames_received, 0);
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }

--- a/lib/src/st2110/st_rx_fastmetadata_session.c
+++ b/lib/src/st2110/st_rx_fastmetadata_session.c
@@ -123,7 +123,6 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
-    s->stat_pkts_out_of_order_per_port[s_port]++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -431,8 +430,6 @@ static int rx_fastmetadata_session_attach(struct mtl_main_impl* impl,
   mt_stat_u64_init(&s->stat_time);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
-  memset(s->stat_pkts_out_of_order_per_port, 0,
-         sizeof(s->stat_pkts_out_of_order_per_port));
 
   ret = rx_fastmetadata_session_init_hw(impl, s);
   if (ret < 0) {
@@ -487,11 +484,11 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
   uint64_t pkts_wrong_ssrc_dropped =
       us->common.stat_pkts_wrong_ssrc_dropped - snap->common.stat_pkts_wrong_ssrc_dropped;
   uint64_t pkts_enqueue_fail = us->stat_pkts_enqueue_fail - snap->stat_pkts_enqueue_fail;
-  int pkts_wrong_interlace_dropped =
+  uint64_t pkts_wrong_interlace_dropped =
       us->stat_pkts_wrong_interlace_dropped - snap->stat_pkts_wrong_interlace_dropped;
-  uint32_t interlace_first_field =
+  uint64_t interlace_first_field =
       us->stat_interlace_first_field - snap->stat_interlace_first_field;
-  uint32_t interlace_second_field =
+  uint64_t interlace_second_field =
       us->stat_interlace_second_field - snap->stat_interlace_second_field;
 
   if (pkts_redundant) {
@@ -505,11 +502,12 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
   s->stat_last_time = cur_time_ns;
 
   if (pkts_out_of_order) {
-    warn("RX_FMD_SESSION(%d): out of order pkts %" PRIu64 " (%d:%d)\n", idx,
-         pkts_out_of_order, s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_P],
-         s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_R]);
-    s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_P] = 0;
-    s->stat_pkts_out_of_order_per_port[MTL_SESSION_PORT_R] = 0;
+    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
+    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
+    warn("RX_FMD_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64 ")\n",
+         idx, pkts_out_of_order, d_p, d_r);
   }
 
   if (pkts_wrong_pt_dropped) {
@@ -521,7 +519,7 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
            pkts_wrong_ssrc_dropped);
   }
   if (pkts_wrong_interlace_dropped) {
-    notice("RX_FMD_SESSION(%d): wrong hdr interlace dropped pkts %d\n", idx,
+    notice("RX_FMD_SESSION(%d): wrong hdr interlace dropped pkts %" PRIu64 "\n", idx,
            pkts_wrong_interlace_dropped);
   }
   if (pkts_enqueue_fail) {
@@ -529,8 +527,9 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
            pkts_enqueue_fail);
   }
   if (s->ops.interlaced) {
-    notice("RX_FMD_SESSION(%d): interlace first field %u second field %u\n", idx,
-           interlace_first_field, interlace_second_field);
+    notice("RX_FMD_SESSION(%d): interlace first field %" PRIu64 " second field %" PRIu64
+           "\n",
+           idx, interlace_first_field, interlace_second_field);
   }
 
   memcpy(snap, us, sizeof(*snap));

--- a/lib/src/st2110/st_rx_fastmetadata_session.c
+++ b/lib/src/st2110/st_rx_fastmetadata_session.c
@@ -123,6 +123,7 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets++;
+    s->port_user_stats.common.stat_pkts_out_of_order++;
   }
   s->latest_seq_id[s_port] = seq_id;
 
@@ -160,7 +161,8 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
   if (seq_id != (uint16_t)(s->session_seq_id + 1)) {
     dbg("%s(%d,%d), session seq_id %u out of order %d\n", __func__, s->idx, s_port,
         seq_id, s->session_seq_id);
-    s->port_user_stats.common.stat_pkts_out_of_order++;
+    s->port_user_stats.common.stat_pkts_unrecovered +=
+        (uint16_t)(seq_id - s->session_seq_id - 1);
   }
 
   /* update seq id */
@@ -211,8 +213,10 @@ static int rx_fastmetadata_session_handle_mbuf(void* priv, struct rte_mbuf** mbu
     return -EIO;
   }
 
-  for (uint16_t i = 0; i < nb; i++)
-    rx_fastmetadata_session_handle_pkt(impl, s, mbuf[i], s_port);
+  for (uint16_t i = 0; i < nb; i++) {
+    if (rx_fastmetadata_session_handle_pkt(impl, s, mbuf[i], s_port) < 0)
+      s->port_user_stats.common.port[s_port].err_packets++;
+  }
 
   return 0;
 }
@@ -479,6 +483,8 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
   uint64_t pkts_redundant = us->stat_pkts_redundant - snap->stat_pkts_redundant;
   uint64_t pkts_out_of_order =
       us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
+  uint64_t pkts_unrecovered =
+      us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
   uint64_t pkts_wrong_pt_dropped =
       us->common.stat_pkts_wrong_pt_dropped - snap->common.stat_pkts_wrong_pt_dropped;
   uint64_t pkts_wrong_ssrc_dropped =
@@ -508,6 +514,9 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
                    snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
     warn("RX_FMD_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64 ")\n",
          idx, pkts_out_of_order, d_p, d_r);
+  }
+  if (pkts_unrecovered) {
+    warn("RX_FMD_SESSION(%d): unrecovered pkts %" PRIu64 "\n", idx, pkts_unrecovered);
   }
 
   if (pkts_wrong_pt_dropped) {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -921,8 +921,8 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
     /* record the miss pkts */
     float pd_sz_per_pkt = (float)meta->frame_recv_size / slot->pkts_received;
     int miss_pkts = (s->st20_frame_size - meta->frame_recv_size) / pd_sz_per_pkt;
+    if (miss_pkts > 0) s->port_user_stats.common.stat_pkts_unrecovered += miss_pkts;
     dbg("%s(%d), miss pkts %d for current frame\n", __func__, s->idx, miss_pkts);
-    s->port_user_stats.stat_frames_pks_missed += miss_pkts;
 
 #if 0 /* for miss pkt detail */
     int total_pkts = s->st20_frame_size / pd_sz_per_pkt;
@@ -1005,7 +1005,7 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
         (s->st22_expect_size_per_frame - meta->frame_total_size) / pd_sz_per_pkt;
     if (miss_pkts < 0) miss_pkts = 0;
     dbg("%s(%d), miss pkts %d for current frame\n", __func__, s->idx, miss_pkts);
-    s->port_user_stats.stat_frames_pks_missed += miss_pkts;
+    if (miss_pkts > 0) s->port_user_stats.common.stat_pkts_unrecovered += miss_pkts;
 #if 0 /* for miss pkt detail */
     int total_pkts = s->st22_expect_size_per_frame / pd_sz_per_pkt;
     dbg("%s(%d), total_pkts %d\n", __func__, s->idx, total_pkts);
@@ -3527,14 +3527,15 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
   if (d || pkts_idx_dropped || pkts_offset_dropped) {
     uint64_t pkts_idx_oo_bitmap =
         us->stat_pkts_idx_oo_bitmap - snap->stat_pkts_idx_oo_bitmap;
-    uint64_t frames_pks_missed =
-        us->stat_frames_pks_missed - snap->stat_frames_pks_missed;
+    uint64_t pkts_unrecovered =
+        us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
     notice("RX_VIDEO_SESSION(%d,%d): incomplete frames %" PRIu64
            ", pkts (idx error: %" PRIu64
            ", offset "
-           "error: %" PRIu64 ", idx out of bitmap: %" PRIu64 ", missed: %" PRIu64 ")\n",
+           "error: %" PRIu64 ", idx out of bitmap: %" PRIu64 ", unrecovered: %" PRIu64
+           ")\n",
            m_idx, idx, d, pkts_idx_dropped, pkts_offset_dropped, pkts_idx_oo_bitmap,
-           frames_pks_missed);
+           pkts_unrecovered);
   }
   d = us->stat_pkts_rtp_ring_full - snap->stat_pkts_rtp_ring_full;
   if (d) {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1575,7 +1575,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
   struct st_rx_video_slot_impl* slot = rv_slot_by_tmstamp(s, tmstamp, NULL, &exist_ts);
   /* Based on rv_slot_by_tmstamp - exist_ts is only true when slot is found */
   if (exist_ts && !slot->frame) {
-    s->port_user_stats.stat_pkts_redundant_dropped++;
+    s->port_user_stats.common.stat_pkts_redundant++;
     slot->pkts_recv_per_port[s_port]++;
     s->redundant_error_cnt[s_port]++;
     return 0;
@@ -1651,7 +1651,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
     if (is_set) {
       dbg("%s(%d,%d), drop as pkt %d already received\n", __func__, s->idx, s_port,
           pkt_idx);
-      s->port_user_stats.stat_pkts_redundant_dropped++;
+      s->port_user_stats.common.stat_pkts_redundant++;
       slot->pkts_recv_per_port[s_port]++;
       /* tp for the redundant packet */
       if (s->enable_timing_parser)
@@ -1845,7 +1845,7 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
     if (is_set) {
       dbg("%s(%d,%d), drop as pkt %d already received\n", __func__, s->idx, s_port,
           pkt_idx);
-      s->port_user_stats.stat_pkts_redundant_dropped++;
+      s->port_user_stats.common.stat_pkts_redundant++;
       return 0;
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
@@ -1997,7 +1997,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
   struct st_rx_video_slot_impl* slot = rv_slot_by_tmstamp(s, tmstamp, NULL, &exist_ts);
   /* Based on rv_slot_by_tmstamp - exist_ts is only true when slot is found */
   if (exist_ts && !slot->frame) {
-    s->port_user_stats.stat_pkts_redundant_dropped++;
+    s->port_user_stats.common.stat_pkts_redundant++;
     slot->pkts_recv_per_port[s_port]++;
     s->redundant_error_cnt[s_port]++;
     return 0;
@@ -2038,7 +2038,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
     if (is_set) {
       dbg("%s(%d,%d), drop as pkt %d already received\n", __func__, s->idx, s_port,
           pkt_idx);
-      s->port_user_stats.stat_pkts_redundant_dropped++;
+      s->port_user_stats.common.stat_pkts_redundant++;
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
@@ -2172,7 +2172,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
   struct st_rx_video_slot_impl* slot = rv_slot_by_tmstamp(s, tmstamp, payload, &exist_ts);
   /* Based on rv_slot_by_tmstamp - exist_ts is only true when slot is found */
   if (exist_ts && !slot->frame) {
-    s->port_user_stats.stat_pkts_redundant_dropped++;
+    s->port_user_stats.common.stat_pkts_redundant++;
     s->redundant_error_cnt[s_port]++;
     slot->pkts_recv_per_port[s_port]++;
     return 0;
@@ -2203,7 +2203,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
     if (is_set) {
       dbg("%s(%d,%d), drop as pkt %d already received\n", __func__, s->idx, s_port,
           pkt_idx);
-      s->port_user_stats.stat_pkts_redundant_dropped++;
+      s->port_user_stats.common.stat_pkts_redundant++;
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
@@ -3497,20 +3497,20 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
       us->common.stat_pkts_received - snap->common.stat_pkts_received;
   uint64_t bytes_received = us->stat_bytes_received - snap->stat_bytes_received;
   uint64_t slices_received = us->stat_slices_received - snap->stat_slices_received;
-  uint64_t pkts_redundant_dropped =
-      us->stat_pkts_redundant_dropped - snap->stat_pkts_redundant_dropped;
+  uint64_t pkts_redundant =
+      us->common.stat_pkts_redundant - snap->common.stat_pkts_redundant;
 
   char extra_info[128] = "";
-  if (slices_received || pkts_redundant_dropped) {
+  if (slices_received || pkts_redundant) {
     int offset = 0;
     if (slices_received) {
       offset += snprintf(extra_info + offset, sizeof(extra_info) - offset,
                          " slices %" PRIu64, slices_received);
     }
-    if (pkts_redundant_dropped) {
-      offset += snprintf(extra_info + offset, sizeof(extra_info) - offset,
-                         "%sredundant %" PRIu64, slices_received ? " + " : " ",
-                         pkts_redundant_dropped);
+    if (pkts_redundant) {
+      offset +=
+          snprintf(extra_info + offset, sizeof(extra_info) - offset,
+                   "%sredundant %" PRIu64, slices_received ? " + " : " ", pkts_redundant);
     }
   }
   notice("RX_VIDEO_SESSION(%d,%d:%s): fps %f frames %d pkts %" PRIu64 "%s\n", m_idx, idx,

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1660,6 +1660,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
       s->port_user_stats.common.stat_pkts_out_of_order++;
+      s->port_user_stats.common.port[s_port].out_of_order_packets++;
     }
   } else {
     /* the first pkt should always dispatch to control thread */
@@ -1849,6 +1850,7 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
       s->port_user_stats.common.stat_pkts_out_of_order++;
+      s->port_user_stats.common.port[s_port].out_of_order_packets++;
     }
   } else {
     if (!slot->seq_id_got) { /* first packet */
@@ -2042,6 +2044,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
       s->port_user_stats.common.stat_pkts_out_of_order++;
+      s->port_user_stats.common.port[s_port].out_of_order_packets++;
     }
   } else {
     /* first packet */
@@ -2206,6 +2209,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
       s->port_user_stats.common.stat_pkts_out_of_order++;
+      s->port_user_stats.common.port[s_port].out_of_order_packets++;
     }
   } else {
     if (!line1_number && !line1_offset) { /* first packet */
@@ -3542,10 +3546,15 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
     notice("RX_VIDEO_SESSION(%d,%d): dropped pkts %" PRIu64 " as no slot\n", m_idx, idx,
            d);
   }
-  /* TODO tracing out of order per port */
   d = us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
   if (d) {
-    notice("RX_VIDEO_SESSION(%d,%d): out of order pkts %" PRIu64 "\n", m_idx, idx, d);
+    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
+    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
+                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
+    notice("RX_VIDEO_SESSION(%d,%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64
+           ")\n",
+           m_idx, idx, d, d_p, d_r);
   }
   d = us->common.stat_pkts_wrong_pt_dropped - snap->common.stat_pkts_wrong_pt_dropped;
   if (d) {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1659,8 +1659,9 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
       return 0;
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
-      s->port_user_stats.common.stat_pkts_out_of_order++;
-      s->port_user_stats.common.port[s_port].out_of_order_packets++;
+      int gap = pkt_idx - slot->last_pkt_idx - 1;
+      s->port_user_stats.common.stat_pkts_out_of_order += gap;
+      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
     }
   } else {
     /* the first pkt should always dispatch to control thread */
@@ -1849,8 +1850,9 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
       return 0;
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
-      s->port_user_stats.common.stat_pkts_out_of_order++;
-      s->port_user_stats.common.port[s_port].out_of_order_packets++;
+      int gap = pkt_idx - slot->last_pkt_idx - 1;
+      s->port_user_stats.common.stat_pkts_out_of_order += gap;
+      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
     }
   } else {
     if (!slot->seq_id_got) { /* first packet */
@@ -2043,8 +2045,9 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
       return 0;
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
-      s->port_user_stats.common.stat_pkts_out_of_order++;
-      s->port_user_stats.common.port[s_port].out_of_order_packets++;
+      int gap = pkt_idx - slot->last_pkt_idx - 1;
+      s->port_user_stats.common.stat_pkts_out_of_order += gap;
+      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
     }
   } else {
     /* first packet */
@@ -2208,8 +2211,9 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
       return 0;
     }
     if (pkt_idx != (slot->last_pkt_idx + 1)) {
-      s->port_user_stats.common.stat_pkts_out_of_order++;
-      s->port_user_stats.common.port[s_port].out_of_order_packets++;
+      int gap = pkt_idx - slot->last_pkt_idx - 1;
+      s->port_user_stats.common.stat_pkts_out_of_order += gap;
+      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
     }
   } else {
     if (!line1_number && !line1_offset) { /* first packet */
@@ -4418,7 +4422,9 @@ int st20_rx_get_session_stats(st20_rx_handle handle, struct st20_rx_user_stats* 
   }
   struct st_rx_video_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->parent->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->parent->mutex[s->idx]);
   return 0;
 }
 
@@ -4436,9 +4442,11 @@ int st20_rx_reset_session_stats(st20_rx_handle handle) {
   }
   struct st_rx_video_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->parent->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
   rte_atomic32_set(&s->stat_frames_received, 0);
+  rte_spinlock_unlock(&s->parent->mutex[s->idx]);
   return 0;
 }
 

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -2451,7 +2451,9 @@ int st40_tx_get_session_stats(st40_tx_handle handle, struct st40_tx_user_stats* 
   }
   struct st_tx_ancillary_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 
@@ -2469,7 +2471,9 @@ int st40_tx_reset_session_stats(st40_tx_handle handle) {
   }
   struct st_tx_ancillary_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -395,7 +395,7 @@ static int tx_ancillary_session_sync_pacing(struct mtl_main_impl* impl,
   time_to_tx_ns = (int64_t)start_time_tai - (int64_t)cur_tai;
   if (time_to_tx_ns < 0) {
     /* time bigger than the assigned epoch time */
-    s->port_user_stats.stat_epoch_mismatch++;
+    s->port_user_stats.common.stat_epoch_mismatch++;
     time_to_tx_ns = 0; /* send asap */
   }
 
@@ -1775,7 +1775,7 @@ static void tx_ancillary_session_stat(struct st_tx_ancillary_session_impl* s) {
          idx, s->ops_name, framerate, frames_p, pkts_p, pkts_r);
 
   uint64_t d;
-  d = us->stat_epoch_mismatch - snap->stat_epoch_mismatch;
+  d = us->common.stat_epoch_mismatch - snap->common.stat_epoch_mismatch;
   if (d) {
     notice("TX_ANC_SESSION(%d): st40 epoch mismatch %" PRIu64 "\n", idx, d);
   }

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -3021,7 +3021,9 @@ int st30_tx_get_session_stats(st30_tx_handle handle, struct st30_tx_user_stats* 
   }
   struct st_tx_audio_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 
@@ -3039,7 +3041,9 @@ int st30_tx_reset_session_stats(st30_tx_handle handle) {
   }
   struct st_tx_audio_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -317,7 +317,7 @@ static int tx_audio_session_sync_pacing(struct mtl_main_impl* impl,
 
   if (to_epoch < 0) {
     /* time bigger than the assigned epoch time */
-    s->port_user_stats.stat_epoch_mismatch++;
+    s->port_user_stats.common.stat_epoch_mismatch++;
     if (s->ops.notify_frame_late) {
       s->ops.notify_frame_late(s->ops.priv, -to_epoch / pkt_time);
     }
@@ -2282,7 +2282,7 @@ static void tx_audio_session_stat(struct st_tx_audio_sessions_mgr* mgr,
          s->inflight_cnt[MTL_SESSION_PORT_P], s->inflight_cnt[MTL_SESSION_PORT_R]);
 
   uint64_t d;
-  d = us->stat_epoch_mismatch - snap->stat_epoch_mismatch;
+  d = us->common.stat_epoch_mismatch - snap->common.stat_epoch_mismatch;
   if (d) {
     notice("TX_AUDIO_SESSION(%d,%d): epoch mismatch %" PRIu64 "\n", m_idx, idx, d);
   }
@@ -2311,11 +2311,11 @@ static void tx_audio_session_stat(struct st_tx_audio_sessions_mgr* mgr,
   if (d) {
     notice("TX_AUDIO_SESSION(%d,%d): error user timestamp %" PRIu64 "\n", m_idx, idx, d);
   }
-  d = us->stat_recoverable_error - snap->stat_recoverable_error;
+  d = us->common.stat_recoverable_error - snap->common.stat_recoverable_error;
   if (d) {
     notice("TX_AUDIO_SESSION(%d,%d): recoverable_error %" PRIu64 " \n", m_idx, idx, d);
   }
-  d = us->stat_unrecoverable_error - snap->stat_unrecoverable_error;
+  d = us->common.stat_unrecoverable_error - snap->common.stat_unrecoverable_error;
   if (d) {
     err("TX_AUDIO_SESSION(%d,%d): unrecoverable_error %" PRIu64 " \n", m_idx, idx, d);
     /* not reset unrecoverable_error */
@@ -2717,10 +2717,10 @@ int st_audio_queue_fatal_error(struct mtl_main_impl* impl,
     if (ret < 0) {
       err("%s(%d,%d), init mempool fail %d for session %d\n", __func__, idx, port, ret,
           sidx);
-      s->port_user_stats.stat_unrecoverable_error++;
+      s->port_user_stats.common.stat_unrecoverable_error++;
       s->active = false; /* mark current session to dead */
     } else {
-      s->port_user_stats.stat_recoverable_error++;
+      s->port_user_stats.common.stat_recoverable_error++;
     }
     tx_audio_session_put(mgr, sidx);
   }

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -302,7 +302,7 @@ static int tx_fastmetadata_session_sync_pacing(struct mtl_main_impl* impl,
   to_epoch = tx_fastmetadata_pacing_time(pacing, epochs) - ptp_time;
   if (to_epoch < 0) {
     /* time bigger than the assigned epoch time */
-    s->port_user_stats.stat_epoch_mismatch++;
+    s->port_user_stats.common.stat_epoch_mismatch++;
     to_epoch = 0; /* send asap */
   }
 
@@ -1537,7 +1537,7 @@ static void tx_fastmetadata_session_stat(struct st_tx_fastmetadata_session_impl*
          idx, s->ops_name, framerate, frames_p, pkts_p, pkts_r);
 
   uint64_t d;
-  d = us->stat_epoch_mismatch - snap->stat_epoch_mismatch;
+  d = us->common.stat_epoch_mismatch - snap->common.stat_epoch_mismatch;
   if (d) {
     notice("TX_FMD_SESSION(%d): st41 epoch mismatch %" PRIu64 "\n", idx, d);
   }

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -1569,7 +1569,6 @@ static void tx_fastmetadata_session_stat(struct st_tx_fastmetadata_session_impl*
     notice("TX_FMD_SESSION(%d): error user timestamp %" PRIu64 "\n", idx, d);
   }
 
-  us->stat_last_time = s->stat_last_time;
   memcpy(snap, us, sizeof(*snap));
 
   struct mt_stat_u64* stat_time = &s->stat_time;

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -2203,7 +2203,9 @@ int st41_tx_get_session_stats(st41_tx_handle handle, struct st41_tx_user_stats* 
   }
   struct st_tx_fastmetadata_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 
@@ -2221,7 +2223,9 @@ int st41_tx_reset_session_stats(st41_tx_handle handle) {
   }
   struct st_tx_fastmetadata_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -3429,7 +3429,10 @@ static void tv_stat(struct st_tx_video_sessions_mgr* mgr,
          idx, (double)bytes_p * 8 / time_sec / MTL_STAT_M_UNIT,
          (double)bytes_r * 8 / time_sec / MTL_STAT_M_UNIT, s->stat_cpu_busy_score);
   s->stat_last_time = cur_time_ns;
-  s->stat_pkts_burst = 0;
+  if (s->stat_pkts_burst > 0) {
+    notice("TX_VIDEO_SESSION(%d,%d): pkts burst %d\n", m_idx, idx, s->stat_pkts_burst);
+    s->stat_pkts_burst = 0;
+  }
   s->trs_inflight_cnt[0] = 0;
   s->inflight_cnt[0] = 0;
 

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -3505,11 +3505,11 @@ static void tv_stat(struct st_tx_video_sessions_mgr* mgr,
     notice("TX_VIDEO_SESSION(%d,%d): user meta %" PRIu64 " pkt %" PRIu64 "\n", m_idx, idx,
            d_meta, d_meta_pkt);
   }
-  d = us->stat_recoverable_error - snap->stat_recoverable_error;
+  d = us->common.stat_recoverable_error - snap->common.stat_recoverable_error;
   if (d) {
     notice("TX_VIDEO_SESSION(%d,%d): recoverable_error %" PRIu64 " \n", m_idx, idx, d);
   }
-  d = us->stat_unrecoverable_error - snap->stat_unrecoverable_error;
+  d = us->common.stat_unrecoverable_error - snap->common.stat_unrecoverable_error;
   if (d) {
     err("TX_VIDEO_SESSION(%d,%d): unrecoverable_error %" PRIu64 " \n", m_idx, idx, d);
     /* not reset unrecoverable_error */
@@ -4083,7 +4083,7 @@ int st20_tx_queue_fatal_error(struct mtl_main_impl* impl,
   s->queue[s_port] = mt_txq_get(impl, port, &flow);
   if (!s->queue[s_port]) {
     err("%s(%d,%d), get new txq fail\n", __func__, s_port, idx);
-    s->port_user_stats.stat_unrecoverable_error++;
+    s->port_user_stats.common.stat_unrecoverable_error++;
     s->active = false; /* mark current session to dead */
     if (s->ops.notify_event) s->ops.notify_event(s->ops.priv, ST_EVENT_FATAL_ERROR, NULL);
     return -EIO;
@@ -4112,7 +4112,7 @@ int st20_tx_queue_fatal_error(struct mtl_main_impl* impl,
   ret = tv_mempool_init(impl, s->mgr, s);
   if (ret < 0) {
     err("%s(%d,%d), reset mempool fail\n", __func__, s_port, idx);
-    s->port_user_stats.stat_unrecoverable_error++;
+    s->port_user_stats.common.stat_unrecoverable_error++;
     s->active = false; /* mark current session to dead */
     if (s->ops.notify_event) s->ops.notify_event(s->ops.priv, ST_EVENT_FATAL_ERROR, NULL);
     return ret;
@@ -4121,7 +4121,7 @@ int st20_tx_queue_fatal_error(struct mtl_main_impl* impl,
   /* point to next frame */
   s->st20_pkt_idx = 0;
   s->st20_frame_stat = ST21_TX_STAT_WAIT_FRAME;
-  s->port_user_stats.stat_recoverable_error++;
+  s->port_user_stats.common.stat_recoverable_error++;
   if (s->ops.notify_event)
     s->ops.notify_event(s->ops.priv, ST_EVENT_RECOVERY_ERROR, NULL);
 

--- a/lib/src/st2110/st_tx_video_session.c
+++ b/lib/src/st2110/st_tx_video_session.c
@@ -4543,7 +4543,9 @@ int st20_tx_get_session_stats(st20_tx_handle handle, struct st20_tx_user_stats* 
   }
   struct st_tx_video_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memcpy(stats, &s->port_user_stats, sizeof(*stats));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 
@@ -4561,8 +4563,10 @@ int st20_tx_reset_session_stats(st20_tx_handle handle) {
   }
   struct st_tx_video_session_impl* s = s_impl->impl;
 
+  rte_spinlock_lock(&s->mgr->mutex[s->idx]);
   memset(&s->port_user_stats, 0, sizeof(s->port_user_stats));
   memset(&s->stat_snapshot, 0, sizeof(s->stat_snapshot));
+  rte_spinlock_unlock(&s->mgr->mutex[s->idx]);
   return 0;
 }
 


### PR DESCRIPTION
Unify RX/TX session statistics across all session types for consistency and thread safety.

- Type fixes & cleanup: fix int→uint64_t mismatches, remove dead fields, populate err_packets for audio/anc/fmd
- Unified loss counter: add stat_pkts_unrecovered to common st_rx_user_stats (replaces stat_frames_pks_missed)
- Move duplicated fields to common structs: stat_pkts_redundant (RX), stat_epoch_mismatch/stat_recoverable_error/stat_unrecoverable_error (TX)
- Consistent OOO counting: out_of_order_packets now counts missing packets (+= gap_size) not gap events (++), so stat_pkts_unrecovered <= stat_pkts_out_of_order holds
- Thread-safe stats API: get/reset_session_stats now acquire per-session spinlock (negligible data-path impact)
- Docs: add doc/stats_guide.md with pipeline diagram, counter interpretation, and troubleshooting

Fields moved from session-specific structs to common are removed from st20/st30/st40/st41 API headers — see commit 6ef76f20 for the full list.