### PR TITLE
Ci: enable redundant (ST2022-7) performance tests

### DIFF
--- a/.github/workflows/perf-pytest.yml
+++ b/.github/workflows/perf-pytest.yml
@@ -84,7 +84,8 @@ jobs:
             --ip_address "${{ secrets.PERF_CLIENT_IP }}" "${{ secrets.PERF_SUT_IP }}" \
             --username "${{ secrets.RUNNER_USERNAME }}" \
             --key_path "/home/$USER/.ssh/id_ed25519" \
-            --test_time "${{ inputs.test_time || '120' }}"
+            --test_time "${{ inputs.test_time || '120' }}" \
+            --no_capture
       - name: Export workflow tag for PCAP naming
         run: echo "MTL_GITHUB_WORKFLOW=${{ github.workflow }}" >> "$GITHUB_ENV"
       - name: Start MtlManager

--- a/tests/validation/configs/gen_config.py
+++ b/tests/validation/configs/gen_config.py
@@ -16,6 +16,7 @@ def gen_test_config(
     ebu_password: str = None,
     media_path: str = "/mnt/media",
     test_time: int = 120,
+    no_capture: bool = False,
 ) -> str:
     pci_devices = [dev.strip() for dev in pci_device.split(",") if dev.strip()]
 
@@ -31,7 +32,7 @@ def gen_test_config(
     }
 
     has_ebu = all([ebu_ip, ebu_user, ebu_password])
-    has_sniff = len(pci_devices) >= 2
+    has_sniff = len(pci_devices) >= 2 and not no_capture
     test_config["compliance"] = has_ebu and has_sniff
 
     if has_sniff:
@@ -176,6 +177,11 @@ def main() -> None:
     # Optional test settings
     parser.add_argument("--test_time", type=int, default=120)
     parser.add_argument("--media_path", type=str, default="/mnt/media")
+    parser.add_argument(
+        "--no_capture",
+        action="store_true",
+        help="Disable packet capture so the 2nd NIC port is available for redundant (ST2022-7) tests",
+    )
 
     args = parser.parse_args()
 
@@ -198,6 +204,7 @@ def main() -> None:
         ebu_password=args.ebu_password,
         media_path=args.media_path,
         test_time=args.test_time,
+        no_capture=args.no_capture,
     )
 
     with open("test_config.yaml", "w") as file:


### PR DESCRIPTION
Add --no_capture flag to gen_config.py so the 2nd NIC port is used for redundant VFs instead of packet capture.  Pass --no_capture in perf-pytest.yml so test_tx_redundant / test_rx_redundant are no longer skipped.