### PR TITLE
Stats unification & RX redundancy bug fixes

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -31,9 +31,10 @@ Add `-Denable_asan=true` (or `MTL_BUILD_ENABLE_ASAN=true`) if you also want
 AddressSanitizer instrumentation. Existing build directories can be reconfigured with
 `meson configure build -Denable_fuzzing=true`.
 
-Meson injects the `MTL_ENABLE_FUZZING_ST40`, `MTL_ENABLE_FUZZING_ST30`,
-`MTL_ENABLE_FUZZING_ST20`, and `MTL_ENABLE_FUZZING_ST22` defines so the RX
-implementation exposes the minimal helper hooks required by the fuzzers.
+The fuzz harnesses `#include` the production `.c` files directly so that all static
+functions are visible without any wrapper hooks in the library source. The linker flag
+`--allow-multiple-definition` resolves the resulting duplicate non-static symbols
+between the harness and `libmtl`.
 
 ## Building
 

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -69,16 +69,53 @@ All counters are `uint64_t`, monotonic, thread-safe (per-session spinlock).
  ┌──────────────────────────────────────────────────────────────────────────────┐
  │  6. POST-REDUNDANCY TOTAL                                                   │
  │                                                                             │
- │     stat_pkts_received++       ◄── "what the app actually got"              │
+ │     stat_pkts_received++       ◄── "what the app actually got" (per pkt)    │
  └──────┬───────────────────────────────────────────────────────────────────────┘
         │
         ▼
  ┌──────────────────────────────────────────────────────────────────────────────┐
- │  7. DELIVER to frame buffer / RTP ring                                      │
+ │  7. ENQUEUE to slot / RTP ring  (transport)                                 │
+ │                                                                             │
+ │     no free slot          ──► stat_pkts_no_slot++          (video)          │
+ │     ring full             ──► stat_pkts_rtp_ring_full++    (video RTP)      │
+ │     anc enqueue fail      ──► stat_pkts_enqueue_fail++     (anc/fmd)        │
+ │     audio offset overflow ──► stat_pkts_dropped++          (audio)          │
+ │     no free framebuff     ──► stat_slot_get_frame_fail++   (video/audio)    │
+ │                                                                             │
+ │     first pkt of a new frame on this port                                   │
+ │                           ──► port[i].frames++             (audio/anc/fmd)  │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │ frame complete (last pkt arrived, or timeout closed it)
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  8. FRAME COMPLETION  (transport notify_frame_ready → pipeline)             │
+ │                                                                             │
+ │     Video: per-port frame accounting                                        │
+ │       port P delivered enough pkts ──► port[P].frames++                     │
+ │       port P was short             ──► port[P].incomplete_frames++          │
+ │       (same for port R)                                                     │
+ │       gap → estimated missing pkts ──► stat_pkts_unrecovered += est         │
+ │                                                                             │
+ │     ST20p / ST40p: frame delivered with intra-frame loss             │
+ │                                    ──► stat_frames_corrupted++              │
+ │                                        (frame still delivered with          │
+ │                                         ST_FRAME_STATUS_CORRUPTED)          │
+ │                                                                             │
+ │     Pipeline (ST20p / ST30p / ST40p):                                       │
+ │       no free user framebuff       ──► stat_frames_dropped++                │
+ │                                        frame NOT delivered                  │
+ │       handed off to user ring      ──► stat_frames_received++               │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  9. APP get_frame()                                                         │
  └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-`port[i].packets` = what arrived on wire `i`. `stat_pkts_received` = what the app got.
+`port[i].packets` = what arrived on wire `i`. `stat_pkts_received` = packets the
+session accepted (post-redundancy). `stat_frames_received` = frames the app
+actually got.
 
 ## The five counters you monitor
 
@@ -123,8 +160,17 @@ frames did the app receive / drop / send".
 
 Populated by pipeline session types (`ST20p`, `ST30p`, `ST40p` for both
 RX and TX). For transport-only paths and types with no per-frame
-classification (audio `stat_frames_corrupted`, ST41 RX), the relevant
-counters stay 0.
+integrity concept (`stat_frames_corrupted` on `ST30p` audio, `ST41` RX),
+the relevant counters stay 0.
+
+> **ST20 only:** the transport-layer field `incomplete_frames_cnt` (in
+> `st20_rx_user_stats`) is **not** the same as `stat_frames_corrupted`.
+> `incomplete_frames_cnt` fires whenever the transport detects intra-frame
+> loss, including when the frame is then silently discarded because
+> `RECEIVE_INCOMPLETE_FRAME` is not set; `stat_frames_corrupted` only
+> counts corrupted frames the app actually consumed via `get_frame()`.
+> `incomplete_frames_cnt - stat_frames_corrupted` = corrupted frames
+> dropped before reaching the app.
 
 ## `port[i].frames` — two flavors (per-port, **not** a session total)
 
@@ -156,6 +202,83 @@ SSRC, length mismatch, etc.). Does **not** reduce `stat_pkts_received` or cause
 `stat_pkts_unrecovered`. Most common benign cause: another stream on the same multicast
 group leaks in — confirm via `stat_pkts_wrong_pt_dropped` / `stat_pkts_wrong_ssrc_dropped`.
 
+## TX packet processing pipeline
+
+```text
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  APP put_frame() / put_frame_abort()                                        │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  1. PIPELINE INTAKE  (ST20p / ST30p / ST40p)                                │
+ │                                                                             │
+ │     put_frame_abort()         ──► stat_frames_dropped++                     │
+ │                                   notify_frame_done(DROPPED)                │
+ │     put_frame()               ──► hand frame to transport ring              │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │ frame ready for transport
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  2. USER-TIMESTAMP VALIDATION  (only if the app supplied an RTP timestamp)  │
+ │                                                                             │
+ │     timestamp invalid     ──► stat_error_user_timestamp++                   │
+ │                               (the frame is still scheduled)                │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  3. PACING DECISION                                                         │
+ │                                                                             │
+ │     app handed the frame too late, slots had to be skipped                  │
+ │                            ──► stat_epoch_drop += skipped_slots             │
+ │                                notify_frame_late() (if app registered)      │
+ │                                                                             │
+ │     app handed the frame too early, scheduled far in the future             │
+ │                            ──► stat_epoch_onward += onward_slots            │
+ │                                                                             │
+ │     pacing snapped to a different epoch than requested                      │
+ │                            ──► stat_epoch_mismatch++  (audio/anc/fmd)       │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │ frame slot assigned
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  4. PER-PORT BUILD  (transport tasklet, P and R independently)              │
+ │                                                                             │
+ │     packet built and queued ──► port[i].build++                             │
+ │     packet enqueued to NIC  ──► port[i].packets++                           │
+ │                                 port[i].bytes  += pkt_len                   │
+ │     transient build error   ──► stat_recoverable_error++                    │
+ │     fatal build/send error  ──► stat_unrecoverable_error++                  │
+ │                                 (session needs restart)                     │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  5. FRAME COMPLETION  (transport — last packet of frame committed to wire)  │
+ │                                                                             │
+ │     all packets sent on this port ──► port[i].frames++                      │
+ │                                                                             │
+ │     pipeline late-drop watchdog (post-send):                                │
+ │       cur_tai > frame_tai + frame_period                                    │
+ │                                  ──► stat_frames_dropped++                  │
+ │                                      notify_frame_done(DROPPED)             │
+ │     otherwise                       ──► stat_frames_sent++                  │
+ │                                          notify_frame_done(COMPLETE)        │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  6. APP notify_frame_done(status)                                           │
+ └──────────────────────────────────────────────────────────────────────────────┘
+```
+
+`port[i].packets` = what was put on wire `i`. `stat_frames_sent` = frames the
+app successfully delivered end-to-end. `stat_frames_dropped` is the only
+counter that reflects `ST_FRAME_STATUS_DROPPED` — `stat_error_user_timestamp`
+only counts user-supplied RTP timestamp validation failures and is unrelated
+to drops.
+
 ## Per-session quirks
 
 **Video (ST20/ST22).** Loss uses **frame-internal `pkt_idx`**.
@@ -167,15 +290,19 @@ Cross-frame reorders are not tracked. Watch
 **Audio/Anc/FMD (ST30/40/41).** Loss uses post-redundancy `session_seq_id` →
 `stat_pkts_unrecovered` is **exact**. ST30 adds `stat_pkts_dropped`,
 `stat_pkts_len_mismatch_dropped`, `stat_slot_get_frame_fail`. ST40/41 add
-`stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`. ST40p RX
-marks frames whose constituent packets had unrecoverable intra-frame seq
-gaps as `ST_FRAME_STATUS_CORRUPTED` and counts them in
-`stat_frames_corrupted`; the frame is still delivered to the app (the app
-should consult `frame->status`).
+`stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`. ST20p and
+ST40p RX mark frames whose constituent packets had unrecoverable gaps as
+`ST_FRAME_STATUS_CORRUPTED` and count them in `stat_frames_corrupted`;
+the frame is still delivered to the app (the app should consult
+`frame->status`).
 
-**TX (any type).** `stat_epoch_drop` = app late, `stat_epoch_onward` = on time,
-`stat_epoch_mismatch` = pacing snapped to a different epoch,
-`stat_recoverable_error` / `stat_unrecoverable_error` = TX faults.
+**TX (any type).** `stat_epoch_drop` = app handed frame too late, slots were
+skipped (counter advanced by the number of skipped slots).
+`stat_epoch_onward` = system clock ran past `max_onward_epochs` ahead of the
+next free slot — the frame was still scheduled, but pacing skipped onward
+slots (advanced by the onward delta). `stat_epoch_mismatch` = pacing snapped
+to a different epoch than requested. `stat_recoverable_error` /
+`stat_unrecoverable_error` = TX faults during build/send.
 `stat_error_user_timestamp` counts user-supplied RTP timestamp validation
 failures during pacing setup; it does **not** track frames dropped because
 the pipeline handed them to TX too late — those are

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -1,185 +1,175 @@
 # Session Statistics Guide
 
-How to interpret the statistics counters exposed by MTL session APIs. For the full list of
-fields and their descriptions, see the doxygen comments in the header files (`st_api.h`,
-`st20_api.h`, `st30_api.h`, `st40_api.h`, `st41_api.h`).
+How to read MTL per-session counters. Field-level docs live in the headers
+(`st_api.h`, `st20_api.h`, `st30_api.h`, `st40_api.h`, `st41_api.h`).
 
-## Table of Contents
+## API
 
-- [Overview](#overview)
-- [RX Packet Processing Pipeline](#rx-packet-processing-pipeline)
-- [Understanding OOO and Loss Counters](#understanding-ooo-and-loss-counters)
-- [Cross-Session Differences](#cross-session-differences)
-- [Troubleshooting with Stats](#troubleshooting-with-stats)
-
-## Overview
-
-Each RX/TX session exposes statistics via a pair of functions:
-
-- `st*_get_session_stats()` — copies the current counters to a user-provided struct
-- `st*_reset_session_stats()` — zeros all counters
-
-All counters are `uint64_t` and monotonically increase until reset. The library never
-decreases a counter.
-
-### Thread Safety
-
-Both `get` and `reset` acquire the per-session spinlock internally, making them safe to
-call from any thread while the session is active.
-
-**Data-path impact**: the data-path tasklet holds the same spinlock during packet
-processing. A concurrent `get` or `reset` may cause the tasklet to skip one poll cycle
-(trylock failure). The lock is held only for a struct memcpy/memset (~200-400 bytes, tens
-of nanoseconds), which is negligible compared to the microsecond-scale poll interval.
-
-**Recommended pattern**: call `get` followed by `reset` for interval-based monitoring.
-
-| Session type | Get stats | Reset stats |
-|---|---|---|
-| Video TX (ST20) | `st20_tx_get_session_stats()` | `st20_tx_reset_session_stats()` |
-| Video RX (ST20) | `st20_rx_get_session_stats()` | `st20_rx_reset_session_stats()` |
-| Audio TX (ST30) | `st30_tx_get_session_stats()` | `st30_tx_reset_session_stats()` |
-| Audio RX (ST30) | `st30_rx_get_session_stats()` | `st30_rx_reset_session_stats()` |
-| Ancillary TX (ST40) | `st40_tx_get_session_stats()` | `st40_tx_reset_session_stats()` |
-| Ancillary RX (ST40) | `st40_rx_get_session_stats()` | `st40_rx_reset_session_stats()` |
-| Metadata TX (ST41) | `st41_tx_get_session_stats()` | `st41_tx_reset_session_stats()` |
-| Metadata RX (ST41) | `st41_rx_get_session_stats()` | `st41_rx_reset_session_stats()` |
-
-## RX Packet Processing Pipeline
-
-Every incoming packet goes through the following stages. Understanding this order is key to
-interpreting which counters are "pre-redundancy" (counted early) vs "post-redundancy"
-(counted after merging redundant streams).
-
-```text
-NIC queue
-  │
-  ├─1. Early validation (payload type, SSRC, packet length, interlace F-bits)
-  │     └── FAIL → err_packets++
-  │                 stat_pkts_wrong_pt_dropped++ or stat_pkts_wrong_ssrc_dropped++
-  │                 (packet discarded)
-  │
-  ├─2. Per-port sequence check
-  │     └── GAP  → port[].out_of_order_packets += gap_size
-  │                 stat_pkts_out_of_order += gap_size
-  │
-  ├─3. port[].packets++, port[].bytes++          ← "pre-redundancy" counters
-  │
-  ├─4. Redundancy filter (is this packet's timestamp already seen?)
-  │     └── STALE → stat_pkts_redundant++
-  │                  (packet discarded)
-  │
-  ├─5. Post-redundancy loss detection
-  │     Audio/anc/fmd: session_seq_id gap → stat_pkts_unrecovered += gap_size
-  │     Video: frame completion check     → stat_pkts_unrecovered += (total - received)
-  │
-  ├─6. stat_pkts_received++                      ← "post-redundancy" counter
-  │
-  └─7. Deliver to frame buffer / RTP ring
+```c
+st<NN>_<rx|tx>_get_session_stats(handle, &stats);   /* snapshot */
+st<NN>_<rx|tx>_reset_session_stats(handle);         /* zero    */
 ```
 
-**Key insight**: `port[].packets` counts everything that passes validation (step 3),
-including packets that the redundancy filter will later discard (step 4).
-`stat_pkts_received` counts only the packets that make it through all filters (step 6).
+`<NN>` ∈ `20` video, `30` audio, `40` ancillary, `41` fast metadata.
+All counters are `uint64_t`, monotonic, thread-safe (per-session spinlock).
 
-**Video note**: Video (ST20) performs step 5 at frame completion time rather than per-packet.
-It compares expected total packets to received packets and adds the difference to
-`stat_pkts_unrecovered`. See [Video-Specific OOO Behavior](#video-specific-ooo-behavior).
-
-### `port[].frames` Semantics
-
-The `frames` counter means different things depending on the session type:
-
-| Session type | What `frames` counts | When it increments |
-|---|---|---|
-| Video (ST20) | Frame completions | When a frame is notified to app (complete or incomplete) |
-| Audio (ST30) | Frame completions | When a frame buffer is filled and delivered to app |
-| Ancillary (ST40) | New RTP timestamps | When a new timestamp is first seen (frame **start**, not completion) |
-| Metadata (ST41) | New RTP timestamps | When a new timestamp is first seen (frame **start**, not completion) |
-
-**Example**: If an ancillary stream sends 100 frames and you see `port[0].frames = 100`,
-that means 100 distinct timestamps were detected — but some of those frames could be
-incomplete if packets were lost.
-
-## Understanding OOO and Loss Counters
-
-The library provides three levels of out-of-order / loss tracking:
-
-### The Three Counters
-
-| Counter | Scope | Stage | What it detects |
-|---|---|---|---|
-| `port[i].out_of_order_packets` | Per-port | Pre-redundancy | Missing packets on a single port (gap size, not gap count) |
-| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of per-port missing packets |
-| `stat_pkts_unrecovered` | Session | Post-redundancy | Actual missing packets that redundancy could not cover |
-
-**Invariants** (always true):
+## RX packet processing pipeline
 
 ```text
-stat_pkts_out_of_order == port[0].out_of_order_packets + port[1].out_of_order_packets
-stat_pkts_unrecovered <= stat_pkts_out_of_order
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  NIC queue                                                                  │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  1. VALIDATE  (payload type, SSRC, packet length, interlace F-bits)         │
+ │                                                                             │
+ │     FAIL ──► port[i].err_packets++                                          │
+ │              stat_pkts_wrong_{pt,ssrc,len,interlace}_dropped++  (video)     │
+ │              stat_pkts_wrong_{pt,ssrc,interlace}_dropped++      (anc/fmd)   │
+ │              stat_pkts_{wrong_pt,wrong_ssrc,len_mismatch}_dropped++ (audio) │
+ │              packet DISCARDED                                               │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │ pass
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  2. PER-PORT SEQUENCE CHECK                                                 │
+ │                                                                             │
+ │     forward gap  ──► port[i].lost_packets += gap_size                       │
+ │                      stat_lost_packets    += gap_size                       │
+ │     backward seq ──► port[i].reordered_packets++                            │
+ │     same seq     ──► port[i].duplicates_same_port++  (audio/anc/fmd only)   │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  3. PRE-REDUNDANCY TOTALS                                                   │
+ │                                                                             │
+ │     port[i].packets++          ◄── "what arrived on this wire"              │
+ │     port[i].bytes += pkt_len                                                │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  4. REDUNDANCY FILTER  (timestamp/seq already seen on the other port?)      │
+ │                                                                             │
+ │     YES ──► stat_pkts_redundant++   (expected on 2-port sessions)           │
+ │             packet DISCARDED                                                │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │ unique
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  5. POST-REDUNDANCY LOSS DETECTION                                          │
+ │                                                                             │
+ │     Audio/Anc/FMD:  session_seq_id gap ──► stat_pkts_unrecovered += gap     │
+ │     Video:          frame completion   ──► stat_pkts_unrecovered += missing  │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  6. POST-REDUNDANCY TOTAL                                                   │
+ │                                                                             │
+ │     stat_pkts_received++       ◄── "what the app actually got"              │
+ └──────┬───────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+ ┌──────────────────────────────────────────────────────────────────────────────┐
+ │  7. DELIVER to frame buffer / RTP ring                                      │
+ └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Interpreting OOO Scenarios
+`port[i].packets` = what arrived on wire `i`. `stat_pkts_received` = what the app got.
 
-| Scenario | `port[P].ooo` | `port[R].ooo` | `stat_pkts_out_of_order` | `stat_pkts_unrecovered` | Interpretation |
-|---|---:|---:|---:|---:|---|
-| Perfect stream | 0 | 0 | 0 | 0 | All good |
-| Port P lossy, R covers | 50 | 0 | 50 | 0 | Redundancy working |
-| Both ports lossy, some overlap | 50 | 30 | 80 | 5 | 5 packets unrecoverable — real data loss |
-| Single port, some loss | 10 | n/a | 10 | 10 | No redundancy to help |
-| Network reordering | 3 | 2 | 5 | 0 | Packets reordered but none lost |
+## The five counters you monitor
 
-Key takeaways:
-- `stat_pkts_out_of_order > 0` with `stat_pkts_unrecovered == 0` → redundancy is
-  covering the gaps, the stream is healthy at session level.
-- `stat_pkts_unrecovered > 0` → real data loss that redundancy could not cover. Check
-  network path diversity.
-- With a single port, `stat_pkts_unrecovered` equals `stat_pkts_out_of_order`
-  because there is no redundant port to fill gaps.
-- Redundancy recovery rate: `(ooo - unrecovered) / ooo`.
+| Counter | Meaning |
+|---|---|
+| `port[i].lost_packets` | Packets missing on **this** port (pre-redundancy) |
+| `port[i].reordered_packets` | Backward arrival on the same port |
+| `port[i].duplicates_same_port` | Same seq twice on the same port (audio/anc/fmd; always 0 for video) |
+| `stat_pkts_redundant` | Cross-port duplicate filtered — **expected** on 2-port sessions |
+| `stat_pkts_unrecovered` | Missing on **all** ports — real loss |
 
-### Video-Specific OOO Behavior
+```text
+stat_lost_packets     == Σ port[i].lost_packets
+stat_pkts_unrecovered <= stat_lost_packets
+save_rate (%)         == 100 * lost / (lost + unrecovered)
+```
 
-Video (ST20) works differently from audio/anc/fmd:
+`save_rate` answers: **"is redundancy covering the gaps?"** 100% = yes.
 
-- Video detects OOO using **frame-internal `pkt_idx`** (packet index within the current
-  frame), not RTP sequence numbers
-- When a packet arrives with `pkt_idx != last_pkt_idx + 1`, the gap size
-  (`pkt_idx - last_pkt_idx - 1`) is added to both `port[].out_of_order_packets`
-  and `stat_pkts_out_of_order`
-- Video has **no `session_seq_id`** — frames are identified by RTP timestamp, and each
-  frame resets the packet index tracking
-- `stat_pkts_unrecovered` for video counts missing packets in corrupted frames
-  (estimated from `(frame_size - recv_size) / avg_pkt_size`)
+### Reading table
 
-**Practical implication**: For video, `stat_pkts_unrecovered` and `stat_frames_dropped`
-are the primary loss indicators. `common.port[].incomplete_frames` shows per-port
-contribution.
+| `port[P].lost` | `port[R].lost` | `unrec` | `redundant` | Verdict |
+|---:|---:|---:|---:|---|
+| 0 | 0 | 0 | ≈ received | Healthy |
+| 50 | 0 | 0 | ≈ received | P degraded, R covers (`save_rate=100%`) |
+| 50 | 30 | 5 | < received | 5 pkts lost on both → real loss |
+| 10 | n/a | 10 | 0 | Single-port, no redundancy |
 
----
+## `port[i].frames` — two flavors
 
-## Cross-Session Differences
+| Sessions | `frames++` when… | `incomplete_frames` |
+|---|---|---|
+| Video (ST20/ST22) | This port delivered enough pkts to **complete** the frame | Bumped when this port was short |
+| Audio/Anc/FMD     | New frame's **first** packet arrived on this port (race winner) | Always 0 |
 
-### OOO Counters at a Glance
+`port[0].frames + port[1].frames` ≠ total frames. Use `stat_pkts_received` and the
+type-specific `stat_frames_dropped` / `incomplete_frames_cnt` for end-to-end totals.
 
-| Counter | Scope | Stage | Video (ST20) | Audio/Anc/FMD |
-|---|---|---|---|---|
-| `port[].out_of_order_packets` | Per-port | Pre-redundancy | Missing pkts from `pkt_idx` gaps | Missing pkts from RTP `seq_number` gaps |
-| `stat_pkts_out_of_order` | Session | Pre-redundancy | Sum of port missing pkts | Sum of port missing pkts |
-| `stat_pkts_unrecovered` | Session | Post-redundancy | Missing pkts in corrupted frames | Missing pkts from `session_seq_id` gaps |
+**Video invariant** (per port): `frames + incomplete_frames == total complete frames`.
 
-### How `stat_pkts_unrecovered` Is Computed
+> **Example.** TX=6766, RX `port[P].frames=6465`, `port[R].frames=300`,
+> `unrecovered=0`, `frames_dropped=0`. Then `port[P].incomplete_frames≈300` and
+> `port[R].incomplete_frames≈6465`: redundancy is healing every frame, but **R is
+> dropping ≥1 pkt per frame**. Check `mtl_get_port_stats(R).rx_hw_dropped_packets`,
+> switch port stats, MTU, SFP/cable on R.
 
-| Session type | Source | Computation | Exact? |
-|---|---|---|---|
-| Video (ST20) | Corrupted frame at slot completion | `(frame_size - recv_size) / avg_pkt_size` | Estimated |
-| Video (ST22) | Corrupted frame at slot completion | `(expect_size - recv_size) / avg_pkt_size` | Estimated |
-| Audio (ST30) | Post-redundancy `session_seq_id` gap | `(uint16_t)(seq_id - session_seq_id - 1)` per gap | Exact |
-| Ancillary (ST40) | Post-redundancy `session_seq_id` gap | `(uint16_t)(seq_id - session_seq_id - 1)` per gap | Exact |
-| Metadata (ST41) | Post-redundancy `session_seq_id` gap | `(uint16_t)(seq_id - session_seq_id - 1)` per gap | Exact |
+### `err_packets` — not data loss
 
----
+`port[i].err_packets` = packets that arrived but the session refused (wrong PT, wrong
+SSRC, length mismatch, etc.). Does **not** reduce `stat_pkts_received` or cause
+`stat_pkts_unrecovered`. Most common benign cause: another stream on the same multicast
+group leaks in — confirm via `stat_pkts_wrong_pt_dropped` / `stat_pkts_wrong_ssrc_dropped`.
+
+## Per-session quirks
+
+**Video (ST20/ST22).** Loss uses **frame-internal `pkt_idx`**.
+`stat_pkts_unrecovered` is **estimated** as `(frame_size − recv_size) / avg_pkt_size`.
+Cross-frame reorders are not tracked. Watch
+`stat_frames_dropped`, `incomplete_frames_cnt`, `stat_pkts_rtp_ring_full`,
+`stat_pkts_no_slot`, `stat_slot_get_frame_fail`.
+
+**Audio/Anc/FMD (ST30/40/41).** Loss uses post-redundancy `session_seq_id` →
+`stat_pkts_unrecovered` is **exact**. ST30 adds `stat_pkts_dropped`,
+`stat_pkts_len_mismatch_dropped`, `stat_slot_get_frame_fail`. ST40/41 add
+`stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`.
+
+**TX (any type).** `stat_epoch_drop` = app late, `stat_epoch_onward` = on time,
+`stat_epoch_mismatch` = pacing snapped to a different epoch,
+`stat_recoverable_error` / `stat_unrecoverable_error` = TX faults.
+
+## Periodic stat log lines
+
+Emitted every `stat_dump_period_s` (default 10s); zero-delta lines are suppressed.
+
+```text
+RX_<TYPE>_SESSION(idx): fps F.f frames N pkts M [(redundant R)]
+RX_<TYPE>_SESSION(idx): per-port arrivals P=<n> pkts (<f> frames <verb>), R=<n> pkts (<f> frames <verb>)
+RX_<TYPE>_SESSION(idx): per-port loss covered by redundancy: <L> of <T> pkts
+                        (P:<dp>=<%>, R:<dr>=<%>), unrecovered (lost on both) <U>, save_rate=<z>%
+RX_<TYPE>_SESSION(idx): unrecovered pkts <U>                  (single-port form, err)
+```
+
+`<verb>` = `complete` (video) or `first` (audio/anc/fmd).
+
+| Line | Level |
+|---|---|
+| `per-port arrivals` | `notice` |
+| `per-port loss … save_rate=100%` | `warn` |
+| `per-port loss … save_rate<100%` | `warn` + `err` |
+| `unrecovered pkts <U>` (single-port) | `err` |
+| `wrong PT/SSRC/len/interlace dropped` | `notice` |
 
 ## Troubleshooting with Stats
 
@@ -187,8 +177,10 @@ contribution.
 |---|---|---|
 | No packets at all | `port[0].packets == 0` | Wrong IP/port, multicast not joined, NIC link down |
 | Packets arrive but `stat_pkts_received` is 0 | `stat_pkts_wrong_pt_dropped`, `stat_pkts_wrong_ssrc_dropped`, `port[].err_packets` | PT or SSRC mismatch between sender and receiver |
-| `stat_pkts_out_of_order` increasing | `port[P].out_of_order_packets`, `port[R].out_of_order_packets` | Network congestion, packet loss, or RSS misconfiguration |
-| `stat_pkts_unrecovered` increasing | Compare with `stat_pkts_out_of_order` | Real data loss — redundancy could not cover; check path diversity |
+| `stat_lost_packets` increasing | `port[P].lost_packets`, `port[R].lost_packets` | Network congestion, packet loss, or RSS misconfiguration |
+| `stat_pkts_unrecovered` increasing | Compare with `stat_lost_packets` | Real data loss — redundancy could not cover; check path diversity |
+| `port[].duplicates_same_port > 0` (audio/anc/fmd) | Upstream switch / path | Switch loop, cable fault, LAG misconfig, or tcpreplay loop |
+| `port[].reordered_packets > 0` | Upstream switch / path | ECMP/QoS reorder; for ST20 limited to intra-frame reorders |
 | `stat_pkts_redundant` is 0 on 2-port session | `port[1].packets` | Redundant port not receiving data |
 | `stat_pkts_redundant ≈ stat_pkts_received` on 2-port session | — | Normal — each packet arrives on both ports, one copy filtered |
 | Video `stat_frames_dropped` increasing | `stat_pkts_unrecovered`, `stat_pkts_no_slot` | Incomplete frames due to packet loss or frame buffers exhausted |

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -6,8 +6,8 @@ How to read MTL per-session counters. Field-level docs live in the headers
 ## API
 
 ```c
-st<NN>_<rx|tx>_get_session_stats(handle, &stats);   /* snapshot */
-st<NN>_<rx|tx>_reset_session_stats(handle);         /* zero    */
+st<NN>_<rx|tx>_get_session_stats(handle, &stats);
+st<NN>_<rx|tx>_reset_session_stats(handle);
 ```
 
 `<NN>` ∈ `20` video, `30` audio, `40` ancillary, `41` fast metadata.
@@ -107,15 +107,39 @@ save_rate (%)         == 100 * lost / (lost + unrecovered)
 | 50 | 30 | 5 | < received | 5 pkts lost on both → real loss |
 | 10 | n/a | 10 | 0 | Single-port, no redundancy |
 
-## `port[i].frames` — two flavors
+## Frame-level counters
+
+Session-wide, type-agnostic counters living in `st_rx_user_stats` /
+`st_tx_user_stats`. Use these (not `port[i].frames`) to answer "how many
+frames did the app receive / drop / send".
+
+| Counter | Side | Meaning |
+|---|---|---|
+| `stat_frames_received`  | RX | Frames delivered to the app via the get-frame / notify path |
+| `stat_frames_dropped`   | RX | Frames the pipeline could not deliver (no free user slot) |
+| `stat_frames_corrupted` | RX | Frames delivered with `ST_FRAME_STATUS_CORRUPTED` (unrecovered intra-frame loss); the frame is still handed to the app |
+| `stat_frames_sent`      | TX | Frames whose final packet was committed to the wire (`notify_frame_done(COMPLETE)`) |
+| `stat_frames_dropped`   | TX | Frames the pipeline dropped because the app handed them too late (`notify_frame_done(DROPPED)`); also bumped on `put_frame_abort` |
+
+Populated by pipeline session types (`ST20p`, `ST30p`, `ST40p` for both
+RX and TX). For transport-only paths and types with no per-frame
+classification (audio `stat_frames_corrupted`, ST41 RX), the relevant
+counters stay 0.
+
+## `port[i].frames` — two flavors (per-port, **not** a session total)
 
 | Sessions | `frames++` when… | `incomplete_frames` |
 |---|---|---|
 | Video (ST20/ST22) | This port delivered enough pkts to **complete** the frame | Bumped when this port was short |
 | Audio/Anc/FMD     | New frame's **first** packet arrived on this port (race winner) | Always 0 |
 
-`port[0].frames + port[1].frames` ≠ total frames. Use `stat_pkts_received` and the
-type-specific `stat_frames_dropped` / `incomplete_frames_cnt` for end-to-end totals.
+`port[i].frames` is per-port and the two flavors above do not compose: summing
+across ports does not yield total frames delivered to the app. For end-to-end
+frame accounting, use the session-wide common counters:
+`stat_frames_received`, `stat_frames_dropped`, `stat_frames_corrupted` (RX)
+and `stat_frames_sent`, `stat_frames_dropped` (TX) — see
+[Frame-level counters](#frame-level-counters) below. Use `port[i].frames` /
+`incomplete_frames` only for per-port redundancy debugging.
 
 **Video invariant** (per port): `frames + incomplete_frames == total complete frames`.
 
@@ -143,11 +167,20 @@ Cross-frame reorders are not tracked. Watch
 **Audio/Anc/FMD (ST30/40/41).** Loss uses post-redundancy `session_seq_id` →
 `stat_pkts_unrecovered` is **exact**. ST30 adds `stat_pkts_dropped`,
 `stat_pkts_len_mismatch_dropped`, `stat_slot_get_frame_fail`. ST40/41 add
-`stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`.
+`stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`. ST40p RX
+marks frames whose constituent packets had unrecoverable intra-frame seq
+gaps as `ST_FRAME_STATUS_CORRUPTED` and counts them in
+`stat_frames_corrupted`; the frame is still delivered to the app (the app
+should consult `frame->status`).
 
 **TX (any type).** `stat_epoch_drop` = app late, `stat_epoch_onward` = on time,
 `stat_epoch_mismatch` = pacing snapped to a different epoch,
 `stat_recoverable_error` / `stat_unrecoverable_error` = TX faults.
+`stat_error_user_timestamp` counts user-supplied RTP timestamp validation
+failures during pacing setup; it does **not** track frames dropped because
+the pipeline handed them to TX too late — those are
+`stat_frames_dropped` (and surface to the app as
+`notify_frame_done(status=ST_FRAME_STATUS_DROPPED)`).
 
 ## Periodic stat log lines
 

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -92,9 +92,13 @@ All counters are `uint64_t`, monotonic, thread-safe (per-session spinlock).
  │                                                                             │
  │     Video: per-port frame accounting                                        │
  │       port P delivered enough pkts ──► port[P].frames++                     │
- │       port P was short             ──► port[P].incomplete_frames++          │
+ │       port P was short             ──► st20_rx_user_stats                   │
+ │                                          .frames_partial[P]++               │
  │       (same for port R)                                                     │
  │       gap → estimated missing pkts ──► stat_pkts_unrecovered += est         │
+ │                                                                             │
+ │     ST20 / ST22 (transport): intra-frame loss detected                       │
+ │                                    ──► stat_frames_incomplete++             │
  │                                                                             │
  │     ST20p / ST40p: frame delivered with intra-frame loss             │
  │                                    ──► stat_frames_corrupted++              │
@@ -163,37 +167,61 @@ RX and TX). For transport-only paths and types with no per-frame
 integrity concept (`stat_frames_corrupted` on `ST30p` audio, `ST41` RX),
 the relevant counters stay 0.
 
-> **ST20 only:** the transport-layer field `incomplete_frames_cnt` (in
-> `st20_rx_user_stats`) is **not** the same as `stat_frames_corrupted`.
-> `incomplete_frames_cnt` fires whenever the transport detects intra-frame
+> **ST20 / ST22 only:** the transport-layer field `stat_frames_incomplete`
+> (in `st20_rx_user_stats`) is **not** the same as `stat_frames_corrupted`.
+> `stat_frames_incomplete` fires whenever the transport detects intra-frame
 > loss, including when the frame is then silently discarded because
 > `RECEIVE_INCOMPLETE_FRAME` is not set; `stat_frames_corrupted` only
 > counts corrupted frames the app actually consumed via `get_frame()`.
-> `incomplete_frames_cnt - stat_frames_corrupted` = corrupted frames
+> `stat_frames_incomplete - stat_frames_corrupted` = corrupted frames
 > dropped before reaching the app.
 
 ## `port[i].frames` — two flavors (per-port, **not** a session total)
 
-| Sessions | `frames++` when… | `incomplete_frames` |
+| Sessions | `frames++` when… | Partial counter |
 |---|---|---|
-| Video (ST20/ST22) | This port delivered enough pkts to **complete** the frame | Bumped when this port was short |
-| Audio/Anc/FMD     | New frame's **first** packet arrived on this port (race winner) | Always 0 |
+| Video (ST20/ST22) | This port delivered enough pkts to **complete** the frame | `st20_rx_user_stats::frames_partial[i]` (this port was short) |
+| Audio/Anc/FMD     | New frame's **first** packet arrived on this port (race winner) | n/a |
 
 `port[i].frames` is per-port and the two flavors above do not compose: summing
 across ports does not yield total frames delivered to the app. For end-to-end
 frame accounting, use the session-wide common counters:
 `stat_frames_received`, `stat_frames_dropped`, `stat_frames_corrupted` (RX)
 and `stat_frames_sent`, `stat_frames_dropped` (TX) — see
-[Frame-level counters](#frame-level-counters) below. Use `port[i].frames` /
-`incomplete_frames` only for per-port redundancy debugging.
+[Frame-level counters](#frame-level-counters) above. Use `port[i].frames` /
+`st20_rx_user_stats::frames_partial[i]` only for per-port redundancy debugging.
 
-**Video invariant** (per port): `frames + incomplete_frames == total complete frames`.
+**Video frame-mode invariant** (ST20 RX with frame callbacks, per port):
+`port[i].frames + frames_partial[i] == stat_frames_received`.
+Each delivered frame (status `COMPLETE` or `RECONSTRUCTED`) bumps exactly one
+of the two counters per port. Frames that never complete on either port bump
+`stat_frames_incomplete` instead and leave both per-port counters untouched.
 
-> **Example.** TX=6766, RX `port[P].frames=6465`, `port[R].frames=300`,
-> `unrecovered=0`, `frames_dropped=0`. Then `port[P].incomplete_frames≈300` and
-> `port[R].incomplete_frames≈6465`: redundancy is healing every frame, but **R is
-> dropping ≥1 pkt per frame**. Check `mtl_get_port_stats(R).rx_hw_dropped_packets`,
-> switch port stats, MTU, SFP/cable on R.
+> **Does NOT hold for:** ST22 single-port (port R is left at zero, since
+> there is no port R to account for) or any RTP-mode session (only the
+> winning port's `frames` is bumped; `frames_partial` is unused).
+>
+> **Example.** A 2-port redundant RX session reports:
+>
+> ```text
+> stat_frames_received = 1000   (TX sent 1000, all delivered to app)
+> frames_dropped       = 0
+> unrecovered          = 0
+>
+> port[P].frames = 950          frames_partial[P] =  50
+> port[R].frames =  50          frames_partial[R] = 950
+> ```
+>
+> The invariant holds on both ports: 950 + 50 = 1000.
+>
+> **Reading it:** P completes 95% of frames on its own; R only 5%. Every
+> frame still reaches the app because whenever R is short, P fills the gap
+> (and vice versa) — that's redundancy doing its job. But **R is missing
+> packets on 950 of 1000 frames** (95%). R is one switch hiccup away from
+> real loss.
+>
+> Investigate R: `mtl_get_port_stats(R).rx_hw_dropped_packets`, switch port
+> stats, MTU, SFP/cable.
 
 ### `err_packets` — not data loss
 
@@ -284,7 +312,7 @@ to drops.
 **Video (ST20/ST22).** Loss uses **frame-internal `pkt_idx`**.
 `stat_pkts_unrecovered` is **estimated** as `(frame_size − recv_size) / avg_pkt_size`.
 Cross-frame reorders are not tracked. Watch
-`stat_frames_dropped`, `incomplete_frames_cnt`, `stat_pkts_rtp_ring_full`,
+`stat_frames_dropped`, `stat_frames_incomplete`, `stat_pkts_rtp_ring_full`,
 `stat_pkts_no_slot`, `stat_slot_get_frame_fail`.
 
 **Audio/Anc/FMD (ST30/40/41).** Loss uses post-redundancy `session_seq_id` →

--- a/include/st20_api.h
+++ b/include/st20_api.h
@@ -1727,7 +1727,6 @@ struct st20_rx_user_stats {
   uint64_t stat_slices_received;
   uint64_t stat_pkts_idx_dropped;
   uint64_t stat_pkts_offset_dropped;
-  uint64_t stat_frames_dropped;
   uint64_t stat_pkts_idx_oo_bitmap;
   uint64_t stat_pkts_rtp_ring_full;
   uint64_t stat_pkts_no_slot;
@@ -1755,7 +1754,50 @@ struct st20_rx_user_stats {
   uint64_t stat_burst_pkts_max;
   uint64_t stat_burst_succ_cnt;
   uint64_t stat_burst_pkts_sum;
-  uint64_t incomplete_frames_cnt;
+  /**
+   * Transport-layer count of frames the receiver could not assemble fully
+   * from the wire (intra-frame packet loss). Bumped per incomplete frame
+   * for ST20 and ST22.
+   *
+   * Relation to common counters:
+   *   - common.stat_frames_corrupted: subset delivered to the app with
+   *     status=ST_FRAME_STATUS_CORRUPTED (only when
+   *     ST20_RX_FLAG_RECEIVE_INCOMPLETE_FRAME is set). For ST22 the
+   *     pipeline always delivers, so the two should match.
+   *   - common.stat_frames_dropped: pipeline back-pressure (no free user
+   *     slot). Independent of this counter.
+   *
+   * Use stat_frames_incomplete for wire-loss diagnostics; use
+   * common.stat_frames_corrupted for app-visible delivery quality.
+   *
+   * @note ABI rename: this field replaces TWO separate fields previously
+   *       present in this struct:
+   *         - `uint64_t stat_frames_dropped;` (transport-layer; collided
+   *           with `common.stat_frames_dropped` which means pipeline
+   *           back-pressure). Removed.
+   *         - `uint64_t incomplete_frames_cnt;` (same event as the
+   *           transport `stat_frames_dropped` above). Renamed.
+   *       Both old fields were bumped on the same code path; they are now
+   *       merged into a single counter with a clearer name. Migration:
+   *       replace either `incomplete_frames_cnt` or the transport-level
+   *       `stat_frames_dropped` (NOT `common.stat_frames_dropped`) with
+   *       `stat_frames_incomplete`.
+   */
+  uint64_t stat_frames_incomplete; /* old names: incomplete_frames_cnt,
+                                      stat_frames_dropped (transport) */
+  /**
+   * Per-port count of frames where this port could not complete the frame
+   * on its own (the other port's redundant copy filled the missing pkts).
+   * Video-only (ST20 / ST22), so it lives here rather than in the common
+   * per-port struct. Index with `mtl_session_port` (P / R).
+   *
+   * @note ABI move + rename: previously `st_rx_port_stats::incomplete_frames`
+   *       (sat in the common per-port struct, but was always 0 for
+   *       ST30/ST40/ST41). Migration: replace
+   *       `common.port[i].incomplete_frames` with
+   *       `frames_partial[i]` (ST20 / ST22 only).
+   */
+  uint64_t frames_partial[MTL_SESSION_PORT_MAX]; /* old name: port[i].incomplete_frames */
   uint64_t stat_pkts_wrong_kmod_dropped;
 };
 

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -434,7 +434,7 @@ struct st_rx_user_stats {
    * redundancy. The frame is still handed to the application; the
    * application should consult frame->status to decide what to do.
    * Populated by RX session types that classify per-frame integrity
-   * (ST40p today). Always 0 for types with no per-frame corruption
+   * (ST20p, ST40p). Always 0 for types with no per-frame corruption
    * concept (audio ST30, ST41).
    */
   uint64_t stat_frames_corrupted;

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -268,19 +268,74 @@ struct st_rx_port_stats {
   uint64_t packets;
   /** Total number of received bytes (pre-redundancy). */
   uint64_t bytes;
-  /** Total number of received frames / memory buffers. */
+  /**
+   * Per-port frame counter. Two flavors, picked by frame size:
+   *
+   *   - Many packets per frame  (Video ST20 / ST22):
+   *       Increments when a frame is **completed by this port**, i.e. this
+   *       port delivered enough packets to satisfy completion on its own.
+   *       Sister field: incomplete_frames (this port was short, but the
+   *       redundant port covered the gap).
+   *
+   *   - Few packets per frame   (Audio ST30, Ancillary ST40, Metadata ST41):
+   *       Increments when a new frame's **first** packet arrives on this
+   *       port — i.e. this port "won the race" for that frame.
+   *       Sister field: incomplete_frames is unused (always 0).
+   *
+   * port[0].frames + port[1].frames is NOT total frames delivered to the
+   * app; use stat_pkts_received plus the type-specific stat_frames_dropped
+   * / incomplete_frames_cnt for end-to-end accounting.
+   */
   uint64_t frames;
-  /** Total number of incomplete frames */
+  /**
+   * Per-port count of frames where this port could not complete the frame
+   * on its own (the other port's redundant copy filled the missing pkts).
+   * Video (ST20 / ST22) only; always 0 for ST30/ST40/ST41.
+   */
   uint64_t incomplete_frames;
   /** Total number of received packets rejected by handler. */
   uint64_t err_packets;
   /**
-   * Total number of missing packets detected on this port (pre-redundancy).
+   * Per-port count of packets missing on this port (pre-redundancy).
    * Counts actual missing packets, not gap events.
    * For video: sum of pkt_idx gaps within frames.
    * For audio/anc/fmd: sum of RTP sequence number gaps.
+   * In a redundant session, these losses are typically recovered from the
+   * other port — see stat_pkts_unrecovered for true post-redundancy loss.
    */
-  uint64_t out_of_order_packets;
+  uint64_t lost_packets;
+  /**
+   * Per-port count of packets that arrived out of order on this port.
+   *
+   * For audio (ST30), ancillary (ST40), fast-metadata (ST41): incremented
+   * when an RTP packet arrives with seq strictly less than the highest seq
+   * previously seen on this port (intra-port reorder; same-port duplicates
+   * go to duplicates_same_port instead).
+   *
+   * For video (ST20/ST22): incremented when a packet arrives with frame
+   * pkt_idx strictly less than last_pkt_idx on this port (intra-frame
+   * reorder).  Cross-frame reorders are not tracked because video has no
+   * per-port latest_seq_id.
+   *
+   * A non-zero value typically points to ECMP, QoS reorder, or LAG hashing
+   * upstream of MTL.  The library still accepts the packet if it carries
+   * unique data; this counter is purely an observability signal.
+   */
+  uint64_t reordered_packets;
+  /**
+   * Per-port count of packets whose seq matched the highest seq already
+   * accepted on this port (genuine same-port duplicate, distinct from the
+   * normal cross-port redundant copy counted by stat_pkts_redundant).
+   *
+   * Tracked for audio (ST30), ancillary (ST40), fast-metadata (ST41).
+   * Always 0 for video (ST20/ST22): the slot+bitmap completion model
+   * cannot distinguish a same-port duplicate from a normal cross-port
+   * redundant copy, so both surface as stat_pkts_redundant.
+   *
+   * A non-zero value strongly suggests a switch loop, cable fault, LAG
+   * misconfiguration, or a tcpreplay loop upstream of MTL.
+   */
+  uint64_t duplicates_same_port;
 };
 
 /**
@@ -314,16 +369,19 @@ struct st_rx_user_stats {
   /** Total number of accepted packets (post-redundancy). */
   uint64_t stat_pkts_received;
   /**
-   * Total missing packets detected pre-redundancy: sum(port[].out_of_order_packets).
+   * Session-wide total of per-port packet loss (pre-redundancy).
+   * Equals sum(port[].lost_packets) across all ports of this session.
+   * In a redundant session this counts packets missed on individual ports;
+   * losses recovered from the other port are still counted here.
    * For video: sum of pkt_idx gaps within frames.
    * For audio/anc/fmd: sum of RTP sequence number gaps.
    */
-  uint64_t stat_pkts_out_of_order;
+  uint64_t stat_lost_packets;
   /**
    * Total packets lost post-redundancy (unrecoverable by redundancy).
    * For audio/anc/fmd: number of missing packets inferred from RTP sequence gaps.
    * For video: number of missing packets in corrupted/incomplete frames.
-   * Invariant: stat_pkts_unrecovered <= stat_pkts_out_of_order.
+   * Invariant: stat_pkts_unrecovered <= stat_lost_packets.
    */
   uint64_t stat_pkts_unrecovered;
   /** Total number of packets dropped due to wrong SSRC */

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -336,8 +336,16 @@ struct st_rx_port_stats {
 /**
  * A structure used to retrieve general statistics for a tx session.
  * Contains per-port statistics and additional counters for transmission events.
+ *
+ * Fields are visually grouped by which layer fills them. Callers can
+ * ignore the grouping — every field is always present and zero-
+ * initialized when the corresponding layer is inactive.
  */
 struct st_tx_user_stats {
+  /* ------------------------------------------------------------------ */
+  /*  Transport layer — filled by the TX session tasklet, all types.    */
+  /* ------------------------------------------------------------------ */
+
   struct st_tx_port_stats port[MTL_SESSION_PORT_MAX]; /**< Per-port TX statistics */
   /** Total number of epoch mismatch events */
   uint64_t stat_epoch_drop;
@@ -353,6 +361,12 @@ struct st_tx_user_stats {
   uint64_t stat_recoverable_error;
   /** Total number of unrecoverable transmission errors (session needed restart) */
   uint64_t stat_unrecoverable_error;
+
+  /* ------------------------------------------------------------------ */
+  /*  Pipeline layer — filled by ST20p / ST22p / ST30p / ST40p only.    */
+  /*  Always 0 for transport-only TX paths.                             */
+  /* ------------------------------------------------------------------ */
+
   /**
    * Total frames whose final packet was committed to the wire, equivalent
    * to the count of notify_frame_done(status=ST_FRAME_STATUS_COMPLETE)
@@ -375,8 +389,16 @@ struct st_tx_user_stats {
 /**
  * A structure used to retrieve general statistics for a rx session.
  * Contains per-port statistics and additional counters for reception events.
+ *
+ * Fields are visually grouped by which layer fills them. Callers can
+ * ignore the grouping — every field is always present and zero-
+ * initialized when the corresponding layer is inactive.
  */
 struct st_rx_user_stats {
+  /* ------------------------------------------------------------------ */
+  /*  Transport layer — filled by the RX session tasklet, all types.    */
+  /* ------------------------------------------------------------------ */
+
   struct st_rx_port_stats port[MTL_SESSION_PORT_MAX]; /**< Per-port RX statistics */
   /** Total number of accepted packets (post-redundancy). */
   uint64_t stat_pkts_received;
@@ -402,6 +424,12 @@ struct st_rx_user_stats {
   uint64_t stat_pkts_wrong_pt_dropped;
   /** Total number of redundant packets filtered (post-redundancy duplicates). */
   uint64_t stat_pkts_redundant;
+
+  /* ------------------------------------------------------------------ */
+  /*  Pipeline layer — filled by ST20p / ST22p / ST30p / ST40p only.    */
+  /*  Always 0 for transport-only RX paths (e.g. raw RTP, ST41).        */
+  /* ------------------------------------------------------------------ */
+
   /**
    * Total frames delivered to the application via the get-frame /
    * notify-frame-available path, regardless of frame status. This is the

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -282,9 +282,12 @@ struct st_rx_port_stats {
    *       port — i.e. this port "won the race" for that frame.
    *       Sister field: incomplete_frames is unused (always 0).
    *
-   * port[0].frames + port[1].frames is NOT total frames delivered to the
-   * app; use stat_pkts_received plus the type-specific stat_frames_dropped
-   * / incomplete_frames_cnt for end-to-end accounting.
+   * port[i].frames is per-port, not session-wide. The two semantics above
+   * do not compose: summing across ports does not yield total frames
+   * delivered to the app. For end-to-end frame accounting use the common
+   * counters in st_rx_user_stats: stat_frames_received,
+   * stat_frames_dropped, stat_frames_corrupted. Use port[i].frames /
+   * incomplete_frames only for per-port redundancy debugging.
    */
   uint64_t frames;
   /**
@@ -358,6 +361,23 @@ struct st_tx_user_stats {
   uint64_t stat_recoverable_error;
   /** Total number of unrecoverable transmission errors (session needed restart) */
   uint64_t stat_unrecoverable_error;
+  /**
+   * Total frames whose final packet was committed to the wire, equivalent
+   * to the count of notify_frame_done(status=ST_FRAME_STATUS_COMPLETE)
+   * callbacks. Populated by pipeline TX session types
+   * (ST20p / ST22p / ST30p / ST40p); 0 for transport-only TX where the
+   * caller drives packet emission directly.
+   */
+  uint64_t stat_frames_sent;
+  /**
+   * Total frames the TX pipeline dropped because the application handed
+   * them over too late for their target wire time. Equivalent to the count
+   * of notify_frame_done(status=ST_FRAME_STATUS_DROPPED) callbacks.
+   * Distinct from stat_error_user_timestamp, which counts user RTP
+   * timestamp validation failures during pacing setup. Populated by
+   * pipeline TX session types only.
+   */
+  uint64_t stat_frames_dropped;
 };
 
 /**
@@ -390,6 +410,34 @@ struct st_rx_user_stats {
   uint64_t stat_pkts_wrong_pt_dropped;
   /** Total number of redundant packets filtered (post-redundancy duplicates). */
   uint64_t stat_pkts_redundant;
+  /**
+   * Total frames delivered to the application via the get-frame /
+   * notify-frame-available path, regardless of frame status. This is the
+   * canonical session-wide "frames received" counter — independent of
+   * port[i].frames, whose semantics differ between video and
+   * audio/anc/fmd. Populated by pipeline RX session types
+   * (ST20p / ST22p / ST30p / ST40p); 0 for transport-only RX paths that
+   * deliver RTP packets rather than frames (e.g. ST41).
+   */
+  uint64_t stat_frames_received;
+  /**
+   * Total frames the RX pipeline could not deliver because no free user
+   * slot was available (back-pressure / app not draining fast enough).
+   * The frame's pre-staged data is discarded; the application never sees
+   * a notify-frame-available for it. Populated by pipeline RX session
+   * types only.
+   */
+  uint64_t stat_frames_dropped;
+  /**
+   * Total frames delivered with status ST_FRAME_STATUS_CORRUPTED, i.e.
+   * frames whose constituent packets had unrecoverable gaps after
+   * redundancy. The frame is still handed to the application; the
+   * application should consult frame->status to decide what to do.
+   * Populated by RX session types that classify per-frame integrity
+   * (ST40p today). Always 0 for types with no per-frame corruption
+   * concept (audio ST30, ST41).
+   */
+  uint64_t stat_frames_corrupted;
 };
 
 /**

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -274,28 +274,20 @@ struct st_rx_port_stats {
    *   - Many packets per frame  (Video ST20 / ST22):
    *       Increments when a frame is **completed by this port**, i.e. this
    *       port delivered enough packets to satisfy completion on its own.
-   *       Sister field: incomplete_frames (this port was short, but the
-   *       redundant port covered the gap).
+   *       Sister field (video-only): `st20_rx_user_stats::frames_partial[i]`
+   *       (this port was short, but the redundant port covered the gap).
    *
    *   - Few packets per frame   (Audio ST30, Ancillary ST40, Metadata ST41):
    *       Increments when a new frame's **first** packet arrives on this
    *       port — i.e. this port "won the race" for that frame.
-   *       Sister field: incomplete_frames is unused (always 0).
    *
    * port[i].frames is per-port, not session-wide. The two semantics above
    * do not compose: summing across ports does not yield total frames
    * delivered to the app. For end-to-end frame accounting use the common
    * counters in st_rx_user_stats: stat_frames_received,
-   * stat_frames_dropped, stat_frames_corrupted. Use port[i].frames /
-   * incomplete_frames only for per-port redundancy debugging.
+   * stat_frames_dropped, stat_frames_corrupted.
    */
   uint64_t frames;
-  /**
-   * Per-port count of frames where this port could not complete the frame
-   * on its own (the other port's redundant copy filled the missing pkts).
-   * Video (ST20 / ST22) only; always 0 for ST30/ST40/ST41.
-   */
-  uint64_t incomplete_frames;
   /** Total number of received packets rejected by handler. */
   uint64_t err_packets;
   /**

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -101,6 +101,9 @@ static int rx_st20p_packet_convert(void* priv, void* frame,
   }
   if (!framebuff) {
     rte_atomic32_inc(&ctx->stat_busy);
+    /* relaxed atomic: written from tasklet, read from any thread via
+     * st20p_rx_get_session_stats(); no ordering vs other state required. */
+    __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
     mt_pthread_mutex_unlock(&ctx->lock);
     return -EBUSY;
   }
@@ -174,6 +177,7 @@ static int rx_st20p_frame_ready(void* priv, void* frame,
   /* not any free frame */
   if (!framebuff) {
     rte_atomic32_inc(&ctx->stat_busy);
+    __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
     mt_pthread_mutex_unlock(&ctx->lock);
     return -EBUSY;
   }
@@ -292,6 +296,7 @@ static int rx_st20p_query_ext_frame(void* priv, struct st20_ext_frame* ext_frame
   /* not any free frame */
   if (!framebuff) {
     rte_atomic32_inc(&ctx->stat_busy);
+    __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
     mt_pthread_mutex_unlock(&ctx->lock);
     return -EBUSY;
   }
@@ -901,6 +906,7 @@ struct st_frame* st20p_rx_get_frame(st20p_rx_handle handle) {
     frame->user_meta_size = 0;
   }
   ctx->stat_get_frame_succ++;
+  __atomic_fetch_add(&ctx->stat_frames_received, 1, __ATOMIC_RELAXED);
   MT_USDT_ST20P_RX_FRAME_GET(idx, framebuff->idx, frame->addr[0]);
   /* check if dump USDT enabled */
   if (MT_USDT_ST20P_RX_FRAME_DUMP_ENABLED()) {
@@ -1210,7 +1216,14 @@ int st20p_rx_get_session_stats(st20p_rx_handle handle, struct st20_rx_user_stats
     return 0;
   }
 
-  return st20_rx_get_session_stats(ctx->transport, stats);
+  int ret = st20_rx_get_session_stats(ctx->transport, stats);
+  if (ret < 0) return ret;
+  /* Overlay pipeline-tracked frame-level counters; transport never sets these. */
+  stats->common.stat_frames_received =
+      __atomic_load_n(&ctx->stat_frames_received, __ATOMIC_RELAXED);
+  stats->common.stat_frames_dropped =
+      __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  return 0;
 }
 
 int st20p_rx_reset_session_stats(st20p_rx_handle handle) {
@@ -1228,6 +1241,8 @@ int st20p_rx_reset_session_stats(st20p_rx_handle handle) {
     return 0;
   }
 
+  __atomic_store_n(&ctx->stat_frames_received, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
   return st20_rx_reset_session_stats(ctx->transport);
 }
 

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -907,6 +907,8 @@ struct st_frame* st20p_rx_get_frame(st20p_rx_handle handle) {
   }
   ctx->stat_get_frame_succ++;
   __atomic_fetch_add(&ctx->stat_frames_received, 1, __ATOMIC_RELAXED);
+  if (frame->status == ST_FRAME_STATUS_CORRUPTED)
+    __atomic_fetch_add(&ctx->stat_frames_corrupted, 1, __ATOMIC_RELAXED);
   MT_USDT_ST20P_RX_FRAME_GET(idx, framebuff->idx, frame->addr[0]);
   /* check if dump USDT enabled */
   if (MT_USDT_ST20P_RX_FRAME_DUMP_ENABLED()) {
@@ -1223,6 +1225,8 @@ int st20p_rx_get_session_stats(st20p_rx_handle handle, struct st20_rx_user_stats
       __atomic_load_n(&ctx->stat_frames_received, __ATOMIC_RELAXED);
   stats->common.stat_frames_dropped =
       __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  stats->common.stat_frames_corrupted =
+      __atomic_load_n(&ctx->stat_frames_corrupted, __ATOMIC_RELAXED);
   return 0;
 }
 
@@ -1243,6 +1247,7 @@ int st20p_rx_reset_session_stats(st20p_rx_handle handle) {
 
   __atomic_store_n(&ctx->stat_frames_received, 0, __ATOMIC_RELAXED);
   __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_corrupted, 0, __ATOMIC_RELAXED);
   return st20_rx_reset_session_stats(ctx->transport);
 }
 

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.h
@@ -71,6 +71,7 @@ struct st20p_rx_ctx {
   /* cumulative user-facing counters; reset only by reset_session_stats */
   uint64_t stat_frames_received;
   uint64_t stat_frames_dropped;
+  uint64_t stat_frames_corrupted;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st20_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.h
@@ -68,6 +68,9 @@ struct st20p_rx_ctx {
   uint32_t stat_get_frame_try;
   uint32_t stat_get_frame_succ;
   uint32_t stat_put_frame;
+  /* cumulative user-facing counters; reset only by reset_session_stats */
+  uint64_t stat_frames_received;
+  uint64_t stat_frames_dropped;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -124,6 +124,9 @@ static bool tx_st20p_if_frame_late(struct st20p_tx_ctx* ctx,
       ctx->idx, framebuff->idx, (int64_t)(cur_tai - frame_tai), frame_period_ns);
 
   ctx->stat_drop_frame++;
+  /* relaxed atomic: written from both tasklet (late drop) and user thread
+   * (put_frame_abort), and read from any thread via st20p_tx_get_session_stats(). */
+  __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
   rtp_ts = frame->rtp_timestamp;
   framebuff->stat = ST20P_TX_FRAME_DROPPED;
 
@@ -250,6 +253,7 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
     ctx->ops.notify_frame_done(ctx->ops.priv, frame);
     framebuff->frame_done_cb_called = true;
   }
+  if (ret == 0) __atomic_fetch_add(&ctx->stat_frames_sent, 1, __ATOMIC_RELAXED);
 
   if (!need_in_user) {
     /* notify app can get frame */
@@ -843,6 +847,7 @@ int st20p_tx_put_frame_abort(st20p_tx_handle handle, struct st_frame* frame) {
 
   framebuff->stat = ST20P_TX_FRAME_FREE;
   ctx->stat_drop_frame++;
+  __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
   dbg("%s(%d), frame %u aborted\n", __func__, idx, producer_idx);
   return 0;
 }
@@ -1207,7 +1212,14 @@ int st20p_tx_get_session_stats(st20p_tx_handle handle, struct st20_tx_user_stats
     return 0;
   }
 
-  return st20_tx_get_session_stats(ctx->transport, stats);
+  int ret = st20_tx_get_session_stats(ctx->transport, stats);
+  if (ret < 0) return ret;
+  /* Overlay pipeline-tracked frame-level counters; transport never sets these. */
+  stats->common.stat_frames_sent =
+      __atomic_load_n(&ctx->stat_frames_sent, __ATOMIC_RELAXED);
+  stats->common.stat_frames_dropped =
+      __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  return 0;
 }
 
 int st20p_tx_reset_session_stats(st20p_tx_handle handle) {
@@ -1225,6 +1237,8 @@ int st20p_tx_reset_session_stats(st20p_tx_handle handle) {
     return 0;
   }
 
+  __atomic_store_n(&ctx->stat_frames_sent, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
   return st20_tx_reset_session_stats(ctx->transport);
 }
 

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -625,7 +625,7 @@ static int tx_st20p_stat(void* priv) {
                          st20p_tx_frame_stat_name_short[i], status_counts[i]);
     }
   }
-  notice("TX_st20p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+  dbg("TX_st20p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   notice("TX_st20p(%d), frame get try %d succ %d, put %d, drop %d\n", ctx->idx,
          ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame,

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.h
@@ -70,6 +70,9 @@ struct st20p_tx_ctx {
   uint32_t stat_get_frame_succ;
   uint32_t stat_put_frame;
   uint32_t stat_drop_frame;
+  /* cumulative user-facing counters; reset only by reset_session_stats */
+  uint64_t stat_frames_sent;
+  uint64_t stat_frames_dropped;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -406,7 +406,7 @@ static int tx_st22p_encode_dump(void* priv) {
                          st22p_tx_frame_stat_name_short[i], status_counts[i]);
     }
   }
-  notice("TX_st22p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+  dbg("TX_st22p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   notice("TX_ST22P(%s), frame get try %d succ %d, put %d\n", ctx->ops_name,
          ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame);

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.c
@@ -80,6 +80,9 @@ static int rx_st30p_frame_ready(void* priv, void* addr, struct st30_rx_frame_met
   /* not any free frame */
   if (!framebuff) {
     ctx->stat_busy++;
+    /* relaxed atomic: written from tasklet, read from any thread via
+     * st30p_rx_get_session_stats(); no ordering vs other state required. */
+    __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
     mt_pthread_mutex_unlock(&ctx->lock);
     return -EBUSY;
   }
@@ -332,6 +335,7 @@ struct st30_frame* st30p_rx_get_frame(st30p_rx_handle handle) {
 
   frame = &framebuff->frame;
   ctx->stat_get_frame_succ++;
+  __atomic_fetch_add(&ctx->stat_frames_received, 1, __ATOMIC_RELAXED);
   MT_USDT_ST30P_RX_FRAME_GET(idx, framebuff->idx, frame->addr);
   dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, framebuff->idx, frame->addr);
   /* check if dump USDT enabled */
@@ -557,7 +561,14 @@ int st30p_rx_get_session_stats(st30p_rx_handle handle, struct st30_rx_user_stats
     return 0;
   }
 
-  return st30_rx_get_session_stats(ctx->transport, stats);
+  int ret = st30_rx_get_session_stats(ctx->transport, stats);
+  if (ret < 0) return ret;
+  /* Overlay pipeline-tracked frame-level counters; transport never sets these. */
+  stats->common.stat_frames_received =
+      __atomic_load_n(&ctx->stat_frames_received, __ATOMIC_RELAXED);
+  stats->common.stat_frames_dropped =
+      __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  return 0;
 }
 
 int st30p_rx_reset_session_stats(st30p_rx_handle handle) {
@@ -575,6 +586,8 @@ int st30p_rx_reset_session_stats(st30p_rx_handle handle) {
     return 0;
   }
 
+  __atomic_store_n(&ctx->stat_frames_received, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
   return st30_rx_reset_session_stats(ctx->transport);
 }
 

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.h
@@ -56,6 +56,9 @@ struct st30p_rx_ctx {
   uint32_t stat_get_frame_succ;
   uint32_t stat_put_frame;
   uint32_t stat_busy;
+  /* cumulative user-facing counters; reset only by reset_session_stats */
+  uint64_t stat_frames_received;
+  uint64_t stat_frames_dropped;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.c
@@ -358,7 +358,7 @@ static int tx_st30p_stat(void* priv) {
                          st30p_tx_frame_stat_name_short[i], status_counts[i]);
     }
   }
-  notice("TX_st30p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+  dbg("TX_st30p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   notice("TX_st30p(%d), frame get try %d succ %d, put %d, drop %d\n", ctx->idx,
          ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame,
@@ -792,7 +792,7 @@ int st30p_tx_get_session_stats(st30p_tx_handle handle, struct st30_tx_user_stats
                          st30p_tx_frame_stat_name_short[i], status_counts[i]);
     }
   }
-  notice("TX_st30p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+  dbg("TX_st30p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   return st30_tx_get_session_stats(ctx->transport, stats);
 }

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.c
@@ -100,6 +100,9 @@ static bool tx_st30p_if_frame_late(struct st30p_tx_ctx* ctx,
       ctx->idx, framebuff->idx, (int64_t)(cur_tai - frame_tai), frame_period_ns);
 
   ctx->stat_drop_frame++;
+  /* relaxed atomic: written from both tasklet (late drop) and user thread
+   * (put_frame_abort), and read from any thread via st30p_tx_get_session_stats(). */
+  __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
   rtp_ts = frame->rtp_timestamp;
   framebuff->stat = ST30P_TX_FRAME_DROPPED;
 
@@ -209,6 +212,7 @@ static int tx_st30p_frame_done(void* priv, uint16_t frame_idx,
     ctx->ops.notify_frame_done(ctx->ops.priv, frame);
     framebuff->frame_done_cb_called = true;
   }
+  if (ret == 0) __atomic_fetch_add(&ctx->stat_frames_sent, 1, __ATOMIC_RELAXED);
 
   /* notify app can get frame */
   tx_st30p_notify_frame_available(ctx);
@@ -559,6 +563,7 @@ int st30p_tx_put_frame_abort(st30p_tx_handle handle, struct st30_frame* frame) {
 
   framebuff->stat = ST30P_TX_FRAME_FREE;
   ctx->stat_drop_frame++;
+  __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
   dbg("%s(%d), frame %u aborted\n", __func__, idx, producer_idx);
   mt_pthread_mutex_unlock(&ctx->lock);
   return 0;
@@ -794,7 +799,14 @@ int st30p_tx_get_session_stats(st30p_tx_handle handle, struct st30_tx_user_stats
   }
   dbg("TX_st30p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
-  return st30_tx_get_session_stats(ctx->transport, stats);
+  int ret = st30_tx_get_session_stats(ctx->transport, stats);
+  if (ret < 0) return ret;
+  /* Overlay pipeline-tracked frame-level counters; transport never sets these. */
+  stats->common.stat_frames_sent =
+      __atomic_load_n(&ctx->stat_frames_sent, __ATOMIC_RELAXED);
+  stats->common.stat_frames_dropped =
+      __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  return 0;
 }
 
 int st30p_tx_reset_session_stats(st30p_tx_handle handle) {
@@ -812,5 +824,7 @@ int st30p_tx_reset_session_stats(st30p_tx_handle handle) {
     return 0;
   }
 
+  __atomic_store_n(&ctx->stat_frames_sent, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
   return st30_tx_reset_session_stats(ctx->transport);
 }

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.h
@@ -63,6 +63,9 @@ struct st30p_tx_ctx {
   uint32_t stat_get_frame_succ;
   uint32_t stat_put_frame;
   uint32_t stat_drop_frame;
+  /* cumulative user-facing counters; reset only by reset_session_stats */
+  uint64_t stat_frames_sent;
+  uint64_t stat_frames_dropped;
 };
 
 #endif

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.c
@@ -8,10 +8,7 @@
 #include "../../mt_stat.h"
 
 static const char* st40p_rx_frame_stat_name[ST40P_RX_FRAME_STATUS_MAX] = {
-    "free",
-    "receiving",
-    "ready",
-    "in_user",
+    "free", "receiving", "pending", "ready", "in_user",
 };
 
 static const char* rx_st40p_stat_name(enum st40p_rx_frame_status stat) {
@@ -124,62 +121,88 @@ static int rx_st40p_rtp_ready(void* priv) {
 
   mt_pthread_mutex_lock(&ctx->lock);
 
-  /* complete previous frame if timestamp advanced */
-  if (ctx->inflight_frame && ctx->inflight_rtp_timestamp != rtp_timestamp) {
-    ctx->inflight_frame->stat = ST40P_RX_FRAME_READY;
-    ctx->framebuff_producer_idx = rx_st40p_next_idx(ctx, ctx->inflight_frame->idx);
-    notify_frame = true;
-    done_frames[done_count] = ctx->inflight_frame;
-    done_infos[done_count] = &ctx->inflight_frame->frame_info;
-    done_count++;
-    ctx->inflight_frame = NULL;
-  }
-
-  if (!ctx->inflight_frame) {
-    framebuff =
-        rx_st40p_next_available(ctx, ctx->framebuff_producer_idx, ST40P_RX_FRAME_FREE);
-
-    if (!framebuff) {
-      ctx->stat_busy++;
-      ret = -EBUSY;
-      goto out;
-    }
-
-    framebuff->stat = ST40P_RX_FRAME_RECEIVING;
-    frame_info = &framebuff->frame_info;
-    frame_info->meta_num = 0;
-    frame_info->udw_buffer_fill = 0;
-    frame_info->pkts_total = 0;
-    frame_info->pkts_recv[MTL_SESSION_PORT_P] = 0;
-    frame_info->pkts_recv[MTL_SESSION_PORT_R] = 0;
-    frame_info->seq_discont = false;
-    frame_info->seq_lost = 0;
-    frame_info->rtp_marker = false;
-    frame_info->receive_timestamp = receive_timestamp;
-    frame_info->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
-    frame_info->rtp_timestamp = rtp_timestamp;
-    frame_info->timestamp = rtp_timestamp;
-    frame_info->epoch = 0;
-    uint8_t f_bits = hdr->first_hdr_chunk.f & 0x3;
-    frame_info->interlaced = (f_bits & 0x2) ? true : false;
-    frame_info->second_field = frame_info->interlaced && (f_bits & 0x1);
-    ctx->inflight_frame = framebuff;
-    ctx->inflight_rtp_timestamp = rtp_timestamp;
-  } else {
-    framebuff = ctx->inflight_frame;
+  /* Route late packet to pending frame if it matches the pending timestamp */
+  if (ctx->pending_frame && rtp_timestamp == ctx->pending_rtp_timestamp) {
+    framebuff = ctx->pending_frame;
     frame_info = &framebuff->frame_info;
     if (!frame_info->receive_timestamp ||
         (frame_info->receive_timestamp > receive_timestamp))
       frame_info->receive_timestamp = receive_timestamp;
+  } else {
+    /* Handle timestamp change on inflight frame */
+    if (ctx->inflight_frame && ctx->inflight_rtp_timestamp != rtp_timestamp) {
+      if (ctx->ops.port.num_port > 1) {
+        /* Multi-port: inflight → PENDING (wait for late marker from redundant port) */
+        if (ctx->pending_frame) {
+          /* Force-deliver existing pending frame first */
+          ctx->pending_frame->stat = ST40P_RX_FRAME_READY;
+          notify_frame = true;
+          done_frames[done_count] = ctx->pending_frame;
+          done_infos[done_count] = &ctx->pending_frame->frame_info;
+          done_count++;
+        }
+        ctx->inflight_frame->stat = ST40P_RX_FRAME_PENDING;
+        ctx->framebuff_producer_idx = rx_st40p_next_idx(ctx, ctx->inflight_frame->idx);
+        ctx->pending_frame = ctx->inflight_frame;
+        ctx->pending_rtp_timestamp = ctx->inflight_rtp_timestamp;
+      } else {
+        /* Single-port: no redundant port → directly READY */
+        ctx->inflight_frame->stat = ST40P_RX_FRAME_READY;
+        ctx->framebuff_producer_idx = rx_st40p_next_idx(ctx, ctx->inflight_frame->idx);
+        notify_frame = true;
+        done_frames[done_count] = ctx->inflight_frame;
+        done_infos[done_count] = &ctx->inflight_frame->frame_info;
+        done_count++;
+      }
+      ctx->inflight_frame = NULL;
+    }
 
-    /* Update field metadata if a later packet carries interlace info */
-    uint8_t pkt_field = hdr->first_hdr_chunk.f & 0x3;
-    bool pkt_interlaced = (pkt_field & 0x2) ? true : false;
-    bool pkt_second_field = pkt_interlaced && (pkt_field & 0x1);
-    if ((frame_info->interlaced != pkt_interlaced) ||
-        (frame_info->second_field != pkt_second_field)) {
-      frame_info->interlaced = pkt_interlaced;
-      frame_info->second_field = pkt_second_field;
+    if (!ctx->inflight_frame) {
+      framebuff =
+          rx_st40p_next_available(ctx, ctx->framebuff_producer_idx, ST40P_RX_FRAME_FREE);
+
+      if (!framebuff) {
+        ctx->stat_busy++;
+        ret = -EBUSY;
+        goto out;
+      }
+
+      framebuff->stat = ST40P_RX_FRAME_RECEIVING;
+      frame_info = &framebuff->frame_info;
+      frame_info->meta_num = 0;
+      frame_info->udw_buffer_fill = 0;
+      frame_info->pkts_total = 0;
+      frame_info->pkts_recv[MTL_SESSION_PORT_P] = 0;
+      frame_info->pkts_recv[MTL_SESSION_PORT_R] = 0;
+      frame_info->seq_discont = false;
+      frame_info->seq_lost = 0;
+      frame_info->rtp_marker = false;
+      frame_info->receive_timestamp = receive_timestamp;
+      frame_info->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
+      frame_info->rtp_timestamp = rtp_timestamp;
+      frame_info->timestamp = rtp_timestamp;
+      frame_info->epoch = 0;
+      uint8_t f_bits = hdr->first_hdr_chunk.f & 0x3;
+      frame_info->interlaced = (f_bits & 0x2) ? true : false;
+      frame_info->second_field = frame_info->interlaced && (f_bits & 0x1);
+      ctx->inflight_frame = framebuff;
+      ctx->inflight_rtp_timestamp = rtp_timestamp;
+    } else {
+      framebuff = ctx->inflight_frame;
+      frame_info = &framebuff->frame_info;
+      if (!frame_info->receive_timestamp ||
+          (frame_info->receive_timestamp > receive_timestamp))
+        frame_info->receive_timestamp = receive_timestamp;
+
+      /* Update field metadata if a later packet carries interlace info */
+      uint8_t pkt_field = hdr->first_hdr_chunk.f & 0x3;
+      bool pkt_interlaced = (pkt_field & 0x2) ? true : false;
+      bool pkt_second_field = pkt_interlaced && (pkt_field & 0x1);
+      if ((frame_info->interlaced != pkt_interlaced) ||
+          (frame_info->second_field != pkt_second_field)) {
+        frame_info->interlaced = pkt_interlaced;
+        frame_info->second_field = pkt_second_field;
+      }
     }
   }
 
@@ -305,13 +328,29 @@ static int rx_st40p_rtp_ready(void* priv) {
 
   if (hdr->base.marker) {
     frame_info->rtp_marker = true;
-    framebuff->stat = ST40P_RX_FRAME_READY;
-    ctx->framebuff_producer_idx = rx_st40p_next_idx(ctx, framebuff->idx);
-    ctx->inflight_frame = NULL;
+    if (framebuff == ctx->pending_frame) {
+      /* Late marker resolves PENDING → READY */
+      framebuff->stat = ST40P_RX_FRAME_READY;
+      ctx->pending_frame = NULL;
+    } else {
+      /* Normal inflight → READY */
+      framebuff->stat = ST40P_RX_FRAME_READY;
+      ctx->framebuff_producer_idx = rx_st40p_next_idx(ctx, framebuff->idx);
+      ctx->inflight_frame = NULL;
+    }
     notify_frame = true;
     done_frames[done_count] = framebuff;
     done_infos[done_count] = frame_info;
     done_count++;
+  }
+
+  /* Assign frame status while still under lock — app thread may read status
+   * after get_frame() returns, so the write must be visible before unlock. */
+  for (int n = 0; n < done_count; n++) {
+    struct st40_frame_info* done_info = done_infos[n];
+    if (done_info)
+      done_info->status =
+          done_info->seq_discont ? ST_FRAME_STATUS_CORRUPTED : ST_FRAME_STATUS_COMPLETE;
   }
 
 out:
@@ -327,8 +366,6 @@ out:
       if (!report_frame || !report_info) continue;
       dbg("%s(%d), frame %u succ, meta_num %u\n", __func__, ctx->idx, report_frame->idx,
           report_info->meta_num);
-      report_info->status =
-          report_info->seq_discont ? ST_FRAME_STATUS_CORRUPTED : ST_FRAME_STATUS_COMPLETE;
       /* notify app to a ready frame */
       rx_st40p_notify_frame_available(ctx);
       MT_USDT_ST40P_RX_FRAME_AVAILABLE(ctx->idx, report_frame->idx,
@@ -684,6 +721,8 @@ int st40p_rx_free(st40p_rx_handle handle) {
     ctx->transport = NULL;
   }
 
+  ctx->inflight_frame = NULL;
+  ctx->pending_frame = NULL;
   rx_st40p_uinit_fbs(ctx);
 
   mt_pthread_mutex_destroy(&ctx->lock);

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.c
@@ -163,6 +163,9 @@ static int rx_st40p_rtp_ready(void* priv) {
 
       if (!framebuff) {
         ctx->stat_busy++;
+        /* relaxed atomic: written under ctx->lock from tasklet, read from any
+         * thread via st40p_rx_get_session_stats() without locking. */
+        __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
         ret = -EBUSY;
         goto out;
       }
@@ -348,9 +351,13 @@ static int rx_st40p_rtp_ready(void* priv) {
    * after get_frame() returns, so the write must be visible before unlock. */
   for (int n = 0; n < done_count; n++) {
     struct st40_frame_info* done_info = done_infos[n];
-    if (done_info)
+    if (done_info) {
       done_info->status =
           done_info->seq_discont ? ST_FRAME_STATUS_CORRUPTED : ST_FRAME_STATUS_COMPLETE;
+      __atomic_fetch_add(&ctx->stat_frames_received, 1, __ATOMIC_RELAXED);
+      if (done_info->seq_discont)
+        __atomic_fetch_add(&ctx->stat_frames_corrupted, 1, __ATOMIC_RELAXED);
+    }
   }
 
 out:
@@ -865,7 +872,16 @@ int st40p_rx_get_session_stats(st40p_rx_handle handle, struct st40_rx_user_stats
     return -EIO;
   }
 
-  return st40_rx_get_session_stats(ctx->transport, stats);
+  int ret = st40_rx_get_session_stats(ctx->transport, stats);
+  if (ret < 0) return ret;
+  /* Overlay pipeline-tracked frame-level counters; transport never sets these. */
+  stats->common.stat_frames_received =
+      __atomic_load_n(&ctx->stat_frames_received, __ATOMIC_RELAXED);
+  stats->common.stat_frames_dropped =
+      __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  stats->common.stat_frames_corrupted =
+      __atomic_load_n(&ctx->stat_frames_corrupted, __ATOMIC_RELAXED);
+  return 0;
 }
 
 int st40p_rx_reset_session_stats(st40p_rx_handle handle) {
@@ -883,6 +899,9 @@ int st40p_rx_reset_session_stats(st40p_rx_handle handle) {
     return -EIO;
   }
 
+  __atomic_store_n(&ctx->stat_frames_received, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_corrupted, 0, __ATOMIC_RELAXED);
   return st40_rx_reset_session_stats(ctx->transport);
 }
 

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.h
@@ -67,6 +67,10 @@ struct st40p_rx_ctx {
   uint32_t stat_put_frame;
   uint32_t stat_busy;
   uint32_t stat_drop_frame;
+  /* cumulative user-facing counters; reset only by reset_session_stats */
+  uint64_t stat_frames_received;
+  uint64_t stat_frames_dropped;
+  uint64_t stat_frames_corrupted;
 };
 
 struct st40p_rx_frame {

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.h
@@ -15,6 +15,7 @@ extern "C" {
 enum st40p_rx_frame_status {
   ST40P_RX_FRAME_FREE = 0,
   ST40P_RX_FRAME_RECEIVING,
+  ST40P_RX_FRAME_PENDING,
   ST40P_RX_FRAME_READY,
   ST40P_RX_FRAME_IN_USER,
   ST40P_RX_FRAME_STATUS_MAX,
@@ -40,6 +41,8 @@ struct st40p_rx_ctx {
   struct st40p_rx_frame* framebuffs;
   struct st40p_rx_frame* inflight_frame;
   uint32_t inflight_rtp_timestamp;
+  struct st40p_rx_frame* pending_frame;
+  uint32_t pending_rtp_timestamp;
   /* session-level continuity (post-dedup) */
   bool session_last_seq_valid;
   uint16_t session_last_seq;

--- a/lib/src/st2110/pipeline/st40_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_tx.c
@@ -103,6 +103,9 @@ static bool tx_st40p_if_frame_late(struct st40p_tx_ctx* ctx,
       ctx->idx, framebuff->idx, (int64_t)(cur_tai - frame_tai), frame_period_ns);
 
   ctx->stat_drop_frame++;
+  /* relaxed atomic: written from both tasklet (late drop) and user thread
+   * (put_frame_abort), and read from any thread via st40p_tx_get_session_stats(). */
+  __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
   rtp_ts = frame_info->rtp_timestamp;
   framebuff->stat = ST40P_TX_FRAME_DROPPED;
 
@@ -215,6 +218,7 @@ static int tx_st40p_frame_done(void* priv, uint16_t frame_idx,
     ctx->ops.notify_frame_done(ctx->ops.priv, frame_info);
     framebuff->frame_done_cb_called = true;
   }
+  if (ret == 0) __atomic_fetch_add(&ctx->stat_frames_sent, 1, __ATOMIC_RELAXED);
 
   /* notify app can get frame */
   tx_st40p_notify_frame_available(ctx);
@@ -554,6 +558,7 @@ int st40p_tx_put_frame_abort(st40p_tx_handle handle, struct st40_frame_info* fra
 
   framebuff->stat = ST40P_TX_FRAME_FREE;
   ctx->stat_drop_frame++;
+  __atomic_fetch_add(&ctx->stat_frames_dropped, 1, __ATOMIC_RELAXED);
   dbg("%s(%d), frame %u aborted\n", __func__, idx, producer_idx);
   return 0;
 }
@@ -781,7 +786,14 @@ int st40p_tx_get_session_stats(st40p_tx_handle handle, struct st40_tx_user_stats
     return -EINVAL;
   }
 
-  return st40_tx_get_session_stats(ctx->transport, stats);
+  int ret = st40_tx_get_session_stats(ctx->transport, stats);
+  if (ret < 0) return ret;
+  /* Overlay pipeline-tracked frame-level counters; transport never sets these. */
+  stats->common.stat_frames_sent =
+      __atomic_load_n(&ctx->stat_frames_sent, __ATOMIC_RELAXED);
+  stats->common.stat_frames_dropped =
+      __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  return 0;
 }
 
 int st40p_tx_reset_session_stats(st40p_tx_handle handle) {
@@ -799,5 +811,7 @@ int st40p_tx_reset_session_stats(st40p_tx_handle handle) {
     return 0;
   }
 
+  __atomic_store_n(&ctx->stat_frames_sent, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
   return st40_tx_reset_session_stats(ctx->transport);
 }

--- a/lib/src/st2110/pipeline/st40_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_tx.c
@@ -401,7 +401,7 @@ static int tx_st40p_stat(void* priv) {
                          st40p_tx_frame_stat_name_short[i], status_counts[i]);
     }
   }
-  notice("TX_st40p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
+  dbg("TX_st40p(%d,%s), framebuffer queue: %s\n", ctx->idx, ctx->ops_name, status_str);
 
   notice("TX_st40p(%d), frame get try %d succ %d, put %d, drop %d\n", ctx->idx,
          ctx->stat_get_frame_try, ctx->stat_get_frame_succ, ctx->stat_put_frame,

--- a/lib/src/st2110/pipeline/st40_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st40_pipeline_tx.h
@@ -55,6 +55,9 @@ struct st40p_tx_ctx {
   uint32_t stat_get_frame_succ;
   uint32_t stat_put_frame;
   uint32_t stat_drop_frame;
+  /* cumulative user-facing counters; reset only by reset_session_stats */
+  uint64_t stat_frames_sent;
+  uint64_t stat_frames_dropped;
 };
 
 struct st40p_tx_frame {

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -1135,6 +1135,17 @@ struct st_rx_ancillary_session_impl {
   uint16_t anc_prev_bitmap_base_seq;
   bool anc_prev_bitmap_valid;
 
+  /* Per-port last accepted F bits and matching timestamp, used to detect
+   * cross-port F-bit divergence (SMPTE 2110-40 producer violation).
+   * last_f_bits[] uses 0xff as sentinel meaning "unset". */
+  uint8_t last_f_bits[MTL_SESSION_PORT_MAX];
+  uint32_t last_f_tmstamp[MTL_SESSION_PORT_MAX];
+  uint64_t f_mismatch_warn_last_ns; /* rate-limit warn emission */
+  /* internal-only debug counter for F-bit mismatches (not exposed in public API,
+   * surfaced only in periodic err() log). */
+  uint64_t stat_internal_field_bit_mismatch;
+  uint64_t stat_internal_field_bit_mismatch_snap;
+
   struct mt_rtcp_rx* rtcp_rx[MTL_SESSION_PORT_MAX];
 
   int64_t tmstamp;

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -1120,20 +1120,17 @@ struct st_rx_ancillary_session_impl {
 
   /* Lightweight per-frame bitmap for cross-port late arrival detection.
    * Ancillary frames are small (typically 1-10 pkts), so a uint64_t covers
-   * up to 64 packets per frame. Packets beyond offset 63 fall back to
-   * watermark-only filtering. */
-  uint64_t anc_bitmap;          /* 1 bit per seq offset within current frame */
-  uint32_t anc_bitmap_tmstamp;  /* timestamp this bitmap belongs to */
-  uint16_t anc_bitmap_base_seq; /* first seq_id of this frame */
-  bool anc_bitmap_valid;        /* false until first frame is established */
-
-  /* Previous-frame bitmap for late-arrival acceptance after timestamp advance.
-   * When tmstamp advances, current bitmap is moved here so that late packets
-   * from the redundant port can still be deduplicated and accepted. */
-  uint64_t anc_prev_bitmap;
-  uint32_t anc_prev_bitmap_tmstamp;
-  uint16_t anc_prev_bitmap_base_seq;
-  bool anc_prev_bitmap_valid;
+   * up to ST_RX_ANC_BITMAP_BITS packets per frame. Packets beyond that
+   * fall back to watermark-only filtering.
+   * `cur` tracks the current frame; `prev` is moved aside when the timestamp
+   * advances so late packets from the redundant port can still be deduped. */
+#define ST_RX_ANC_BITMAP_BITS (sizeof(uint64_t) * 8)
+  struct anc_window {
+    uint64_t bitmap;   /* 1 bit per seq offset within the frame */
+    uint32_t tmstamp;  /* timestamp this bitmap belongs to */
+    uint16_t base_seq; /* first seq_id of this frame */
+    bool valid;        /* false until first frame is established */
+  } anc_window_cur, anc_window_prev;
 
   /* Per-port last accepted F bits and matching timestamp, used to detect
    * cross-port F-bit divergence (SMPTE 2110-40 producer violation).

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -1127,9 +1127,18 @@ struct st_rx_ancillary_session_impl {
   uint16_t anc_bitmap_base_seq; /* first seq_id of this frame */
   bool anc_bitmap_valid;        /* false until first frame is established */
 
+  /* Previous-frame bitmap for late-arrival acceptance after timestamp advance.
+   * When tmstamp advances, current bitmap is moved here so that late packets
+   * from the redundant port can still be deduplicated and accepted. */
+  uint64_t anc_prev_bitmap;
+  uint32_t anc_prev_bitmap_tmstamp;
+  uint16_t anc_prev_bitmap_base_seq;
+  bool anc_prev_bitmap_valid;
+
   struct mt_rtcp_rx* rtcp_rx[MTL_SESSION_PORT_MAX];
 
   int64_t tmstamp;
+  int64_t prev_tmstamp; /* immediately previous frame timestamp */
   /* stat – port_user_stats is the single source for API-visible counters (monotonic) */
   struct st40_rx_user_stats port_user_stats;
   struct st40_rx_user_stats stat_snapshot; /* for delta computation in stat dump */

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -1118,6 +1118,15 @@ struct st_rx_ancillary_session_impl {
    * and 2^15 seq_id wraparound (unlikely). */
   int redundant_error_cnt[MTL_SESSION_PORT_MAX];
 
+  /* Lightweight per-frame bitmap for cross-port late arrival detection.
+   * Ancillary frames are small (typically 1-10 pkts), so a uint64_t covers
+   * up to 64 packets per frame. Packets beyond offset 63 fall back to
+   * watermark-only filtering. */
+  uint64_t anc_bitmap;          /* 1 bit per seq offset within current frame */
+  uint32_t anc_bitmap_tmstamp;  /* timestamp this bitmap belongs to */
+  uint16_t anc_bitmap_base_seq; /* first seq_id of this frame */
+  bool anc_bitmap_valid;        /* false until first frame is established */
+
   struct mt_rtcp_rx* rtcp_rx[MTL_SESSION_PORT_MAX];
 
   int64_t tmstamp;

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -106,6 +106,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   uint32_t pkt_len = mbuf->data_len - sizeof(struct st40_rfc8331_rtp_hdr);
   MTL_MAY_UNUSED(pkt_len);
   uint32_t tmstamp = ntohl(rtp->tmstamp);
+  bool threshold_bypass = false;
 
   if (ops->payload_type && (payload_type != ops->payload_type)) {
     ST40_FUZZ_LOG("%s(%d,%d), drop payload_type %u expected %u\n", __func__, s->idx,
@@ -199,6 +200,21 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
       }
     }
 
+    /* Previous-timestamp window: accept unique late packets for the immediately
+     * previous frame.  This enables the pipeline layer to receive late-arriving
+     * marker packets from the redundant port after the primary has advanced. */
+    if (s->prev_tmstamp >= 0 && tmstamp == (uint32_t)s->prev_tmstamp &&
+        s->anc_prev_bitmap_valid && tmstamp == s->anc_prev_bitmap_tmstamp) {
+      uint16_t offset = (uint16_t)(seq_id - s->anc_prev_bitmap_base_seq);
+      if (offset < 64 && !(s->anc_prev_bitmap & ((uint64_t)1 << offset))) {
+        if (s->port_user_stats.common.stat_pkts_unrecovered > 0)
+          s->port_user_stats.common.stat_pkts_unrecovered--;
+        dbg("%s(%d,%d), prev-frame late arrival seq %u accepted (offset %u)\n", __func__,
+            s->idx, s_port, seq_id, offset);
+        goto accept_pkt;
+      }
+    }
+
     if (!mt_seq16_greater(seq_id, s->session_seq_id)) {
       ST40_FUZZ_LOG("%s(%d,%d), redundant seq %u last %d\n", __func__, s->idx, s_port,
                     seq_id, s->session_seq_id);
@@ -222,6 +238,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     /* threshold exceeded on all ports — accept the packet and undo the redundant count
      * so the packet is only counted as received, not both */
     s->port_user_stats.common.stat_pkts_redundant--;
+    threshold_bypass = true;
     warn(
         "%s(%d), redundant error threshold reached, accept packet seq %u (old seq_id "
         "%d), timestamp %u (old timestamp %ld)\n",
@@ -255,15 +272,28 @@ accept_pkt:
   /* Update per-frame bitmap: track which seq offsets have been delivered.
    * base_seq = old_session_seq + 1 = first expected seq of this frame.
    * This ensures late arrivals (seq < first accepted seq) still fit in the bitmap. */
-  if (!s->anc_bitmap_valid || tmstamp != s->anc_bitmap_tmstamp) {
-    s->anc_bitmap = 0;
-    s->anc_bitmap_tmstamp = tmstamp;
-    s->anc_bitmap_base_seq = (uint16_t)(old_session_seq + 1);
-    s->anc_bitmap_valid = true;
-  }
-  {
-    uint16_t offset = (uint16_t)(seq_id - s->anc_bitmap_base_seq);
-    if (offset < 64) s->anc_bitmap |= ((uint64_t)1 << offset);
+  if (s->anc_prev_bitmap_valid && tmstamp == s->anc_prev_bitmap_tmstamp) {
+    /* This packet belongs to the previous frame — update prev bitmap only */
+    uint16_t offset = (uint16_t)(seq_id - s->anc_prev_bitmap_base_seq);
+    if (offset < 64) s->anc_prev_bitmap |= ((uint64_t)1 << offset);
+  } else {
+    if (!s->anc_bitmap_valid || tmstamp != s->anc_bitmap_tmstamp) {
+      /* Save current bitmap as prev before resetting for new frame */
+      if (s->anc_bitmap_valid) {
+        s->anc_prev_bitmap = s->anc_bitmap;
+        s->anc_prev_bitmap_tmstamp = s->anc_bitmap_tmstamp;
+        s->anc_prev_bitmap_base_seq = s->anc_bitmap_base_seq;
+        s->anc_prev_bitmap_valid = true;
+      }
+      s->anc_bitmap = 0;
+      s->anc_bitmap_tmstamp = tmstamp;
+      s->anc_bitmap_base_seq = (uint16_t)(old_session_seq + 1);
+      s->anc_bitmap_valid = true;
+    }
+    {
+      uint16_t offset = (uint16_t)(seq_id - s->anc_bitmap_base_seq);
+      if (offset < 64) s->anc_bitmap |= ((uint64_t)1 << offset);
+    }
   }
 
   /* enqueue to packet ring to let app to handle */
@@ -279,7 +309,13 @@ accept_pkt:
   }
   rte_mbuf_refcnt_update(mbuf, 1); /* free when app put */
 
-  if (tmstamp != s->tmstamp) {
+  /* Only advance timestamp forward — prev-frame late arrivals must not roll back.
+   * Exception: threshold bypass is a recovery mechanism that may legitimately
+   * move the timestamp backward when the session is stuck. */
+  if (tmstamp != s->tmstamp &&
+      (mt_seq32_greater(tmstamp, s->tmstamp) || threshold_bypass)) {
+    s->prev_tmstamp = s->tmstamp;
+
     rte_atomic32_inc(&s->stat_frames_received);
     s->port_user_stats.common.port[s_port].frames++;
     s->tmstamp = tmstamp;
@@ -308,6 +344,8 @@ static void rx_ancillary_session_reset(struct st_rx_ancillary_session_impl* s,
 
   s->session_seq_id = -1;
   s->tmstamp = -1;
+  s->prev_tmstamp = -1;
+  s->anc_prev_bitmap_valid = false;
   s->stat_last_time = init_stat_time_now ? mt_get_monotonic_time() : 0;
   s->stat_max_notify_rtp_us = 0;
   rte_atomic32_set(&s->stat_frames_received, 0);

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -201,7 +201,6 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
     s->latest_seq_id[s_port] = seq_id;
 
-  /* count per-port stats before redundancy filtering for consistent reporting */
   s->port_user_stats.common.port[s_port].packets++;
   s->port_user_stats.common.port[s_port].bytes += mbuf->pkt_len;
 
@@ -261,7 +260,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
 
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
-        return -EIO;
+        return -EAGAIN; /* filtered redundant, not an error */
       }
     }
     /* threshold exceeded on all ports — accept the packet and undo the redundant count
@@ -417,8 +416,8 @@ static int rx_ancillary_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf,
   }
 
   for (uint16_t i = 0; i < nb; i++) {
-    if (rx_ancillary_session_handle_pkt(impl, s, mbuf[i], s_port) < 0)
-      s->port_user_stats.common.port[s_port].err_packets++;
+    int rc = rx_ancillary_session_handle_pkt(impl, s, mbuf[i], s_port);
+    if (rc < 0 && rc != -EAGAIN) s->port_user_stats.common.port[s_port].err_packets++;
   }
 
   return 0;

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -162,14 +162,16 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   if (unlikely(s->tmstamp == -1)) s->tmstamp = tmstamp - 1;
 
   /* not a big deal as long as stream is continous */
-  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1) &&
+      mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
     uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
     s->port_user_stats.common.stat_pkts_out_of_order += gap;
   }
-  s->latest_seq_id[s_port] = seq_id;
+  if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
+    s->latest_seq_id[s_port] = seq_id;
 
   /* count per-port stats before redundancy filtering for consistent reporting */
   s->port_user_stats.common.port[s_port].packets++;

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -206,16 +206,17 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   s->port_user_stats.common.port[s_port].bytes += mbuf->pkt_len;
 
   /* in ancillary we assume packet is redundant when the seq_id is old (it's possible to
-  get multiple packets with the same timestamp)) */
+  get multiple packets with the same timestamp) */
   if ((mt_seq32_greater(s->tmstamp, tmstamp)) ||
       !mt_seq16_greater(seq_id, s->session_seq_id)) {
     /* Check per-frame bitmap: if this is a same-frame late arrival carrying unique data,
      * accept it instead of filtering.  This handles cross-port reordering where port R
      * delivers seq N+2..N+5 before port P delivers seq N..N+1. */
-    if (s->anc_bitmap_valid && tmstamp == s->anc_bitmap_tmstamp &&
+    if (s->anc_window_cur.valid && tmstamp == s->anc_window_cur.tmstamp &&
         !mt_seq32_greater(s->tmstamp, tmstamp)) {
-      uint16_t offset = (uint16_t)(seq_id - s->anc_bitmap_base_seq);
-      if (offset < 64 && !(s->anc_bitmap & ((uint64_t)1 << offset))) {
+      uint16_t offset = (uint16_t)(seq_id - s->anc_window_cur.base_seq);
+      if (offset < ST_RX_ANC_BITMAP_BITS &&
+          !(s->anc_window_cur.bitmap & ((uint64_t)1 << offset))) {
         /* bit is clear — this seq was never delivered, accept as late arrival.
          * This packet was previously counted as unrecovered when the gap was seen,
          * so undo that count now that it has arrived. */
@@ -231,9 +232,10 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
      * previous frame.  This enables the pipeline layer to receive late-arriving
      * marker packets from the redundant port after the primary has advanced. */
     if (s->prev_tmstamp >= 0 && tmstamp == (uint32_t)s->prev_tmstamp &&
-        s->anc_prev_bitmap_valid && tmstamp == s->anc_prev_bitmap_tmstamp) {
-      uint16_t offset = (uint16_t)(seq_id - s->anc_prev_bitmap_base_seq);
-      if (offset < 64 && !(s->anc_prev_bitmap & ((uint64_t)1 << offset))) {
+        s->anc_window_prev.valid && tmstamp == s->anc_window_prev.tmstamp) {
+      uint16_t offset = (uint16_t)(seq_id - s->anc_window_prev.base_seq);
+      if (offset < ST_RX_ANC_BITMAP_BITS &&
+          !(s->anc_window_prev.bitmap & ((uint64_t)1 << offset))) {
         if (s->port_user_stats.common.stat_pkts_unrecovered > 0)
           s->port_user_stats.common.stat_pkts_unrecovered--;
         dbg("%s(%d,%d), prev-frame late arrival seq %u accepted (offset %u)\n", __func__,
@@ -297,27 +299,24 @@ accept_pkt:
   /* Update per-frame bitmap: track which seq offsets have been delivered.
    * base_seq = old_session_seq + 1 = first expected seq of this frame.
    * This ensures late arrivals (seq < first accepted seq) still fit in the bitmap. */
-  if (s->anc_prev_bitmap_valid && tmstamp == s->anc_prev_bitmap_tmstamp) {
+  if (s->anc_window_prev.valid && tmstamp == s->anc_window_prev.tmstamp) {
     /* This packet belongs to the previous frame — update prev bitmap only */
-    uint16_t offset = (uint16_t)(seq_id - s->anc_prev_bitmap_base_seq);
-    if (offset < 64) s->anc_prev_bitmap |= ((uint64_t)1 << offset);
+    uint16_t offset = (uint16_t)(seq_id - s->anc_window_prev.base_seq);
+    if (offset < ST_RX_ANC_BITMAP_BITS)
+      s->anc_window_prev.bitmap |= ((uint64_t)1 << offset);
   } else {
-    if (!s->anc_bitmap_valid || tmstamp != s->anc_bitmap_tmstamp) {
+    if (!s->anc_window_cur.valid || tmstamp != s->anc_window_cur.tmstamp) {
       /* Save current bitmap as prev before resetting for new frame */
-      if (s->anc_bitmap_valid) {
-        s->anc_prev_bitmap = s->anc_bitmap;
-        s->anc_prev_bitmap_tmstamp = s->anc_bitmap_tmstamp;
-        s->anc_prev_bitmap_base_seq = s->anc_bitmap_base_seq;
-        s->anc_prev_bitmap_valid = true;
-      }
-      s->anc_bitmap = 0;
-      s->anc_bitmap_tmstamp = tmstamp;
-      s->anc_bitmap_base_seq = (uint16_t)(old_session_seq + 1);
-      s->anc_bitmap_valid = true;
+      if (s->anc_window_cur.valid) s->anc_window_prev = s->anc_window_cur;
+      s->anc_window_cur.bitmap = 0;
+      s->anc_window_cur.tmstamp = tmstamp;
+      s->anc_window_cur.base_seq = (uint16_t)(old_session_seq + 1);
+      s->anc_window_cur.valid = true;
     }
     {
-      uint16_t offset = (uint16_t)(seq_id - s->anc_bitmap_base_seq);
-      if (offset < 64) s->anc_bitmap |= ((uint64_t)1 << offset);
+      uint16_t offset = (uint16_t)(seq_id - s->anc_window_cur.base_seq);
+      if (offset < ST_RX_ANC_BITMAP_BITS)
+        s->anc_window_cur.bitmap |= ((uint64_t)1 << offset);
     }
   }
 
@@ -370,7 +369,8 @@ static void rx_ancillary_session_reset(struct st_rx_ancillary_session_impl* s,
   s->session_seq_id = -1;
   s->tmstamp = -1;
   s->prev_tmstamp = -1;
-  s->anc_prev_bitmap_valid = false;
+  memset(&s->anc_window_cur, 0, sizeof(s->anc_window_cur));
+  memset(&s->anc_window_prev, 0, sizeof(s->anc_window_prev));
   s->stat_last_time = init_stat_time_now ? mt_get_monotonic_time() : 0;
   s->stat_max_notify_rtp_us = 0;
   rte_atomic32_set(&s->stat_frames_received, 0);

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -210,7 +210,8 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
 
   /* hole in seq id packets going into the session check if the seq_id of the session is
    * consistent */
-  if (seq_id != (uint16_t)(s->session_seq_id + 1)) {
+  if (seq_id != (uint16_t)(s->session_seq_id + 1) &&
+      mt_seq16_greater(seq_id, s->session_seq_id)) {
     if (s->interlace_auto && s->interlace_detected) {
       s->interlace_detected = false;
       dbg("%s(%d,%d), reset interlace detect after seq discont %u->%u\n", __func__,

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -181,6 +181,24 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   get multiple packets with the same timestamp)) */
   if ((mt_seq32_greater(s->tmstamp, tmstamp)) ||
       !mt_seq16_greater(seq_id, s->session_seq_id)) {
+    /* Check per-frame bitmap: if this is a same-frame late arrival carrying unique data,
+     * accept it instead of filtering.  This handles cross-port reordering where port R
+     * delivers seq N+2..N+5 before port P delivers seq N..N+1. */
+    if (s->anc_bitmap_valid && tmstamp == s->anc_bitmap_tmstamp &&
+        !mt_seq32_greater(s->tmstamp, tmstamp)) {
+      uint16_t offset = (uint16_t)(seq_id - s->anc_bitmap_base_seq);
+      if (offset < 64 && !(s->anc_bitmap & ((uint64_t)1 << offset))) {
+        /* bit is clear — this seq was never delivered, accept as late arrival.
+         * This packet was previously counted as unrecovered when the gap was seen,
+         * so undo that count now that it has arrived. */
+        if (s->port_user_stats.common.stat_pkts_unrecovered > 0)
+          s->port_user_stats.common.stat_pkts_unrecovered--;
+        dbg("%s(%d,%d), late arrival seq %u accepted via bitmap (offset %u)\n", __func__,
+            s->idx, s_port, seq_id, offset);
+        goto accept_pkt;
+      }
+    }
+
     if (!mt_seq16_greater(seq_id, s->session_seq_id)) {
       ST40_FUZZ_LOG("%s(%d,%d), redundant seq %u last %d\n", __func__, s->idx, s_port,
                     seq_id, s->session_seq_id);
@@ -209,7 +227,12 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
         "%d), timestamp %u (old timestamp %ld)\n",
         __func__, s->idx, seq_id, s->session_seq_id, tmstamp, s->tmstamp);
   }
+
+accept_pkt:
   s->redundant_error_cnt[s_port] = 0;
+
+  /* Save session_seq before update — needed for bitmap base calculation */
+  int old_session_seq = s->session_seq_id;
 
   /* hole in seq id packets going into the session check if the seq_id of the session is
    * consistent */
@@ -226,8 +249,22 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
         (uint16_t)(seq_id - s->session_seq_id - 1);
   }
 
-  /* update seq id */
-  s->session_seq_id = seq_id;
+  /* update seq id — only advance, never lower for late arrivals */
+  if (mt_seq16_greater(seq_id, s->session_seq_id)) s->session_seq_id = seq_id;
+
+  /* Update per-frame bitmap: track which seq offsets have been delivered.
+   * base_seq = old_session_seq + 1 = first expected seq of this frame.
+   * This ensures late arrivals (seq < first accepted seq) still fit in the bitmap. */
+  if (!s->anc_bitmap_valid || tmstamp != s->anc_bitmap_tmstamp) {
+    s->anc_bitmap = 0;
+    s->anc_bitmap_tmstamp = tmstamp;
+    s->anc_bitmap_base_seq = (uint16_t)(old_session_seq + 1);
+    s->anc_bitmap_valid = true;
+  }
+  {
+    uint16_t offset = (uint16_t)(seq_id - s->anc_bitmap_base_seq);
+    if (offset < 64) s->anc_bitmap |= ((uint64_t)1 << offset);
+  }
 
   /* enqueue to packet ring to let app to handle */
   int ret = rte_ring_sp_enqueue(s->packet_ring, (void*)mbuf);

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -201,6 +201,9 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
         return -EIO;
       }
     }
+    /* threshold exceeded on all ports — accept the packet and undo the redundant count
+     * so the packet is only counted as received, not both */
+    s->port_user_stats.common.stat_pkts_redundant--;
     warn(
         "%s(%d), redundant error threshold reached, accept packet seq %u (old seq_id "
         "%d), timestamp %u (old timestamp %ld)\n",

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -390,19 +390,6 @@ static void rx_ancillary_session_reset(struct st_rx_ancillary_session_impl* s,
   s->f_mismatch_warn_last_ns = 0;
 }
 
-#ifdef MTL_ENABLE_FUZZING_ST40
-int st_rx_ancillary_session_fuzz_handle_pkt(struct mtl_main_impl* impl,
-                                            struct st_rx_ancillary_session_impl* s,
-                                            struct rte_mbuf* mbuf,
-                                            enum mtl_session_port s_port) {
-  return rx_ancillary_session_handle_pkt(impl, s, mbuf, s_port);
-}
-
-void st_rx_ancillary_session_fuzz_reset(struct st_rx_ancillary_session_impl* s) {
-  rx_ancillary_session_reset(s, false);
-}
-#endif
-
 static int rx_ancillary_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf,
                                             uint16_t nb) {
   struct st_rx_session_priv* s_priv = priv;

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -128,7 +128,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     }
   }
 
-  uint8_t f_bits = rfc8331->first_hdr_chunk.f & 0x3;
+  uint8_t f_bits = rfc8331->first_hdr_chunk.f; /* 2-bit field, no mask needed */
 
   /* Drop if F is 0b01 (invalid: bit 0 set, bit 1 clear) */
   if (f_bits == 0x1) {
@@ -158,6 +158,26 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     }
   }
 
+  /* Cross-port F-bit divergence: a mismatch on the same timestamp means the
+   * producer sends different field bits per port — a SMPTE 2110-40 violation.
+   * Rate-limit the warn to one per second. MTL only ever has P/R (max 2). */
+  if (s->ops.num_port > 1) {
+    int other = s_port ^ 1;
+    if (s->last_f_bits[other] != 0xff && s->last_f_tmstamp[other] == tmstamp &&
+        s->last_f_bits[other] != f_bits) {
+      s->stat_internal_field_bit_mismatch++;
+      uint64_t now_ns = mt_get_monotonic_time();
+      if (now_ns - s->f_mismatch_warn_last_ns > NS_PER_S) {
+        err("RX_ANC_SESSION(%d): redundant ports disagree on F bits at ts %u "
+            "(port%d=F=0x%x port%d=F=0x%x) — SMPTE 2110-40 producer violation\n",
+            s->idx, tmstamp, other, s->last_f_bits[other], s_port, f_bits);
+        s->f_mismatch_warn_last_ns = now_ns;
+      }
+    }
+  }
+  s->last_f_bits[s_port] = f_bits;
+  s->last_f_tmstamp[s_port] = tmstamp;
+
   if (unlikely(s->latest_seq_id[s_port] == -1)) s->latest_seq_id[s_port] = seq_id - 1;
   if (unlikely(s->session_seq_id == -1)) s->session_seq_id = seq_id - 1;
   if (unlikely(s->tmstamp == -1)) s->tmstamp = tmstamp - 1;
@@ -168,8 +188,15 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
     uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
-    s->port_user_stats.common.stat_pkts_out_of_order += gap;
+    s->port_user_stats.common.port[s_port].lost_packets += gap;
+    s->port_user_stats.common.stat_lost_packets += gap;
+  } else if (seq_id == (uint16_t)s->latest_seq_id[s_port]) {
+    /* exact same seq seen again on the same port — a real same-port duplicate
+     * (distinct from a duplicate arriving on the redundant port) */
+    s->port_user_stats.common.port[s_port].duplicates_same_port++;
+  } else if (!mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
+    /* backward arrival on the same port — genuine intra-port reorder */
+    s->port_user_stats.common.port[s_port].reordered_packets++;
   }
   if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
     s->latest_seq_id[s_port] = seq_id;
@@ -252,14 +279,12 @@ accept_pkt:
   int old_session_seq = s->session_seq_id;
 
   /* hole in seq id packets going into the session check if the seq_id of the session is
-   * consistent */
+   * consistent.  Note: do NOT reset interlace_detected here — a session-merged seq gap
+   * does not imply the producer changed interlacing.  Resetting caused spurious
+   * "detected interlaced stream (F=0x?)" log lines on every seq gap, which on a
+   * redundant stream looked like the two ports disagreed on interlacing. */
   if (seq_id != (uint16_t)(s->session_seq_id + 1) &&
       mt_seq16_greater(seq_id, s->session_seq_id)) {
-    if (s->interlace_auto && s->interlace_detected) {
-      s->interlace_detected = false;
-      dbg("%s(%d,%d), reset interlace detect after seq discont %u->%u\n", __func__,
-          s->idx, s_port, s->session_seq_id, seq_id);
-    }
     dbg("%s(%d,%d), session seq_id %u out of order %d\n", __func__, s->idx, s_port,
         seq_id, s->session_seq_id);
     s->port_user_stats.common.stat_pkts_unrecovered +=
@@ -360,7 +385,10 @@ static void rx_ancillary_session_reset(struct st_rx_ancillary_session_impl* s,
   for (int i = 0; i < MTL_SESSION_PORT_MAX; i++) {
     s->latest_seq_id[i] = -1;
     s->redundant_error_cnt[i] = 0;
+    s->last_f_bits[i] = 0xff; /* sentinel: no F bits seen yet on this port */
+    s->last_f_tmstamp[i] = 0;
   }
+  s->f_mismatch_warn_last_ns = 0;
 }
 
 #ifdef MTL_ENABLE_FUZZING_ST40
@@ -647,8 +675,7 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
       us->common.stat_pkts_received - snap->common.stat_pkts_received;
   uint64_t pkts_redundant =
       us->common.stat_pkts_redundant - snap->common.stat_pkts_redundant;
-  uint64_t pkts_out_of_order =
-      us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
+  uint64_t lost_pkts = us->common.stat_lost_packets - snap->common.stat_lost_packets;
   uint64_t pkts_unrecovered =
       us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
   uint64_t pkts_dropped = us->stat_pkts_dropped - snap->stat_pkts_dropped;
@@ -663,6 +690,9 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
       us->stat_interlace_first_field - snap->stat_interlace_first_field;
   uint64_t interlace_second_field =
       us->stat_interlace_second_field - snap->stat_interlace_second_field;
+  uint64_t f_mismatch =
+      s->stat_internal_field_bit_mismatch - s->stat_internal_field_bit_mismatch_snap;
+  s->stat_internal_field_bit_mismatch_snap = s->stat_internal_field_bit_mismatch;
 
   if (pkts_redundant) {
     notice("RX_ANC_SESSION(%d:%s): fps %f frames %d pkts %" PRIu64 " (redundant %" PRIu64
@@ -677,16 +707,58 @@ static void rx_ancillary_session_stat(struct st_rx_ancillary_session_impl* s) {
   if (pkts_dropped) {
     notice("RX_ANC_SESSION(%d): dropped pkts %" PRIu64 "\n", idx, pkts_dropped);
   }
-  if (pkts_out_of_order) {
-    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
-    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
-    warn("RX_ANC_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64 ")\n",
-         idx, pkts_out_of_order, d_p, d_r);
+
+  /* Per-port packet/frame line: port-balance visible at a glance. */
+  uint64_t port_pkts[MTL_SESSION_PORT_MAX] = {0};
+  uint64_t port_frames[MTL_SESSION_PORT_MAX] = {0};
+  uint64_t port_lost[MTL_SESSION_PORT_MAX] = {0};
+  for (int i = 0; i < s->ops.num_port; i++) {
+    port_pkts[i] = us->common.port[i].packets - snap->common.port[i].packets;
+    port_frames[i] = us->common.port[i].frames - snap->common.port[i].frames;
+    port_lost[i] = us->common.port[i].lost_packets - snap->common.port[i].lost_packets;
   }
-  if (pkts_unrecovered) {
-    warn("RX_ANC_SESSION(%d): unrecovered pkts %" PRIu64 "\n", idx, pkts_unrecovered);
+  if (s->ops.num_port > 1) {
+    notice("RX_ANC_SESSION(%d): per-port arrivals P=%" PRIu64 " pkts (%" PRIu64
+           " frames first), R=%" PRIu64 " pkts (%" PRIu64 " frames first)\n",
+           idx, port_pkts[MTL_SESSION_PORT_P], port_frames[MTL_SESSION_PORT_P],
+           port_pkts[MTL_SESSION_PORT_R], port_frames[MTL_SESSION_PORT_R]);
+  }
+
+  if (lost_pkts) {
+    uint64_t total_pkts = port_pkts[MTL_SESSION_PORT_P] + port_pkts[MTL_SESSION_PORT_R];
+    if (s->ops.num_port > 1) {
+      double pct_p =
+          port_pkts[MTL_SESSION_PORT_P]
+              ? 100.0 * port_lost[MTL_SESSION_PORT_P] /
+                    (port_pkts[MTL_SESSION_PORT_P] + port_lost[MTL_SESSION_PORT_P])
+              : 0.0;
+      double pct_r =
+          port_pkts[MTL_SESSION_PORT_R]
+              ? 100.0 * port_lost[MTL_SESSION_PORT_R] /
+                    (port_pkts[MTL_SESSION_PORT_R] + port_lost[MTL_SESSION_PORT_R])
+              : 0.0;
+      double save_rate =
+          (lost_pkts + pkts_unrecovered)
+              ? 100.0 * (double)lost_pkts / (double)(lost_pkts + pkts_unrecovered)
+              : 100.0;
+      warn("RX_ANC_SESSION(%d): per-port loss %" PRIu64 " of %" PRIu64 " pkts (P:%" PRIu64
+           "=%.1f%%, R:%" PRIu64 "=%.1f%%), unrecovered (lost on both) %" PRIu64
+           ", save_rate=%.1f%%\n",
+           idx, lost_pkts, total_pkts + lost_pkts, port_lost[MTL_SESSION_PORT_P], pct_p,
+           port_lost[MTL_SESSION_PORT_R], pct_r, pkts_unrecovered, save_rate);
+    } else {
+      warn("RX_ANC_SESSION(%d): per-port lost pkts %" PRIu64 ", unrecovered %" PRIu64
+           "\n",
+           idx, lost_pkts, pkts_unrecovered);
+    }
+  } else if (pkts_unrecovered) {
+    /* unrecovered without per-port loss in this window — orphan, surface separately */
+    err("RX_ANC_SESSION(%d): unrecovered pkts (lost on all ports) %" PRIu64 "\n", idx,
+        pkts_unrecovered);
+  }
+  if (f_mismatch) {
+    err("RX_ANC_SESSION(%d): F-bit mismatches between redundant ports %" PRIu64 "\n", idx,
+        f_mismatch);
   }
 
   if (pkts_wrong_pt_dropped) {

--- a/lib/src/st2110/st_rx_ancillary_session.h
+++ b/lib/src/st2110/st_rx_ancillary_session.h
@@ -11,14 +11,6 @@
 
 #define ST_RX_ANCILLARY_PREFIX "RC_"
 
-#ifdef MTL_ENABLE_FUZZING_ST40
-int st_rx_ancillary_session_fuzz_handle_pkt(struct mtl_main_impl* impl,
-                                            struct st_rx_ancillary_session_impl* s,
-                                            struct rte_mbuf* mbuf,
-                                            enum mtl_session_port s_port);
-void st_rx_ancillary_session_fuzz_reset(struct st_rx_ancillary_session_impl* s);
-#endif
-
 int st_rx_ancillary_sessions_sch_uinit(struct mtl_sch_impl* sch);
 
 #endif

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -301,14 +301,16 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
 
   /* redundant stream seq_id out of order is not a big deal as long as stream is continous
    */
-  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1) &&
+      mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
     uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
     s->port_user_stats.common.stat_pkts_out_of_order += gap;
   }
-  s->latest_seq_id[s_port] = seq_id;
+  if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
+    s->latest_seq_id[s_port] = seq_id;
 
   /* count per-port stats before redundancy filtering for consistent reporting */
   s->port_user_stats.common.port[s_port].packets++;
@@ -470,14 +472,16 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
 
   /* redundant stream seq_id out of order is not a big deal as long as stream is continous
    */
-  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1) &&
+      mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
     uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
     s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
     s->port_user_stats.common.stat_pkts_out_of_order += gap;
   }
-  s->latest_seq_id[s_port] = seq_id;
+  if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
+    s->latest_seq_id[s_port] = seq_id;
 
   /* count per-port stats before redundancy filtering for consistent reporting */
   s->port_user_stats.common.port[s_port].packets++;

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -327,6 +327,9 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
         return -EIO;
       }
     }
+    /* threshold exceeded on all ports — accept the packet and undo the redundant count
+     * so the packet is only counted as received, not both */
+    s->port_user_stats.common.stat_pkts_redundant--;
     warn("%s(%d), redundant error threshold reached, accept packet tmstamp (%d) %ld\n",
          __func__, s->idx, tmstamp, s->tmstamp);
   }
@@ -501,7 +504,9 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
       }
     }
 
-    /* should never happen */
+    /* threshold exceeded on all ports — accept the packet and undo the redundant count
+     * so the packet is only counted as received, not both */
+    s->port_user_stats.common.stat_pkts_redundant--;
     warn("%s(%d), redundant error threshold reached, accept packet tmstamp (%d) %ld\n",
          __func__, s->idx, tmstamp, s->tmstamp);
   }

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -306,8 +306,15 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
-    s->port_user_stats.common.stat_pkts_out_of_order += gap;
+    s->port_user_stats.common.port[s_port].lost_packets += gap;
+    s->port_user_stats.common.stat_lost_packets += gap;
+  } else if (seq_id == (uint16_t)s->latest_seq_id[s_port]) {
+    /* exact same seq seen again on the same port — same-port duplicate
+     * (distinct from a duplicate arriving on the redundant port) */
+    s->port_user_stats.common.port[s_port].duplicates_same_port++;
+  } else if (!mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
+    /* backward arrival on the same port — genuine intra-port reorder */
+    s->port_user_stats.common.port[s_port].reordered_packets++;
   }
   if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
     s->latest_seq_id[s_port] = seq_id;
@@ -358,6 +365,8 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
       MT_USDT_ST30_RX_NO_FRAMEBUFFER(s->mgr->idx, s->idx, tmstamp);
       return -EIO;
     }
+
+    s->port_user_stats.common.port[s_port].frames++;
   }
 
   uint32_t offset = s->st30_pkt_idx * s->pkt_len;
@@ -432,7 +441,6 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     s->frame_recv_size = 0;
     s->st30_pkt_idx = 0;
     rte_atomic32_inc(&s->stat_frames_received);
-    s->port_user_stats.common.port[s_port].frames++;
     s->st30_cur_frame = NULL;
   }
 
@@ -482,8 +490,15 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
     uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
-    s->port_user_stats.common.stat_pkts_out_of_order += gap;
+    s->port_user_stats.common.port[s_port].lost_packets += gap;
+    s->port_user_stats.common.stat_lost_packets += gap;
+  } else if (seq_id == (uint16_t)s->latest_seq_id[s_port]) {
+    /* exact same seq seen again on the same port — same-port duplicate
+     * (distinct from a duplicate arriving on the redundant port) */
+    s->port_user_stats.common.port[s_port].duplicates_same_port++;
+  } else if (!mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
+    /* backward arrival on the same port — genuine intra-port reorder */
+    s->port_user_stats.common.port[s_port].reordered_packets++;
   }
   if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
     s->latest_seq_id[s_port] = seq_id;
@@ -1000,8 +1015,7 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
       us->common.stat_pkts_received - snap->common.stat_pkts_received;
   uint64_t pkts_redundant =
       us->common.stat_pkts_redundant - snap->common.stat_pkts_redundant;
-  uint64_t pkts_out_of_order =
-      us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
+  uint64_t lost_pkts = us->common.stat_lost_packets - snap->common.stat_lost_packets;
   uint64_t pkts_unrecovered =
       us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
   uint64_t pkts_dropped = us->stat_pkts_dropped - snap->stat_pkts_dropped;
@@ -1025,17 +1039,53 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
   }
 
   s->stat_last_time = cur_time_ns;
-  if (pkts_out_of_order) {
-    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
-    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
-    warn("RX_AUDIO_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64
-         ")\n",
-         idx, pkts_out_of_order, d_p, d_r);
+
+  /* Per-port packet/frame line: port-balance visible at a glance. */
+  uint64_t port_pkts[MTL_SESSION_PORT_MAX] = {0};
+  uint64_t port_frames[MTL_SESSION_PORT_MAX] = {0};
+  uint64_t port_lost[MTL_SESSION_PORT_MAX] = {0};
+  for (int i = 0; i < s->ops.num_port; i++) {
+    port_pkts[i] = us->common.port[i].packets - snap->common.port[i].packets;
+    port_frames[i] = us->common.port[i].frames - snap->common.port[i].frames;
+    port_lost[i] = us->common.port[i].lost_packets - snap->common.port[i].lost_packets;
   }
-  if (pkts_unrecovered) {
-    warn("RX_AUDIO_SESSION(%d): unrecovered pkts %" PRIu64 "\n", idx, pkts_unrecovered);
+  if (s->ops.num_port > 1) {
+    /* port[].frames here counts frames whose first packet arrived on this
+     * port — i.e. this port "won the race" for that frame. */
+    notice("RX_AUDIO_SESSION(%d,%d): per-port arrivals P=%" PRIu64 " pkts (%" PRIu64
+           " frames first), R=%" PRIu64 " pkts (%" PRIu64 " frames first)\n",
+           m_idx, idx, port_pkts[MTL_SESSION_PORT_P], port_frames[MTL_SESSION_PORT_P],
+           port_pkts[MTL_SESSION_PORT_R], port_frames[MTL_SESSION_PORT_R]);
+  }
+
+  if (lost_pkts) {
+    if (s->ops.num_port > 1) {
+      double pct_p =
+          port_pkts[MTL_SESSION_PORT_P]
+              ? 100.0 * port_lost[MTL_SESSION_PORT_P] /
+                    (port_pkts[MTL_SESSION_PORT_P] + port_lost[MTL_SESSION_PORT_P])
+              : 0.0;
+      double pct_r =
+          port_pkts[MTL_SESSION_PORT_R]
+              ? 100.0 * port_lost[MTL_SESSION_PORT_R] /
+                    (port_pkts[MTL_SESSION_PORT_R] + port_lost[MTL_SESSION_PORT_R])
+              : 0.0;
+      double save_rate =
+          (lost_pkts + pkts_unrecovered)
+              ? 100.0 * (double)lost_pkts / (double)(lost_pkts + pkts_unrecovered)
+              : 100.0;
+      uint64_t total_pkts = port_pkts[MTL_SESSION_PORT_P] + port_pkts[MTL_SESSION_PORT_R];
+      warn("RX_AUDIO_SESSION(%d): per-port loss %" PRIu64 " of %" PRIu64
+           " pkts (P:%" PRIu64 "=%.1f%%, R:%" PRIu64
+           "=%.1f%%), unrecovered (lost on both) %" PRIu64 ", save_rate=%.1f%%\n",
+           idx, lost_pkts, total_pkts + lost_pkts, port_lost[MTL_SESSION_PORT_P], pct_p,
+           port_lost[MTL_SESSION_PORT_R], pct_r, pkts_unrecovered, save_rate);
+    } else {
+      warn("RX_AUDIO_SESSION(%d): per-port lost pkts %" PRIu64 "\n", idx, lost_pkts);
+    }
+  } else if (pkts_unrecovered) {
+    err("RX_AUDIO_SESSION(%d): unrecovered pkts (lost on all ports) %" PRIu64 "\n", idx,
+        pkts_unrecovered);
   }
 
   if (pkts_dropped) {

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -581,22 +581,6 @@ static void rx_audio_session_reset(struct st_rx_audio_session_impl* s,
   if (init_stat_time_now) s->usdt_dump_fd = -1;
 }
 
-#ifdef MTL_ENABLE_FUZZING_ST30
-int st_rx_audio_session_fuzz_handle_pkt(struct mtl_main_impl* impl,
-                                        struct st_rx_audio_session_impl* s,
-                                        struct rte_mbuf* mbuf,
-                                        enum mtl_session_port s_port) {
-  if (!s || !mbuf) return -EINVAL;
-  if (s->ops.type == ST30_TYPE_RTP_LEVEL)
-    return rx_audio_session_handle_rtp_pkt(impl, s, mbuf, s_port);
-  return rx_audio_session_handle_frame_pkt(impl, s, mbuf, s_port);
-}
-
-void st_rx_audio_session_fuzz_reset(struct st_rx_audio_session_impl* s) {
-  rx_audio_session_reset(s, false);
-}
-#endif
-
 static int ra_stop_pcap(struct st_rx_audio_session_impl* s,
                         enum mtl_session_port s_port) {
   struct mt_rx_pcap* pcap = &s->pcap[s_port];

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -320,6 +320,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   if (!mt_seq32_greater(tmstamp, s->tmstamp)) {
     dbg("%s(%d,%d), drop as pkt seq_id %u (%u) or tmstamp %u (%ld) is old\n", __func__,
         s->idx, s_port, seq_id, s->latest_seq_id[s_port], tmstamp, s->tmstamp);
+    s->redundant_error_cnt[s_port]++;
     s->port_user_stats.common.stat_pkts_redundant++;
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
@@ -491,6 +492,7 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   if (!mt_seq32_greater(tmstamp, s->tmstamp)) {
     dbg("%s(%d,%d), drop as pkt seq_id %u (%u) or tmstamp %u (%ld) is old\n", __func__,
         s->idx, s_port, seq_id, s->latest_seq_id[s_port], tmstamp, s->tmstamp);
+    s->redundant_error_cnt[s_port]++;
     s->port_user_stats.common.stat_pkts_redundant++;
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -335,7 +335,8 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
 
   /* hole in seq id packets going into the session check if the seq_id of the session is
    * consistent */
-  if (seq_id != (uint16_t)(s->session_seq_id + 1)) {
+  if (seq_id != (uint16_t)(s->session_seq_id + 1) &&
+      mt_seq16_greater(seq_id, s->session_seq_id)) {
     dbg("%s(%d,%d), session seq_id %u out of order %d\n", __func__, s->idx, s_port,
         seq_id, s->session_seq_id);
     s->port_user_stats.common.stat_pkts_unrecovered +=
@@ -509,7 +510,8 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
 
   /* hole in seq id packets going into the session check if the seq_id of the session is
    * consistent */
-  if (seq_id != (uint16_t)(s->session_seq_id + 1)) {
+  if (seq_id != (uint16_t)(s->session_seq_id + 1) &&
+      mt_seq16_greater(seq_id, s->session_seq_id)) {
     dbg("%s(%d,%d), session seq_id %u out of order %d\n", __func__, s->idx, s_port,
         seq_id, s->session_seq_id);
     s->port_user_stats.common.stat_pkts_unrecovered +=

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -319,7 +319,6 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
     s->latest_seq_id[s_port] = seq_id;
 
-  /* count per-port stats before redundancy filtering for consistent reporting */
   s->port_user_stats.common.port[s_port].packets++;
   s->port_user_stats.common.port[s_port].bytes += mbuf->pkt_len;
 
@@ -331,7 +330,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     s->port_user_stats.common.stat_pkts_redundant++;
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
-        return -EIO;
+        return -EAGAIN; /* filtered redundant, not an error */
       }
     }
     /* threshold exceeded on all ports — accept the packet and undo the redundant count
@@ -503,7 +502,6 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
     s->latest_seq_id[s_port] = seq_id;
 
-  /* count per-port stats before redundancy filtering for consistent reporting */
   s->port_user_stats.common.port[s_port].packets++;
   s->port_user_stats.common.port[s_port].bytes += mbuf->pkt_len;
 
@@ -515,7 +513,7 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
     s->port_user_stats.common.stat_pkts_redundant++;
     for (int i = 0; i < s->ops.num_port; i++) {
       if (s->redundant_error_cnt[i] < ST_SESSION_REDUNDANT_ERROR_THRESHOLD) {
-        return -EIO;
+        return -EAGAIN; /* filtered redundant, not an error */
       }
     }
 
@@ -688,13 +686,13 @@ static int rx_audio_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf, uint
 
   if (ST30_TYPE_FRAME_LEVEL == st30_type) {
     for (uint16_t i = 0; i < nb; i++) {
-      if (rx_audio_session_handle_frame_pkt(impl, s, mbuf[i], s_port) < 0)
-        s->port_user_stats.common.port[s_port].err_packets++;
+      int rc = rx_audio_session_handle_frame_pkt(impl, s, mbuf[i], s_port);
+      if (rc < 0 && rc != -EAGAIN) s->port_user_stats.common.port[s_port].err_packets++;
     }
   } else {
     for (uint16_t i = 0; i < nb; i++) {
-      if (rx_audio_session_handle_rtp_pkt(impl, s, mbuf[i], s_port) < 0)
-        s->port_user_stats.common.port[s_port].err_packets++;
+      int rc = rx_audio_session_handle_rtp_pkt(impl, s, mbuf[i], s_port);
+      if (rc < 0 && rc != -EAGAIN) s->port_user_stats.common.port[s_port].err_packets++;
     }
   }
 

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -354,7 +354,8 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
 
   /* The package is accepted and goes into the frame */
 
-  s->session_seq_id = seq_id;
+  /* only advance, never go backward */
+  if (mt_seq16_greater(seq_id, s->session_seq_id)) s->session_seq_id = seq_id;
 
   if (!s->st30_cur_frame) {
     s->st30_cur_frame = rx_audio_session_get_frame(s);
@@ -537,7 +538,8 @@ static int rx_audio_session_handle_rtp_pkt(struct mtl_main_impl* impl,
   }
 
   /* The package is accepted and goes into the frame */
-  s->session_seq_id = seq_id;
+  /* only advance, never go backward */
+  if (mt_seq16_greater(seq_id, s->session_seq_id)) s->session_seq_id = seq_id;
 
   /* enqueue the packet ring to app */
   int ret = rte_ring_sp_enqueue(s->st30_rtps_ring, (void*)mbuf);

--- a/lib/src/st2110/st_rx_audio_session.h
+++ b/lib/src/st2110/st_rx_audio_session.h
@@ -11,14 +11,6 @@
 
 #define ST_RX_AUDIO_PREFIX "RA_"
 
-#ifdef MTL_ENABLE_FUZZING_ST30
-int st_rx_audio_session_fuzz_handle_pkt(struct mtl_main_impl* impl,
-                                        struct st_rx_audio_session_impl* s,
-                                        struct rte_mbuf* mbuf,
-                                        enum mtl_session_port s_port);
-void st_rx_audio_session_fuzz_reset(struct st_rx_audio_session_impl* s);
-#endif
-
 int st_rx_audio_sessions_sch_uinit(struct mtl_sch_impl* sch);
 
 #endif

--- a/lib/src/st2110/st_rx_fastmetadata_session.c
+++ b/lib/src/st2110/st_rx_fastmetadata_session.c
@@ -119,14 +119,23 @@ static int rx_fastmetadata_session_handle_pkt(struct mtl_main_impl* impl,
   if (unlikely(s->tmstamp == -1)) s->tmstamp = tmstamp - 1;
 
   /* not a big deal as long as stream is continous */
-  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1)) {
+  if (seq_id != (uint16_t)(s->latest_seq_id[s_port] + 1) &&
+      mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
     uint16_t gap = (uint16_t)(seq_id - s->latest_seq_id[s_port] - 1);
     dbg("%s(%d,%d), non-continuous seq now %u last %d\n", __func__, s->idx, s_port,
         seq_id, s->latest_seq_id[s_port]);
-    s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
-    s->port_user_stats.common.stat_pkts_out_of_order += gap;
+    s->port_user_stats.common.port[s_port].lost_packets += gap;
+    s->port_user_stats.common.stat_lost_packets += gap;
+  } else if (seq_id == (uint16_t)s->latest_seq_id[s_port]) {
+    /* exact same seq seen again on the same port — same-port duplicate
+     * (distinct from a duplicate arriving on the redundant port) */
+    s->port_user_stats.common.port[s_port].duplicates_same_port++;
+  } else if (!mt_seq16_greater(seq_id, s->latest_seq_id[s_port])) {
+    /* backward arrival on the same port — genuine intra-port reorder */
+    s->port_user_stats.common.port[s_port].reordered_packets++;
   }
-  s->latest_seq_id[s_port] = seq_id;
+  if (mt_seq16_greater(seq_id, s->latest_seq_id[s_port]))
+    s->latest_seq_id[s_port] = seq_id;
 
   /* count per-port stats before redundancy filtering for consistent reporting */
   s->port_user_stats.common.port[s_port].packets++;
@@ -483,8 +492,7 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
       us->common.stat_pkts_received - snap->common.stat_pkts_received;
   uint64_t pkts_redundant =
       us->common.stat_pkts_redundant - snap->common.stat_pkts_redundant;
-  uint64_t pkts_out_of_order =
-      us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
+  uint64_t lost_pkts = us->common.stat_lost_packets - snap->common.stat_lost_packets;
   uint64_t pkts_unrecovered =
       us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
   uint64_t pkts_wrong_pt_dropped =
@@ -509,16 +517,51 @@ static void rx_fastmetadata_session_stat(struct st_rx_fastmetadata_session_impl*
   }
   s->stat_last_time = cur_time_ns;
 
-  if (pkts_out_of_order) {
-    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
-    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
-    warn("RX_FMD_SESSION(%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64 ")\n",
-         idx, pkts_out_of_order, d_p, d_r);
+  /* Per-port packet/frame line: port-balance visible at a glance. */
+  uint64_t port_pkts[MTL_SESSION_PORT_MAX] = {0};
+  uint64_t port_frames[MTL_SESSION_PORT_MAX] = {0};
+  uint64_t port_lost[MTL_SESSION_PORT_MAX] = {0};
+  for (int i = 0; i < s->ops.num_port; i++) {
+    port_pkts[i] = us->common.port[i].packets - snap->common.port[i].packets;
+    port_frames[i] = us->common.port[i].frames - snap->common.port[i].frames;
+    port_lost[i] = us->common.port[i].lost_packets - snap->common.port[i].lost_packets;
+  }
+  if (s->ops.num_port > 1) {
+    notice("RX_FMD_SESSION(%d): port stats P=%" PRIu64 " pkts/%" PRIu64
+           " frames, R=%" PRIu64 " pkts/%" PRIu64 " frames\n",
+           idx, port_pkts[MTL_SESSION_PORT_P], port_frames[MTL_SESSION_PORT_P],
+           port_pkts[MTL_SESSION_PORT_R], port_frames[MTL_SESSION_PORT_R]);
+  }
+
+  if (lost_pkts) {
+    if (s->ops.num_port > 1) {
+      double pct_p =
+          port_pkts[MTL_SESSION_PORT_P]
+              ? 100.0 * port_lost[MTL_SESSION_PORT_P] /
+                    (port_pkts[MTL_SESSION_PORT_P] + port_lost[MTL_SESSION_PORT_P])
+              : 0.0;
+      double pct_r =
+          port_pkts[MTL_SESSION_PORT_R]
+              ? 100.0 * port_lost[MTL_SESSION_PORT_R] /
+                    (port_pkts[MTL_SESSION_PORT_R] + port_lost[MTL_SESSION_PORT_R])
+              : 0.0;
+      double save_rate =
+          (lost_pkts + pkts_unrecovered)
+              ? 100.0 * (double)lost_pkts / (double)(lost_pkts + pkts_unrecovered)
+              : 100.0;
+      uint64_t total_pkts = port_pkts[MTL_SESSION_PORT_P] + port_pkts[MTL_SESSION_PORT_R];
+      warn("RX_FMD_SESSION(%d): per-port loss covered by redundancy: %" PRIu64
+           " of %" PRIu64 " pkts (P:%" PRIu64 "=%.1f%%, R:%" PRIu64
+           "=%.1f%%, save_rate=%.1f%%)\n",
+           idx, lost_pkts, total_pkts + lost_pkts, port_lost[MTL_SESSION_PORT_P], pct_p,
+           port_lost[MTL_SESSION_PORT_R], pct_r, save_rate);
+    } else {
+      warn("RX_FMD_SESSION(%d): per-port lost pkts %" PRIu64 "\n", idx, lost_pkts);
+    }
   }
   if (pkts_unrecovered) {
-    warn("RX_FMD_SESSION(%d): unrecovered pkts %" PRIu64 "\n", idx, pkts_unrecovered);
+    err("RX_FMD_SESSION(%d): unrecovered pkts (lost on all ports) %" PRIu64 "\n", idx,
+        pkts_unrecovered);
   }
 
   if (pkts_wrong_pt_dropped) {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1658,7 +1658,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
         rv_tp_pkt_handle(s, mbuf, s_port, slot, tmstamp, pkt_idx);
       return 0;
     }
-    if (pkt_idx != (slot->last_pkt_idx + 1)) {
+    if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
       s->port_user_stats.common.stat_pkts_out_of_order += gap;
       s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
@@ -1849,7 +1849,7 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
       s->port_user_stats.common.stat_pkts_redundant++;
       return 0;
     }
-    if (pkt_idx != (slot->last_pkt_idx + 1)) {
+    if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
       s->port_user_stats.common.stat_pkts_out_of_order += gap;
       s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
@@ -2044,7 +2044,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
-    if (pkt_idx != (slot->last_pkt_idx + 1)) {
+    if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
       s->port_user_stats.common.stat_pkts_out_of_order += gap;
       s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
@@ -2210,7 +2210,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
-    if (pkt_idx != (slot->last_pkt_idx + 1)) {
+    if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
       s->port_user_stats.common.stat_pkts_out_of_order += gap;
       s->port_user_stats.common.port[s_port].out_of_order_packets += gap;

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -987,7 +987,21 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
   int ret = -EIO;
 
   if (st_is_frame_complete(status)) {
-    s->port_user_stats.common.port[MTL_SESSION_PORT_P].frames++;
+    /* Per-port completeness accounting (mirrors ST20). With redundancy,
+     * the frame may be complete overall while one port was missing pkts;
+     * surface that asymmetry via incomplete_frames. */
+    if (ops->num_port > 1) {
+      if (slot->pkts_recv_per_port[MTL_SESSION_PORT_P] >= slot->pkts_received)
+        s->port_user_stats.common.port[MTL_SESSION_PORT_P].frames++;
+      else
+        s->port_user_stats.common.port[MTL_SESSION_PORT_P].incomplete_frames++;
+      if (slot->pkts_recv_per_port[MTL_SESSION_PORT_R] >= slot->pkts_received)
+        s->port_user_stats.common.port[MTL_SESSION_PORT_R].frames++;
+      else
+        s->port_user_stats.common.port[MTL_SESSION_PORT_R].incomplete_frames++;
+    } else {
+      s->port_user_stats.common.port[MTL_SESSION_PORT_P].frames++;
+    }
     ret = st22_notify_frame_ready(s, frame->addr, meta);
     if (ret < 0) {
       err("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
@@ -1660,8 +1674,12 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
     }
     if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
-      s->port_user_stats.common.stat_pkts_out_of_order += gap;
-      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+      s->port_user_stats.common.stat_lost_packets += gap;
+      s->port_user_stats.common.port[s_port].lost_packets += gap;
+    } else if (pkt_idx < slot->last_pkt_idx) {
+      /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
+       * behind the highest accepted index in the current frame */
+      s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
     /* the first pkt should always dispatch to control thread */
@@ -1851,8 +1869,12 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
     }
     if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
-      s->port_user_stats.common.stat_pkts_out_of_order += gap;
-      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+      s->port_user_stats.common.stat_lost_packets += gap;
+      s->port_user_stats.common.port[s_port].lost_packets += gap;
+    } else if (pkt_idx < slot->last_pkt_idx) {
+      /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
+       * behind the highest accepted index in the current frame */
+      s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
     if (!slot->seq_id_got) { /* first packet */
@@ -2046,8 +2068,12 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
     }
     if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
-      s->port_user_stats.common.stat_pkts_out_of_order += gap;
-      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+      s->port_user_stats.common.stat_lost_packets += gap;
+      s->port_user_stats.common.port[s_port].lost_packets += gap;
+    } else if (pkt_idx < slot->last_pkt_idx) {
+      /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
+       * behind the highest accepted index in the current frame */
+      s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
     /* first packet */
@@ -2212,8 +2238,12 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
     }
     if (pkt_idx > (slot->last_pkt_idx + 1)) {
       int gap = pkt_idx - slot->last_pkt_idx - 1;
-      s->port_user_stats.common.stat_pkts_out_of_order += gap;
-      s->port_user_stats.common.port[s_port].out_of_order_packets += gap;
+      s->port_user_stats.common.stat_lost_packets += gap;
+      s->port_user_stats.common.port[s_port].lost_packets += gap;
+    } else if (pkt_idx < slot->last_pkt_idx) {
+      /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
+       * behind the highest accepted index in the current frame */
+      s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
     if (!line1_number && !line1_offset) { /* first packet */
@@ -3551,15 +3581,60 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
     notice("RX_VIDEO_SESSION(%d,%d): dropped pkts %" PRIu64 " as no slot\n", m_idx, idx,
            d);
   }
-  d = us->common.stat_pkts_out_of_order - snap->common.stat_pkts_out_of_order;
+  /* Per-port arrival line: port-balance visible at a glance.
+   * port[].frames counts frames the port could have completed alone (got all
+   * pkts).  port[].incomplete_frames counts frames that needed the other port
+   * to fill the gap.  Both incremented per side regardless of the other.
+   */
+  if (s->ops.num_port > 1) {
+    uint64_t port_pkts_p = us->common.port[MTL_SESSION_PORT_P].packets -
+                           snap->common.port[MTL_SESSION_PORT_P].packets;
+    uint64_t port_pkts_r = us->common.port[MTL_SESSION_PORT_R].packets -
+                           snap->common.port[MTL_SESSION_PORT_R].packets;
+    uint64_t port_frames_p = us->common.port[MTL_SESSION_PORT_P].frames -
+                             snap->common.port[MTL_SESSION_PORT_P].frames;
+    uint64_t port_frames_r = us->common.port[MTL_SESSION_PORT_R].frames -
+                             snap->common.port[MTL_SESSION_PORT_R].frames;
+    uint64_t port_incomp_p = us->common.port[MTL_SESSION_PORT_P].incomplete_frames -
+                             snap->common.port[MTL_SESSION_PORT_P].incomplete_frames;
+    uint64_t port_incomp_r = us->common.port[MTL_SESSION_PORT_R].incomplete_frames -
+                             snap->common.port[MTL_SESSION_PORT_R].incomplete_frames;
+    notice("RX_VIDEO_SESSION(%d,%d): per-port arrivals P=%" PRIu64 " pkts (%" PRIu64
+           " frames complete, %" PRIu64 " needed redundancy), R=%" PRIu64
+           " pkts (%" PRIu64 " frames complete, %" PRIu64 " needed redundancy)\n",
+           m_idx, idx, port_pkts_p, port_frames_p, port_incomp_p, port_pkts_r,
+           port_frames_r, port_incomp_r);
+  }
+  d = us->common.stat_lost_packets - snap->common.stat_lost_packets;
+  uint64_t pkts_unrec =
+      us->common.stat_pkts_unrecovered - snap->common.stat_pkts_unrecovered;
   if (d) {
-    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_P].out_of_order_packets;
-    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].out_of_order_packets -
-                   snap->common.port[MTL_SESSION_PORT_R].out_of_order_packets;
-    notice("RX_VIDEO_SESSION(%d,%d): out of order pkts %" PRIu64 " (%" PRIu64 ":%" PRIu64
-           ")\n",
-           m_idx, idx, d, d_p, d_r);
+    uint64_t port_pkts_p = us->common.port[MTL_SESSION_PORT_P].packets -
+                           snap->common.port[MTL_SESSION_PORT_P].packets;
+    uint64_t port_pkts_r = us->common.port[MTL_SESSION_PORT_R].packets -
+                           snap->common.port[MTL_SESSION_PORT_R].packets;
+    uint64_t d_p = us->common.port[MTL_SESSION_PORT_P].lost_packets -
+                   snap->common.port[MTL_SESSION_PORT_P].lost_packets;
+    uint64_t d_r = us->common.port[MTL_SESSION_PORT_R].lost_packets -
+                   snap->common.port[MTL_SESSION_PORT_R].lost_packets;
+    if (s->ops.num_port > 1) {
+      double pct_p = port_pkts_p ? 100.0 * d_p / (port_pkts_p + d_p) : 0.0;
+      double pct_r = port_pkts_r ? 100.0 * d_r / (port_pkts_r + d_r) : 0.0;
+      double save_rate =
+          (d + pkts_unrec) ? 100.0 * (double)d / (double)(d + pkts_unrec) : 100.0;
+      notice("RX_VIDEO_SESSION(%d,%d): per-port loss %" PRIu64 " of %" PRIu64
+             " pkts (P:%" PRIu64 "=%.1f%%, R:%" PRIu64
+             "=%.1f%%), unrecovered (lost on both) %" PRIu64 ", save_rate=%.1f%%\n",
+             m_idx, idx, d, port_pkts_p + port_pkts_r + d, d_p, pct_p, d_r, pct_r,
+             pkts_unrec, save_rate);
+    } else {
+      notice("RX_VIDEO_SESSION(%d,%d): per-port lost pkts %" PRIu64 "\n", m_idx, idx, d);
+    }
+  } else if (pkts_unrec) {
+    /* unrecovered without per-port loss is unusual but possible (e.g. single-port */
+    /* session): surface it explicitly so the user is not blindsided. */
+    err("RX_VIDEO_SESSION(%d,%d): unrecovered pkts %" PRIu64 "\n", m_idx, idx,
+        pkts_unrec);
   }
   d = us->common.stat_pkts_wrong_pt_dropped - snap->common.stat_pkts_wrong_pt_dropped;
   if (d) {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1705,7 +1705,10 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
       return -EIO;
     }
   }
-  slot->last_pkt_idx = pkt_idx;
+  /* only advance, never regress: a reorder must not move the high-water
+   * mark backward, otherwise the next forward jump re-counts already-lost
+   * packets as new losses */
+  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
 
   /* if enable_timing_parser */
   if (s->enable_timing_parser) rv_tp_pkt_handle(s, mbuf, s_port, slot, tmstamp, pkt_idx);
@@ -1893,7 +1896,8 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
       return -EIO;
     }
   }
-  slot->last_pkt_idx = pkt_idx;
+  /* only advance high-water mark; see rv_handle_frame_pkt */
+  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
 
   /* enqueue the packet ring to app */
   int ret = rte_ring_sp_enqueue(s->rtps_ring, (void*)mbuf);
@@ -2097,7 +2101,8 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
         __func__, s->idx, s_port, seq_id, tmstamp, p_counter, sep_counter,
         payload_length);
   }
-  slot->last_pkt_idx = pkt_idx;
+  /* only advance high-water mark; see rv_handle_frame_pkt */
+  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
 
   /* copy payload */
   uint32_t offset;
@@ -2259,7 +2264,8 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
       return -EIO;
     }
   }
-  slot->last_pkt_idx = pkt_idx;
+  /* only advance high-water mark; see rv_handle_frame_pkt */
+  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
 
   /* calculate offset */
   uint32_t offset =

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -888,13 +888,13 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
     if (slot->pkts_recv_per_port[MTL_SESSION_PORT_P] >= slot->pkts_received) {
       s->port_user_stats.common.port[MTL_SESSION_PORT_P].frames++;
     } else {
-      s->port_user_stats.common.port[MTL_SESSION_PORT_P].incomplete_frames++;
+      s->port_user_stats.frames_partial[MTL_SESSION_PORT_P]++;
     }
 
     if (slot->pkts_recv_per_port[MTL_SESSION_PORT_R] >= slot->pkts_received) {
       s->port_user_stats.common.port[MTL_SESSION_PORT_R].frames++;
     } else {
-      s->port_user_stats.common.port[MTL_SESSION_PORT_R].incomplete_frames++;
+      s->port_user_stats.frames_partial[MTL_SESSION_PORT_R]++;
     }
 
     /* notify frame */
@@ -916,7 +916,7 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
     MT_USDT_ST20_RX_FRAME_INCOMPLETE(s->parent->idx, s->idx, frame->idx, slot->tmstamp,
                                      meta->frame_recv_size, s->st20_frame_size);
     meta->status = ST_FRAME_STATUS_CORRUPTED;
-    s->port_user_stats.stat_frames_dropped++;
+    s->port_user_stats.stat_frames_incomplete++;
 
     /* record the miss pkts */
     float pd_sz_per_pkt = (float)meta->frame_recv_size / slot->pkts_received;
@@ -934,7 +934,6 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
 #endif
 
     rte_atomic32_inc(&s->cbs_incomplete_frame_cnt);
-    s->port_user_stats.incomplete_frames_cnt++;
     /* notify the incomplete frame if user required */
     if (ops->flags & ST20_RX_FLAG_RECEIVE_INCOMPLETE_FRAME) {
       rv_notify_frame_ready(s, frame->addr, meta);
@@ -989,16 +988,16 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
   if (st_is_frame_complete(status)) {
     /* Per-port completeness accounting (mirrors ST20). With redundancy,
      * the frame may be complete overall while one port was missing pkts;
-     * surface that asymmetry via incomplete_frames. */
+     * surface that asymmetry via frames_partial. */
     if (ops->num_port > 1) {
       if (slot->pkts_recv_per_port[MTL_SESSION_PORT_P] >= slot->pkts_received)
         s->port_user_stats.common.port[MTL_SESSION_PORT_P].frames++;
       else
-        s->port_user_stats.common.port[MTL_SESSION_PORT_P].incomplete_frames++;
+        s->port_user_stats.frames_partial[MTL_SESSION_PORT_P]++;
       if (slot->pkts_recv_per_port[MTL_SESSION_PORT_R] >= slot->pkts_received)
         s->port_user_stats.common.port[MTL_SESSION_PORT_R].frames++;
       else
-        s->port_user_stats.common.port[MTL_SESSION_PORT_R].incomplete_frames++;
+        s->port_user_stats.frames_partial[MTL_SESSION_PORT_R]++;
     } else {
       s->port_user_stats.common.port[MTL_SESSION_PORT_P].frames++;
     }
@@ -1012,7 +1011,7 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
     double reactive = 1080.0 / 1125.0;
     s->trs = s->frame_time * reactive / meta->pkts_total;
   } else {
-    s->port_user_stats.stat_frames_dropped++;
+    s->port_user_stats.stat_frames_incomplete++;
     /* record the miss pkts */
     float pd_sz_per_pkt = (float)s->st22_expect_size_per_frame / slot->pkts_received;
     int miss_pkts =
@@ -1310,7 +1309,7 @@ static void rv_st22_slot_drop_frame(struct st_rx_video_session_impl* s,
                                     struct st_rx_video_slot_impl* slot) {
   rv_put_frame(s, slot->frame);
   slot->frame = NULL;
-  s->port_user_stats.stat_frames_dropped++;
+  s->port_user_stats.stat_frames_incomplete++;
   rte_atomic32_inc(&s->cbs_incomplete_frame_cnt);
    rv_slot_init_frame_size(slot);
   slot->pkts_received = 0;
@@ -3554,7 +3553,7 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
          (double)bytes_received * 8 / time_sec / MTL_STAT_M_UNIT, s->stat_cpu_busy_score);
   s->stat_last_time = cur_time_ns;
 
-  d = us->stat_frames_dropped - snap->stat_frames_dropped;
+  d = us->stat_frames_incomplete - snap->stat_frames_incomplete;
   uint64_t pkts_idx_dropped = us->stat_pkts_idx_dropped - snap->stat_pkts_idx_dropped;
   uint64_t pkts_offset_dropped =
       us->stat_pkts_offset_dropped - snap->stat_pkts_offset_dropped;
@@ -3583,7 +3582,7 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
   }
   /* Per-port arrival line: port-balance visible at a glance.
    * port[].frames counts frames the port could have completed alone (got all
-   * pkts).  port[].incomplete_frames counts frames that needed the other port
+   * pkts).  frames_partial[] counts frames that needed the other port
    * to fill the gap.  Both incremented per side regardless of the other.
    */
   if (s->ops.num_port > 1) {
@@ -3595,10 +3594,10 @@ static void rv_stat(struct st_rx_video_sessions_mgr* mgr,
                              snap->common.port[MTL_SESSION_PORT_P].frames;
     uint64_t port_frames_r = us->common.port[MTL_SESSION_PORT_R].frames -
                              snap->common.port[MTL_SESSION_PORT_R].frames;
-    uint64_t port_incomp_p = us->common.port[MTL_SESSION_PORT_P].incomplete_frames -
-                             snap->common.port[MTL_SESSION_PORT_P].incomplete_frames;
-    uint64_t port_incomp_r = us->common.port[MTL_SESSION_PORT_R].incomplete_frames -
-                             snap->common.port[MTL_SESSION_PORT_R].incomplete_frames;
+    uint64_t port_incomp_p =
+        us->frames_partial[MTL_SESSION_PORT_P] - snap->frames_partial[MTL_SESSION_PORT_P];
+    uint64_t port_incomp_r =
+        us->frames_partial[MTL_SESSION_PORT_R] - snap->frames_partial[MTL_SESSION_PORT_R];
     notice("RX_VIDEO_SESSION(%d,%d): per-port arrivals P=%" PRIu64 " pkts (%" PRIu64
            " frames complete, %" PRIu64 " needed redundancy), R=%" PRIu64
            " pkts (%" PRIu64 " frames complete, %" PRIu64 " needed redundancy)\n",

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -3376,29 +3376,6 @@ static int rv_attach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
   return 0;
 }
 
-#if defined(MTL_ENABLE_FUZZING_ST20) || defined(MTL_ENABLE_FUZZING_ST22)
-void st_rx_video_session_fuzz_reset(struct st_rx_video_session_impl* s) {
-  rv_session_reset(s, true);
-}
-
-int st_rx_video_session_fuzz_handle_pkt(struct st_rx_video_session_impl* s,
-                                        struct rte_mbuf* mbuf,
-                                        enum mtl_session_port s_port) {
-  if (!s || !mbuf) return -EINVAL;
-
-  bool ctrl_thread = true;
-
-  if (s->pkt_handler) return s->pkt_handler(s, mbuf, s_port, ctrl_thread);
-
-  if (s->st22_info) return rv_handle_st22_pkt(s, mbuf, s_port, ctrl_thread);
-
-  if (st20_is_frame_type(s->ops.type))
-    return rv_handle_frame_pkt(s, mbuf, s_port, ctrl_thread);
-
-  return rv_handle_rtp_pkt(s, mbuf, s_port, ctrl_thread);
-}
-#endif
-
 static int rv_poll_vsync(struct mtl_main_impl* impl, struct st_rx_video_session_impl* s) {
   struct st_vsync_info* vsync = &s->vsync;
   uint64_t cur_tsc = mt_get_tsc(impl);

--- a/lib/src/st2110/st_rx_video_session.h
+++ b/lib/src/st2110/st_rx_video_session.h
@@ -98,11 +98,4 @@ int st_rx_video_session_migrate(struct mtl_main_impl* impl,
                                 struct st_rx_video_sessions_mgr* mgr,
                                 struct st_rx_video_session_impl* s, int idx);
 
-#if defined(MTL_ENABLE_FUZZING_ST20) || defined(MTL_ENABLE_FUZZING_ST22)
-int st_rx_video_session_fuzz_handle_pkt(struct st_rx_video_session_impl* s,
-                                        struct rte_mbuf* mbuf,
-                                        enum mtl_session_port s_port);
-void st_rx_video_session_fuzz_reset(struct st_rx_video_session_impl* s);
-#endif
-
 #endif

--- a/meson.build
+++ b/meson.build
@@ -25,13 +25,6 @@ add_global_arguments('-D_DEFAULT_SOURCE', language : 'c')
 enable_fuzzing_opt = get_option('enable_fuzzing')
 enable_unit_tests_opt = get_option('enable_unit_tests')
 
-if enable_fuzzing_opt
-  add_global_arguments('-DMTL_ENABLE_FUZZING_ST40', language : 'c')
-  add_global_arguments('-DMTL_ENABLE_FUZZING_ST30', language : 'c')
-  add_global_arguments('-DMTL_ENABLE_FUZZING_ST20', language : 'c')
-  add_global_arguments('-DMTL_ENABLE_FUZZING_ST22', language : 'c')
-endif
-
 # get external variables
 add_global_arguments('-D__MTL_GIT__="'+ run_command('git', 'describe', '--abbrev=8', '--dirty', '--always', check: false).stdout().strip() + '"', language : 'c')
 add_global_arguments('-D__MTL_LIB_BUILD__="' + meson.project_version() + '"', language : 'c')

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ endif
 add_global_arguments('-D_DEFAULT_SOURCE', language : 'c')
 
 enable_fuzzing_opt = get_option('enable_fuzzing')
+enable_unit_tests_opt = get_option('enable_unit_tests')
 
 if enable_fuzzing_opt
   add_global_arguments('-DMTL_ENABLE_FUZZING_ST40', language : 'c')
@@ -75,6 +76,10 @@ mtl_internal_dep = declare_dependency(
 
 if enable_fuzzing_opt
   subdir('tests/fuzz')
+endif
+
+if enable_unit_tests_opt
+  subdir('tests/unit')
 endif
 
 pkg = import('pkgconfig')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,8 @@ option('enable_asan', type: 'boolean', value: false, description: 'enable/disabl
 option('enable_usdt', type: 'boolean', value: true, description: 'enable/disable USDT(User Statically-Defined Tracing) support')
 option('enable_fuzzing', type: 'boolean', value: false,
 	description: 'enable libFuzzer harnesses for RX paths')
+option('enable_unit_tests', type: 'boolean', value: false,
+	description: 'enable unit tests (exposes internal symbols via fuzz wrappers)')
 
 option('enable_tap', type: 'boolean', value: false, description: 'enable/disable Windows TAP')
 option('dpdk_root_dir', type: 'string', value: '..\dpdk', description: 'dpdk source code root dir, for Windows')

--- a/tests/fuzz/meson.build
+++ b/tests/fuzz/meson.build
@@ -2,7 +2,7 @@
 
 fuzz_cc = meson.get_compiler('c')
 fuzz_c_args = []
-fuzz_link_args = []
+fuzz_link_args = ['-Wl,--allow-multiple-definition']
 fuzzer_deps = []
 asan_enabled = get_option('enable_asan')
 
@@ -12,7 +12,11 @@ else
   error('compiler must support -fsanitize=fuzzer-no-link to build fuzzers')
 endif
 
-if fuzz_cc.has_link_argument('-fsanitize=fuzzer')
+# has_link_argument('-fsanitize=fuzzer') can fail because meson's test program
+# contains int main() which conflicts with libFuzzer's own main.  Since we already
+# confirmed -fsanitize=fuzzer-no-link above, the linker flag will work with real
+# fuzzer entry points (LLVMFuzzerTestOneInput), so accept it unconditionally.
+if fuzz_cc.has_link_argument('-fsanitize=fuzzer') or fuzz_cc.has_argument('-fsanitize=fuzzer-no-link')
   fuzz_link_args += ['-fsanitize=fuzzer']
 else
   fuzzer_lib = fuzz_cc.find_library('Fuzzer', required : false)

--- a/tests/fuzz/st20/st20_rx_frame_fuzz.c
+++ b/tests/fuzz/st20/st20_rx_frame_fuzz.c
@@ -18,7 +18,12 @@
 #include "st20_api.h"
 #include "st2110/st_fmt.h"
 #include "st2110/st_pkt.h"
-#include "st2110/st_rx_video_session.h"
+/*
+ * Include the production .c directly so that all static functions become visible.
+ * Disable USDT to avoid linker references to probe semaphores.
+ */
+#undef MTL_HAS_USDT
+#include "st2110/st_rx_video_session.c"
 #include "st40_api.h"
 #include "st41_api.h"
 #include "st_api.h"
@@ -197,7 +202,7 @@ static void st20_fuzz_reset_context(void) {
     g_session.slots[i].frame_bitmap = g_slot_bitmaps[i];
   }
 
-  st_rx_video_session_fuzz_reset(&g_session);
+  rv_session_reset(&g_session, true);
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -222,7 +227,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   mbuf->data_len = pkt_size;
   mbuf->pkt_len = pkt_size;
 
-  st_rx_video_session_fuzz_handle_pkt(&g_session, mbuf, MTL_SESSION_PORT_P);
+  rv_handle_frame_pkt(&g_session, mbuf, MTL_SESSION_PORT_P, true);
   rte_pktmbuf_free(mbuf);
   return 0;
 }

--- a/tests/fuzz/st22/st22_rx_frame_fuzz.c
+++ b/tests/fuzz/st22/st22_rx_frame_fuzz.c
@@ -18,7 +18,12 @@
 #include "st20_api.h"
 #include "st2110/st_fmt.h"
 #include "st2110/st_pkt.h"
-#include "st2110/st_rx_video_session.h"
+/*
+ * Include the production .c directly so that all static functions become visible.
+ * Disable USDT to avoid linker references to probe semaphores.
+ */
+#undef MTL_HAS_USDT
+#include "st2110/st_rx_video_session.c"
 #include "st40_api.h"
 #include "st41_api.h"
 #include "st_api.h"
@@ -210,7 +215,7 @@ static void st22_fuzz_reset_context(void) {
     g_session.slots[i].frame_bitmap = g_slot_bitmaps[i];
   }
 
-  st_rx_video_session_fuzz_reset(&g_session);
+  rv_session_reset(&g_session, true);
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -235,7 +240,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   mbuf->data_len = pkt_size;
   mbuf->pkt_len = pkt_size;
 
-  st_rx_video_session_fuzz_handle_pkt(&g_session, mbuf, MTL_SESSION_PORT_P);
+  rv_handle_st22_pkt(&g_session, mbuf, MTL_SESSION_PORT_P, true);
   rte_pktmbuf_free(mbuf);
   return 0;
 }

--- a/tests/fuzz/st30/st30_rx_frame_fuzz.c
+++ b/tests/fuzz/st30/st30_rx_frame_fuzz.c
@@ -18,7 +18,12 @@
 
 #include "st20_api.h"
 #include "st2110/st_pkt.h"
-#include "st2110/st_rx_audio_session.h"
+/*
+ * Include the production .c directly so that all static functions become visible.
+ * Disable USDT to avoid linker references to probe semaphores.
+ */
+#undef MTL_HAS_USDT
+#include "st2110/st_rx_audio_session.c"
 #include "st30_api.h"
 #include "st40_api.h"
 #include "st41_api.h"
@@ -177,7 +182,7 @@ static void st30_fuzz_reset_context(size_t payload_len) {
   g_session.port_maps[MTL_SESSION_PORT_P] = MTL_PORT_P;
   g_session.usdt_dump_fd = -1;
 
-  st_rx_audio_session_fuzz_reset(&g_session);
+  rx_audio_session_reset(&g_session, false);
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -205,7 +210,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   size_t payload = pkt_size - sizeof(struct st_rfc3550_audio_hdr);
   st30_fuzz_reset_context(payload);
 
-  st_rx_audio_session_fuzz_handle_pkt(&g_impl, &g_session, mbuf, MTL_SESSION_PORT_P);
+  rx_audio_session_handle_frame_pkt(&g_impl, &g_session, mbuf, MTL_SESSION_PORT_P);
   rte_pktmbuf_free(mbuf);
   return 0;
 }

--- a/tests/fuzz/st40/st40_rx_rtp_fuzz.c
+++ b/tests/fuzz/st40/st40_rx_rtp_fuzz.c
@@ -18,7 +18,14 @@
 
 #include "st20_api.h"
 #include "st2110/st_pkt.h"
-#include "st2110/st_rx_ancillary_session.h"
+/*
+ * Include the production .c directly so that all static functions become visible.
+ * Non-static symbols duplicate those in libmtl; the linker flag
+ * --allow-multiple-definition resolves this safely (identical code).
+ * Disable USDT to avoid linker references to probe semaphores.
+ */
+#undef MTL_HAS_USDT
+#include "st2110/st_rx_ancillary_session.c"
 #include "st40_api.h"
 #include "st41_api.h"
 #include "st_api.h"
@@ -136,7 +143,7 @@ static void st40_fuzz_reset_context(void) {
   g_session.ops.name = "st40_rx_fuzz";
   g_session.redundant_error_cnt[MTL_SESSION_PORT_P] = 0;
 
-  st_rx_ancillary_session_fuzz_reset(&g_session);
+  rx_ancillary_session_reset(&g_session, false);
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
@@ -160,7 +167,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   mbuf->data_len = pkt_size;
   mbuf->pkt_len = pkt_size;
 
-  st_rx_ancillary_session_fuzz_handle_pkt(&g_impl, &g_session, mbuf, MTL_SESSION_PORT_P);
+  rx_ancillary_session_handle_pkt(&g_impl, &g_session, mbuf, MTL_SESSION_PORT_P);
   rte_pktmbuf_free(mbuf);
   return 0;
 }

--- a/tests/integration_tests/noctx/testcases/st20p_redundant_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st20p_redundant_tests.cpp
@@ -126,7 +126,6 @@ TEST_F(NoCtxTest, st20p_redundant_latency_drops_even_odd) {
 
     ASSERT_NEAR(packetsSend, packetsRecieved, packetsSend / 10)
         << "Comparison against primary stream";
-    ASSERT_LE(stats.common.stat_pkts_out_of_order, packetsRecieved / 1000)
-        << "Out of order packets";
+    ASSERT_LE(stats.common.stat_lost_packets, packetsRecieved / 1000) << "Lost packets";
   }
 }

--- a/tests/integration_tests/noctx/testcases/st30p_redundant_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st30p_redundant_tests.cpp
@@ -99,9 +99,9 @@ TEST_F(NoCtxTest, st30p_redundant_latency) {
       << "Comparison against primary stream (port 0)";
   ASSERT_NEAR(packetsSend, packetsRecievedPort1, packetsSend / 10)
       << "Comparison against primary stream (port 1)";
-  ASSERT_LE(stats.common.stat_pkts_out_of_order,
+  ASSERT_LE(stats.common.stat_lost_packets,
             (packetsRecievedPort0 + packetsRecievedPort1) / 1000)
-      << "Out of order packets";
+      << "Lost packets";
   ASSERT_NEAR(framesSend, framesRecieved, framesSend / 100)
       << "Comparison against primary stream";
 }
@@ -204,9 +204,9 @@ TEST_F(NoCtxTest, st30p_redundant_latency2) {
   ASSERT_GT(packetsRecievedPort0, 0u) << "Primary port must have received packets";
   ASSERT_NEAR(packetsSend, stats.common.stat_pkts_received, packetsSend / 100)
       << "Accepted packets should match TX";
-  ASSERT_LE(stats.common.stat_pkts_out_of_order,
+  ASSERT_LE(stats.common.stat_lost_packets,
             (packetsRecievedPort0 + packetsRecievedPort1) / 1000)
-      << "Out of order packets";
+      << "Lost packets";
   ASSERT_NEAR(framesSend, framesRecieved, framesSend / 100)
       << "Comparison against primary stream";
 }

--- a/tests/tools/RxTxApp/src/rx_st20p_app.c
+++ b/tests/tools/RxTxApp/src/rx_st20p_app.c
@@ -378,10 +378,9 @@ static int app_rx_st20p_result(struct st_app_rx_st20p_session* s) {
     struct st20_rx_user_stats wire = {0};
     if (st20p_rx_get_session_stats(s->handle, &wire) == 0) {
       bool wire_trouble = wire.common.stat_pkts_unrecovered ||
-                          wire.common.stat_lost_packets || wire.stat_frames_dropped ||
+                          wire.common.stat_lost_packets || wire.stat_frames_incomplete ||
                           wire.stat_pkts_idx_dropped || wire.stat_pkts_offset_dropped ||
-                          wire.stat_pkts_rtp_ring_full || wire.stat_pkts_no_slot ||
-                          wire.incomplete_frames_cnt;
+                          wire.stat_pkts_rtp_ring_full || wire.stat_pkts_no_slot;
       if (!fps_ok || wire_trouble) {
         const char* cause;
         if (wire.common.stat_pkts_unrecovered > 0) {
@@ -403,16 +402,15 @@ static int app_rx_st20p_result(struct st_app_rx_st20p_session* s) {
         } else {
           cause = "wire anomaly without classification \u2014 please file a bug";
         }
-        notce(
-            "%s(%d), reconciliation: wire received=%" PRIu64 " lost=%" PRIu64
-            " unrecovered=%" PRIu64 " redundant=%" PRIu64 " incomplete_frames=%" PRIu64
-            " frames_dropped=%" PRIu64 " idx_dropped=%" PRIu64 " offset_dropped=%" PRIu64
-            " ring_full=%" PRIu64 " no_slot=%" PRIu64 " \u21d2 %s\n",
-            __func__, idx, wire.common.stat_pkts_received, wire.common.stat_lost_packets,
-            wire.common.stat_pkts_unrecovered, wire.common.stat_pkts_redundant,
-            wire.incomplete_frames_cnt, wire.stat_frames_dropped,
-            wire.stat_pkts_idx_dropped, wire.stat_pkts_offset_dropped,
-            wire.stat_pkts_rtp_ring_full, wire.stat_pkts_no_slot, cause);
+        notce("%s(%d), reconciliation: wire received=%" PRIu64 " lost=%" PRIu64
+              " unrecovered=%" PRIu64 " redundant=%" PRIu64 " frames_incomplete=%" PRIu64
+              " idx_dropped=%" PRIu64 " offset_dropped=%" PRIu64 " ring_full=%" PRIu64
+              " no_slot=%" PRIu64 " \u21d2 %s\n",
+              __func__, idx, wire.common.stat_pkts_received,
+              wire.common.stat_lost_packets, wire.common.stat_pkts_unrecovered,
+              wire.common.stat_pkts_redundant, wire.stat_frames_incomplete,
+              wire.stat_pkts_idx_dropped, wire.stat_pkts_offset_dropped,
+              wire.stat_pkts_rtp_ring_full, wire.stat_pkts_no_slot, cause);
       }
     }
   }

--- a/tests/tools/RxTxApp/src/rx_st20p_app.c
+++ b/tests/tools/RxTxApp/src/rx_st20p_app.c
@@ -366,10 +366,56 @@ static int app_rx_st20p_result(struct st_app_rx_st20p_session* s) {
 
   if (!s->stat_frame_total_received) return -EINVAL;
 
+  bool fps_ok = ST_APP_EXPECT_NEAR(framerate, s->expect_fps, s->expect_fps * 0.05);
   notce("%s(%d), %s, fps %f, %d frame received\n", __func__, idx,
-        ST_APP_EXPECT_NEAR(framerate, s->expect_fps, s->expect_fps * 0.05) ? "OK"
-                                                                           : "FAILED",
-        framerate, s->stat_frame_total_received);
+        fps_ok ? "OK" : "FAILED", framerate, s->stat_frame_total_received);
+
+  /* When fps is off or wire-layer reports any anomaly, fetch wire-layer counters
+   * and classify the cause from already-published stats so the user can tell
+   * whether frames were dropped due to packet loss, protocol drops, slow
+   * consumer, etc.  All numbers come from existing counters; we only print. */
+  if (s->handle) {
+    struct st20_rx_user_stats wire = {0};
+    if (st20p_rx_get_session_stats(s->handle, &wire) == 0) {
+      bool wire_trouble = wire.common.stat_pkts_unrecovered ||
+                          wire.common.stat_lost_packets || wire.stat_frames_dropped ||
+                          wire.stat_pkts_idx_dropped || wire.stat_pkts_offset_dropped ||
+                          wire.stat_pkts_rtp_ring_full || wire.stat_pkts_no_slot ||
+                          wire.incomplete_frames_cnt;
+      if (!fps_ok || wire_trouble) {
+        const char* cause;
+        if (wire.common.stat_pkts_unrecovered > 0) {
+          cause = "true bilateral data loss \u2192 incomplete frames";
+        } else if (wire.common.stat_pkts_wrong_pt_dropped ||
+                   wire.common.stat_pkts_wrong_ssrc_dropped ||
+                   wire.stat_pkts_wrong_interlace_dropped ||
+                   wire.stat_pkts_wrong_len_dropped) {
+          cause = "producer protocol violation (check wrong_*_dropped)";
+        } else if (wire.stat_pkts_rtp_ring_full || wire.stat_pkts_no_slot) {
+          cause = "receiver too slow (ring full / no slot)";
+        } else if (wire.stat_pkts_idx_dropped || wire.stat_pkts_offset_dropped) {
+          cause =
+              "out-of-bounds pkt idx/offset \u2014 producer pacing or wire corruption";
+        } else if (wire.common.stat_lost_packets > 0) {
+          cause = "wire pkt loss healed by redundancy (no frame impact)";
+        } else if (!fps_ok) {
+          cause = "no wire anomaly \u2014 check upstream pacing or test fixture";
+        } else {
+          cause = "wire anomaly without classification \u2014 please file a bug";
+        }
+        notce(
+            "%s(%d), reconciliation: wire received=%" PRIu64 " lost=%" PRIu64
+            " unrecovered=%" PRIu64 " redundant=%" PRIu64 " incomplete_frames=%" PRIu64
+            " frames_dropped=%" PRIu64 " idx_dropped=%" PRIu64 " offset_dropped=%" PRIu64
+            " ring_full=%" PRIu64 " no_slot=%" PRIu64 " \u21d2 %s\n",
+            __func__, idx, wire.common.stat_pkts_received, wire.common.stat_lost_packets,
+            wire.common.stat_pkts_unrecovered, wire.common.stat_pkts_redundant,
+            wire.incomplete_frames_cnt, wire.stat_frames_dropped,
+            wire.stat_pkts_idx_dropped, wire.stat_pkts_offset_dropped,
+            wire.stat_pkts_rtp_ring_full, wire.stat_pkts_no_slot, cause);
+      }
+    }
+  }
   return 0;
 }
 

--- a/tests/tools/RxTxApp/src/rx_st30p_app.c
+++ b/tests/tools/RxTxApp/src/rx_st30p_app.c
@@ -200,10 +200,48 @@ static int app_rx_st30p_result(struct st_app_rx_st30p_session* s) {
 
   if (!s->stat_frame_total_received) return -EINVAL;
 
+  bool fps_ok = ST_APP_EXPECT_NEAR(framerate, s->expect_fps, s->expect_fps * 0.05);
   notce("%s(%d), %s, fps %f, %d frame received\n", __func__, idx,
-        ST_APP_EXPECT_NEAR(framerate, s->expect_fps, s->expect_fps * 0.05) ? "OK"
-                                                                           : "FAILED",
-        framerate, s->stat_frame_total_received);
+        fps_ok ? "OK" : "FAILED", framerate, s->stat_frame_total_received);
+
+  /* When fps is off or wire-layer reports any anomaly, fetch wire-layer counters
+   * and classify the cause from already-published stats so the user can tell
+   * whether audio frames were lost, dropped due to len mismatch, slow consumer,
+   * etc.  All numbers come from existing counters; we only print. */
+  if (s->handle) {
+    struct st30_rx_user_stats wire = {0};
+    if (st30p_rx_get_session_stats(s->handle, &wire) == 0) {
+      bool wire_trouble = wire.common.stat_pkts_unrecovered ||
+                          wire.common.stat_lost_packets || wire.stat_pkts_dropped ||
+                          wire.stat_pkts_len_mismatch_dropped ||
+                          wire.stat_slot_get_frame_fail;
+      if (!fps_ok || wire_trouble) {
+        const char* cause;
+        if (wire.common.stat_pkts_unrecovered > 0) {
+          cause = "true bilateral data loss \u2192 audio gap";
+        } else if (wire.common.stat_pkts_wrong_pt_dropped ||
+                   wire.common.stat_pkts_wrong_ssrc_dropped ||
+                   wire.stat_pkts_len_mismatch_dropped) {
+          cause = "producer protocol violation (check wrong_*_dropped / len_mismatch)";
+        } else if (wire.stat_slot_get_frame_fail) {
+          cause = "no free framebuffer \u2014 receiver too slow";
+        } else if (wire.common.stat_lost_packets > 0) {
+          cause = "wire pkt loss healed by redundancy (no audio impact)";
+        } else if (!fps_ok) {
+          cause = "no wire anomaly \u2014 check upstream pacing or test fixture";
+        } else {
+          cause = "wire anomaly without classification \u2014 please file a bug";
+        }
+        notce("%s(%d), reconciliation: wire received=%" PRIu64 " lost=%" PRIu64
+              " unrecovered=%" PRIu64 " redundant=%" PRIu64 " dropped=%" PRIu64
+              " len_mismatch=%" PRIu64 " slot_get_fail=%" PRIu64 " \u21d2 %s\n",
+              __func__, idx, wire.common.stat_pkts_received,
+              wire.common.stat_lost_packets, wire.common.stat_pkts_unrecovered,
+              wire.common.stat_pkts_redundant, wire.stat_pkts_dropped,
+              wire.stat_pkts_len_mismatch_dropped, wire.stat_slot_get_frame_fail, cause);
+      }
+    }
+  }
   return 0;
 }
 

--- a/tests/tools/RxTxApp/src/rx_st40p_app.c
+++ b/tests/tools/RxTxApp/src/rx_st40p_app.c
@@ -179,6 +179,42 @@ static int app_rx_st40p_result(struct st_app_rx_st40p_session* s) {
                                                                          : "FAILED",
       framerate, s->stat_frame_total_received, s->stat_frame_seq_discont,
       s->stat_frame_marker_missing, s->stat_seq_lost_total);
+
+  /* When the pipeline observed seq gaps, the user has no easy way to tell whether
+   * the wire layer also lost the packets (true loss) or healed them via redundancy /
+   * the late-arrival bitmap (cross-port reorder, harmless).  Fetch the wire-layer
+   * counters and classify the cause from already-published stats. */
+  if (s->stat_seq_lost_total > 0 && s->handle) {
+    struct st40_rx_user_stats wire = {0};
+    if (st40p_rx_get_session_stats(s->handle, &wire) == 0) {
+      const char* cause;
+      if (wire.common.stat_pkts_unrecovered > 0) {
+        cause = "true bilateral data loss";
+      } else if (wire.common.stat_pkts_wrong_pt_dropped ||
+                 wire.stat_pkts_wrong_interlace_dropped ||
+                 wire.common.stat_pkts_wrong_ssrc_dropped) {
+        cause = "producer protocol violation (check wrong_*_dropped)";
+      } else if (wire.stat_pkts_enqueue_fail) {
+        cause = "RTP ring full \u2014 receiver too slow";
+      } else if (wire.common.stat_lost_packets > 0) {
+        cause =
+            "cross-port reorder / late arrival beyond pipeline merge window (not data "
+            "loss)";
+      } else {
+        cause =
+            "unknown \u2014 pipeline saw a gap the wire layer did not, please file a bug";
+      }
+      notce("%s(%d), seq_lost=%u reconciliation: wire lost=%" PRIu64
+            " unrecovered=%" PRIu64 " redundant=%" PRIu64 " wrong_pt=%" PRIu64
+            " wrong_ssrc=%" PRIu64 " wrong_interlace=%" PRIu64 " enqueue_fail=%" PRIu64
+            " \u21d2 %s\n",
+            __func__, idx, s->stat_seq_lost_total, wire.common.stat_lost_packets,
+            wire.common.stat_pkts_unrecovered, wire.common.stat_pkts_redundant,
+            wire.common.stat_pkts_wrong_pt_dropped,
+            wire.common.stat_pkts_wrong_ssrc_dropped,
+            wire.stat_pkts_wrong_interlace_dropped, wire.stat_pkts_enqueue_fail, cause);
+    }
+  }
   return 0;
 }
 

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,100 @@
+# MTL Unit Tests
+
+> **In-process tests for the Media Transport Library that find real bugs without requiring a NIC, hugepages, root, or PTP hardware.**
+
+[![ASan](https://img.shields.io/badge/ASan-required-blue)](#quick-start)
+[![No hardware](https://img.shields.io/badge/hardware-not%20required-success)](#what-makes-this-different)
+
+---
+
+## What this is
+
+A `gtest` binary (`UnitTest`) that drives MTL's RX session and pipeline code
+paths **directly** — using real DPDK mbufs from a no-hugepage EAL — and
+asserts on production behaviour. The suite covers ST 2110-20 (video),
+ST 2110-30 (audio), ST 2110-40 (ancillary), and the ST 2110-40 pipeline. Tests
+run on any developer laptop in a fraction of a second.
+
+TX paths, DMA, kernel-socket / AF_XDP backends, and multi-process scenarios
+are out of scope — see [`tests/integration_tests/`](../integration_tests/) and
+[`tests/validation/`](../validation/) for those.
+
+## What makes this different
+
+| Property            | Value                                                       |
+| ------------------- | ----------------------------------------------------------- |
+| Hardware required   | **None** — no NIC, no PTP clock, no hugepages               |
+| Privileges required | **None** — runs as a regular user                           |
+| Memory checking     | **AddressSanitizer** preloaded on every run                 |
+| Code under test     | The **production `.c` files** (not a separate test build)   |
+| Determinism         | **Single-threaded**, no timers, no I/O                      |
+| Isolation           | One `mtl_init` per process; per-test ring/state reset       |
+
+If a test fails it's a real defect — there are no flaky network-timing tests
+in this binary.
+
+## Quick start
+
+```bash
+# 1. configure (one-time)
+meson setup build_unit -Denable_unit_tests=true
+
+# 2. build
+ninja -C build_unit
+
+# 3. run
+LD_PRELOAD=/lib/x86_64-linux-gnu/libasan.so.6 \
+    ./build_unit/tests/unit/UnitTest
+```
+
+Filter to a single suite or test:
+
+```bash
+# one suite
+./build_unit/tests/unit/UnitTest --gtest_filter='St40RxRedundancyTest.*'
+
+# one test
+./build_unit/tests/unit/UnitTest \
+    --gtest_filter='St20RxErrPacketsTest.WrongPtCountedAsErr'
+
+# everything related to err_packets across all media
+./build_unit/tests/unit/UnitTest --gtest_filter='*ErrPackets*'
+
+# list everything without running
+./build_unit/tests/unit/UnitTest --gtest_list_tests
+```
+
+> **Why `LD_PRELOAD=libasan.so`?** `libmtl.so` is built with AddressSanitizer
+> when `enable_unit_tests=true`. Preloading the runtime first prevents
+> init-order interposition issues between gtest, libstdc++, and libasan.
+
+## Test layout
+
+Tests are organised per-media. Each session type has its own subdirectory
+under `session/`, with per-feature files inside:
+
+- `session/st20/` — ST 2110-20 (video)
+- `session/st30/` — ST 2110-30 (audio)
+- `session/st40/` — ST 2110-40 (ancillary)
+- `pipeline/`     — pipeline layer (frame assembly above the session filter)
+
+The shared per-media gtest fixture lives in `<media>/<media>_rx_test_base.h`;
+each per-feature file derives a thin subclass so `--gtest_filter` selects only
+that feature's tests.
+
+For the always-current list of suites and tests:
+
+```bash
+./build_unit/tests/unit/UnitTest --gtest_list_tests
+```
+
+## Troubleshooting
+
+| Symptom                                   | Likely cause                                                                                  | Fix                                                                                |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `AddressSanitizer:DEADLYSIGNAL` at startup| `LD_PRELOAD=libasan.so.6` not set                                                             | Use the launch command shown above                                                 |
+| `libasan: failed to find runtime library` | Wrong libasan major (e.g. .so.5 vs .so.6)                                                     | `dpkg -L libasan6 \| grep libasan.so` to locate the right path                     |
+| Linker: multiple definition of `<symbol>` | New `.c` file in `unit_sources` is missing the `#undef MTL_HAS_USDT` or wrong `#include` order| Match an existing harness `.c` exactly                                             |
+| Test passes alone, fails in suite         | Shared ring or session state not drained                                                      | Add cleanup to fixture `TearDown()`; never rely on test order                      |
+| `EAL: cannot init memory` on second run   | Stale shared-memory file under `/var/run/dpdk`                                                | `--no-shconf --in-memory` are already set; delete `/dev/hugepages/rtemap_*` if any leaked |
+| New test green but suite total didn't grow| The `.cpp` was not added to `unit_sources`                                                    | Add to [`tests/unit/meson.build`](meson.build)                                     |

--- a/tests/unit/common/ut_common.c
+++ b/tests/unit/common/ut_common.c
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Shared infrastructure for unit test harnesses.
+ */
+
+#include "ut_common.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* ── globals ──────────────────────────────────────────────────────────── */
+
+static bool g_eal_ready;
+static struct rte_mempool* g_pool;
+
+/* ── EAL init ─────────────────────────────────────────────────────────── */
+
+int ut_eal_init(void) {
+  if (g_eal_ready && g_pool) return 0;
+
+  if (!g_eal_ready) {
+    static char a0[] = "unit_test";
+    static char a1[] = "--no-huge";
+    static char a2[] = "--no-shconf";
+    static char a3[] = "-c1";
+    static char a4[] = "-n1";
+    static char a5[] = "--no-pci";
+    static char a6[] = "--vdev=net_null0";
+    static char* args[] = {a0, a1, a2, a3, a4, a5, a6};
+    int rc = rte_eal_init(7, args);
+    if (rc < 0 && rte_eal_has_hugepages() == 0) {
+      /* EAL already initialised — fine */
+    } else if (rc < 0) {
+      return -1;
+    }
+    g_eal_ready = true;
+  }
+
+  if (!g_pool) {
+    g_pool = rte_pktmbuf_pool_create("ut_pool", UT_POOL_SIZE, 0, 0,
+                                     RTE_MBUF_DEFAULT_BUF_SIZE, rte_socket_id());
+    if (!g_pool) return -1;
+  }
+
+  return 0;
+}
+
+/* ── pool accessor ────────────────────────────────────────────────────── */
+
+struct rte_mempool* ut_pool(void) {
+  return g_pool;
+}
+
+/* ── ring factory ─────────────────────────────────────────────────────── */
+
+struct rte_ring* ut_ring_create(const char* name, unsigned int size) {
+  return rte_ring_create(name, size, rte_socket_id(), RING_F_SP_ENQ | RING_F_SC_DEQ);
+}
+
+/* ── drain helper ─────────────────────────────────────────────────────── */
+
+void ut_ring_drain(struct rte_ring* ring) {
+  if (!ring) return;
+  struct rte_mbuf* pkt = NULL;
+  while (rte_ring_sc_dequeue(ring, (void**)&pkt) == 0) rte_pktmbuf_free(pkt);
+}

--- a/tests/unit/common/ut_common.h
+++ b/tests/unit/common/ut_common.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Shared infrastructure for unit test harnesses.
+ * Provides idempotent EAL init, mempool, ring factory, and PTP stubs.
+ *
+ * This header is safe to include from any C translation unit — it does
+ * NOT include internal MTL headers.
+ */
+
+#ifndef _UT_COMMON_H_
+#define _UT_COMMON_H_
+
+#include <rte_eal.h>
+#include <rte_mbuf.h>
+#include <rte_mempool.h>
+#include <rte_ring.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define UT_POOL_SIZE 2048
+#define UT_RING_SIZE 512
+
+/** Initialise DPDK EAL (idempotent — safe to call from multiple harnesses). */
+int ut_eal_init(void);
+
+/** Return the shared mempool (created on first call after ut_eal_init). */
+struct rte_mempool* ut_pool(void);
+
+/** Create an SP/SC ring with the given name and size.  Caller owns the ring. */
+struct rte_ring* ut_ring_create(const char* name, unsigned int size);
+
+/** Drain all mbufs from a ring and free them. */
+void ut_ring_drain(struct rte_ring* ring);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _UT_COMMON_H_ */

--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ */
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_languages('cpp', required : true)
+
+unit_cpp_args = ['-Wall', '-Werror']
+unit_c_args = ['-Wall', '-Werror']
+unit_link_args = ['-Wl,--allow-multiple-definition']
+
+unit_include_dirs = [
+  include_directories('../../include'),
+  include_directories('../../lib/src'),
+  include_directories('.'),
+]
+
+gtest_dep = dependency('gtest', required : true)
+libpthread_dep = meson.get_compiler('c').find_library('pthread', required : true)
+
+unit_sources = [
+  'common/ut_common.c',
+  'session/st40_harness.c',
+  'session/st40/redundancy_test.cpp',
+  'session/st40/timestamp_test.cpp',
+  'session/st40/header_validation_test.cpp',
+  'session/st40/stats_test.cpp',
+  'session/st40/reorder_test.cpp',
+  'session/st40/f_bits_test.cpp',
+  'session/st40/marker_test.cpp',
+  'session/st40/prev_window_test.cpp',
+  'session/st40/bitmap_test.cpp',
+  'session/st40/err_packets_test.cpp',
+  'session/st30_harness.c',
+  'session/st30/redundancy_test.cpp',
+  'session/st30/timestamp_test.cpp',
+  'session/st30/header_validation_test.cpp',
+  'session/st30/stats_test.cpp',
+  'session/st30/reorder_test.cpp',
+  'session/st30/err_packets_test.cpp',
+  'session/st20_harness.c',
+  'session/st20/slot_test.cpp',
+  'session/st20/redundancy_test.cpp',
+  'session/st20/bitmap_test.cpp',
+  'session/st20/header_validation_test.cpp',
+  'session/st20/reorder_test.cpp',
+  'session/st20/stats_test.cpp',
+  'session/st20/err_packets_test.cpp',
+  'pipeline/st40p_harness.c',
+  'pipeline/st40p_test.cpp',
+  'main.cpp',
+]
+
+executable('UnitTest', unit_sources,
+  c_args : unit_c_args,
+  cpp_args : unit_cpp_args,
+  link_args : unit_link_args,
+  include_directories : unit_include_dirs,
+  dependencies : [mtl_internal_dep, dpdk_dep, libm_dep, gtest_dep, libpthread_dep,
+                  usdt_provider_header_dep],
+  install : false)

--- a/tests/unit/pipeline/st40p_harness.c
+++ b/tests/unit/pipeline/st40p_harness.c
@@ -1,0 +1,310 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C harness for ST40 pipeline-layer unit tests.
+ * Tests rx_st40p_rtp_ready() — the frame-assembly callback that runs
+ * above the session-layer redundancy filter.
+ */
+
+#include <rte_eal.h>
+#include <rte_ether.h>
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+#include <rte_ring.h>
+#include <rte_udp.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Include the production pipeline .c so that all static functions
+ * (rx_st40p_rtp_ready, rx_st40p_next_available, etc.) become visible.
+ * Disable USDT to avoid linker references to probe semaphores.
+ * Suppress -Wunused-variable for variables only used in USDT macros.
+ */
+#undef MTL_HAS_USDT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#include "st2110/pipeline/st40_pipeline_rx.c"
+#pragma GCC diagnostic pop
+
+/*
+ * Provide stubs for symbols called by rx_st40p_rtp_ready() that would
+ * otherwise resolve to libmtl.so (which requires real HW / hugepages).
+ * With --allow-multiple-definition these override the libmtl versions.
+ */
+
+uint64_t mt_mbuf_time_stamp(struct mtl_main_impl* impl, struct rte_mbuf* mbuf,
+                            enum mtl_port port) {
+  (void)impl;
+  (void)mbuf;
+  (void)port;
+  return 0; /* HW timestamps are irrelevant for frame-assembly tests */
+}
+
+#include "common/ut_common.h"
+
+/* ── constants ────────────────────────────────────────────────────────── */
+
+#define UT40P_RING_SIZE 512
+#define UT40P_UDW_BUFF_SIZE 4096
+/* L2+L3+L4 header sizes — must match st40_rx_get_mbuf skip logic */
+#define UT40P_L234_HDR_LEN                                      \
+  (sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr) + \
+   sizeof(struct rte_udp_hdr))
+
+/* ── opaque context ───────────────────────────────────────────────────── */
+
+struct ut40p_ctx {
+  /* mock impl — just needs type for sanity checks */
+  struct mtl_main_impl impl;
+
+  /* mock transport: handle → session → packet_ring */
+  struct st_rx_ancillary_session_handle_impl handle;
+  struct st_rx_ancillary_session_impl session;
+  /* mock sessions mgr — only mutex[idx] is touched by the transport stats path. */
+  struct st_rx_ancillary_sessions_mgr session_mgr;
+
+  /* the pipeline context under test */
+  struct st40p_rx_ctx pipeline;
+
+  /* frame buffers allocated by us (not via mt_rte_zmalloc) */
+  struct st40p_rx_frame* framebuffs;
+  uint8_t** udw_buffers; /* per-frame UDW buffers */
+  int framebuff_cnt;
+};
+
+#include "pipeline/st40p_harness.h"
+
+/* ── globals ──────────────────────────────────────────────────────────── */
+
+static struct rte_ring* g_mock_ring;
+
+/* ── init ─────────────────────────────────────────────────────────────── */
+
+int ut40p_init(void) {
+  if (ut_eal_init() < 0) return -1;
+
+  if (!g_mock_ring) {
+    g_mock_ring = ut_ring_create("st40p_ring", UT40P_RING_SIZE);
+    if (!g_mock_ring) return -1;
+  }
+  return 0;
+}
+
+/* ── context create / destroy ─────────────────────────────────────────── */
+
+ut40p_ctx* ut40p_ctx_create(int num_port, int framebuff_cnt) {
+  ut40p_ctx* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx) return NULL;
+
+  ctx->framebuff_cnt = framebuff_cnt;
+
+  /* minimal impl */
+  ctx->impl.type = MT_HANDLE_MAIN;
+
+  /* mock session: idx, packet_ring, mgr (with a live spinlock) */
+  ctx->session.idx = 0;
+  ctx->session.packet_ring = g_mock_ring;
+  rte_spinlock_init(&ctx->session_mgr.mutex[0]);
+  ctx->session.mgr = &ctx->session_mgr;
+
+  /* mock transport handle */
+  ctx->handle.type = MT_HANDLE_RX_ANC;
+  ctx->handle.impl = &ctx->session;
+
+  /* allocate frame buffers */
+  ctx->framebuffs = calloc(framebuff_cnt, sizeof(struct st40p_rx_frame));
+  ctx->udw_buffers = calloc(framebuff_cnt, sizeof(uint8_t*));
+  if (!ctx->framebuffs || !ctx->udw_buffers) {
+    ut40p_ctx_destroy(ctx);
+    return NULL;
+  }
+
+  for (int i = 0; i < framebuff_cnt; i++) {
+    struct st40p_rx_frame* fb = &ctx->framebuffs[i];
+    fb->stat = ST40P_RX_FRAME_FREE;
+    fb->idx = i;
+    fb->frame_info.meta = fb->meta;
+    fb->frame_info.priv = fb;
+
+    ctx->udw_buffers[i] = calloc(1, UT40P_UDW_BUFF_SIZE);
+    if (!ctx->udw_buffers[i]) {
+      ut40p_ctx_destroy(ctx);
+      return NULL;
+    }
+    fb->frame_info.udw_buff_addr = ctx->udw_buffers[i];
+    fb->frame_info.udw_buffer_size = UT40P_UDW_BUFF_SIZE;
+  }
+
+  /* pipeline context */
+  struct st40p_rx_ctx* p = &ctx->pipeline;
+  p->impl = &ctx->impl;
+  p->idx = 0;
+  p->socket_id = rte_socket_id();
+  p->type = MT_ST40_HANDLE_PIPELINE_RX;
+
+  p->transport = (st40_rx_handle)&ctx->handle;
+  p->framebuff_cnt = framebuff_cnt;
+  p->framebuff_producer_idx = 0;
+  p->framebuff_consumer_idx = 0;
+  p->framebuffs = ctx->framebuffs;
+  p->inflight_frame = NULL;
+
+  p->ops.port.num_port = num_port;
+
+  /* port mapping: session port 0 → DPDK port id 0, session port 1 → 1 */
+  p->port_map[MTL_SESSION_PORT_P] = MTL_PORT_P;
+  p->port_map[MTL_SESSION_PORT_R] = MTL_PORT_R;
+  p->port_id[MTL_SESSION_PORT_P] = 0;
+  p->port_id[MTL_SESSION_PORT_R] = 1;
+
+  p->ready = true;
+  if (pthread_mutex_init(&p->lock, NULL) != 0) {
+    ut40p_ctx_destroy(ctx);
+    return NULL;
+  }
+
+  /* drain any stale mbufs from a previous test */
+  ut_ring_drain(g_mock_ring);
+
+  return ctx;
+}
+
+void ut40p_ctx_destroy(ut40p_ctx* ctx) {
+  if (!ctx) return;
+
+  ut_ring_drain(g_mock_ring);
+  pthread_mutex_destroy(&ctx->pipeline.lock);
+
+  if (ctx->udw_buffers) {
+    for (int i = 0; i < ctx->framebuff_cnt; i++) free(ctx->udw_buffers[i]);
+    free(ctx->udw_buffers);
+  }
+  free(ctx->framebuffs);
+  free(ctx);
+}
+
+/* ── mbuf builder ─────────────────────────────────────────────────────── */
+
+/*
+ * Build an mbuf with L2+L3+L4 prefix followed by an RFC 8331 RTP header
+ * with anc_count=0 (no ANC payload), for testing frame assembly.
+ *
+ * Layout:
+ *   [rte_ether_hdr][rte_ipv4_hdr][rte_udp_hdr][st40_rfc8331_rtp_hdr][payload_hdr]
+ */
+static struct rte_mbuf* make_pipeline_mbuf(uint16_t seq, uint32_t ts, int marker,
+                                           uint16_t dpdk_port_id) {
+  struct rte_mbuf* m = rte_pktmbuf_alloc(ut_pool());
+  if (!m) return NULL;
+
+  /* anc_count=0: no ANC payload, simplifies frame-assembly-only tests. */
+  size_t rtp_len = sizeof(struct st40_rfc8331_rtp_hdr);
+  size_t total = UT40P_L234_HDR_LEN + rtp_len;
+
+  if (rte_pktmbuf_tailroom(m) < total) {
+    rte_pktmbuf_free(m);
+    return NULL;
+  }
+
+  uint8_t* buf = rte_pktmbuf_mtod(m, uint8_t*);
+  memset(buf, 0, total);
+
+  /* RTP header starts after L2+L3+L4 */
+  struct st40_rfc8331_rtp_hdr* rtp =
+      (struct st40_rfc8331_rtp_hdr*)(buf + UT40P_L234_HDR_LEN);
+  rtp->base.version = 2;
+  rtp->base.seq_number = htons(seq);
+  rtp->base.tmstamp = htonl(ts);
+  rtp->base.marker = marker ? 1 : 0;
+
+  /* anc_count = 0: no ANC payload to parse, simplifies frame-assembly tests */
+  uint32_t chunk = 0; /* anc_count=0, f=0b00 (progressive) */
+  rtp->swapped_first_hdr_chunk = htonl(chunk);
+
+  m->data_len = total;
+  m->pkt_len = total;
+  m->port = dpdk_port_id;
+  return m;
+}
+
+/* ── enqueue functions ────────────────────────────────────────────────── */
+
+int ut40p_enqueue_pkt(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                      enum mtl_session_port port) {
+  uint16_t dpdk_port_id = (port == MTL_SESSION_PORT_R) ? 1 : 0;
+  return ut40p_enqueue_pkt_port_id(ctx, seq, ts, marker, dpdk_port_id);
+}
+
+int ut40p_enqueue_pkt_port_id(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                              uint16_t dpdk_port_id) {
+  (void)ctx;
+  struct rte_mbuf* m = make_pipeline_mbuf(seq, ts, marker, dpdk_port_id);
+  if (!m) return -1;
+
+  if (rte_ring_sp_enqueue(g_mock_ring, m) != 0) {
+    rte_pktmbuf_free(m);
+    return -1;
+  }
+  return 0;
+}
+
+void ut40p_enqueue_burst(ut40p_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
+                         int last_marker, enum mtl_session_port port) {
+  for (int i = 0; i < count; i++) {
+    int marker = last_marker && (i == count - 1);
+    ut40p_enqueue_pkt(ctx, seq_start + i, ts, marker, port);
+  }
+}
+
+/* ── process functions ────────────────────────────────────────────────── */
+
+int ut40p_process(ut40p_ctx* ctx) {
+  return rx_st40p_rtp_ready(&ctx->pipeline);
+}
+
+void ut40p_process_all(ut40p_ctx* ctx) {
+  while (rx_st40p_rtp_ready(&ctx->pipeline) == 0) {
+    /* keep processing until ring is empty or error */
+  }
+}
+
+/* ── frame get/put ────────────────────────────────────────────────────── */
+
+struct st40_frame_info* ut40p_get_frame(ut40p_ctx* ctx) {
+  return st40p_rx_get_frame(&ctx->pipeline);
+}
+
+int ut40p_put_frame(ut40p_ctx* ctx, struct st40_frame_info* frame) {
+  return st40p_rx_put_frame(&ctx->pipeline, frame);
+}
+
+/* ── stat accessors ───────────────────────────────────────────────────── */
+
+uint32_t ut40p_stat_busy(const ut40p_ctx* ctx) {
+  return ctx->pipeline.stat_busy;
+}
+
+uint32_t ut40p_stat_drop_frame(const ut40p_ctx* ctx) {
+  return ctx->pipeline.stat_drop_frame;
+}
+
+uint64_t ut40p_stat_frames_received(const ut40p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_received;
+}
+
+uint64_t ut40p_stat_frames_dropped(const ut40p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_dropped;
+}
+
+uint64_t ut40p_stat_frames_corrupted(const ut40p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_corrupted;
+}
+
+int ut40p_get_session_stats(ut40p_ctx* ctx, struct st40_rx_user_stats* stats) {
+  return st40p_rx_get_session_stats(&ctx->pipeline, stats);
+}
+
+int ut40p_reset_session_stats(ut40p_ctx* ctx) {
+  return st40p_rx_reset_session_stats(&ctx->pipeline);
+}

--- a/tests/unit/pipeline/st40p_harness.h
+++ b/tests/unit/pipeline/st40p_harness.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C header for ST40 pipeline-layer unit tests.
+ * Tests the frame-assembly logic in rx_st40p_rtp_ready().
+ */
+
+#ifndef _ST40P_PIPELINE_HARNESS_H_
+#define _ST40P_PIPELINE_HARNESS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "mtl_api.h"
+#include "st40_pipeline_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ut40p_ctx ut40p_ctx;
+
+int ut40p_init(void);
+
+/** Create a pipeline test context.
+ *  num_port: 1 or 2 (redundant).
+ *  framebuff_cnt: number of frame buffers (3 is typical). */
+ut40p_ctx* ut40p_ctx_create(int num_port, int framebuff_cnt);
+void ut40p_ctx_destroy(ut40p_ctx* ctx);
+
+/** Enqueue one ANC RTP packet into the mock transport ring.
+ *  The mbuf is built with L2+L3+L4 headers followed by an RFC 8331 RTP header
+ *  with anc_count=0 (no ANC payload).
+ *  port: MTL_SESSION_PORT_P or MTL_SESSION_PORT_R. */
+int ut40p_enqueue_pkt(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                      enum mtl_session_port port);
+
+/** Enqueue one ANC RTP packet with a custom DPDK port_id (for unmapped port tests). */
+int ut40p_enqueue_pkt_port_id(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                              uint16_t dpdk_port_id);
+
+/** Enqueue a burst of sequential packets. marker on last if last_marker. */
+void ut40p_enqueue_burst(ut40p_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
+                         int last_marker, enum mtl_session_port port);
+
+/** Call rx_st40p_rtp_ready() once — processes one mbuf from the ring. */
+int ut40p_process(ut40p_ctx* ctx);
+
+/** Call rx_st40p_rtp_ready() in a loop until the ring is empty. */
+void ut40p_process_all(ut40p_ctx* ctx);
+
+/** Get next READY frame (wraps st40p_rx_get_frame). Returns NULL if none. */
+struct st40_frame_info* ut40p_get_frame(ut40p_ctx* ctx);
+
+/** Return a frame to the pipeline (wraps st40p_rx_put_frame). */
+int ut40p_put_frame(ut40p_ctx* ctx, struct st40_frame_info* frame);
+
+/* ── stat accessors ───────────────────────────────────────────────── */
+
+uint32_t ut40p_stat_busy(const ut40p_ctx* ctx);
+uint32_t ut40p_stat_drop_frame(const ut40p_ctx* ctx);
+uint64_t ut40p_stat_frames_received(const ut40p_ctx* ctx);
+uint64_t ut40p_stat_frames_dropped(const ut40p_ctx* ctx);
+uint64_t ut40p_stat_frames_corrupted(const ut40p_ctx* ctx);
+
+/* ── public-API wrappers ─────────────────────────────────────────── */
+
+/** Wraps st40p_rx_get_session_stats() — exercises the atomic overlay path. */
+int ut40p_get_session_stats(ut40p_ctx* ctx, struct st40_rx_user_stats* stats);
+
+/** Wraps st40p_rx_reset_session_stats() — exercises the atomic reset path. */
+int ut40p_reset_session_stats(ut40p_ctx* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST40P_PIPELINE_HARNESS_H_ */

--- a/tests/unit/pipeline/st40p_test.cpp
+++ b/tests/unit/pipeline/st40p_test.cpp
@@ -1,0 +1,812 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Unit tests for ST2110-40 (ancillary) RX pipeline — frame assembly layer.
+ * Tests rx_st40p_rtp_ready() which sits above the session-layer redundancy
+ * filter and assembles RTP packets into frames.
+ */
+
+#include <gtest/gtest.h>
+
+#include "pipeline/st40p_harness.h"
+
+/* ── fixture ───────────────────────────────────────────────────────── */
+
+class St40PipelineRxTest : public ::testing::Test {
+ protected:
+  ut40p_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut40p_init(), 0) << "EAL init failed";
+    ctx_ = ut40p_ctx_create(2, 3); /* 2 ports, 3 frame buffers */
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  void TearDown() override {
+    ut40p_ctx_destroy(ctx_);
+    ctx_ = nullptr;
+  }
+
+  /* convenience wrappers */
+  int enqueue(uint16_t seq, uint32_t ts, bool marker, enum mtl_session_port port) {
+    return ut40p_enqueue_pkt(ctx_, seq, ts, marker ? 1 : 0, port);
+  }
+
+  void enqueue_burst(uint16_t seq_start, int count, uint32_t ts, bool last_marker,
+                     enum mtl_session_port port) {
+    ut40p_enqueue_burst(ctx_, seq_start, count, ts, last_marker ? 1 : 0, port);
+  }
+
+  int process() {
+    return ut40p_process(ctx_);
+  }
+
+  void process_all() {
+    ut40p_process_all(ctx_);
+  }
+
+  struct st40_frame_info* get_frame() {
+    return ut40p_get_frame(ctx_);
+  }
+
+  int put_frame(struct st40_frame_info* f) {
+    return ut40p_put_frame(ctx_, f);
+  }
+
+  uint32_t stat_busy() {
+    return ut40p_stat_busy(ctx_);
+  }
+  uint64_t stat_frames_received() {
+    return ut40p_stat_frames_received(ctx_);
+  }
+  uint64_t stat_frames_dropped() {
+    return ut40p_stat_frames_dropped(ctx_);
+  }
+  uint64_t stat_frames_corrupted() {
+    return ut40p_stat_frames_corrupted(ctx_);
+  }
+};
+
+/* ── Normal pipeline operation ────────────────────────────────────────── */
+
+/* Single complete frame: 6 packets with marker on last. */
+TEST_F(St40PipelineRxTest, SingleFrameCompletion) {
+  enqueue_burst(0, 6, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->rtp_timestamp, 1000u);
+  EXPECT_EQ(frame->pkts_total, 6u);
+  EXPECT_TRUE(frame->rtp_marker);
+  EXPECT_EQ(frame->status, ST_FRAME_STATUS_COMPLETE);
+  put_frame(frame);
+}
+
+/* Timestamp change completes the previous frame without marker. */
+TEST_F(St40PipelineRxTest, TimestampChangeCompletesFrame) {
+  /* Single-port: ts change → immediate READY (no PENDING) */
+  ut40p_ctx_destroy(ctx_);
+  ctx_ = ut40p_ctx_create(1, 3);
+
+  /* frame 1: 3 pkts, no marker */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  /* frame 2: 1 pkt with new ts → completes frame 1 */
+  enqueue(3, 2000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* frame1 = get_frame();
+  ASSERT_NE(frame1, nullptr);
+  EXPECT_EQ(frame1->rtp_timestamp, 1000u);
+  EXPECT_EQ(frame1->pkts_total, 3u);
+  EXPECT_FALSE(frame1->rtp_marker)
+      << "Frame completed by ts change should not have marker";
+  put_frame(frame1);
+}
+
+/* Fill all frame buffers — additional packets should increment stat_busy. */
+TEST_F(St40PipelineRxTest, FramebufferExhaustion) {
+  /* 3 framebuffs: fill all with inflight frames via ts changes.
+   * ts=1000 → ts=2000 (completes frame 1, starts frame 2)
+   * ts=2000 → ts=3000 (completes frame 2, starts frame 3)
+   * All 3 frames are READY or RECEIVING; no free buffers. */
+  enqueue(0, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(1, 2000, false, MTL_SESSION_PORT_P); /* completes ts=1000 */
+  enqueue(2, 3000, false, MTL_SESSION_PORT_P); /* completes ts=2000 */
+  process_all();
+
+  /* frames 1 and 2 are READY, frame 3 is RECEIVING (inflight).
+   * No free framebuffs. Next ts change will try to allocate but fail. */
+  enqueue(3, 4000, false, MTL_SESSION_PORT_P); /* completes ts=3000 → no free fb */
+  process_all();
+
+  EXPECT_GE(stat_busy(), 1u) << "Should hit framebuffer exhaustion";
+  /* Every stat_busy hit must also surface as stat_frames_dropped so the
+   * back-pressure is visible via session stats. */
+  EXPECT_EQ(stat_frames_dropped(), stat_busy());
+}
+
+/* Sequence discontinuity tracking: gap between seq 1 and 3. */
+TEST_F(St40PipelineRxTest, SequenceDiscontinuity) {
+  enqueue(0, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(1, 1000, false, MTL_SESSION_PORT_P);
+  /* skip seq 2 */
+  enqueue(3, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_TRUE(frame->seq_discont);
+  EXPECT_EQ(frame->seq_lost, 1u);
+  put_frame(frame);
+}
+
+/* Per-port sequence tracking: P has gap, R does not. */
+TEST_F(St40PipelineRxTest, PerPortSequenceTracking) {
+  enqueue(0, 1000, false, MTL_SESSION_PORT_P);
+  /* P skips seq 1 */
+  enqueue(2, 1000, false, MTL_SESSION_PORT_P);
+  /* R fills in seq 1 */
+  enqueue(1, 1000, false, MTL_SESSION_PORT_R);
+  enqueue(3, 1000, true, MTL_SESSION_PORT_R);
+  process_all();
+
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_TRUE(frame->port_seq_discont[MTL_SESSION_PORT_P]);
+  EXPECT_EQ(frame->port_seq_lost[MTL_SESSION_PORT_P], 1u);
+  /* R sees seq 1 then 3 — gap of 1 too (since per-port tracks independently) */
+  EXPECT_TRUE(frame->port_seq_discont[MTL_SESSION_PORT_R]);
+  EXPECT_EQ(frame->pkts_recv[MTL_SESSION_PORT_P], 2u);
+  EXPECT_EQ(frame->pkts_recv[MTL_SESSION_PORT_R], 2u);
+  put_frame(frame);
+}
+
+/* Multiple frames delivered in sequence. */
+TEST_F(St40PipelineRxTest, MultiFrameDelivery) {
+  for (uint32_t ts = 1000; ts <= 3000; ts += 1000) {
+    enqueue_burst(0 + (ts - 1000) / 1000 * 4, 4, ts, true, MTL_SESSION_PORT_P);
+  }
+  process_all();
+
+  for (uint32_t ts = 1000; ts <= 3000; ts += 1000) {
+    auto* frame = get_frame();
+    ASSERT_NE(frame, nullptr) << "Frame ts=" << ts << " should be available";
+    EXPECT_EQ(frame->rtp_timestamp, ts);
+    EXPECT_TRUE(frame->rtp_marker);
+    put_frame(frame);
+  }
+
+  /* no more frames */
+  EXPECT_EQ(get_frame(), nullptr);
+}
+
+/* Frame put recycles the buffer for reuse. */
+TEST_F(St40PipelineRxTest, FramePutRecyclesBuffer) {
+  /* fill and consume one frame */
+  enqueue_burst(0, 4, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  put_frame(frame);
+
+  /* the returned slot should be reusable — send another frame */
+  enqueue_burst(4, 4, 2000, true, MTL_SESSION_PORT_P);
+  process_all();
+  frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->rtp_timestamp, 2000u);
+  put_frame(frame);
+}
+
+/* Packet from unmapped port is dropped. */
+TEST_F(St40PipelineRxTest, UnmappedPortDropped) {
+  /* Enqueue a packet with port_id=99 (not mapped to any session port) */
+  ASSERT_EQ(ut40p_enqueue_pkt_port_id(ctx_, 0, 1000, 1, 99), 0);
+  int rc = process();
+  EXPECT_EQ(rc, -EIO);
+  EXPECT_EQ(get_frame(), nullptr) << "Unmapped port packet should not produce a frame";
+}
+
+/* ── RTP marker bit tests ─────────────────────────────────────────────── */
+
+/* Redundant-path scenario: P sends body, R sends tail with marker, same timestamp.
+ *   P sends seq 0-4 (no marker), R sends seq 5-6 (marker on 6).
+ * At the pipeline layer, both ports' packets arrive via the same packet_ring
+ * (session layer already deduplicated). Marker must survive. */
+TEST_F(St40PipelineRxTest, MarkerPreservedMidFrameSwitchover) {
+  /* P sends body: seq 0-4, no marker */
+  for (int i = 0; i < 5; i++) enqueue(i, 1000, false, MTL_SESSION_PORT_P);
+  /* R sends tail: seq 5-6, marker on 6 */
+  enqueue(5, 1000, false, MTL_SESSION_PORT_R);
+  enqueue(6, 1000, true, MTL_SESSION_PORT_R);
+  process_all();
+
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->rtp_timestamp, 1000u);
+  EXPECT_EQ(frame->pkts_total, 7u);
+  EXPECT_TRUE(frame->rtp_marker)
+      << "Marker from R port must survive mid-frame switchover at pipeline layer";
+  put_frame(frame);
+}
+
+/* Marker preservation on framebuffer exhaustion.
+ *
+ * When all framebuffers are occupied and a new timestamp arrives, the pipeline
+ * must still process the marker correctly when framebuffers become available. */
+TEST_F(St40PipelineRxTest, MarkerPreservedOnFramebufferExhaustion) {
+  /* Use single-port ctx with only 2 framebuffs to make exhaustion easier */
+  ut40p_ctx_destroy(ctx_);
+  ctx_ = ut40p_ctx_create(1, 2);
+  ASSERT_NE(ctx_, nullptr);
+
+  /* Frame 1: ts=1000, 3 pkts, no marker */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  /* Frame 2: ts=2000 → completes frame 1, starts frame 2 */
+  enqueue(3, 2000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* Now: frame 1 is READY (slot 0), frame 2 is RECEIVING (slot 1).
+   * Both framebuffers are occupied. */
+
+  /* Frame 3: ts=3000 → completes frame 2, but no free fb for frame 3 */
+  enqueue(4, 3000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* Frame 2 is now READY (slot 1). Frame 3 hit stat_busy.
+   * The ts=3000 packet triggered a timestamp change, completing frame 2,
+   * but no framebuffer was available — the packet was dropped before
+   * marker processing. */
+
+  /* Now send a marker for ts=3000 — it also can't allocate a new fb */
+  enqueue(5, 3000, true, MTL_SESSION_PORT_P); /* MARKER */
+  process_all();
+
+  EXPECT_GE(stat_busy(), 1u);
+
+  /* Frame 1 does not have marker (completed by ts change — expected) */
+  auto* frame1 = get_frame();
+  ASSERT_NE(frame1, nullptr);
+  EXPECT_EQ(frame1->rtp_timestamp, 1000u);
+  EXPECT_FALSE(frame1->rtp_marker); /* no marker in frame 1 — correct */
+  put_frame(frame1);
+
+  /* Frame 2 does not have marker either (completed by ts change — expected) */
+  auto* frame2 = get_frame();
+  ASSERT_NE(frame2, nullptr);
+  EXPECT_EQ(frame2->rtp_timestamp, 2000u);
+  EXPECT_FALSE(frame2->rtp_marker); /* no marker in frame 2 — correct */
+  put_frame(frame2);
+
+  /* Frame 3 was never assembled (all its packets hit stat_busy).
+   * Put frames 1 and 2 to free slots, then retry frame 3. */
+  enqueue(10, 3000, false, MTL_SESSION_PORT_P);
+  enqueue(11, 3000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* frame3 = get_frame();
+  ASSERT_NE(frame3, nullptr);
+  EXPECT_EQ(frame3->rtp_timestamp, 3000u);
+  EXPECT_TRUE(frame3->rtp_marker) << "Frame 3 should have marker after retry";
+  put_frame(frame3);
+}
+
+/* Single-packet frame with marker. */
+TEST_F(St40PipelineRxTest, MarkerOnSinglePacketFrame) {
+  enqueue(0, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->pkts_total, 1u);
+  EXPECT_TRUE(frame->rtp_marker);
+  put_frame(frame);
+}
+
+/* Frame status is COMPLETE when no seq discontinuity, CORRUPTED when there
+ * is. Each delivery must bump stat_frames_received; only CORRUPTED deliveries
+ * must additionally bump stat_frames_corrupted. */
+TEST_F(St40PipelineRxTest, FrameStatusCompleteVsCorrupted) {
+  ASSERT_EQ(stat_frames_received(), 0u);
+  ASSERT_EQ(stat_frames_corrupted(), 0u);
+
+  /* Clean frame */
+  enqueue_burst(0, 4, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* clean = get_frame();
+  ASSERT_NE(clean, nullptr);
+  EXPECT_EQ(clean->status, ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(stat_frames_received(), 1u);
+  EXPECT_EQ(stat_frames_corrupted(), 0u);
+  put_frame(clean);
+
+  /* Corrupted frame: seq gap between 4 and 6. */
+  enqueue(4, 2000, false, MTL_SESSION_PORT_P);
+  enqueue(6, 2000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* corrupted = get_frame();
+  ASSERT_NE(corrupted, nullptr);
+  EXPECT_EQ(corrupted->status, ST_FRAME_STATUS_CORRUPTED);
+  EXPECT_EQ(stat_frames_received(), 2u);
+  EXPECT_EQ(stat_frames_corrupted(), 1u);
+  put_frame(corrupted);
+
+  /* Second corrupted frame: corrupted accumulates independently of received. */
+  enqueue(7, 3000, false, MTL_SESSION_PORT_P);
+  enqueue(9, 3000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* corrupted2 = get_frame();
+  ASSERT_NE(corrupted2, nullptr);
+  EXPECT_EQ(corrupted2->status, ST_FRAME_STATUS_CORRUPTED);
+  EXPECT_EQ(stat_frames_received(), 3u);
+  EXPECT_EQ(stat_frames_corrupted(), 2u);
+  put_frame(corrupted2);
+
+  /* Final clean frame: received bumps, corrupted does not. */
+  enqueue_burst(10, 4, 4000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* clean2 = get_frame();
+  ASSERT_NE(clean2, nullptr);
+  EXPECT_EQ(clean2->status, ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(stat_frames_received(), 4u);
+  EXPECT_EQ(stat_frames_corrupted(), 2u) << "corrupted must not bump on COMPLETE";
+  put_frame(clean2);
+}
+
+/* st40p_rx_get_session_stats() must surface every pipeline-owned frame
+ * counter exactly as the pipeline tracks it. Drives one clean frame, one
+ * corrupted frame and a framebuffer-exhaustion drop so all three counters
+ * are non-zero, then compares the API output to the raw context fields. */
+TEST_F(St40PipelineRxTest, GetSessionStatsOverlay) {
+  enqueue_burst(0, 4, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+  auto* f0 = get_frame();
+  ASSERT_NE(f0, nullptr);
+  put_frame(f0);
+
+  enqueue(4, 2000, false, MTL_SESSION_PORT_P);
+  enqueue(6, 2000, true, MTL_SESSION_PORT_P); /* seq gap */
+  process_all();
+  auto* f1 = get_frame();
+  ASSERT_NE(f1, nullptr);
+  /* Hold f1 so the next ts changes have no free framebuff and bump dropped. */
+
+  enqueue(7, 3000, false, MTL_SESSION_PORT_P);
+  enqueue(8, 4000, false, MTL_SESSION_PORT_P);
+  enqueue(9, 5000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  struct st40_rx_user_stats api_stats;
+  ASSERT_EQ(ut40p_get_session_stats(ctx_, &api_stats), 0);
+
+  EXPECT_EQ(api_stats.common.stat_frames_received, stat_frames_received());
+  EXPECT_EQ(api_stats.common.stat_frames_dropped, stat_frames_dropped());
+  EXPECT_EQ(api_stats.common.stat_frames_corrupted, stat_frames_corrupted());
+  /* Guard against a trivially-equal pass on all-zero counters. */
+  EXPECT_GT(api_stats.common.stat_frames_received, 0u);
+  EXPECT_GT(api_stats.common.stat_frames_dropped, 0u);
+  EXPECT_GT(api_stats.common.stat_frames_corrupted, 0u);
+  /* Corrupted is a subset of received. */
+  EXPECT_LE(api_stats.common.stat_frames_corrupted,
+            api_stats.common.stat_frames_received);
+
+  put_frame(f1);
+}
+
+/* st40p_rx_reset_session_stats() must zero all three pipeline-owned frame
+ * counters, and subsequent activity must resume counting from zero. */
+TEST_F(St40PipelineRxTest, ResetClearsFrameCounters) {
+  /* Make all three counters non-zero. */
+  enqueue_burst(0, 4, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+  auto* f0 = get_frame();
+  ASSERT_NE(f0, nullptr);
+  put_frame(f0);
+
+  enqueue(4, 2000, false, MTL_SESSION_PORT_P);
+  enqueue(6, 2000, true, MTL_SESSION_PORT_P);
+  process_all();
+  auto* f1 = get_frame();
+  ASSERT_NE(f1, nullptr);
+
+  enqueue(7, 3000, false, MTL_SESSION_PORT_P);
+  enqueue(8, 4000, false, MTL_SESSION_PORT_P);
+  enqueue(9, 5000, false, MTL_SESSION_PORT_P);
+  process_all();
+  put_frame(f1);
+
+  ASSERT_GT(stat_frames_received(), 0u);
+  ASSERT_GT(stat_frames_dropped(), 0u);
+  ASSERT_GT(stat_frames_corrupted(), 0u);
+
+  ASSERT_EQ(ut40p_reset_session_stats(ctx_), 0);
+
+  EXPECT_EQ(stat_frames_received(), 0u);
+  EXPECT_EQ(stat_frames_dropped(), 0u);
+  EXPECT_EQ(stat_frames_corrupted(), 0u);
+
+  /* Continue at seq=7 so the first post-reset frame is contiguous with the
+   * last accepted seq (6) and arrives clean; framebuff-exhaustion drops do
+   * not advance session_last_seq. */
+  enqueue_burst(7, 4, 6000, true, MTL_SESSION_PORT_P);
+  process_all();
+  auto* after = get_frame();
+  ASSERT_NE(after, nullptr);
+  EXPECT_EQ(after->status, ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(stat_frames_received(), 1u);
+  EXPECT_EQ(stat_frames_corrupted(), 0u)
+      << "clean frame after reset must not bump corrupted";
+  put_frame(after);
+}
+
+/* ── PENDING state: late-marker resolution ───────────────────────────── */
+/*
+ * Marker-primary frame assembly with N-1 fallback:
+ *
+ *   - Marker received → frame immediately READY (zero added latency).
+ *   - Timestamp change without marker → old frame enters PENDING (not READY).
+ *     PENDING frame is not visible to consumer via get_frame().
+ *   - Late marker for PENDING frame → apply marker, promote to READY.
+ *   - Second timestamp change → force-deliver PENDING frame without marker.
+ *   - At most 2 frames buffered (inflight + pending), bounded memory cost.
+ */
+
+/* When P advances timestamp before R's marker, the old frame enters PENDING.
+ * It must NOT be visible via get_frame() until resolved. */
+TEST_F(St40PipelineRxTest, PendingFrameNotVisibleBeforeResolution) {
+  /* Frame body: 4 pkts for ts=1000, no marker */
+  enqueue_burst(0, 4, 1000, false, MTL_SESSION_PORT_P);
+  /* P starts next frame → ts=1000 enters PENDING */
+  enqueue(4, 2000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* PENDING frame should not be delivered yet */
+  EXPECT_EQ(get_frame(), nullptr)
+      << "PENDING frame must not be visible to consumer before resolution";
+
+  /* Resolve: send marker for ts=2000 to make it READY, which also
+   * force-delivers the PENDING ts=1000 frame. */
+  enqueue(5, 3000, false, MTL_SESSION_PORT_P); /* second ts change → force-deliver */
+  process_all();
+
+  auto* frame1 = get_frame();
+  ASSERT_NE(frame1, nullptr);
+  EXPECT_EQ(frame1->rtp_timestamp, 1000u);
+  EXPECT_FALSE(frame1->rtp_marker) << "Force-delivered PENDING frame has no marker";
+  put_frame(frame1);
+}
+
+/* Late marker from R resolves a PENDING frame: the frame becomes READY
+ * with rtp_marker=true and the correct total packet count. */
+TEST_F(St40PipelineRxTest, PendingResolvedByLateMarker) {
+  /* P: 3 pkts for ts=1000, no marker */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  /* P advances to ts=2000 → ts=1000 enters PENDING */
+  enqueue(5, 2000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* Verify frame not yet visible */
+  EXPECT_EQ(get_frame(), nullptr);
+
+  /* R: late packets for ts=1000, marker on last */
+  enqueue(3, 1000, false, MTL_SESSION_PORT_R);
+  enqueue(4, 1000, true, MTL_SESSION_PORT_R); /* MARKER */
+  process_all();
+
+  /* PENDING frame resolved by marker → now READY */
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->rtp_timestamp, 1000u);
+  EXPECT_TRUE(frame->rtp_marker) << "Late marker must resolve PENDING frame";
+  EXPECT_EQ(frame->pkts_total, 5u) << "Late packets must be counted in frame";
+  put_frame(frame);
+}
+
+/* Second timestamp change force-delivers a PENDING frame without marker.
+ *
+ * Sequence: ts=1000 (no marker) → ts=2000 (ts=1000 PENDING) →
+ *           ts=3000 (ts=1000 force-READY, ts=2000 PENDING) */
+TEST_F(St40PipelineRxTest, PendingForcedBySecondTimestampChange) {
+  /* Frame 1: ts=1000, 3 pkts, no marker */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  /* ts change → ts=1000 PENDING */
+  enqueue(3, 2000, false, MTL_SESSION_PORT_P);
+  process_all();
+  EXPECT_EQ(get_frame(), nullptr) << "ts=1000 should be PENDING, not READY";
+
+  /* Frame 2: ts=2000, 2 pkts, no marker */
+  enqueue(4, 2000, false, MTL_SESSION_PORT_P);
+  /* Second ts change → ts=1000 force-delivered, ts=2000 PENDING */
+  enqueue(5, 3000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  auto* frame1 = get_frame();
+  ASSERT_NE(frame1, nullptr);
+  EXPECT_EQ(frame1->rtp_timestamp, 1000u);
+  EXPECT_EQ(frame1->pkts_total, 3u);
+  EXPECT_FALSE(frame1->rtp_marker) << "Force-delivered frame should not have marker";
+  put_frame(frame1);
+
+  /* ts=2000 should still be PENDING */
+  EXPECT_EQ(get_frame(), nullptr) << "ts=2000 should be PENDING, not yet READY";
+}
+
+/* Normal marker path: frame with marker goes directly to READY — no PENDING.
+ * This must continue working unchanged with the PENDING state logic. */
+TEST_F(St40PipelineRxTest, NoPendingWhenMarkerPresent) {
+  /* Frame with marker on last packet */
+  enqueue_burst(0, 4, 1000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* Frame should be immediately available — no PENDING state */
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->rtp_timestamp, 1000u);
+  EXPECT_TRUE(frame->rtp_marker);
+  EXPECT_EQ(frame->pkts_total, 4u);
+  put_frame(frame);
+
+  /* Second frame with marker — also immediate */
+  enqueue_burst(4, 3, 2000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->rtp_timestamp, 2000u);
+  EXPECT_TRUE(frame->rtp_marker);
+  put_frame(frame);
+}
+
+/* A PENDING frame accumulates late packets from R, including their count.
+ * The marker resolves it and the total reflects all received packets. */
+TEST_F(St40PipelineRxTest, PendingLatePacketsAccumulate) {
+  /* P: 3 pkts for ts=1000, no marker */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  /* P advances to ts=2000 → ts=1000 PENDING */
+  enqueue(6, 2000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* R: 3 late pkts for ts=1000 (seq 3,4,5), marker on seq 5 */
+  enqueue(3, 1000, false, MTL_SESSION_PORT_R);
+  enqueue(4, 1000, false, MTL_SESSION_PORT_R);
+  enqueue(5, 1000, true, MTL_SESSION_PORT_R); /* MARKER */
+  process_all();
+
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr);
+  EXPECT_EQ(frame->rtp_timestamp, 1000u);
+  EXPECT_TRUE(frame->rtp_marker);
+  EXPECT_EQ(frame->pkts_total, 6u) << "3 from P + 3 from R";
+  EXPECT_EQ(frame->pkts_recv[MTL_SESSION_PORT_P], 3u);
+  EXPECT_EQ(frame->pkts_recv[MTL_SESSION_PORT_R], 3u);
+  put_frame(frame);
+}
+
+/* Multiple successive frames cycling through PENDING → resolved.
+ * Each frame's marker arrives late from R after P has advanced. */
+TEST_F(St40PipelineRxTest, PendingMultiFrameCycle) {
+  /* Frame 1: P sends body, advances to ts=2000 */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(3, 2000, false, MTL_SESSION_PORT_P); /* ts=1000 → PENDING */
+  /* R sends late marker for ts=1000 → resolves PENDING */
+  enqueue(3, 1000, true, MTL_SESSION_PORT_R);
+
+  /* Frame 2: P sends body at ts=2000, advances to ts=3000 */
+  enqueue(4, 2000, false, MTL_SESSION_PORT_P);
+  enqueue(5, 3000, false, MTL_SESSION_PORT_P); /* ts=2000 → PENDING */
+  /* R sends late marker for ts=2000 */
+  enqueue(5, 2000, true, MTL_SESSION_PORT_R);
+
+  /* Frame 3: complete with marker */
+  enqueue(6, 3000, true, MTL_SESSION_PORT_P); /* ts=3000 → READY via marker */
+
+  process_all();
+
+  auto* f1 = get_frame();
+  ASSERT_NE(f1, nullptr);
+  EXPECT_EQ(f1->rtp_timestamp, 1000u);
+  EXPECT_TRUE(f1->rtp_marker) << "Frame 1: late marker from R resolved PENDING";
+  put_frame(f1);
+
+  auto* f2 = get_frame();
+  ASSERT_NE(f2, nullptr);
+  EXPECT_EQ(f2->rtp_timestamp, 2000u);
+  EXPECT_TRUE(f2->rtp_marker) << "Frame 2: late marker from R resolved PENDING";
+  put_frame(f2);
+
+  auto* f3 = get_frame();
+  ASSERT_NE(f3, nullptr);
+  EXPECT_EQ(f3->rtp_timestamp, 3000u);
+  EXPECT_TRUE(f3->rtp_marker) << "Frame 3: marker on-time, no PENDING";
+  put_frame(f3);
+
+  EXPECT_EQ(get_frame(), nullptr);
+}
+
+/* ── Single-port vs multi-port PENDING behavior ──────────────────────── */
+/*
+ * These tests verify the behavioral split: single-port sessions never enter
+ * PENDING (timestamp change → immediate READY), while multi-port sessions
+ * defer delivery until a late marker or a second timestamp change.
+ */
+
+/* Single-port: timestamp change delivers frame immediately, no PENDING. */
+TEST_F(St40PipelineRxTest, SinglePortTsChangeImmediateReady) {
+  ut40p_ctx_destroy(ctx_);
+  ctx_ = ut40p_ctx_create(1, 3);
+
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(3, 2000, false, MTL_SESSION_PORT_P); /* ts change */
+  process_all();
+
+  auto* frame = get_frame();
+  ASSERT_NE(frame, nullptr) << "Single-port: ts change must deliver frame immediately";
+  EXPECT_EQ(frame->rtp_timestamp, 1000u);
+  EXPECT_FALSE(frame->rtp_marker);
+  put_frame(frame);
+}
+
+/* Multi-port: same packet sequence as above → frame enters PENDING, not visible. */
+TEST_F(St40PipelineRxTest, MultiPortTsChangePending) {
+  /* Default fixture is 2-port */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(3, 2000, false, MTL_SESSION_PORT_P); /* ts change */
+  process_all();
+
+  EXPECT_EQ(get_frame(), nullptr)
+      << "Multi-port: ts change must enter PENDING, not deliver";
+}
+
+/* Single-port: three rapid ts changes → all three frames immediately READY.
+ * No PENDING, no force-delivery — each frame completes on ts change. */
+TEST_F(St40PipelineRxTest, SinglePortRapidTsChangesAllReady) {
+  ut40p_ctx_destroy(ctx_);
+  ctx_ = ut40p_ctx_create(1, 4); /* 4 fbs to hold all frames */
+
+  enqueue(0, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(1, 2000, false, MTL_SESSION_PORT_P); /* completes ts=1000 */
+  enqueue(2, 3000, false, MTL_SESSION_PORT_P); /* completes ts=2000 */
+  enqueue(3, 4000, false, MTL_SESSION_PORT_P); /* completes ts=3000 */
+  process_all();
+
+  for (uint32_t ts = 1000; ts <= 3000; ts += 1000) {
+    auto* f = get_frame();
+    ASSERT_NE(f, nullptr) << "ts=" << ts << " must be immediately READY";
+    EXPECT_EQ(f->rtp_timestamp, ts);
+    EXPECT_FALSE(f->rtp_marker);
+    put_frame(f);
+  }
+}
+
+/* Multi-port: three rapid ts changes without markers.
+ * Frame 1 is force-delivered when frame 2 enters PENDING on the third change.
+ * Frame 2 stays PENDING. Frame 3 is inflight. */
+TEST_F(St40PipelineRxTest, MultiPortRapidTsChangesForceDelivery) {
+  ut40p_ctx_destroy(ctx_);
+  ctx_ = ut40p_ctx_create(2, 4);
+
+  enqueue(0, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(1, 2000, false, MTL_SESSION_PORT_P); /* ts=1000 → PENDING */
+  enqueue(2, 3000, false, MTL_SESSION_PORT_P); /* ts=1000 force-READY, ts=2000 PENDING */
+  process_all();
+
+  /* Only ts=1000 should be visible (force-delivered) */
+  auto* f1 = get_frame();
+  ASSERT_NE(f1, nullptr);
+  EXPECT_EQ(f1->rtp_timestamp, 1000u);
+  EXPECT_FALSE(f1->rtp_marker) << "Force-delivered frame has no marker";
+  put_frame(f1);
+
+  /* ts=2000 is PENDING, ts=3000 is inflight — neither visible */
+  EXPECT_EQ(get_frame(), nullptr) << "ts=2000 PENDING, ts=3000 inflight";
+}
+
+/* Multi-port: PENDING frame occupies a framebuffer slot.
+ * With 2 fbs total: pending(1) + inflight(1) = 0 free → next ts change hits busy. */
+TEST_F(St40PipelineRxTest, MultiPortPendingReducesAvailableFramebuffers) {
+  ut40p_ctx_destroy(ctx_);
+  ctx_ = ut40p_ctx_create(2, 2);
+
+  /* ts=1000 fills fb 0 */
+  enqueue(0, 1000, false, MTL_SESSION_PORT_P);
+  /* ts=2000: fb 0 → PENDING, fb 1 starts inflight */
+  enqueue(1, 2000, false, MTL_SESSION_PORT_P);
+  /* ts=3000: fb 0 force-READY, fb 1 → PENDING, try alloc new fb → no free → busy */
+  enqueue(2, 3000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  EXPECT_GE(stat_busy(), 1u)
+      << "PENDING must occupy a framebuffer slot, causing exhaustion";
+
+  /* Force-delivered ts=1000 should still be retrievable */
+  auto* f = get_frame();
+  ASSERT_NE(f, nullptr);
+  EXPECT_EQ(f->rtp_timestamp, 1000u);
+  put_frame(f);
+}
+
+/* Single-port: same 2-fb sequence — no PENDING means both frames are READY.
+ * The third ts change still hits busy (both fbs occupied), but both are consumable. */
+TEST_F(St40PipelineRxTest, SinglePortNoPendingAvoidsBusyWith2Fbs) {
+  ut40p_ctx_destroy(ctx_);
+  ctx_ = ut40p_ctx_create(1, 2);
+
+  enqueue(0, 1000, false, MTL_SESSION_PORT_P);
+  enqueue(1, 2000, false, MTL_SESSION_PORT_P); /* ts=1000 → READY */
+  /* ts=1000 READY (fb 0), ts=2000 inflight (fb 1). No free fb.
+   * ts=3000 completes ts=2000 → READY (fb 1), tries alloc → fb 0 still READY → busy. */
+  enqueue(2, 3000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  EXPECT_GE(stat_busy(), 1u) << "ts=3000 hit busy (both fbs occupied)";
+
+  /* Both frames are READY and consumable — single port doesn't block on PENDING */
+  auto* f1 = get_frame();
+  ASSERT_NE(f1, nullptr);
+  EXPECT_EQ(f1->rtp_timestamp, 1000u);
+  put_frame(f1);
+
+  auto* f2 = get_frame();
+  ASSERT_NE(f2, nullptr);
+  EXPECT_EQ(f2->rtp_timestamp, 2000u);
+  put_frame(f2);
+}
+
+/* Multi-port: late non-marker packet routes to PENDING but does NOT resolve it.
+ * The frame stays PENDING until a marker or a second ts change. */
+TEST_F(St40PipelineRxTest, MultiPortLateNonMarkerKeepsPending) {
+  /* P: body for ts=1000 */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  /* P advances → ts=1000 PENDING */
+  enqueue(5, 2000, false, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* R: late non-marker packets route to pending ts=1000 */
+  enqueue(3, 1000, false, MTL_SESSION_PORT_R);
+  enqueue(4, 1000, false, MTL_SESSION_PORT_R); /* no marker */
+  process_all();
+
+  /* Frame must still be invisible (PENDING, not resolved) */
+  EXPECT_EQ(get_frame(), nullptr)
+      << "Non-marker late packets must not resolve PENDING frame";
+}
+
+/* Multi-port: marker on the current inflight does not affect a pending frame.
+ * The inflight completes independently; pending stays PENDING. */
+TEST_F(St40PipelineRxTest, MultiPortMarkerOnInflightLeavesPendingAlone) {
+  /* P: body for ts=1000, no marker */
+  enqueue_burst(0, 3, 1000, false, MTL_SESSION_PORT_P);
+  /* P advances → ts=1000 enters PENDING */
+  enqueue(3, 2000, false, MTL_SESSION_PORT_P);
+  /* P completes ts=2000 with marker */
+  enqueue(4, 2000, true, MTL_SESSION_PORT_P);
+  process_all();
+
+  /* ts=2000 is READY (marker). ts=1000 is PENDING.
+   * get_frame scans from consumer_idx: fb 0 (PENDING, skip) → fb 1 (READY). */
+  auto* f = get_frame();
+  ASSERT_NE(f, nullptr);
+  EXPECT_EQ(f->rtp_timestamp, 2000u) << "Inflight marker delivers independently";
+  EXPECT_TRUE(f->rtp_marker);
+  put_frame(f);
+
+  /* ts=1000 still PENDING — not visible */
+  EXPECT_EQ(get_frame(), nullptr) << "PENDING ts=1000 must remain invisible";
+
+  /* Force-deliver ts=1000 via ts change: start ts=3000 inflight, then ts=4000 */
+  enqueue(5, 3000, false, MTL_SESSION_PORT_P); /* new inflight, no ts change */
+  enqueue(6, 4000, false,
+          MTL_SESSION_PORT_P); /* ts change: ts=1000 force-READY, ts=3000 PENDING */
+  process_all();
+
+  auto* f1 = get_frame();
+  ASSERT_NE(f1, nullptr);
+  EXPECT_EQ(f1->rtp_timestamp, 1000u);
+  EXPECT_FALSE(f1->rtp_marker) << "Force-delivered PENDING frame has no marker";
+  put_frame(f1);
+}

--- a/tests/unit/session/st20/bitmap_test.cpp
+++ b/tests/unit/session/st20/bitmap_test.cpp
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Sequence-id and bitmap edge cases:
+ * 32-bit seq wrap, packet index outside the bitmap, intra-frame ordering,
+ * cross-port interleaving to fill a frame.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St20RxBitmapTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20/st20_rx_test_base.h"
+
+class St20RxBitmapTest : public St20RxBaseTest {};
+
+/* 32-bit seq_id wrap: base = 0xFFFFFFFF, next seq = 0 must take the wrap
+ * branch (seq_id_u32 < seq_id_base_u32) and resolve to pkt_idx == 1. */
+TEST_F(St20RxBitmapTest, SeqIdWrapAround32) {
+  feed_seq(0, 0xFFFFFFFF, 1000, MTL_SESSION_PORT_P);
+  feed_seq(1, 0x00000000, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(idx_oo_bitmap(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+}
+
+/* Wrap with a forward gap: base = 0xFFFFFFFE, then jump straight to seq = 0
+ * (skipping 0xFFFFFFFF). With UT20 geometry (2 pkts/frame) we feed
+ * pkt_idx 0 and pkt_idx 1, but make pkt_idx 1's seq wrap past one missing
+ * value. Wrap formula yields pkt_idx == 2 internally — but our bitmap is
+ * 8 bits so it stays in range and the gap arithmetic is exercised across
+ * the 32-bit boundary. We use ut20_feed_pkt directly to keep line_num
+ * within the frame regardless of the resolved pkt_idx. */
+TEST_F(St20RxBitmapTest, SeqIdWrapAround32WithGap) {
+  /* First pkt: seq=0xFFFFFFFE, line 0 → establishes base_u32 = 0xFFFFFFFE. */
+  ut20_feed_pkt(ctx_, 0xFFFFFFFE, 1000, 0, 0, 40, MTL_SESSION_PORT_P);
+  /* Second pkt: seq=0x00000000 → wrap branch, pkt_idx = 0 + (0xFFFFFFFF -
+   * 0xFFFFFFFE) + 1 = 2. Use line 1 so the offset stays inside the frame. */
+  ut20_feed_pkt(ctx_, 0x00000000, 1000, 1, 0, 40, MTL_SESSION_PORT_P);
+
+  /* Both packets accepted; the missing seq=0xFFFFFFFF (pkt_idx 1) counted lost. */
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(idx_oo_bitmap(), 0u);
+}
+
+/* Reorder across the wrap: pkt_idx 1 (seq 0) arrives before pkt_idx 0
+ * (seq 0xFFFFFFFF). The first-packet path computes base = seq - pkt_idx,
+ * so base = 0 - 1 = 0xFFFFFFFF, and the late seq 0xFFFFFFFF then resolves
+ * via the non-wrap branch to pkt_idx 0. Both packets must be accepted. */
+TEST_F(St20RxBitmapTest, ReorderAcrossWrapAccepted) {
+  feed_seq(1, 0x00000000, 1000, MTL_SESSION_PORT_P); /* base = 0xFFFFFFFF */
+  feed_seq(0, 0xFFFFFFFF, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(idx_oo_bitmap(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+}
+
+/* Packet index outside the bitmap range is rejected and counted in
+ * stat_pkts_idx_oo_bitmap. The bitmap is 1 byte = 8 bits, so pkt_idx >= 8
+ * is out of range. */
+TEST_F(St20RxBitmapTest, PktIdxOutOfBitmap) {
+  /* First pkt establishes seq_id_base */
+  feed_seq(0, 100, 1000, MTL_SESSION_PORT_P);
+
+  /* Now send a pkt whose seq gives pkt_idx = 100 (base=100, seq=200 → idx=100).
+   * Use line 0 / offset 0 / length 40 — the line fields don't matter for this
+   * test, only the seq_id distance from base matters. */
+  ut20_feed_pkt(ctx_, 200, 1000, 0, 0, 40, MTL_SESSION_PORT_P);
+
+  EXPECT_GE(idx_oo_bitmap(), 1u) << "Out-of-bitmap pkt_idx should be rejected";
+}
+
+/* Out-of-order packets within a frame: pkt 1 arrives before pkt 0.
+ * Both must be accepted (bitmap allows any order). The backward arrival
+ * must be counted as intra-frame reorder, must not inflate lost or
+ * redundant counters, and must not cause OOO underflow from negative gap. */
+TEST_F(St20RxBitmapTest, OutOfOrderWithinFrame) {
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(ooo(), 0u)
+      << "Backward pkt_idx should not cause OOO underflow or double-counting";
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 1u)
+      << "pkt_idx 0 arriving after pkt_idx 1 must count as intra-frame reorder";
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+}
+
+/* Interleaved ports fill one frame: P sends pkt 0, R sends pkt 1.
+ * The frame should complete as reconstructed from both ports. */
+TEST_F(St20RxBitmapTest, InterleavedPortsFillFrame) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(redundant(), 0u);
+}

--- a/tests/unit/session/st20/err_packets_test.cpp
+++ b/tests/unit/session/st20/err_packets_test.cpp
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Tests for the per-port `err_packets` counter on the ST 2110-20 RX session.
+ * The `_handle_mbuf` wrapper increments
+ * `port_user_stats.common.port[s_port].err_packets` whenever the per-packet
+ * handler returns < 0.
+ *
+ * Test goals:
+ *   1. Every genuine error path (wrong PT, wrong SSRC, bad offset) MUST
+ *      increment err_packets and the corresponding per-reason counter,
+ *      exactly once each.
+ *   2. err_packets MUST equal the sum of per-reason drop counters
+ *      (no double-counting, no silent drops).
+ *   3. Successful packets MUST NOT increment err_packets.
+ *   4. ST20 bitmap-based redundancy dedup returns 0 (not -EIO), so
+ *      legitimate redundant packets MUST NOT count as errors.
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20_harness.h"
+
+class St20RxErrPacketsTest : public ::testing::Test {
+ protected:
+  ut20_test_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut20_init(), 0);
+    ctx_ = ut20_ctx_create(2);
+    ASSERT_NE(ctx_, nullptr);
+    ut20_ctx_set_pt(ctx_, 96);
+    ut20_ctx_set_ssrc(ctx_, 0xDEAD);
+  }
+  void TearDown() override {
+    if (ctx_) ut20_ctx_destroy(ctx_);
+  }
+
+  uint64_t err_p() {
+    return ut20_stat_port_err_packets(ctx_, MTL_SESSION_PORT_P);
+  }
+  uint64_t err_r() {
+    return ut20_stat_port_err_packets(ctx_, MTL_SESSION_PORT_R);
+  }
+  uint64_t pkts_p() {
+    return ut20_stat_port_packets(ctx_, MTL_SESSION_PORT_P);
+  }
+  uint64_t pkts_r() {
+    return ut20_stat_port_packets(ctx_, MTL_SESSION_PORT_R);
+  }
+};
+
+/* Good packets via the wrapper: per-port packets++ , err_packets stays 0. */
+TEST_F(St20RxErrPacketsTest, GoodPacketsNotCountedAsErr) {
+  /* feed a complete frame (2 packets) on primary */
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(err_p(), 0u) << "good packets must not bump err_packets";
+  EXPECT_EQ(pkts_p(), 2u) << "wrapper must increment per-port packets counter";
+  EXPECT_EQ(err_r(), 0u);
+  EXPECT_EQ(pkts_r(), 0u);
+}
+
+/* Wrong payload type: -EINVAL → err_packets++ AND wrong_pt++. */
+TEST_F(St20RxErrPacketsTest, WrongPtCountedAsErr) {
+  /* pt=200 differs from session pt=96 */
+  ut20_feed_pkt_via_wrapper(ctx_, /*seq=*/0, /*ts=*/1000, /*line=*/0, /*off=*/0,
+                            /*len=*/40, MTL_SESSION_PORT_P, /*pt=*/200, /*ssrc=*/0xDEAD);
+
+  EXPECT_EQ(ut20_stat_wrong_pt(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u) << "wrong-PT packet must bump err_packets[P]";
+  EXPECT_EQ(pkts_p(), 0u) << "rejected packets must NOT bump good-packets counter";
+  EXPECT_EQ(err_r(), 0u);
+}
+
+/* Wrong SSRC: -EINVAL → err_packets++ AND wrong_ssrc++. */
+TEST_F(St20RxErrPacketsTest, WrongSsrcCountedAsErr) {
+  ut20_feed_pkt_via_wrapper(ctx_, 0, 1000, 0, 0, 40, MTL_SESSION_PORT_P, /*pt=*/96,
+                            /*ssrc=*/0xBAD);
+
+  EXPECT_EQ(ut20_stat_wrong_ssrc(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 0u);
+}
+
+/* err_packets per port must equal the sum of all per-port drop reasons.
+ * This is the master invariant: nothing silently bumps err_packets. */
+TEST_F(St20RxErrPacketsTest, ErrPacketsEqualsSumOfReasons) {
+  /* feed assorted bad packets on primary */
+  ut20_feed_pkt_via_wrapper(ctx_, 0, 1000, 0, 0, 40, MTL_SESSION_PORT_P, /*pt=*/200,
+                            0xDEAD); /* wrong PT */
+  ut20_feed_pkt_via_wrapper(ctx_, 1, 1000, 0, 0, 40, MTL_SESSION_PORT_P, /*pt=*/200,
+                            0xDEAD); /* wrong PT */
+  ut20_feed_pkt_via_wrapper(ctx_, 2, 1000, 0, 0, 40, MTL_SESSION_PORT_P, 96,
+                            /*ssrc=*/0xBAD); /* wrong SSRC */
+  ut20_feed_pkt_via_wrapper(ctx_, 3, 1000, /*line=*/9999, /*off=*/0, /*len=*/40,
+                            MTL_SESSION_PORT_P, 96, 0xDEAD); /* offset out of frame */
+
+  uint64_t reasons = ut20_stat_wrong_pt(ctx_) + ut20_stat_wrong_ssrc(ctx_) +
+                     ut20_stat_wrong_interlace(ctx_) + ut20_stat_offset_dropped(ctx_) +
+                     ut20_stat_wrong_len(ctx_) + ut20_stat_no_slot(ctx_) +
+                     ut20_stat_idx_oo_bitmap(ctx_);
+  EXPECT_GT(reasons, 0u);
+  EXPECT_EQ(err_p(), reasons)
+      << "every err_packets bump must be explainable by a per-reason counter";
+}
+
+/* Mixed burst: 1 valid, 1 wrong-pt, 1 valid → exactly 1 err_packet. */
+TEST_F(St20RxErrPacketsTest, MixedBurstOnlyBadCounted) {
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_pkt_via_wrapper(ctx_, 99, 1000, 0, 0, 40, MTL_SESSION_PORT_P, /*pt=*/200,
+                            0xDEAD);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(err_p(), 1u) << "only the wrong-PT packet may be counted as error";
+  EXPECT_EQ(pkts_p(), 2u) << "the two valid packets must be counted as good";
+}
+
+/* Duplicate-bitmap packet from redundant port: returns 0 in ST20 (bitmap
+ * dedup, not the -EIO redundancy filter used by ST30/ST40), must not
+ * count as error. */
+TEST_F(St20RxErrPacketsTest, BitmapDuplicateRedundantNotErr) {
+  /* full frame on P, then same frame on R: every R packet is a bitmap dup */
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_R);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(ut20_stat_redundant(ctx_), 2u)
+      << "both R packets must be classified as redundant";
+  EXPECT_EQ(err_r(), 0u)
+      << "ST20 bitmap-redundant packets must NOT count as errors (regression guard)";
+}

--- a/tests/unit/session/st20/header_validation_test.cpp
+++ b/tests/unit/session/st20/header_validation_test.cpp
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * RFC 4175 header validation:
+ * payload type, SSRC, interlace and the ReturnValue* contract for the
+ * underlying packet handler.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St20RxHeaderValidationTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20/st20_rx_test_base.h"
+
+class St20RxHeaderValidationTest : public St20RxBaseTest {};
+
+/* Accepted packet must return 0. */
+TEST_F(St20RxHeaderValidationTest, ReturnValueAccepted) {
+  int rc = ut20_feed_frame_pkt(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  EXPECT_EQ(rc, 0);
+}
+
+/* Wrong payload type must return -EINVAL. */
+TEST_F(St20RxHeaderValidationTest, ReturnValueWrongPT) {
+  ut20_ctx_set_pt(ctx_, 96);
+  int rc = ut20_feed_pkt_pt(ctx_, 0, 1000, 0, 0, 40, MTL_SESSION_PORT_P, 97);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* Wrong SSRC must return -EINVAL. */
+TEST_F(St20RxHeaderValidationTest, ReturnValueWrongSSRC) {
+  ut20_ctx_set_ssrc(ctx_, 1234);
+  int rc = ut20_feed_pkt_ssrc(ctx_, 0, 1000, 0, 0, 40, MTL_SESSION_PORT_P, 5678);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* No slot available must return -EIO. */
+TEST_F(St20RxHeaderValidationTest, ReturnValueNoSlot) {
+  /* Fill both slots with completed frames */
+  feed_full(5000, MTL_SESSION_PORT_P);
+  feed_full(6000, MTL_SESSION_PORT_P);
+
+  /* Old timestamp, both slots hold newer ts → no slot */
+  int rc = ut20_feed_frame_pkt(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  EXPECT_LT(rc, 0) << "Should reject when no slot available";
+}
+
+/* Wrong PT packets are dropped and counted in wrong_pt stat. */
+TEST_F(St20RxHeaderValidationTest, WrongPayloadTypeDropped) {
+  ut20_ctx_set_pt(ctx_, 96);
+  for (int i = 0; i < 5; i++)
+    ut20_feed_pkt_pt(ctx_, i, 1000, 0, 0, 40, MTL_SESSION_PORT_P, 97);
+
+  EXPECT_EQ(wrong_pt(), 5u);
+  EXPECT_EQ(received(), 0u);
+}
+
+/* Wrong SSRC packets are dropped and counted in wrong_ssrc stat. */
+TEST_F(St20RxHeaderValidationTest, WrongSSRCDropped) {
+  ut20_ctx_set_ssrc(ctx_, 0xDEAD);
+  for (int i = 0; i < 3; i++)
+    ut20_feed_pkt_ssrc(ctx_, i, 1000, 0, 0, 40, MTL_SESSION_PORT_P, 0xBEEF);
+
+  EXPECT_EQ(wrong_ssrc(), 3u);
+  EXPECT_EQ(received(), 0u);
+}
+
+/* Second-field bit on a progressive stream triggers wrong_interlace. */
+TEST_F(St20RxHeaderValidationTest, WrongInterlaceDropped) {
+  /* ops.interlaced = false by default; send row_number with second_field bit set */
+  int rc = ut20_feed_pkt(ctx_, 0, 1000, 0x8000, 0, 40, MTL_SESSION_PORT_P);
+  EXPECT_EQ(rc, -EINVAL);
+  EXPECT_EQ(wrong_interlace(), 1u);
+}

--- a/tests/unit/session/st20/redundancy_test.cpp
+++ b/tests/unit/session/st20/redundancy_test.cpp
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Bitmap-based dedup and cross-port redundancy:
+ * duplicate detection on same and cross ports, normal redundancy, burst
+ * switchover (clean and reordered).
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St20RxRedundancyTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20/st20_rx_test_base.h"
+
+class St20RxRedundancyTest : public St20RxBaseTest {};
+
+/* Same packet sent twice on same port: the second is a bitmap duplicate. */
+TEST_F(St20RxRedundancyTest, DuplicatePacketSamePort) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), 1u);
+  EXPECT_EQ(redundant(), 1u);
+}
+
+/* Same packet sent on P then R: the cross-port duplicate is rejected by bitmap. */
+TEST_F(St20RxRedundancyTest, DuplicatePacketCrossPort) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(received(), 1u);
+  EXPECT_EQ(redundant(), 1u);
+}
+
+/* Full frame on P, duplicate full frame on R. The first frame completes
+ * and is delivered; R's packets hit the frame-gone path (slot exists but
+ * frame is NULL after delivery). */
+TEST_F(St20RxRedundancyTest, NormalRedundancyTwoPorts) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed_full(1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(redundant(), 2u) << "Both pkts from port R should be redundant";
+}
+
+/* Clean burst switchover: frame 1 entirely from P, frame 2 entirely from R.
+ * Both frames should be delivered. */
+TEST_F(St20RxRedundancyTest, BurstSwitchoverVideoClean) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed_full(2000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 2);
+  EXPECT_EQ(redundant(), 0u);
+}
+
+/* Reordered burst switchover: frame 2 starts on R while frame 1's late
+ * packets arrive on P. ST20's slot architecture keeps frame 1's slot
+ * active while frame 2 occupies the other slot.
+ *   1. P sends pkt 0 of frame ts=1000 (slot 0 allocated)
+ *   2. R sends full frame ts=2000 (slot 1 allocated, completes)
+ *   3. P sends pkt 1 of frame ts=1000 (goes to slot 0, completing frame 1)
+ * Verifies late arrivals from P are accepted when the other slot advances. */
+TEST_F(St20RxRedundancyTest, BurstSwitchoverVideoReordered) {
+  /* pkt 0 of frame 1 from P */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+
+  /* full frame 2 from R */
+  feed_full(2000, MTL_SESSION_PORT_R);
+
+  /* late pkt 1 of frame 1 from P — should complete frame 1 in its slot */
+  feed(1, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 2) << "Both frames should be delivered";
+  EXPECT_EQ(received(), 4u) << "All 4 packets (2+2) should be received";
+  EXPECT_EQ(redundant(), 0u) << "No packets should be filtered as redundant";
+}
+
+/* Bitmap duplicate returns 0, not a negative error code. */
+TEST_F(St20RxRedundancyTest, ReturnValueRedundantBitmap) {
+  ut20_feed_frame_pkt(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  int rc = ut20_feed_frame_pkt(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  EXPECT_EQ(rc, 0) << "Bitmap duplicate returns 0, not error";
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Cross-port reconstruction edge cases.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/* First arrival is NOT pkt 0: base must be derived from the packet's
+ * frame offset, not from its seq. Otherwise R's later pkt 0 would map to
+ * a wrap-around pkt_idx and be rejected as out-of-bitmap. */
+TEST_F(St20RxRedundancyTest, FirstPktNonZeroBaseFromOffset) {
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(idx_oo_bitmap(), 0u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 1u);
+}
+
+/* ST 2022-7 Class A (PD ≤ 10ms ≈ <1 frame @60fps): P advances to the next
+ * frame while R is still finishing the previous one. Both frames complete. */
+TEST_F(St20RxRedundancyTest, OneFrameOffsetBothComplete) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed(0, 2000, MTL_SESSION_PORT_P);
+  feed_full(1000, MTL_SESSION_PORT_R);
+  feed(1, 2000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 2);
+  EXPECT_EQ(no_slot(), 0u);
+}
+
+/* Wire corruption (RFC 3550 violates ST 2022-7 §6 but physically possible):
+ * one port's seq is corrupted mid-frame; redundancy must recover via the
+ * healthy port and surface the corrupt pkt as out-of-bitmap. */
+TEST_F(St20RxRedundancyTest, WireCorruptedSeqRecoveredByPeer) {
+  ut20_feed_pkt(ctx_, 100, 1000, 0, 0, 40, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 50, 1000, 1, 0, 40, MTL_SESSION_PORT_P); /* corrupt */
+  ut20_feed_pkt(ctx_, 100, 1000, 0, 0, 40, MTL_SESSION_PORT_R);
+  ut20_feed_pkt(ctx_, 101, 1000, 1, 0, 40, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_GE(idx_oo_bitmap(), 1u);
+}
+
+/* Per-frame seq base reset: a huge inter-frame seq jump (NIC reset, sender
+ * restart) is absorbed because the new RTP timestamp opens a fresh slot. */
+TEST_F(St20RxRedundancyTest, SeqJumpAtFrameBoundaryAbsorbed) {
+  ut20_feed_pkt(ctx_, 100, 1000, 0, 0, 40, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 101, 1000, 1, 0, 40, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 99999, 2000, 0, 0, 40, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 100000, 2000, 1, 0, 40, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 2);
+  EXPECT_EQ(idx_oo_bitmap(), 0u);
+}
+
+/* Non-conformant TX (violates ST 2022-7 §6: identical RTP headers required):
+ * P and R use different RTP timestamps for the "same" frame. No cross-port
+ * dedup happens — each port's frame completes independently. Pinned to
+ * catch a future regression that mis-merges the slots. */
+TEST_F(St20RxRedundancyTest, MismatchedTimestampsNoMerge) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1001, MTL_SESSION_PORT_R);
+  feed(1, 1001, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 2);
+  EXPECT_EQ(redundant(), 0u);
+}
+
+/* Late R duplicate of a completed frame: must hit the
+ * `exist_ts && !slot->frame` fast-path and count as redundant, not as
+ * no_slot or as bitmap dups against an unrelated slot. */
+TEST_F(St20RxRedundancyTest, LateRDuplicateOfCompletedFrameIsRedundant) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed_full(2000, MTL_SESSION_PORT_P);
+
+  uint64_t red_before = redundant();
+  feed_full(1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(redundant() - red_before, 2u);
+  EXPECT_EQ(no_slot(), 0u);
+}

--- a/tests/unit/session/st20/reorder_test.cpp
+++ b/tests/unit/session/st20/reorder_test.cpp
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Intra-frame reorder accounting:
+ * the per-port reordered_packets counter, in-order baseline, per-port
+ * isolation, frame-boundary leak, and reorder-then-duplicate.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St20RxReorderTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20/st20_rx_test_base.h"
+
+class St20RxReorderTest : public St20RxBaseTest {};
+
+/* Each new frame (new RTP timestamp) opens a fresh slot with last_pkt_idx
+ * starting at 0 — in-order delivery must not be misclassified as reorder,
+ * neither on the active port nor on the inactive port. */
+TEST_F(St20RxReorderTest, InOrderDoesNotBumpReorder) {
+  feed_full(1000, MTL_SESSION_PORT_P); /* in-order, frame 1 */
+  feed_full(1001, MTL_SESSION_PORT_P); /* in-order, frame 2 */
+
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u);
+}
+
+/* Reorder followed by a duplicate of the late packet must count exactly one
+ * reorder and one redundant — never a second reorder. */
+TEST_F(St20RxReorderTest, ReorderThenDuplicateNotDoubleCounted) {
+  feed(1, 1000, MTL_SESSION_PORT_P); /* sets last_pkt_idx=1 */
+  feed(0, 1000, MTL_SESSION_PORT_P); /* reorder: bit not yet set */
+  feed(0, 1000, MTL_SESSION_PORT_P); /* duplicate: bit already set */
+
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(redundant(), 1u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+}
+
+/* Regression: after a reorder, slot->last_pkt_idx must NOT regress, otherwise
+ * the next forward jump re-counts already-lost packets as new losses.
+ *
+ * Sequence on a single port (line_num=0 for all so the frame offset check
+ * does not interfere; pkt_idx is derived purely from RTP seq):
+ *   seq 1000 → pkt_idx 0, base established
+ *   seq 1005 → pkt_idx 5, forward jump → gap = 4 lost (pkts 1..4)
+ *   seq 1003 → pkt_idx 3, reorder (recovers one of the "lost" pkts)
+ *   seq 1006 → pkt_idx 6, only pkt 4 is a NEW loss between the prior
+ *              high-water mark (5) and 6
+ *
+ * Expected port_lost == 4 (the four lost in the first forward jump; the
+ * implementation does not decrement on reorder recovery, but it must NOT
+ * inflate by another 2 just because last_pkt_idx regressed to 3). */
+TEST_F(St20RxReorderTest, ReorderDoesNotRegressLastPktIdx) {
+  /* Payload 10 bytes/pkt so 4 pkts (40B) fit in the 80B harness frame
+   * without auto-closing the slot at frame_recv_size >= frame_size. */
+  ut20_feed_pkt(ctx_, 1000, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 1005, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 1003, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 1006, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 4u)
+      << "If last_pkt_idx regresses on reorder, pkt 6 over-counts lost as "
+         "6-3-1=2 instead of 0, inflating port_lost from 4 to 6";
+}
+
+/* Cross-port variant: slot->last_pkt_idx is per-slot (shared across P+R for
+ * the same RTP timestamp). A reorder arriving on one port must not poison
+ * the gap arithmetic for the next forward packet on the OTHER port.
+ *   1. P sends pkt 0 (last_pkt_idx = 0)
+ *   2. R sends pkt 5 (gap = 4 → port_lost(R) += 4, last_pkt_idx = 5)
+ *   3. P sends pkt 3 (reorder; last_pkt_idx must STAY 5, not regress)
+ *   4. R sends pkt 6 (in-order continuation: gap = 0)
+ * Without the high-water-mark guard, step 3 regresses last_pkt_idx to 3,
+ * and step 4 computes gap = 6 - 3 - 1 = 2, falsely inflating port_lost(R) to 6. */
+TEST_F(St20RxReorderTest, ReorderOnOnePortDoesNotPoisonOtherPort) {
+  ut20_feed_pkt(ctx_, 1000, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 1005, 1000, 0, 0, 10, MTL_SESSION_PORT_R);
+  ut20_feed_pkt(ctx_, 1003, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 1006, 1000, 0, 0, 10, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 4u)
+      << "Reorder on P must not inflate lost count for the next forward pkt on R";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+}
+
+/* Multi-step reorder: large initial gap, then several reorders fill it in
+ * out of order, then resume forward. Ensures the high-water-mark fix holds
+ * across a sequence of regressions, and that lost is counted exactly once
+ * per missing slot (not re-added on each subsequent forward step). */
+TEST_F(St20RxReorderTest, MultipleReordersDoNotInflateLost) {
+  /* 8 pkts of 10 bytes each fit the 80B harness frame. */
+  ut20_feed_pkt(ctx_, 100, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* pkt 0 */
+  ut20_feed_pkt(ctx_, 106, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* pkt 6, gap=5 */
+  ut20_feed_pkt(ctx_, 102, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* reorder */
+  ut20_feed_pkt(ctx_, 104, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* reorder */
+  ut20_feed_pkt(ctx_, 101, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* reorder */
+  ut20_feed_pkt(ctx_, 107, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* in-order, gap=0 */
+
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 3u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 5u)
+      << "Lost must be counted exactly once when pkt 6 arrived; the three "
+         "subsequent reorders must not inflate it, and pkt 7 must compute "
+         "gap from the high-water mark (6), not the last reordered idx";
+}

--- a/tests/unit/session/st20/slot_test.cpp
+++ b/tests/unit/session/st20/slot_test.cpp
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Slot management:
+ * slot allocation/reuse, frame-gone path, threshold bypass for past timestamps,
+ * incomplete-frame and frame-completion accounting.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St20RxSlotTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20/st20_rx_test_base.h"
+
+class St20RxSlotTest : public St20RxBaseTest {};
+
+/* Single port sends a complete 2-packet frame. Expects 1 frame received. */
+TEST_F(St20RxSlotTest, SinglePortFullFrame) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(frames_received(), 1);
+}
+
+/* Two consecutive frames occupy two separate slots. Both delivered. */
+TEST_F(St20RxSlotTest, TwoFramesTwoSlots) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed_full(2000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 2);
+  EXPECT_EQ(redundant(), 0u);
+}
+
+/* Three consecutive frames with 2 slots: slot 0 is reused for the third frame.
+ * Frame 1 must be complete before the slot is recycled. */
+TEST_F(St20RxSlotTest, SlotReuse) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed_full(2000, MTL_SESSION_PORT_P);
+  feed_full(3000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(redundant(), 0u);
+}
+
+/* After both slots hold newer timestamps, a packet with an older timestamp
+ * is rejected because no slot can accept it. */
+TEST_F(St20RxSlotTest, OldTimestampAfterSlotReuse) {
+  feed_full(2000, MTL_SESSION_PORT_P);
+  feed_full(3000, MTL_SESSION_PORT_P);
+
+  uint64_t recv_before = received();
+  feed(0, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), recv_before) << "Old-timestamp packet should be rejected";
+}
+
+/* Redundancy error threshold bypass for video. ST20 has two threshold paths:
+ *  (a) rv_slot_by_tmstamp: old ts rejected when all slots are newer
+ *  (b) frame-gone: exist_ts && !slot->frame → redundant_error_cnt++
+ * Path (b) increments the counter. After both ports exceed threshold=20,
+ * path (a) lets the old-timestamp packet allocate a new slot. */
+TEST_F(St20RxSlotTest, ThresholdBypassVideo) {
+  /* Fill both slots with completed frames */
+  feed_full(5000, MTL_SESSION_PORT_P);
+  feed_full(6000, MTL_SESSION_PORT_P);
+  EXPECT_EQ(frames_received(), 2);
+
+  uint64_t recv_before = received();
+
+  /* Send 21 old-timestamp packets for completed-frame timestamps.
+   * These hit path (b): exist_ts && !slot->frame, incrementing
+   * redundant_error_cnt on each port. */
+  for (int i = 0; i < 21; i++) {
+    feed_seq(0, 50000 + i, 5000, MTL_SESSION_PORT_P);
+    feed_seq(0, 60000 + i, 5000, MTL_SESSION_PORT_R);
+  }
+
+  /* Now send a truly old timestamp that hits path (a) in rv_slot_by_tmstamp.
+   * With threshold exceeded, it should be accepted (new slot allocated). */
+  feed_seq(0, 90000, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_GT(received(), recv_before)
+      << "After exceeding threshold on both ports, old-ts packet should be accepted";
+}
+
+/* Frame-gone path: complete a frame, then send same-ts packets.
+ * The slot exists (exist_ts=true) but frame is NULL → counted as redundant. */
+TEST_F(St20RxSlotTest, FrameGoneRedundant) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  EXPECT_EQ(frames_received(), 1);
+
+  uint64_t red_before = redundant();
+  feed(0, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_GT(redundant(), red_before)
+      << "Pkt for completed frame should be counted as redundant";
+}
+
+/* Incomplete frame evicted by slot reuse. Only pkt 0 of frame ts=1000
+ * is sent, then two full frames fill both slots. The third frame forces
+ * slot reuse, evicting the incomplete frame 1. */
+TEST_F(St20RxSlotTest, IncompleteFrameOnSlotReuse) {
+  /* partial frame 1 — only pkt 0 */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+
+  /* full frame 2 → fills slot 1 */
+  feed_full(2000, MTL_SESSION_PORT_P);
+
+  /* full frame 3 → forces slot 0 reuse, evicts incomplete frame 1 */
+  feed_full(3000, MTL_SESSION_PORT_P);
+
+  /* frame 1 was notified as incomplete (dropped), frames 2 & 3 complete */
+  EXPECT_EQ(frames_received(), 2) << "Only complete frames increment stat";
+  EXPECT_GE(frames_incomplete(), 1u) << "Incomplete frame should be counted";
+}
+
+/* After completing a frame the bitmap is reset. A new frame reusing the
+ * same slot must not get false duplicate rejections from a stale bitmap. */
+TEST_F(St20RxSlotTest, FrameCompletionResetsBitmap) {
+  /* Frame 1 and 2 fill both slots */
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed_full(2000, MTL_SESSION_PORT_P);
+
+  /* Frame 3 reuses slot 0 (previously held frame 1) */
+  feed_full(3000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(redundant(), 0u) << "No false duplicates from stale bitmap";
+}
+
+/* Frame-gone path must not double-count as received. After completing a
+ * frame, redundant packets for the same timestamp hit the frame-gone path
+ * and must be counted as redundant ONLY, not also as received.
+ * Invariant: received + redundant == total accepted packets. */
+TEST_F(St20RxSlotTest, FrameGoneNoDoubleCount) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(received(), 2u);
+
+  /* Send duplicates for the completed frame */
+  feed(0, 1000, MTL_SESSION_PORT_R);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+
+  /* Received must NOT increase — these are redundant */
+  EXPECT_EQ(received(), 2u) << "Frame-gone redundant packets must not increment received";
+  EXPECT_EQ(redundant(), 2u);
+  /* Invariant: received + redundant == total accepted packets */
+  EXPECT_EQ(received() + redundant(), 4u);
+}
+
+/* Multiple frames delivered in sequence with zero redundant. */
+TEST_F(St20RxSlotTest, MultipleFrameDelivery) {
+  for (uint32_t ts = 1000; ts < 1010; ts++) {
+    feed_full(ts, MTL_SESSION_PORT_P);
+  }
+
+  EXPECT_EQ(frames_received(), 10);
+  EXPECT_EQ(redundant(), 0u);
+}
+
+/* Slot allocation across the 32-bit RTP timestamp wrap boundary.
+ * Slot 0 holds ts near 0xFFFFFFF0, slot 1 holds ts near 0xFFFFFFFE.
+ * A new packet with ts wrapping to 0x00000010 must be ranked as
+ * "newer" by `mt_seq32_greater` and recycle the oldest slot, NOT be
+ * rejected as "timestamp in the past". */
+TEST_F(St20RxSlotTest, SlotTimestampWrapAroundAdvance) {
+  feed_full(0xFFFFFFF0, MTL_SESSION_PORT_P);
+  feed_full(0xFFFFFFFE, MTL_SESSION_PORT_P);
+
+  uint64_t recv_before = received();
+  int frames_before = frames_received();
+  feed_full(0x00000010, MTL_SESSION_PORT_P); /* wraps over UINT32_MAX */
+
+  EXPECT_EQ(received() - recv_before, 2u)
+      << "wrapped timestamp must allocate a new slot, not be dropped as past";
+  EXPECT_EQ(frames_received() - frames_before, 1) << "the wrapped frame must complete";
+}

--- a/tests/unit/session/st20/st20_rx_test_base.h
+++ b/tests/unit/session/st20/st20_rx_test_base.h
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Shared gtest fixture for the per-feature ST 2110-20 RX session tests
+ * under tests/unit/session/st20/.
+ *
+ * Each per-feature .cpp derives a thin subclass:
+ *
+ *   class St20RxSlotTest : public St20RxBaseTest {};
+ *
+ * so that --gtest_filter='St20RxSlotTest.*' selects only that feature's
+ * tests, while all setup/teardown and stat-accessor wrappers live here in
+ * one place.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "session/st20_harness.h"
+
+class St20RxBaseTest : public ::testing::Test {
+ protected:
+  ut20_test_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut20_init(), 0);
+    ctx_ = ut20_ctx_create(2);
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  void TearDown() override {
+    if (ctx_) ut20_ctx_destroy(ctx_);
+  }
+
+  /* convenience wrappers */
+  uint64_t received() {
+    return ut20_stat_received(ctx_);
+  }
+  uint64_t redundant() {
+    return ut20_stat_redundant(ctx_);
+  }
+  uint64_t ooo() {
+    return ut20_stat_lost_pkts(ctx_);
+  }
+  uint64_t port_reordered(enum mtl_session_port p) {
+    return ut20_stat_port_reordered(ctx_, p);
+  }
+  uint64_t port_lost(enum mtl_session_port p) {
+    return ut20_stat_port_lost(ctx_, p);
+  }
+  uint64_t port_pkts(enum mtl_session_port p) {
+    return ut20_stat_port_packets(ctx_, p);
+  }
+  uint64_t no_slot() {
+    return ut20_stat_no_slot(ctx_);
+  }
+  uint64_t idx_oo_bitmap() {
+    return ut20_stat_idx_oo_bitmap(ctx_);
+  }
+  uint64_t frames_incomplete() {
+    return ut20_stat_frames_incomplete(ctx_);
+  }
+  int frames_received() {
+    return ut20_frames_received(ctx_);
+  }
+  uint64_t wrong_pt() {
+    return ut20_stat_wrong_pt(ctx_);
+  }
+  uint64_t wrong_ssrc() {
+    return ut20_stat_wrong_ssrc(ctx_);
+  }
+  uint64_t wrong_interlace() {
+    return ut20_stat_wrong_interlace(ctx_);
+  }
+  uint64_t offset_dropped() {
+    return ut20_stat_offset_dropped(ctx_);
+  }
+
+  void feed(int pkt_idx, uint32_t ts, enum mtl_session_port port) {
+    ut20_feed_frame_pkt(ctx_, pkt_idx, ts, port);
+  }
+
+  void feed_seq(int pkt_idx, uint32_t seq, uint32_t ts, enum mtl_session_port port) {
+    ut20_feed_frame_pkt_seq(ctx_, pkt_idx, seq, ts, port);
+  }
+
+  void feed_full(uint32_t ts, enum mtl_session_port port) {
+    ut20_feed_full_frame(ctx_, ts, port);
+  }
+};

--- a/tests/unit/session/st20/stats_test.cpp
+++ b/tests/unit/session/st20/stats_test.cpp
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Per-port and session-wide stats invariants for ST 2110-20:
+ * per-port packet counters, lost-packets composition invariant, and the
+ * received/redundant accounting invariant under cross-port redundancy.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St20RxStatsTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20/st20_rx_test_base.h"
+
+class St20RxStatsTest : public St20RxBaseTest {};
+
+/* Per-port packet counters (port_user_stats.common.port[].packets) are
+ * bumped by the _handle_mbuf wrapper. Tests below feed via the wrapper
+ * to exercise that accounting path; the non-wrapper helpers in the base
+ * fixture skip the wrapper layer and are therefore not used here. */
+
+/* Bitmap-redundant arrivals on the secondary port still bump per-port
+ * counters: per-port stats represent wire-level RX, not the merged stream. */
+TEST_F(St20RxStatsTest, RedundantStillCountsPerPort) {
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_R);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(redundant(), 2u);
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_P), 2u);
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_R), 2u);
+}
+
+/* Each accepted packet is counted as EITHER received OR redundant — never
+ * both. Holds across redundancy, reorder, and frame-gone paths. */
+TEST_F(St20RxStatsTest, ReceivedPlusRedundantInvariant) {
+  /* frame 1: P delivers fully; R duplicates → all R pkts hit frame-gone */
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_R);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 1000, MTL_SESSION_PORT_R);
+  /* frame 2: clean P-only */
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 0, 2000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt_via_wrapper(ctx_, 1, 2000, MTL_SESSION_PORT_P);
+
+  /* total accepted into the session: 2 (P f1) + 2 (R f1 dup) + 2 (P f2) = 6 */
+  EXPECT_EQ(received() + redundant(), 6u)
+      << "every accepted packet must land in exactly one of {received, redundant}";
+  EXPECT_EQ(frames_received(), 2);
+}
+
+/* lost_packets invariant: stat_lost_packets equals the sum of per-port
+ * lost counters. Holds independently of which port the loss occurred on. */
+TEST_F(St20RxStatsTest, LostPacketsInvariant) {
+  /* feed 4-pkt frames (override default ppf via a forward gap) by sending
+   * pkt_idx 0,1 on each port for two distinct timestamps with a gap. */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(0, 2000, MTL_SESSION_PORT_R);
+  feed(1, 2000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(ooo(), port_lost(MTL_SESSION_PORT_P) + port_lost(MTL_SESSION_PORT_R))
+      << "stat_lost_packets must equal the sum of per-port lost_packets";
+}

--- a/tests/unit/session/st20_harness.c
+++ b/tests/unit/session/st20_harness.c
@@ -1,0 +1,383 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C harness for ST20 (video) RX redundancy unit tests (session layer).
+ *
+ * Test geometry: 16x2 progressive YUV422-10bit
+ *   pgroup   = { size=5, coverage=2 }
+ *   linesize = 16 / 2 * 5 = 40 bytes
+ *   frame_size = fb_size = 40 * 2 = 80 bytes
+ *   payload_per_pkt = 40 bytes (exactly one line)
+ *   total_pkts_per_frame = 2
+ *   bitmap_size = 1 byte (manually set; integer division would give 0)
+ */
+
+#include <rte_atomic.h>
+#include <stdlib.h>
+#include <string.h>
+
+#undef MTL_HAS_USDT
+#include "common/ut_common.h"
+#include "st2110/st_rx_video_session.c"
+
+/* ── geometry constants ───────────────────────────────────────────────── */
+
+#define UT20_WIDTH 16
+#define UT20_HEIGHT 2
+#define UT20_LINESIZE 40   /* 16/2 * 5 */
+#define UT20_FRAME_SIZE 80 /* UT20_LINESIZE * UT20_HEIGHT */
+#define UT20_PAYLOAD_PER_PKT UT20_LINESIZE
+#define UT20_PKTS_PER_FRAME 2
+#define UT20_BITMAP_SIZE 1 /* 8 bits >= UT20_PKTS_PER_FRAME */
+
+#define UT20_FRAME_COUNT 2
+
+/* ── opaque context ───────────────────────────────────────────────────── */
+
+struct ut20_test_ctx {
+  struct mtl_main_impl impl;
+  struct st_rx_video_sessions_mgr mgr;
+  struct st_rx_video_session_impl session;
+
+  struct st_frame_trans frames[UT20_FRAME_COUNT];
+  uint8_t frame_storage[UT20_FRAME_COUNT][UT20_FRAME_SIZE];
+  uint8_t bitmaps[ST_VIDEO_RX_REC_NUM_OFO][UT20_BITMAP_SIZE];
+};
+
+#include "session/st20_harness.h"
+
+/* ── PTP time stub ────────────────────────────────────────────────────── */
+
+static uint64_t ut20_ptp_time(struct mtl_main_impl* impl, enum mtl_port port) {
+  (void)port;
+  impl->ptp_usync += 1000;
+  return impl->ptp_usync;
+}
+
+/* ── frame-ready callback ─────────────────────────────────────────────── */
+
+static int ut20_notify_frame_ready(void* priv, void* frame,
+                                   struct st20_rx_frame_meta* meta) {
+  (void)meta;
+  struct st_rx_video_session_impl* s = priv;
+  if (!s || !frame) return 0;
+
+  for (int i = 0; i < s->st20_frames_cnt; i++) {
+    if (!s->st20_frames) break;
+    if (s->st20_frames[i].addr == frame) {
+      rte_atomic32_dec(&s->st20_frames[i].refcnt);
+      break;
+    }
+  }
+  return 0;
+}
+
+/* ── init (delegates to common) ───────────────────────────────────────── */
+
+int ut20_init(void) {
+  return ut_eal_init();
+}
+
+/* ── context create / destroy ─────────────────────────────────────────── */
+
+ut20_test_ctx* ut20_ctx_create(int num_port) {
+  ut20_test_ctx* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx) return NULL;
+
+  ctx->impl.type = MT_HANDLE_MAIN;
+  ctx->impl.tsc_hz = rte_get_tsc_hz();
+  ctx->impl.ptp_usync = 1000000;
+  ctx->impl.ptp_usync_tsc = rte_get_tsc_cycles();
+  for (int i = 0; i < MTL_PORT_MAX; i++) {
+    ctx->impl.inf[i].parent = &ctx->impl;
+    ctx->impl.inf[i].port = i;
+    ctx->impl.inf[i].ptp_get_time_fn = ut20_ptp_time;
+  }
+
+  ctx->mgr.parent = &ctx->impl;
+  ctx->mgr.idx = 0;
+
+  for (int i = 0; i < UT20_FRAME_COUNT; i++) {
+    memset(&ctx->frames[i], 0, sizeof(ctx->frames[i]));
+    ctx->frames[i].idx = i;
+    ctx->frames[i].addr = ctx->frame_storage[i];
+    rte_atomic32_set(&ctx->frames[i].refcnt, 0);
+  }
+
+  struct st_rx_video_session_impl* s = &ctx->session;
+  s->impl = &ctx->impl;
+  s->parent = &ctx->mgr;
+  s->idx = 0;
+  s->socket_id = rte_socket_id();
+  s->attached = true;
+
+  s->ops.type = ST20_TYPE_FRAME_LEVEL;
+  s->ops.num_port = num_port;
+  s->ops.width = UT20_WIDTH;
+  s->ops.height = UT20_HEIGHT;
+  s->ops.fps = ST_FPS_P30;
+  s->ops.fmt = ST20_FMT_YUV_422_10BIT;
+  s->ops.interlaced = false;
+  s->ops.payload_type = 0;
+  s->ops.ssrc = 0;
+  s->ops.framebuff_cnt = UT20_FRAME_COUNT;
+  s->ops.notify_frame_ready = ut20_notify_frame_ready;
+  s->ops.priv = s;
+  s->ops.name = "ut20_test";
+
+  s->st20_pg.fmt = ST20_FMT_YUV_422_10BIT;
+  s->st20_pg.size = 5;
+  s->st20_pg.coverage = 2;
+  s->st20_pg.name = "YUV422P10LE";
+
+  s->st20_linesize = UT20_LINESIZE;
+  s->st20_bytes_in_line = UT20_LINESIZE;
+  s->st20_frame_size = UT20_FRAME_SIZE;
+  s->st20_fb_size = UT20_FRAME_SIZE;
+  s->st20_frame_bitmap_size = UT20_BITMAP_SIZE;
+  s->st20_uframe_size = 0;
+
+  s->st20_frames = ctx->frames;
+  s->st20_frames_cnt = UT20_FRAME_COUNT;
+
+  s->frame_time = 33333333.0;
+  s->frame_time_sampling = 3003.0;
+
+  s->slot_max = (num_port > 1) ? 2 : 1;
+  for (int i = 0; i < ST_VIDEO_RX_REC_NUM_OFO; i++) {
+    s->slots[i].frame_bitmap = ctx->bitmaps[i];
+    s->slots[i].idx = i;
+  }
+
+  s->dma_dev = NULL;
+  s->enable_timing_parser = false;
+  s->st22_info = NULL;
+  s->pkt_handler = rv_handle_frame_pkt;
+
+  s->port_maps[MTL_SESSION_PORT_P] = MTL_PORT_P;
+  s->port_maps[MTL_SESSION_PORT_R] = MTL_PORT_R;
+
+  for (int i = 0; i < MTL_SESSION_PORT_MAX; i++) {
+    s->priv[i].session = s;
+    s->priv[i].impl = &ctx->impl;
+    s->priv[i].s_port = (enum mtl_session_port)i;
+  }
+
+  rv_session_reset(s, true);
+  return ctx;
+}
+
+void ut20_ctx_destroy(ut20_test_ctx* ctx) {
+  free(ctx);
+}
+
+/* ── mbuf builder ─────────────────────────────────────────────────────── */
+
+static struct rte_mbuf* make_video_mbuf_full(uint32_t seq, uint32_t ts, uint16_t line_num,
+                                             uint16_t line_offset, uint16_t line_length,
+                                             uint8_t pt, uint32_t ssrc) {
+  struct rte_mbuf* m = rte_pktmbuf_alloc(ut_pool());
+  if (!m) return NULL;
+
+  size_t total = sizeof(struct st_rfc4175_video_hdr) + line_length;
+
+  if (rte_pktmbuf_tailroom(m) < total) {
+    rte_pktmbuf_free(m);
+    return NULL;
+  }
+
+  uint8_t* buf = rte_pktmbuf_mtod(m, uint8_t*);
+  memset(buf, 0, total);
+
+  size_t hdr_offset =
+      sizeof(struct st_rfc4175_video_hdr) - sizeof(struct st20_rfc4175_rtp_hdr);
+  struct st20_rfc4175_rtp_hdr* rtp = (struct st20_rfc4175_rtp_hdr*)(buf + hdr_offset);
+
+  rtp->base.version = 2;
+  rtp->base.payload_type = pt;
+  rtp->base.ssrc = htonl(ssrc);
+  rtp->base.marker = 0;
+  rtp->base.seq_number = htons((uint16_t)(seq & 0xFFFF));
+  rtp->base.tmstamp = htonl(ts);
+  rtp->seq_number_ext = htons((uint16_t)(seq >> 16));
+  rtp->row_number = htons(line_num);
+  rtp->row_offset = htons(line_offset);
+  rtp->row_length = htons(line_length);
+
+  m->data_len = total;
+  m->pkt_len = total;
+  m->next = NULL;
+  return m;
+}
+
+static struct rte_mbuf* make_video_mbuf(uint32_t seq, uint32_t ts, uint16_t line_num,
+                                        uint16_t line_offset, uint16_t line_length) {
+  return make_video_mbuf_full(seq, ts, line_num, line_offset, line_length, 0, 0);
+}
+
+/* ── pkt_idx → line/offset mapping ────────────────────────────────────── */
+
+static void pkt_idx_to_line(int pkt_idx, uint16_t* line_num, uint16_t* line_offset,
+                            uint16_t* line_length) {
+  *line_num = (uint16_t)pkt_idx;
+  *line_offset = 0;
+  *line_length = UT20_PAYLOAD_PER_PKT;
+}
+
+/* ── feed functions ───────────────────────────────────────────────────── */
+
+int ut20_feed_pkt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
+                  uint16_t line_offset, uint16_t line_length,
+                  enum mtl_session_port port) {
+  struct rte_mbuf* m = make_video_mbuf(seq, ts, line_num, line_offset, line_length);
+  if (!m) return -1;
+  int rc = rv_handle_frame_pkt(&ctx->session, m, port, true);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut20_feed_frame_pkt(ut20_test_ctx* ctx, int pkt_idx, uint32_t ts,
+                        enum mtl_session_port port) {
+  uint32_t seq = ts * UT20_PKTS_PER_FRAME + (uint32_t)pkt_idx;
+  uint16_t ln, lo, ll;
+  pkt_idx_to_line(pkt_idx, &ln, &lo, &ll);
+  return ut20_feed_pkt(ctx, seq, ts, ln, lo, ll, port);
+}
+
+int ut20_feed_frame_pkt_seq(ut20_test_ctx* ctx, int pkt_idx, uint32_t seq, uint32_t ts,
+                            enum mtl_session_port port) {
+  uint16_t ln, lo, ll;
+  pkt_idx_to_line(pkt_idx, &ln, &lo, &ll);
+  return ut20_feed_pkt(ctx, seq, ts, ln, lo, ll, port);
+}
+
+void ut20_feed_full_frame(ut20_test_ctx* ctx, uint32_t ts, enum mtl_session_port port) {
+  for (int i = 0; i < UT20_PKTS_PER_FRAME; i++) {
+    ut20_feed_frame_pkt(ctx, i, ts, port);
+  }
+}
+
+int ut20_feed_pkt_pt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
+                     uint16_t line_offset, uint16_t line_length,
+                     enum mtl_session_port port, uint8_t pt) {
+  struct rte_mbuf* m =
+      make_video_mbuf_full(seq, ts, line_num, line_offset, line_length, pt, 0);
+  if (!m) return -1;
+  int rc = rv_handle_frame_pkt(&ctx->session, m, port, true);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut20_feed_pkt_ssrc(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
+                       uint16_t line_offset, uint16_t line_length,
+                       enum mtl_session_port port, uint32_t ssrc) {
+  struct rte_mbuf* m =
+      make_video_mbuf_full(seq, ts, line_num, line_offset, line_length, 0, ssrc);
+  if (!m) return -1;
+  int rc = rv_handle_frame_pkt(&ctx->session, m, port, true);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut20_feed_pkt_via_wrapper(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts,
+                              uint16_t line_num, uint16_t line_offset,
+                              uint16_t line_length, enum mtl_session_port port,
+                              uint8_t pt, uint32_t ssrc) {
+  struct rte_mbuf* m =
+      make_video_mbuf_full(seq, ts, line_num, line_offset, line_length, pt, ssrc);
+  if (!m) return -1;
+  struct rte_mbuf* mbufs[1] = {m};
+  int rc = rv_handle_mbuf(&ctx->session.priv[port], mbufs, 1);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut20_feed_frame_pkt_via_wrapper(ut20_test_ctx* ctx, int pkt_idx, uint32_t ts,
+                                    enum mtl_session_port port) {
+  uint32_t seq = ts * UT20_PKTS_PER_FRAME + (uint32_t)pkt_idx;
+  uint16_t ln, lo, ll;
+  pkt_idx_to_line(pkt_idx, &ln, &lo, &ll);
+  return ut20_feed_pkt_via_wrapper(ctx, seq, ts, ln, lo, ll, port,
+                                   ctx->session.ops.payload_type, ctx->session.ops.ssrc);
+}
+
+/* ── config setters ───────────────────────────────────────────────────── */
+
+void ut20_ctx_set_pt(ut20_test_ctx* ctx, uint8_t pt) {
+  ctx->session.ops.payload_type = pt;
+}
+
+void ut20_ctx_set_ssrc(ut20_test_ctx* ctx, uint32_t ssrc) {
+  ctx->session.ops.ssrc = ssrc;
+}
+
+/* ── stat accessors ───────────────────────────────────────────────────── */
+
+uint64_t ut20_stat_received(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_received;
+}
+
+uint64_t ut20_stat_redundant(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_redundant;
+}
+
+uint64_t ut20_stat_lost_pkts(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_lost_packets;
+}
+
+uint64_t ut20_stat_port_reordered(const ut20_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].reordered_packets;
+}
+
+uint64_t ut20_stat_port_lost(const ut20_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].lost_packets;
+}
+
+uint64_t ut20_stat_no_slot(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_no_slot;
+}
+
+uint64_t ut20_stat_idx_oo_bitmap(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_idx_oo_bitmap;
+}
+
+uint64_t ut20_stat_frames_incomplete(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_frames_incomplete;
+}
+
+int ut20_frames_received(const ut20_test_ctx* ctx) {
+  return rte_atomic32_read(&ctx->session.stat_frames_received);
+}
+
+int ut20_total_frame_pkts(void) {
+  return UT20_PKTS_PER_FRAME;
+}
+
+uint64_t ut20_stat_wrong_pt(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_wrong_pt_dropped;
+}
+
+uint64_t ut20_stat_wrong_ssrc(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_wrong_ssrc_dropped;
+}
+
+uint64_t ut20_stat_wrong_interlace(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_wrong_interlace_dropped;
+}
+
+uint64_t ut20_stat_offset_dropped(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_offset_dropped;
+}
+
+uint64_t ut20_stat_wrong_len(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_wrong_len_dropped;
+}
+
+uint64_t ut20_stat_port_err_packets(const ut20_test_ctx* ctx,
+                                    enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].err_packets;
+}
+
+uint64_t ut20_stat_port_packets(const ut20_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].packets;
+}

--- a/tests/unit/session/st20_harness.h
+++ b/tests/unit/session/st20_harness.h
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C harness API for the ST 2110-20 (video) RX session unit tests.
+ *
+ * The harness wraps a single `st_rx_video_session_impl` configured for a
+ * tiny synthetic geometry (16x2 YUV422-10bit, 2 packets per frame). All
+ * MTL internal types are kept opaque so the C++ test layer never includes
+ * libmtl headers.
+ *
+ * Two feeder families are exposed:
+ *
+ *   ut20_feed_*                — call the per-packet handler directly.
+ *                                Use to assert on filter/state behaviour.
+ *   ut20_feed_*_via_wrapper    — call the public `_handle_mbuf` wrapper
+ *                                the production tasklet uses. Use whenever
+ *                                the test asserts on per-port `err_packets`
+ *                                or `packets` accounting.
+ */
+
+#ifndef _ST20_SESSION_HARNESS_H_
+#define _ST20_SESSION_HARNESS_H_
+
+#include <stdint.h>
+
+#include "mtl_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ut20_test_ctx ut20_test_ctx;
+
+/* Initialise the shared DPDK EAL and mempool. Idempotent — safe to call
+ * once per gtest fixture SetUp(). Returns 0 on success, < 0 on failure. */
+int ut20_init(void);
+
+/* Create a context with `num_port` enabled (1 = single-port, 2 = redundant).
+ * Caller owns the returned pointer and must free it with ut20_ctx_destroy().
+ * Returns NULL on allocation failure. */
+ut20_test_ctx* ut20_ctx_create(int num_port);
+void ut20_ctx_destroy(ut20_test_ctx* ctx);
+
+/* Build and feed one RFC 4175 video packet directly to the per-packet
+ * handler. `seq` is the RTP sequence number, `ts` the RTP timestamp,
+ * `line_num/line_offset/line_length` describe the row covered.
+ * Returns the production handler's return code (0 = accepted, < 0 = error
+ * reason; see `rv_handle_frame_pkt`). */
+int ut20_feed_pkt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
+                  uint16_t line_offset, uint16_t line_length, enum mtl_session_port port);
+
+/* Convenience: feed packet `pkt_idx` (0 .. UT20_PKTS_PER_FRAME-1) of a
+ * frame at timestamp `ts`. Auto-derives line_num/offset/length and uses
+ * `pkt_idx` as the RTP sequence number (no per-port sequence tracking). */
+int ut20_feed_frame_pkt(ut20_test_ctx* ctx, int pkt_idx, uint32_t ts,
+                        enum mtl_session_port port);
+
+/* Same as ut20_feed_frame_pkt() but with an explicit RTP sequence number,
+ * for tests that need to drive seq independently of pkt_idx (e.g. wrap or
+ * threshold tests). */
+int ut20_feed_frame_pkt_seq(ut20_test_ctx* ctx, int pkt_idx, uint32_t seq, uint32_t ts,
+                            enum mtl_session_port port);
+
+/* Feed every packet of one full frame on `port`, in pkt_idx order. */
+void ut20_feed_full_frame(ut20_test_ctx* ctx, uint32_t ts, enum mtl_session_port port);
+
+/* Feed one packet with an overridden RTP payload type (`pt`) — for negative
+ * tests that assert PT validation. All other fields as ut20_feed_pkt(). */
+int ut20_feed_pkt_pt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
+                     uint16_t line_offset, uint16_t line_length,
+                     enum mtl_session_port port, uint8_t pt);
+
+/* Feed one packet with an overridden RTP SSRC — for SSRC-validation tests. */
+int ut20_feed_pkt_ssrc(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
+                       uint16_t line_offset, uint16_t line_length,
+                       enum mtl_session_port port, uint32_t ssrc);
+
+/* Configure the session's expected RTP payload type / SSRC. Call after
+ * ut20_ctx_create() and before feeding any packet. */
+void ut20_ctx_set_pt(ut20_test_ctx* ctx, uint8_t pt);
+void ut20_ctx_set_ssrc(ut20_test_ctx* ctx, uint32_t ssrc);
+
+/* Wrapper feeders — drive the production `_handle_mbuf` wrapper instead
+ * of the per-packet handler. Use these (not the direct feeders above)
+ * whenever the test asserts on per-port `err_packets` or per-port
+ * `packets`, since those counters live in the wrapper and not the
+ * per-packet handler.
+ * `pt`/`ssrc` are sent on the wire (use the session-configured values
+ * to test the happy path; pass mismatched values to test error paths). */
+int ut20_feed_pkt_via_wrapper(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts,
+                              uint16_t line_num, uint16_t line_offset,
+                              uint16_t line_length, enum mtl_session_port port,
+                              uint8_t pt, uint32_t ssrc);
+int ut20_feed_frame_pkt_via_wrapper(ut20_test_ctx* ctx, int pkt_idx, uint32_t ts,
+                                    enum mtl_session_port port);
+
+/* Per-port counter accessors (live inside `port_user_stats.common.port[]`). */
+uint64_t ut20_stat_port_err_packets(const ut20_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut20_stat_port_packets(const ut20_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut20_stat_port_reordered(const ut20_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut20_stat_port_lost(const ut20_test_ctx* ctx, enum mtl_session_port port);
+
+/* Session-wide counters. */
+uint64_t ut20_stat_received(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_redundant(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_lost_pkts(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_no_slot(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_idx_oo_bitmap(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_frames_incomplete(const ut20_test_ctx* ctx);
+
+/* Number of frames the production handler has marked completed/delivered
+ * since session reset. Returns the live value of `stat_frames_received`. */
+int ut20_frames_received(const ut20_test_ctx* ctx);
+
+/* Per-reason drop counters (each rejection bumps exactly one of these). */
+uint64_t ut20_stat_wrong_pt(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_wrong_ssrc(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_wrong_interlace(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_offset_dropped(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_wrong_len(const ut20_test_ctx* ctx);
+
+/* Fixed geometry constant: number of packets that make up one full frame
+ * in the harness's synthetic 16x2 YUV422-10bit configuration. Tests use it
+ * to derive expected counts without hard-coding the value. */
+int ut20_total_frame_pkts(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST20_SESSION_HARNESS_H_ */

--- a/tests/unit/session/st30/err_packets_test.cpp
+++ b/tests/unit/session/st30/err_packets_test.cpp
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Tests for the per-port `err_packets` counter on the ST 2110-30 RX session.
+ * The `_handle_mbuf` wrapper increments
+ * `port_user_stats.common.port[s_port].err_packets` whenever the per-packet
+ * handler returns < 0.
+ *
+ * Test goals:
+ *   1. Every genuine error path (wrong PT, wrong SSRC, wrong length) MUST
+ *      increment err_packets and the corresponding per-reason counter,
+ *      exactly once each.
+ *   2. err_packets MUST equal the sum of per-reason drop counters.
+ *   3. Successful packets MUST NOT increment err_packets.
+ *   4. Redundancy-filtered packets (legitimate duplicates) MUST NOT
+ *      count as errors.
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st30_harness.h"
+
+class St30RxErrPacketsTest : public ::testing::Test {
+ protected:
+  ut30_test_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut30_init(), 0);
+    ctx_ = ut30_ctx_create(2);
+    ASSERT_NE(ctx_, nullptr);
+    ut30_ctx_set_pt(ctx_, 97);
+    ut30_ctx_set_ssrc(ctx_, 0xCAFE);
+  }
+  void TearDown() override {
+    if (ctx_) ut30_ctx_destroy(ctx_);
+  }
+
+  uint64_t err_p() {
+    return ut30_stat_port_err_packets(ctx_, MTL_SESSION_PORT_P);
+  }
+  uint64_t err_r() {
+    return ut30_stat_port_err_packets(ctx_, MTL_SESSION_PORT_R);
+  }
+  uint64_t pkts_p() {
+    return ut30_stat_port_pkts(ctx_, MTL_SESSION_PORT_P);
+  }
+  uint64_t pkts_r() {
+    return ut30_stat_port_pkts(ctx_, MTL_SESSION_PORT_R);
+  }
+  /* defaults: pt=97, ssrc=0xCAFE, payload_len=192 */
+  void feed_good(uint16_t seq, uint32_t ts, mtl_session_port port) {
+    ut30_feed_pkt_via_wrapper(ctx_, seq, ts, port, 97, 0xCAFE, 192);
+  }
+};
+
+TEST_F(St30RxErrPacketsTest, GoodPacketsNotCountedAsErr) {
+  feed_good(0, 1000, MTL_SESSION_PORT_P);
+  feed_good(1, 1001, MTL_SESSION_PORT_P);
+  EXPECT_EQ(err_p(), 0u);
+  EXPECT_EQ(pkts_p(), 2u);
+}
+
+TEST_F(St30RxErrPacketsTest, WrongPtCountedAsErr) {
+  ut30_feed_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P, /*pt=*/200, 0xCAFE, 192);
+  EXPECT_EQ(ut30_stat_wrong_pt(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 0u);
+}
+
+TEST_F(St30RxErrPacketsTest, WrongSsrcCountedAsErr) {
+  ut30_feed_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P, 97, /*ssrc=*/0xBAD, 192);
+  EXPECT_EQ(ut30_stat_wrong_ssrc(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 0u);
+}
+
+TEST_F(St30RxErrPacketsTest, WrongPayloadLenCountedAsErr) {
+  ut30_feed_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P, 97, 0xCAFE,
+                            /*payload_len=*/100);
+  EXPECT_EQ(ut30_stat_len_mismatch(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 0u);
+}
+
+TEST_F(St30RxErrPacketsTest, ErrPacketsEqualsSumOfReasons) {
+  /* mix three distinct error kinds */
+  ut30_feed_pkt_via_wrapper(ctx_, 0, 1000, MTL_SESSION_PORT_P, /*pt=*/200, 0xCAFE, 192);
+  ut30_feed_pkt_via_wrapper(ctx_, 1, 1001, MTL_SESSION_PORT_P, 97, /*ssrc=*/0xBAD, 192);
+  ut30_feed_pkt_via_wrapper(ctx_, 2, 1002, MTL_SESSION_PORT_P, 97, 0xCAFE,
+                            /*len=*/100);
+
+  uint64_t reasons = ut30_stat_wrong_pt(ctx_) + ut30_stat_wrong_ssrc(ctx_) +
+                     ut30_stat_len_mismatch(ctx_);
+  EXPECT_EQ(reasons, 3u);
+  EXPECT_EQ(err_p(), reasons)
+      << "every err_packets bump must be explainable by a per-reason counter";
+}
+
+/* Mixed burst: only the bad packet bumps err_packets. */
+TEST_F(St30RxErrPacketsTest, MixedBurstOnlyBadCounted) {
+  feed_good(0, 1000, MTL_SESSION_PORT_P);
+  ut30_feed_pkt_via_wrapper(ctx_, 1, 1001, MTL_SESSION_PORT_P, /*pt=*/200, 0xCAFE, 192);
+  feed_good(2, 1002, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 2u);
+}
+
+/* Redundancy-filtered packets must not inflate err_packets. */
+TEST_F(St30RxErrPacketsTest, RedundancyFilterDoesNotBumpErrCounter) {
+  /* P delivers the frame first */
+  feed_good(0, 1000, MTL_SESSION_PORT_P);
+  feed_good(1, 1001, MTL_SESSION_PORT_P);
+  /* R sends the same packets a beat later -- legitimate redundancy. */
+  feed_good(0, 1000, MTL_SESSION_PORT_R);
+  feed_good(1, 1001, MTL_SESSION_PORT_R);
+
+  /* Sanity: the redundancy filter classified them. */
+  EXPECT_EQ(ut30_stat_redundant(ctx_), 2u);
+  /* Redundant packets must NOT be counted as port-level errors. */
+  EXPECT_EQ(err_r(), 0u) << "redundant-filtered packets must not be classified as errors";
+}
+
+/* A healthy redundant stream must have zero unexplained err_packets. */
+TEST_F(St30RxErrPacketsTest, HealthyRedundantStreamHasZeroUnexplainedErrors) {
+  for (int i = 0; i < 5; i++) {
+    feed_good(i, 1000 + i, MTL_SESSION_PORT_P);
+    feed_good(i, 1000 + i, MTL_SESSION_PORT_R);
+  }
+  uint64_t reasons = ut30_stat_wrong_pt(ctx_) + ut30_stat_wrong_ssrc(ctx_) +
+                     ut30_stat_len_mismatch(ctx_);
+  EXPECT_EQ(reasons, 0u) << "no real error reasons in a healthy stream";
+  EXPECT_EQ(err_r(), 0u)
+      << "redundant-port err_packets must be zero when there are no real errors";
+  EXPECT_EQ(err_p(), 0u);
+}
+
+/* Per stats_guide.md: a redundant packet lands in port[].packets (pre-redundancy)
+ * and stat_pkts_redundant, but NOT in err_packets. */
+TEST_F(St30RxErrPacketsTest, RedundantPacketCountedExactlyOnce) {
+  /* prime session timestamp on P */
+  feed_good(0, 2000, MTL_SESSION_PORT_P);
+  /* one redundant packet on R (old timestamp gets filtered) */
+  feed_good(99, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(ut30_stat_redundant(ctx_), 1u) << "the R packet must be filtered";
+  EXPECT_EQ(pkts_r(), 1u) << "redundant packet counts in pre-redundancy port[].packets";
+  EXPECT_EQ(err_r(), 0u) << "redundant packet must not be counted as error";
+  EXPECT_EQ(pkts_r() + err_r(), 1u) << "counted exactly once, not double-counted as err";
+}

--- a/tests/unit/session/st30/header_validation_test.cpp
+++ b/tests/unit/session/st30/header_validation_test.cpp
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * RFC 3550 header validation:
+ * payload type, SSRC and packet length checks; ReturnValue* contract for the
+ * underlying packet handler.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St30RxHeaderValidationTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st30/st30_rx_test_base.h"
+
+class St30RxHeaderValidationTest : public St30RxBaseTest {};
+
+/* Accepted packet must return 0. */
+TEST_F(St30RxHeaderValidationTest, ReturnValueAccepted) {
+  int rc = feed(0, 1000, MTL_SESSION_PORT_P);
+  EXPECT_EQ(rc, 0);
+}
+
+/* Wrong payload type must return -EINVAL. */
+TEST_F(St30RxHeaderValidationTest, ReturnValueWrongPT) {
+  ut30_ctx_set_pt(ctx_, 96);
+  int rc = ut30_feed_pkt_pt(ctx_, 0, 1000, MTL_SESSION_PORT_P, 97);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* Wrong SSRC must return -EINVAL. */
+TEST_F(St30RxHeaderValidationTest, ReturnValueWrongSSRC) {
+  ut30_ctx_set_ssrc(ctx_, 1234);
+  int rc = ut30_feed_pkt_ssrc(ctx_, 0, 1000, MTL_SESSION_PORT_P, 5678);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* Wrong payload length must return -EINVAL. */
+TEST_F(St30RxHeaderValidationTest, ReturnValueWrongLen) {
+  int rc = ut30_feed_pkt_len(ctx_, 0, 1000, MTL_SESSION_PORT_P, 100);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* Wrong PT packets are dropped and counted in wrong_pt stat. */
+TEST_F(St30RxHeaderValidationTest, WrongPayloadTypeDropped) {
+  ut30_ctx_set_pt(ctx_, 96);
+  for (int i = 0; i < 5; i++) ut30_feed_pkt_pt(ctx_, i, 1000 + i, MTL_SESSION_PORT_P, 97);
+
+  EXPECT_EQ(wrong_pt(), 5u);
+  EXPECT_EQ(received(), 0u);
+}
+
+/* Wrong SSRC packets are dropped and counted in wrong_ssrc stat. */
+TEST_F(St30RxHeaderValidationTest, WrongSSRCDropped) {
+  ut30_ctx_set_ssrc(ctx_, 0xDEAD);
+  for (int i = 0; i < 3; i++)
+    ut30_feed_pkt_ssrc(ctx_, i, 1000 + i, MTL_SESSION_PORT_P, 0xBEEF);
+
+  EXPECT_EQ(wrong_ssrc(), 3u);
+  EXPECT_EQ(received(), 0u);
+}
+
+/* Wrong payload length packets are dropped and counted in len_mismatch stat. */
+TEST_F(St30RxHeaderValidationTest, WrongPacketLenDropped) {
+  ut30_feed_pkt_len(ctx_, 0, 1000, MTL_SESSION_PORT_P, 50);
+  ut30_feed_pkt_len(ctx_, 1, 1001, MTL_SESSION_PORT_P, 300);
+
+  EXPECT_EQ(len_mismatch(), 2u);
+  EXPECT_EQ(received(), 0u);
+}

--- a/tests/unit/session/st30/redundancy_test.cpp
+++ b/tests/unit/session/st30/redundancy_test.cpp
@@ -1,0 +1,146 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Timestamp-only redundancy filter:
+ * normal redundancy, single-port baseline, same-vs-new timestamp acceptance,
+ * burst switchover, threshold bypass and same-port duplicates.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St30RxRedundancyTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st30/st30_rx_test_base.h"
+
+class St30RxRedundancyTest : public St30RxBaseTest {};
+
+/* Same packets on both ports. ST30 filters by timestamp: R's packets
+ * have timestamps not strictly greater than P's, so all are filtered.
+ * feed_burst auto-increments ts per packet (real ST30 behavior). */
+TEST_F(St30RxRedundancyTest, NormalRedundancy) {
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_P);
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_R);
+
+  feed_burst(4, 4, 2000, MTL_SESSION_PORT_P);
+  feed_burst(4, 4, 2000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 8u);
+  EXPECT_EQ(received(), 8u);
+}
+
+/* Timestamp-only filter: R's packets are filtered even with higher seq_ids,
+ * because their timestamps are not strictly greater than P's latest.
+ * This is the key ST30 difference from ST40 (which checks both ts and seq). */
+TEST_F(St30RxRedundancyTest, TimestampOnlyFilter) {
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_P);
+
+  /* port 1 has HIGHER seq_ids but same/old timestamps → filtered */
+  for (int i = 0; i < 4; i++) {
+    int rc = feed(4 + i, 1000 + i, MTL_SESSION_PORT_R);
+    EXPECT_LT(rc, 0) << "seq " << (4 + i)
+                     << " should be filtered (ts not greater, ST30 ignores seq)";
+  }
+
+  EXPECT_EQ(redundant(), 4u);
+  EXPECT_EQ(received(), 4u);
+}
+
+/* New timestamp always accepted even if seq goes backward.
+ * R has lower seq_ids but strictly newer timestamps, so packets are accepted.
+ * A source switch with new timestamps must not produce phantom unrecovered. */
+TEST_F(St30RxRedundancyTest, NewTimestampAlwaysAccepted) {
+  feed_burst(10, 4, 2000, MTL_SESSION_PORT_P);
+  feed_burst(0, 4, 3000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(received(), 8u);
+  /* Session seq after P = 13. R brings seq 0. The seq gap wraps to 65522
+   * via uint16_t arithmetic. This is phantom loss from source switch,
+   * not real packet loss. */
+  EXPECT_EQ(unrecovered(), 0u)
+      << "Source switch with new timestamp should not produce phantom unrecovered";
+}
+
+/* Same timestamp, different seq on second port. Even though R has a
+ * higher seq_id, it is filtered because the timestamp is not strictly
+ * greater. */
+TEST_F(St30RxRedundancyTest, SameTimestampDiffSeqFiltered) {
+  feed(5, 1000, MTL_SESSION_PORT_P);
+
+  int rc = feed(6, 1000, MTL_SESSION_PORT_R);
+  EXPECT_LT(rc, 0) << "Same timestamp should be filtered even with newer seq";
+  EXPECT_EQ(redundant(), 1u);
+}
+
+/* Burst switchover for audio: R has newer timestamps and is processed
+ * first, then P arrives with old timestamps. P's late arrivals have
+ * stale timestamps and must be filtered. */
+TEST_F(St30RxRedundancyTest, BurstSwitchoverAudio) {
+  /* establish history */
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_P);
+
+  /* port 1 arrives first with NEW timestamps */
+  feed_burst(6, 4, 2000, MTL_SESSION_PORT_R);
+
+  /* port 0 late arrivals with OLD timestamps */
+  feed(4, 1004, MTL_SESSION_PORT_P);
+  feed(5, 1005, MTL_SESSION_PORT_P);
+
+  /* both late packets should be filtered (old timestamp < 2003) */
+  EXPECT_EQ(redundant(), 2u);
+  /* the 4 packets from port 1 advance seq from 3 to 6 — gap of 2 */
+  EXPECT_EQ(unrecovered(), 2u);
+}
+
+/* Multiple packets with the same timestamp on the same port. Only the
+ * first packet per timestamp is accepted; subsequent ones are filtered. */
+TEST_F(St30RxRedundancyTest, SameTimestampFiltered) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  /* same ts again — filtered */
+  int rc = feed(1, 1000, MTL_SESSION_PORT_P);
+  EXPECT_LT(rc, 0) << "Same timestamp should be filtered";
+  /* a third one too */
+  rc = feed(5, 1000, MTL_SESSION_PORT_P);
+  EXPECT_LT(rc, 0) << "Same timestamp should be filtered";
+  EXPECT_EQ(redundant(), 2u);
+  EXPECT_EQ(received(), 1u);
+}
+
+/* Redundancy error threshold bypass: 21 old-timestamp packets on both
+ * ports should force-accept once both exceed threshold=20. */
+TEST_F(St30RxRedundancyTest, ThresholdBypass) {
+  /* establish state with a newer timestamp */
+  feed_burst(0, 4, 5000, MTL_SESSION_PORT_P);
+  /* also init port 1 with same timestamps so its error counter resets */
+  feed_burst(0, 4, 5004, MTL_SESSION_PORT_R);
+
+  uint64_t recv_before = received();
+
+  /* send 21 old-timestamp packets on BOTH ports, alternating */
+  for (int i = 0; i < 21; i++) {
+    feed(50 + i, 1000 + i, MTL_SESSION_PORT_P);
+    feed(50 + i, 1000 + i, MTL_SESSION_PORT_R);
+  }
+
+  /* After both ports exceed threshold (20), the 21st pair should be accepted.
+   * Requires redundant_error_cnt to be incremented in the ST30 handler. */
+  EXPECT_GT(received(), recv_before)
+      << "After exceeding threshold on both ports, packets should be accepted";
+}
+
+/* Interleaved ports with increasing timestamps. P and R alternate, each
+ * packet with a strictly newer timestamp. All packets accepted. */
+TEST_F(St30RxRedundancyTest, InterleavedPortsIncreasingTs) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1001, MTL_SESSION_PORT_R);
+  feed(2, 1002, MTL_SESSION_PORT_P);
+  feed(3, 1003, MTL_SESSION_PORT_R);
+  feed(4, 1004, MTL_SESSION_PORT_P);
+  feed(5, 1005, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(received(), 6u);
+}

--- a/tests/unit/session/st30/reorder_test.cpp
+++ b/tests/unit/session/st30/reorder_test.cpp
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Per-port reorder and same-port duplicate accounting:
+ * the per-port reordered_packets and duplicates_same_port counters,
+ * and their interaction with cross-port redundancy.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St30RxReorderTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st30/st30_rx_test_base.h"
+
+class St30RxReorderTest : public St30RxBaseTest {};
+
+/* Backward arrival on same port: must bump reordered_packets, not lost. */
+TEST_F(St30RxReorderTest, ReorderedPacketsCounted) {
+  /* feed strictly increasing ts (required by ST30) but re-send seq 1 */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1001, MTL_SESSION_PORT_P);
+  feed(1, 1002, MTL_SESSION_PORT_P); /* backward seq, fresh ts */
+  feed(3, 1003, MTL_SESSION_PORT_P);
+
+  EXPECT_GE(port_reordered(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 0u);
+}
+
+/* Same seq re-sent on same port must bump duplicates_same_port. */
+TEST_F(St30RxReorderTest, DuplicateSamePortCounted) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1001, MTL_SESSION_PORT_P);
+  feed(1, 1002, MTL_SESSION_PORT_P); /* same seq, fresh ts */
+  feed(2, 1003, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u);
+}
+
+/* Reorder must NOT inflate lost_packets. */
+TEST_F(St30RxReorderTest, ReorderDoesNotInflateLost) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1001, MTL_SESSION_PORT_P);
+  feed(2, 1002, MTL_SESSION_PORT_P);
+  uint64_t lost_before = port_ooo(MTL_SESSION_PORT_P);
+
+  feed(1, 1003, MTL_SESSION_PORT_P); /* pure reorder */
+
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), lost_before);
+}
+
+/* Multiple same-port duplicates must each be counted. */
+TEST_F(St30RxReorderTest, DuplicateSamePortMultiple) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1001, MTL_SESSION_PORT_P);
+  feed(1, 1002, MTL_SESSION_PORT_P);
+  feed(1, 1003, MTL_SESSION_PORT_P);
+  feed(1, 1004, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 3u);
+}
+
+/* Cross-port normal redundancy must NOT count as same-port duplicate. */
+TEST_F(St30RxReorderTest, CrossPortRedundantIsNotSamePortDuplicate) {
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_P);
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_R), 0u);
+  EXPECT_GE(redundant(), 1u);
+}

--- a/tests/unit/session/st30/st30_rx_test_base.h
+++ b/tests/unit/session/st30/st30_rx_test_base.h
@@ -1,0 +1,92 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Shared gtest fixture for the per-feature ST 2110-30 RX session tests
+ * under tests/unit/session/st30/.
+ *
+ * Each per-feature .cpp derives a thin subclass:
+ *
+ *   class St30RxStatsTest : public St30RxBaseTest {};
+ *
+ * so that --gtest_filter='St30RxStatsTest.*' selects only that feature's
+ * tests, while all setup/teardown and stat-accessor wrappers live here in
+ * one place.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "session/st30_harness.h"
+
+class St30RxBaseTest : public ::testing::Test {
+ protected:
+  ut30_test_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut30_init(), 0) << "EAL init failed";
+    ctx_ = ut30_ctx_create(2); /* 2 ports = redundant */
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  void TearDown() override {
+    ut30_ctx_destroy(ctx_);
+    ctx_ = nullptr;
+  }
+
+  int feed(uint16_t seq, uint32_t ts, enum mtl_session_port port) {
+    return ut30_feed_pkt(ctx_, seq, ts, port);
+  }
+
+  void feed_burst(uint16_t seq_start, int count, uint32_t ts,
+                  enum mtl_session_port port) {
+    ut30_feed_burst(ctx_, seq_start, count, ts, port);
+  }
+
+  uint64_t unrecovered() {
+    return ut30_stat_unrecovered(ctx_);
+  }
+  uint64_t redundant() {
+    return ut30_stat_redundant(ctx_);
+  }
+  uint64_t received() {
+    return ut30_stat_received(ctx_);
+  }
+  uint64_t ooo() {
+    return ut30_stat_lost_pkts(ctx_);
+  }
+  int session_seq() {
+    return ut30_session_seq_id(ctx_);
+  }
+  int frames_done() {
+    return ut30_frames_received(ctx_);
+  }
+  int ppf() {
+    return ut30_pkts_per_frame(ctx_);
+  }
+
+  uint64_t port_pkts(enum mtl_session_port p) {
+    return ut30_stat_port_pkts(ctx_, p);
+  }
+  uint64_t port_bytes(enum mtl_session_port p) {
+    return ut30_stat_port_bytes(ctx_, p);
+  }
+  uint64_t port_ooo(enum mtl_session_port p) {
+    return ut30_stat_port_lost(ctx_, p);
+  }
+  uint64_t wrong_pt() {
+    return ut30_stat_wrong_pt(ctx_);
+  }
+  uint64_t wrong_ssrc() {
+    return ut30_stat_wrong_ssrc(ctx_);
+  }
+  uint64_t len_mismatch() {
+    return ut30_stat_len_mismatch(ctx_);
+  }
+  uint64_t port_reordered(enum mtl_session_port p) {
+    return ut30_stat_port_reordered(ctx_, p);
+  }
+  uint64_t port_duplicates(enum mtl_session_port p) {
+    return ut30_stat_port_duplicates(ctx_, p);
+  }
+};

--- a/tests/unit/session/st30/stats_test.cpp
+++ b/tests/unit/session/st30/stats_test.cpp
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Per-port and session-wide stats invariants:
+ * per-port packet/OOO/reorder/duplicate counters, frame completion, and
+ * the global lost == sum(per-port-lost) invariant.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St30RxStatsTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st30/st30_rx_test_base.h"
+
+class St30RxStatsTest : public St30RxBaseTest {};
+
+/* Per-port packet counters track packets received on each port independently. */
+TEST_F(St30RxStatsTest, PortPacketCount) {
+  /* feed 5 pkts on P with increasing ts */
+  for (int i = 0; i < 5; i++) feed(i, 1000 + i, MTL_SESSION_PORT_P);
+  /* feed 3 pkts on R with further increasing ts */
+  for (int i = 0; i < 3; i++) feed(5 + i, 2000 + i, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_P), 5u);
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_R), 3u);
+}
+
+/* Per-port OOO: gap on P only, R is sequential. OOO must be isolated. */
+TEST_F(St30RxStatsTest, PortOOOPerPort) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(5, 1005, MTL_SESSION_PORT_P); /* gap of 4 */
+  feed(6, 2000, MTL_SESSION_PORT_R);
+  feed(7, 2001, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), 4u);
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_R), 0u);
+}
+
+/* Three complete frames: 3×pkts_per_frame packets produce 3 frames. */
+TEST_F(St30RxStatsTest, MultipleFrames) {
+  ut30_ctx_destroy(ctx_);
+  ctx_ = ut30_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  int total = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  for (int f = 0; f < 3; f++) {
+    for (int i = 0; i < total; i++) {
+      feed(seq++, ts++, MTL_SESSION_PORT_P);
+    }
+  }
+
+  EXPECT_EQ(frames_done(), 3);
+}
+
+/* Sequence gap produces exact unrecovered count with per-packet timestamps. */
+TEST_F(St30RxStatsTest, SeqGapExactCount) {
+  ut30_ctx_destroy(ctx_);
+  ctx_ = ut30_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1001, MTL_SESSION_PORT_P);
+  feed(5, 1005, MTL_SESSION_PORT_P); /* gap of 3 in session_seq */
+
+  EXPECT_EQ(unrecovered(), 3u);
+}
+
+/* Backward sequence arrival on the same port must not inflate the per-port
+ * OOO counter due to unsigned 16-bit wrapping. */
+TEST_F(St30RxStatsTest, PerPortOOOBackwardSeq) {
+  /* establish port P latest_seq_id = 5 */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(5, 1005, MTL_SESSION_PORT_P);
+
+  uint64_t ooo_before = port_ooo(MTL_SESSION_PORT_P);
+
+  /* feed seq 3 (backward) with newer timestamp so it passes redundancy */
+  feed(3, 2000, MTL_SESSION_PORT_P);
+
+  /* Backward seq should not add ~65533 phantom OOO events */
+  EXPECT_LE(port_ooo(MTL_SESSION_PORT_P), ooo_before + 10u)
+      << "Backward seq arrival should not produce phantom OOO";
+}
+
+/* Duplicate seq_id on the same port must not inflate per-port OOO counter
+ * due to unsigned 16-bit wrapping (gap should be 0, not 65535). */
+TEST_F(St30RxStatsTest, DuplicateSeqPortOOOWrapping) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(5, 1005, MTL_SESSION_PORT_P);
+
+  uint64_t ooo_before = port_ooo(MTL_SESSION_PORT_P);
+
+  /* re-feed seq 5 with same ts — filtered as redundant */
+  feed(5, 1005, MTL_SESSION_PORT_P);
+
+  /* Duplicate seq should not inflate OOO counter */
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), ooo_before)
+      << "Duplicate seq on same port should not inflate OOO counter";
+}
+
+/* stat_lost_packets == port[0].lost + port[1].lost invariant. */
+TEST_F(St30RxStatsTest, LostPacketsInvariant) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1001, MTL_SESSION_PORT_P);
+  feed(0, 1002, MTL_SESSION_PORT_R);
+  feed(3, 1003, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(ooo(), port_ooo(MTL_SESSION_PORT_P) + port_ooo(MTL_SESSION_PORT_R));
+}
+
+/* Gap across the 16-bit RTP seq wrap boundary. With latest=65534 and seq=1,
+ * the true forward gap is 2 (seq 65535 and 0 missed). Both per-port OOO and
+ * session-level unrecovered must reflect the true gap, not ~65535. */
+TEST_F(St30RxStatsTest, PortLostNotInflatedAtSeqWrap) {
+  /* establish latest_seq_id[P] = 65534 */
+  feed(65533, 1000, MTL_SESSION_PORT_P);
+  feed(65534, 1001, MTL_SESSION_PORT_P);
+  uint64_t lost_before = port_ooo(MTL_SESSION_PORT_P);
+  uint64_t unrec_before = unrecovered();
+
+  /* forward jump across the wrap: gap = 2 (seq 65535 and 0 missing) */
+  feed(1, 1002, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P) - lost_before, 2u)
+      << "per-port lost gap across seq wrap must be the true forward gap (2),"
+         " not a phantom ~65535 from naive subtraction";
+  EXPECT_EQ(unrecovered() - unrec_before, 2u)
+      << "session-seq gap across wrap must equal the true forward gap (2)";
+}

--- a/tests/unit/session/st30/timestamp_test.cpp
+++ b/tests/unit/session/st30/timestamp_test.cpp
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Timestamp filter edge cases:
+ * 32-bit wrap, rapid advance, old-vs-new seq with stale ts, audio frame
+ * boundary and seq-wrap accounting against reorder.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St30RxTimestampTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st30/st30_rx_test_base.h"
+
+class St30RxTimestampTest : public St30RxBaseTest {};
+
+/* Audio frame boundary: feed exactly pkts_per_frame packets with
+ * incrementing timestamps and verify exactly one frame is completed. */
+TEST_F(St30RxTimestampTest, AudioFrameBoundary) {
+  ut30_ctx_destroy(ctx_);
+  ctx_ = ut30_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  int total_pkts = ppf();
+  ASSERT_GT(total_pkts, 0);
+
+  /* each packet needs a unique (increasing) timestamp */
+  for (int i = 0; i < total_pkts; i++) {
+    feed(i, 1000 + i, MTL_SESSION_PORT_P);
+  }
+
+  EXPECT_EQ(received(), (uint64_t)total_pkts);
+  EXPECT_EQ(frames_done(), 1);
+  EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* 32-bit timestamp wraparound from near UINT32_MAX to near zero.
+ * The wrapped timestamps should be accepted as strictly greater. */
+TEST_F(St30RxTimestampTest, TimestampWrapAround) {
+  ut30_ctx_destroy(ctx_);
+  ctx_ = ut30_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  feed_burst(0, 4, 0xFFFFFFF0, MTL_SESSION_PORT_P);
+  feed_burst(4, 4, 0x00000010, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(received(), 8u);
+}
+
+/* Large timestamp jump: packets are accepted but the sequence gap between
+ * them is correctly counted as unrecovered. */
+TEST_F(St30RxTimestampTest, RapidTimestampAdvance) {
+  ut30_ctx_destroy(ctx_);
+  ctx_ = ut30_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(100, 999000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), 2u);
+  EXPECT_EQ(unrecovered(), 99u);
+}
+
+/* Backward timestamp with newer seq_id. ST30 filters on timestamp ONLY,
+ * so this must be rejected even though the seq_id advances. */
+TEST_F(St30RxTimestampTest, OldTimestampNewSeq) {
+  feed_burst(0, 4, 5000, MTL_SESSION_PORT_P);
+
+  /* newer seq but older timestamp — must be rejected */
+  int rc = feed(4, 1000, MTL_SESSION_PORT_P);
+  EXPECT_LT(rc, 0) << "Packet with old timestamp must be rejected";
+  EXPECT_GE(redundant(), 1u);
+}
+
+/* Back-to-back monotonic timestamps on a single port, no gaps.
+ * All packets accepted, zero unrecovered and redundant. */
+TEST_F(St30RxTimestampTest, BackToBackMonotonic) {
+  ut30_ctx_destroy(ctx_);
+  ctx_ = ut30_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  for (int i = 0; i < 40; i++) {
+    feed(i, 1000 + i, MTL_SESSION_PORT_P);
+  }
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(received(), 40u);
+}
+
+/* Seq-wrap must be seen as forward, not reorder. */
+TEST_F(St30RxTimestampTest, SeqWrapNotCountedAsReorder) {
+  feed(65534, 1000, MTL_SESSION_PORT_P);
+  feed(65535, 1001, MTL_SESSION_PORT_P);
+  uint64_t reord_before = port_reordered(MTL_SESSION_PORT_P);
+
+  feed(0, 1002, MTL_SESSION_PORT_P);
+  feed(1, 1003, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), reord_before);
+}
+
+/* session_seq_id is updated unconditionally after the gap-detection branch
+ * in the audio rx path (`s->session_seq_id = seq_id;`), unlike the ancillary
+ * path which guards with `mt_seq16_greater`. If a packet with a backward seq
+ * but a *new* timestamp slips past the redundancy filter, session_seq_id
+ * would move backwards and a subsequent forward packet would compute a
+ * massive phantom gap via uint16 wrap. This test drives that scenario and
+ * verifies the unrecovered counter does NOT inflate. */
+TEST_F(St30RxTimestampTest, SessionSeqDoesNotMoveBackwardOnNewTs) {
+  /* normal forward burst: session_seq advances to 100 */
+  for (uint16_t i = 90; i <= 100; i++) feed(i, 1000 + i, MTL_SESSION_PORT_P);
+  uint64_t unrec_before = unrecovered();
+  ASSERT_EQ(unrec_before, 0u);
+
+  /* backward seq with newer ts — may occur on a misbehaving sender or after
+   * a stream restart. Per the user-visible contract, the lib must not let
+   * this poison session_seq_id and inflate unrecovered on the next packet. */
+  feed(50, 2000, MTL_SESSION_PORT_P);
+
+  /* now a normal forward packet: if session_seq_id was set to 50 above,
+   * the gap (uint16_t)(101 - 50 - 1) = 50 phantom unrecovered. */
+  feed(101, 2001, MTL_SESSION_PORT_P);
+
+  EXPECT_LE(unrecovered() - unrec_before, 1u)
+      << "session_seq_id must not move backward on a newer-ts packet;"
+         " doing so inflates stat_pkts_unrecovered via uint16 wrap";
+}

--- a/tests/unit/session/st30_harness.c
+++ b/tests/unit/session/st30_harness.c
@@ -1,0 +1,312 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C harness for ST30 (audio) RX redundancy unit tests (session layer).
+ */
+
+#include <rte_atomic.h>
+#include <stdlib.h>
+#include <string.h>
+
+#undef MTL_HAS_USDT
+#include "common/ut_common.h"
+#include "st2110/st_rx_audio_session.c"
+
+/* ── tuning constants ─────────────────────────────────────────────────── */
+
+#define UT30_FRAME_COUNT 2
+#define UT30_FRAME_CAPACITY 8192
+
+/*
+ * Audio config: 2-channel 48 kHz PCM16 @ 1 ms ptime.
+ * Payload per packet = 48000 * 0.001 * 2ch * 2bytes = 192 bytes.
+ */
+#define UT30_CHANNELS 2
+#define UT30_PKT_PAYLOAD 192
+
+/* ── opaque context ───────────────────────────────────────────────────── */
+
+struct ut30_test_ctx {
+  struct mtl_main_impl impl;
+  struct st_rx_audio_sessions_mgr mgr;
+  struct st_rx_audio_session_impl session;
+
+  struct st_frame_trans frames[UT30_FRAME_COUNT];
+  uint8_t frame_storage[UT30_FRAME_COUNT][UT30_FRAME_CAPACITY];
+};
+
+#include "session/st30_harness.h"
+
+/* ── PTP time stub ────────────────────────────────────────────────────── */
+
+static uint64_t ut30_ptp_time(struct mtl_main_impl* impl, enum mtl_port port) {
+  (void)port;
+  impl->ptp_usync += 1000;
+  return impl->ptp_usync;
+}
+
+/* ── frame-ready callback ─────────────────────────────────────────────── */
+
+static int ut30_notify_frame_ready(void* priv, void* frame,
+                                   struct st30_rx_frame_meta* meta) {
+  (void)meta;
+  struct st_rx_audio_session_impl* s = priv;
+  if (!s || !frame) return 0;
+
+  for (int i = 0; i < s->st30_frames_cnt; i++) {
+    if (!s->st30_frames) break;
+    if (s->st30_frames[i].addr == frame) {
+      rte_atomic32_dec(&s->st30_frames[i].refcnt);
+      break;
+    }
+  }
+  return 0;
+}
+
+/* ── init (delegates to common) ───────────────────────────────────────── */
+
+int ut30_init(void) {
+  return ut_eal_init();
+}
+
+/* ── context create / destroy ─────────────────────────────────────────── */
+
+ut30_test_ctx* ut30_ctx_create(int num_port) {
+  ut30_test_ctx* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx) return NULL;
+
+  ctx->impl.type = MT_HANDLE_MAIN;
+  ctx->impl.tsc_hz = rte_get_tsc_hz();
+  ctx->impl.ptp_usync = 0;
+  for (int i = 0; i < MTL_PORT_MAX; i++) {
+    ctx->impl.inf[i].parent = &ctx->impl;
+    ctx->impl.inf[i].port = i;
+    ctx->impl.inf[i].ptp_get_time_fn = ut30_ptp_time;
+  }
+
+  ctx->mgr.parent = &ctx->impl;
+  ctx->mgr.idx = 0;
+
+  for (int i = 0; i < UT30_FRAME_COUNT; i++) {
+    memset(&ctx->frames[i], 0, sizeof(ctx->frames[i]));
+    ctx->frames[i].idx = i;
+    ctx->frames[i].addr = ctx->frame_storage[i];
+    rte_atomic32_set(&ctx->frames[i].refcnt, 0);
+  }
+
+  struct st_rx_audio_session_impl* s = &ctx->session;
+  s->idx = 0;
+  s->socket_id = rte_socket_id();
+  s->mgr = &ctx->mgr;
+  s->attached = true;
+  s->usdt_dump_fd = -1;
+
+  s->ops.type = ST30_TYPE_FRAME_LEVEL;
+  s->ops.num_port = num_port;
+  s->ops.channel = UT30_CHANNELS;
+  s->ops.sampling = ST30_SAMPLING_48K;
+  s->ops.fmt = ST30_FMT_PCM16;
+  s->ops.ptime = ST30_PTIME_1MS;
+  s->ops.framebuff_cnt = UT30_FRAME_COUNT;
+  s->ops.notify_frame_ready = ut30_notify_frame_ready;
+  s->ops.priv = s;
+  s->ops.name = "ut30_test";
+  s->ops.payload_type = 0;
+  s->ops.ssrc = 0;
+
+  s->st30_frames = ctx->frames;
+  s->st30_frames_cnt = UT30_FRAME_COUNT;
+
+  s->pkt_len = UT30_PKT_PAYLOAD;
+  size_t pkt_multiple = UT30_FRAME_CAPACITY / UT30_PKT_PAYLOAD;
+  if (!pkt_multiple) pkt_multiple = 1;
+  s->st30_total_pkts = (int)pkt_multiple;
+  s->st30_frame_size = pkt_multiple * UT30_PKT_PAYLOAD;
+  s->ops.framebuff_size = (uint32_t)s->st30_frame_size;
+  s->st30_pkt_size = UT30_PKT_PAYLOAD + sizeof(struct st_rfc3550_audio_hdr);
+
+  s->port_maps[MTL_SESSION_PORT_P] = MTL_PORT_P;
+  s->port_maps[MTL_SESSION_PORT_R] = MTL_PORT_R;
+
+  for (int i = 0; i < MTL_SESSION_PORT_MAX; i++) {
+    s->priv[i].session = s;
+    s->priv[i].impl = &ctx->impl;
+    s->priv[i].s_port = (enum mtl_session_port)i;
+  }
+
+  rx_audio_session_reset(s, false);
+  return ctx;
+}
+
+void ut30_ctx_destroy(ut30_test_ctx* ctx) {
+  free(ctx);
+}
+
+/* ── mbuf builder ─────────────────────────────────────────────────────── */
+
+static struct rte_mbuf* make_audio_mbuf_full(uint16_t seq, uint32_t ts, uint8_t pt,
+                                             uint32_t ssrc, uint32_t payload_len) {
+  struct rte_mbuf* m = rte_pktmbuf_alloc(ut_pool());
+  if (!m) return NULL;
+
+  size_t total = sizeof(struct st_rfc3550_audio_hdr) + payload_len;
+
+  if (rte_pktmbuf_tailroom(m) < total) {
+    rte_pktmbuf_free(m);
+    return NULL;
+  }
+
+  uint8_t* buf = rte_pktmbuf_mtod(m, uint8_t*);
+  memset(buf, 0, total);
+
+  size_t hdr_offset =
+      sizeof(struct st_rfc3550_audio_hdr) - sizeof(struct st_rfc3550_rtp_hdr);
+  struct st_rfc3550_rtp_hdr* rtp = (struct st_rfc3550_rtp_hdr*)(buf + hdr_offset);
+  rtp->version = 2;
+  rtp->seq_number = htons(seq);
+  rtp->tmstamp = htonl(ts);
+  rtp->ssrc = htonl(ssrc);
+  rtp->payload_type = pt;
+  rtp->marker = 0;
+
+  m->data_len = total;
+  m->pkt_len = total;
+  return m;
+}
+
+static struct rte_mbuf* make_audio_mbuf(uint16_t seq, uint32_t ts) {
+  return make_audio_mbuf_full(seq, ts, 0, 0, UT30_PKT_PAYLOAD);
+}
+
+/* ── feed functions ───────────────────────────────────────────────────── */
+
+int ut30_feed_pkt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                  enum mtl_session_port port) {
+  struct rte_mbuf* m = make_audio_mbuf(seq, ts);
+  if (!m) return -1;
+  int rc = rx_audio_session_handle_frame_pkt(&ctx->impl, &ctx->session, m, port);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+void ut30_feed_burst(ut30_test_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
+                     enum mtl_session_port port) {
+  for (int i = 0; i < count; i++) {
+    ut30_feed_pkt(ctx, seq_start + i, ts + i, port);
+  }
+}
+
+int ut30_feed_pkt_pt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                     enum mtl_session_port port, uint8_t payload_type) {
+  struct rte_mbuf* m = make_audio_mbuf_full(seq, ts, payload_type, 0, UT30_PKT_PAYLOAD);
+  if (!m) return -1;
+  int rc = rx_audio_session_handle_frame_pkt(&ctx->impl, &ctx->session, m, port);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut30_feed_pkt_ssrc(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                       enum mtl_session_port port, uint32_t ssrc) {
+  struct rte_mbuf* m = make_audio_mbuf_full(seq, ts, 0, ssrc, UT30_PKT_PAYLOAD);
+  if (!m) return -1;
+  int rc = rx_audio_session_handle_frame_pkt(&ctx->impl, &ctx->session, m, port);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut30_feed_pkt_len(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                      enum mtl_session_port port, uint32_t payload_len) {
+  struct rte_mbuf* m = make_audio_mbuf_full(seq, ts, 0, 0, payload_len);
+  if (!m) return -1;
+  int rc = rx_audio_session_handle_frame_pkt(&ctx->impl, &ctx->session, m, port);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut30_feed_pkt_via_wrapper(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                              enum mtl_session_port port, uint8_t pt, uint32_t ssrc,
+                              uint32_t payload_len) {
+  struct rte_mbuf* m = make_audio_mbuf_full(seq, ts, pt, ssrc, payload_len);
+  if (!m) return -1;
+  struct rte_mbuf* mbufs[1] = {m};
+  int rc = rx_audio_session_handle_mbuf(&ctx->session.priv[port], mbufs, 1);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+/* ── config setters ───────────────────────────────────────────────────── */
+
+void ut30_ctx_set_pt(ut30_test_ctx* ctx, uint8_t pt) {
+  ctx->session.ops.payload_type = pt;
+}
+
+void ut30_ctx_set_ssrc(ut30_test_ctx* ctx, uint32_t ssrc) {
+  ctx->session.ops.ssrc = ssrc;
+}
+
+/* ── stat accessors ───────────────────────────────────────────────────── */
+
+uint64_t ut30_stat_unrecovered(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_unrecovered;
+}
+
+uint64_t ut30_stat_redundant(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_redundant;
+}
+
+uint64_t ut30_stat_received(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_received;
+}
+
+uint64_t ut30_stat_lost_pkts(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_lost_packets;
+}
+
+int ut30_session_seq_id(const ut30_test_ctx* ctx) {
+  return ctx->session.session_seq_id;
+}
+
+int ut30_frames_received(const ut30_test_ctx* ctx) {
+  return rte_atomic32_read(&ctx->session.stat_frames_received);
+}
+
+int ut30_pkts_per_frame(const ut30_test_ctx* ctx) {
+  return ctx->session.st30_total_pkts;
+}
+
+uint64_t ut30_stat_port_pkts(const ut30_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].packets;
+}
+
+uint64_t ut30_stat_port_bytes(const ut30_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].bytes;
+}
+
+uint64_t ut30_stat_port_lost(const ut30_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].lost_packets;
+}
+
+uint64_t ut30_stat_port_reordered(const ut30_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].reordered_packets;
+}
+
+uint64_t ut30_stat_port_duplicates(const ut30_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].duplicates_same_port;
+}
+
+uint64_t ut30_stat_port_err_packets(const ut30_test_ctx* ctx,
+                                    enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].err_packets;
+}
+
+uint64_t ut30_stat_wrong_pt(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_wrong_pt_dropped;
+}
+
+uint64_t ut30_stat_wrong_ssrc(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_wrong_ssrc_dropped;
+}
+
+uint64_t ut30_stat_len_mismatch(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_len_mismatch_dropped;
+}

--- a/tests/unit/session/st30_harness.h
+++ b/tests/unit/session/st30_harness.h
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C harness API for the ST 2110-30 (audio) RX session unit tests.
+ *
+ * The harness wraps a single `st_rx_audio_session_impl` configured for a
+ * tiny synthetic geometry. ST30 uses TIMESTAMP-only redundancy filtering
+ * (no per-frame bitmap), which is reflected in the available accessors.
+ *
+ * Two feeder families are exposed:
+ *
+ *   ut30_feed_*                — call the per-packet handler directly.
+ *                                Use to assert on filter/state behaviour.
+ *   ut30_feed_*_via_wrapper    — call the public `_handle_mbuf` wrapper
+ *                                the production tasklet uses. Use whenever
+ *                                the test asserts on per-port `err_packets`
+ *                                or `packets` accounting.
+ */
+
+#ifndef _ST30_SESSION_HARNESS_H_
+#define _ST30_SESSION_HARNESS_H_
+
+#include <stdint.h>
+
+#include "mtl_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ut30_test_ctx ut30_test_ctx;
+
+/* Initialise the shared DPDK EAL and mempool. Idempotent — safe to call
+ * once per gtest fixture SetUp(). Returns 0 on success, < 0 on failure. */
+int ut30_init(void);
+
+/* Create a context with `num_port` enabled (1 = single-port, 2 = redundant).
+ * Caller owns the returned pointer and must free it with ut30_ctx_destroy().
+ * Returns NULL on allocation failure. */
+ut30_test_ctx* ut30_ctx_create(int num_port);
+void ut30_ctx_destroy(ut30_test_ctx* ctx);
+
+/* Feed one RFC 3550 audio packet directly to the per-packet handler.
+ * Returns the production handler's return code (0 = accepted, < 0 = error
+ * reason; e.g. -EIO for redundancy filtering). */
+int ut30_feed_pkt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                  enum mtl_session_port port);
+
+/* Convenience: feed `count` consecutive packets starting at `seq_start`,
+ * all with the same `ts`. */
+void ut30_feed_burst(ut30_test_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
+                     enum mtl_session_port port);
+
+/* Negative-test feeders: override one RTP field while keeping the others
+ * at session defaults. */
+int ut30_feed_pkt_pt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                     enum mtl_session_port port, uint8_t payload_type);
+int ut30_feed_pkt_ssrc(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                       enum mtl_session_port port, uint32_t ssrc);
+int ut30_feed_pkt_len(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                      enum mtl_session_port port, uint32_t payload_len);
+
+/* Configure the session's expected RTP payload type / SSRC. Call after
+ * ut30_ctx_create() and before feeding any packet. */
+void ut30_ctx_set_pt(ut30_test_ctx* ctx, uint8_t pt);
+void ut30_ctx_set_ssrc(ut30_test_ctx* ctx, uint32_t ssrc);
+
+/* Wrapper feeder — drives the production `_handle_mbuf` wrapper instead of
+ * the per-packet handler. Use this whenever the test asserts on per-port
+ * `err_packets` or per-port `packets`. All RTP fields are explicit so a
+ * single function covers happy-path and negative-path tests. */
+int ut30_feed_pkt_via_wrapper(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                              enum mtl_session_port port, uint8_t pt, uint32_t ssrc,
+                              uint32_t payload_len);
+
+/* Per-port counter accessors. */
+uint64_t ut30_stat_port_err_packets(const ut30_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut30_stat_port_pkts(const ut30_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut30_stat_port_bytes(const ut30_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut30_stat_port_lost(const ut30_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut30_stat_port_reordered(const ut30_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut30_stat_port_duplicates(const ut30_test_ctx* ctx, enum mtl_session_port port);
+
+/* Session-wide counters. `unrecovered` counts gaps the redundancy filter
+ * could not heal; `redundant` counts cross-port duplicates dropped by the
+ * filter; `received` counts accepted packets after filtering. */
+uint64_t ut30_stat_unrecovered(const ut30_test_ctx* ctx);
+uint64_t ut30_stat_redundant(const ut30_test_ctx* ctx);
+uint64_t ut30_stat_received(const ut30_test_ctx* ctx);
+uint64_t ut30_stat_lost_pkts(const ut30_test_ctx* ctx);
+
+/* Last accepted RTP sequence number (a.k.a. session "watermark") — used by
+ * tests that need to set up a known starting point before injecting reorder
+ * or wrap. */
+int ut30_session_seq_id(const ut30_test_ctx* ctx);
+
+/* Number of frames delivered since session reset (live value of the
+ * stat counter). */
+int ut30_frames_received(const ut30_test_ctx* ctx);
+
+/* Number of audio packets that constitute one frame in this harness's
+ * synthetic configuration. Tests use it to derive expected counts. */
+int ut30_pkts_per_frame(const ut30_test_ctx* ctx);
+
+/* Per-reason drop counters. */
+uint64_t ut30_stat_wrong_pt(const ut30_test_ctx* ctx);
+uint64_t ut30_stat_wrong_ssrc(const ut30_test_ctx* ctx);
+uint64_t ut30_stat_len_mismatch(const ut30_test_ctx* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST30_SESSION_HARNESS_H_ */

--- a/tests/unit/session/st40/bitmap_test.cpp
+++ b/tests/unit/session/st40/bitmap_test.cpp
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Per-frame bitmap stress (ST_RX_ANC_BITMAP_BITS = 64):
+ * exact-fit, oversize fallback, cross-port interleave, prev-window late
+ * marker, and reset.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxBitmapTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxBitmapTest : public St40RxBaseTest {};
+
+/* Bitmap capacity boundary: a frame whose packet count exactly equals the
+ * bitmap width must be tracked end-to-end with no off-by-one at offset 63.
+ * A full replay on R must be classified entirely as redundant. */
+TEST_F(St40RxBitmapTest, BitmapExactlyFull) {
+  constexpr int N = 64; /* == ST_RX_ANC_BITMAP_BITS */
+  constexpr uint32_t ts = 1000;
+
+  feed_burst(0, N, ts, true, MTL_SESSION_PORT_P);
+  /* R replays the same frame: every packet is a duplicate. */
+  feed_burst(0, N, ts, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(received(), static_cast<uint64_t>(N));
+  EXPECT_EQ(redundant(), static_cast<uint64_t>(N));
+  EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* Frame larger than the bitmap: packets at offsets >= ST_RX_ANC_BITMAP_BITS
+ * fall back to watermark-only filtering. Verify the frame is fully accepted
+ * and that duplicates of an in-bitmap seq are still filtered as redundant. */
+TEST_F(St40RxBitmapTest, BitmapOversizeFrameFallback) {
+  constexpr int N = 80; /* exceeds bitmap width */
+  constexpr uint32_t ts = 1000;
+
+  feed_burst(0, N, ts, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), static_cast<uint64_t>(N));
+  EXPECT_EQ(unrecovered(), 0u);
+
+  /* A duplicate within the bitmap range must still be filtered. */
+  feed(10, ts, false, MTL_SESSION_PORT_R);
+  EXPECT_EQ(redundant(), 1u);
+}
+
+/* Worst-case cross-port interleave on a single frame: P delivers all even
+ * seq, then R delivers all odd seq with the same timestamp. The bitmap
+ * must accept every odd seq from R as a fill rather than as a duplicate. */
+TEST_F(St40RxBitmapTest, BitmapCrossPortInterleave) {
+  constexpr int N = 32; /* 32 evens + 32 odds = 64 packets */
+  constexpr uint32_t ts = 2000;
+
+  for (int i = 0; i < N; i++)
+    feed(static_cast<uint16_t>(2 * i), ts, false, MTL_SESSION_PORT_P);
+  for (int i = 0; i < N; i++) {
+    bool last = (i == N - 1);
+    feed(static_cast<uint16_t>(2 * i + 1), ts, last, MTL_SESSION_PORT_R);
+  }
+
+  EXPECT_EQ(redundant(), 0u)
+      << "Odd-seq packets from R should fill bitmap holes, not be redundant";
+  EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* Late marker arriving on the redundant port after P has already advanced
+ * to the next frame must be accepted via the previous-frame window and
+ * decrement stat_pkts_unrecovered exactly once. */
+TEST_F(St40RxBitmapTest, BitmapPrevWindowLateMarker) {
+  constexpr uint32_t ts_n = 5000;
+  constexpr uint32_t ts_n1 = 6500;
+
+  /* Frame N on P delivers seq 0..4 with no marker; seq 5 (the marker) is
+   * missing from P. */
+  feed_burst(0, 5, ts_n, false, MTL_SESSION_PORT_P);
+
+  /* P advances to frame N+1 without the missing seq, opening a forward gap
+   * that increments stat_pkts_unrecovered. */
+  feed_burst(6, 4, ts_n1, true, MTL_SESSION_PORT_P);
+  uint64_t unrec_before_late = unrecovered();
+  ASSERT_GE(unrec_before_late, 1u);
+
+  /* R now delivers the late marker for frame N. */
+  int rc = feed(5, ts_n, true, MTL_SESSION_PORT_R);
+  EXPECT_EQ(rc, 0) << "Late prev-frame marker must be accepted via prev window";
+  EXPECT_EQ(unrecovered(), unrec_before_late - 1)
+      << "Accepting the late marker must decrement stat_pkts_unrecovered exactly once";
+}
+
+/* rx_ancillary_session_reset must fully clear both per-frame bitmap windows
+ * (cur and prev). If reset leaves anc_window_cur populated, a subsequent
+ * stream that happens to reuse the same timestamp can hit the late-accept
+ * branch against a stale bitmap and deliver a duplicate to the application.
+ *
+ * Scenario:
+ *   1. Stream 1 sends seq 0..5 at ts=1000, populating anc_window_cur.
+ *   2. Session is reset.
+ *   3. Stream 2 sends seq 7 at the same ts=1000; this becomes the new
+ *      session head.
+ *   4. seq 6 arrives on R. With reset working correctly, anc_window_cur is
+ *      empty so the late-accept check fails and the packet is classified
+ *      redundant. */
+TEST_F(St40RxBitmapTest, BitmapResetClearsState) {
+  feed_burst(0, 6, 1000, true, MTL_SESSION_PORT_P);
+  ASSERT_EQ(received(), 6u);
+
+  ut40_session_reset(ctx_);
+  ASSERT_EQ(received(), 0u);
+  ASSERT_EQ(redundant(), 0u);
+
+  feed(7, 1000, false, MTL_SESSION_PORT_P);
+  ASSERT_EQ(received(), 1u);
+
+  feed(6, 1000, false, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(received(), 1u)
+      << "seq 6 on R must be classified redundant, not accepted as a late arrival";
+  EXPECT_EQ(redundant(), 1u);
+}
+
+/* anc_window_cur.base_seq is uint16_t and the bitmap offset is computed as
+ * `(uint16_t)(seq - base_seq)`. When the frame's first accepted seq is
+ * near the 16-bit boundary (e.g. 65534), in-frame packets at 65535 and 0
+ * must produce offsets 1 and 2 via modular wrap, NOT trip the
+ * `offset >= ST_RX_ANC_BITMAP_BITS` OOB guard. */
+TEST_F(St40RxBitmapTest, BitmapOffsetWrapsAtBaseSeq) {
+  constexpr uint32_t ts = 1000;
+
+  /* seed session_seq_id so the next frame's base_seq is 65534 */
+  feed(65533, 999, true, MTL_SESSION_PORT_P);
+  ASSERT_EQ(session_seq(), 65533);
+
+  /* one frame (single ts) spanning the wrap: 65534, 65535, 0, 1 (marker) */
+  feed(65534, ts, false, MTL_SESSION_PORT_P);
+  feed(65535, ts, false, MTL_SESSION_PORT_P);
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, true, MTL_SESSION_PORT_P);
+
+  /* All four must be received, no duplicate/redundant trigger from a wrap-broken
+   * offset, no unrecovered phantom from a wrap-broken gap. */
+  EXPECT_EQ(received(), 5u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(unrecovered(), 0u);
+}

--- a/tests/unit/session/st40/err_packets_test.cpp
+++ b/tests/unit/session/st40/err_packets_test.cpp
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Tests for the per-port `err_packets` counter on the ST 2110-40 RX session.
+ * The `_handle_mbuf` wrapper increments
+ * `port_user_stats.common.port[s_port].err_packets` whenever the per-packet
+ * handler returns < 0.
+ *
+ * Test goals:
+ *   1. Every genuine error path (wrong PT, wrong SSRC, bad F-bits) MUST
+ *      increment err_packets and the corresponding per-reason counter,
+ *      exactly once each.
+ *   2. err_packets MUST equal the sum of per-reason drop counters.
+ *   3. Successful packets MUST NOT increment err_packets.
+ *   4. Redundancy-filtered packets (legitimate duplicates) MUST NOT
+ *      count as errors.
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40_harness.h"
+
+class St40RxErrPacketsTest : public ::testing::Test {
+ protected:
+  ut_test_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut40_init(), 0);
+    ut40_drain_ring();
+    ctx_ = ut40_ctx_create(2);
+    ASSERT_NE(ctx_, nullptr);
+    ut40_ctx_set_pt(ctx_, 113);
+    ut40_ctx_set_ssrc(ctx_, 0x1234);
+  }
+  void TearDown() override {
+    ut40_drain_ring();
+    if (ctx_) ut40_ctx_destroy(ctx_);
+  }
+
+  uint64_t err_p() {
+    return ut40_stat_port_err_packets(ctx_, MTL_SESSION_PORT_P);
+  }
+  uint64_t err_r() {
+    return ut40_stat_port_err_packets(ctx_, MTL_SESSION_PORT_R);
+  }
+  uint64_t pkts_p() {
+    return ut40_stat_port_pkts(ctx_, MTL_SESSION_PORT_P);
+  }
+  uint64_t pkts_r() {
+    return ut40_stat_port_pkts(ctx_, MTL_SESSION_PORT_R);
+  }
+  int feed_via(uint16_t seq, uint32_t ts, int marker, mtl_session_port port,
+               uint8_t pt = 113, uint32_t ssrc = 0x1234, uint8_t f_bits = 0) {
+    struct ut40_pkt_spec spec = {.seq = seq,
+                                 .ts = ts,
+                                 .marker = marker,
+                                 .port = port,
+                                 .payload_type = pt,
+                                 .ssrc = ssrc,
+                                 .f_bits = f_bits};
+    return ut40_feed_spec_via_wrapper(ctx_, spec);
+  }
+};
+
+TEST_F(St40RxErrPacketsTest, GoodPacketsNotCountedAsErr) {
+  feed_via(0, 1000, /*marker=*/1, MTL_SESSION_PORT_P);
+  feed_via(1, 1001, /*marker=*/1, MTL_SESSION_PORT_P);
+  EXPECT_EQ(err_p(), 0u);
+  EXPECT_EQ(pkts_p(), 2u);
+}
+
+TEST_F(St40RxErrPacketsTest, WrongPtCountedAsErr) {
+  feed_via(0, 1000, 1, MTL_SESSION_PORT_P, /*pt=*/77);
+  EXPECT_EQ(ut40_stat_wrong_pt(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 0u);
+}
+
+TEST_F(St40RxErrPacketsTest, WrongSsrcCountedAsErr) {
+  feed_via(0, 1000, 1, MTL_SESSION_PORT_P, 113, /*ssrc=*/0x9999);
+  EXPECT_EQ(ut40_stat_wrong_ssrc(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 0u);
+}
+
+TEST_F(St40RxErrPacketsTest, InvalidFBitsCountedAsErr) {
+  /* Default progressive session; F-bits=0b01 is an invalid encoding. */
+  feed_via(0, 1000, 1, MTL_SESSION_PORT_P, 113, 0x1234, /*f_bits=*/0b01);
+  EXPECT_EQ(ut40_stat_wrong_interlace(ctx_), 1u);
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 0u);
+}
+
+TEST_F(St40RxErrPacketsTest, ErrPacketsEqualsSumOfReasons) {
+  feed_via(0, 1000, 1, MTL_SESSION_PORT_P, /*pt=*/77);            /* wrong PT */
+  feed_via(1, 1001, 1, MTL_SESSION_PORT_P, 113, /*ssrc=*/0x9999); /* wrong SSRC */
+  feed_via(2, 1002, 1, MTL_SESSION_PORT_P, 113, 0x1234, 0b01);    /* bad F bits */
+
+  uint64_t reasons = ut40_stat_wrong_pt(ctx_) + ut40_stat_wrong_ssrc(ctx_) +
+                     ut40_stat_wrong_interlace(ctx_);
+  EXPECT_EQ(reasons, 3u);
+  EXPECT_EQ(err_p(), reasons)
+      << "every err_packets bump must be explainable by a per-reason counter";
+}
+
+TEST_F(St40RxErrPacketsTest, MixedBurstOnlyBadCounted) {
+  feed_via(0, 1000, 1, MTL_SESSION_PORT_P);
+  feed_via(1, 1001, 1, MTL_SESSION_PORT_P, /*pt=*/77);
+  feed_via(2, 1002, 1, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(err_p(), 1u);
+  EXPECT_EQ(pkts_p(), 2u);
+}
+
+/* Redundancy-filtered packets must not inflate err_packets. */
+TEST_F(St40RxErrPacketsTest, RedundancyFilterDoesNotBumpErrCounter) {
+  /* P sends 5 packets first (each its own marker = its own frame). */
+  for (int i = 0; i < 5; i++) {
+    feed_via(static_cast<uint16_t>(i), 1000 + i, /*marker=*/1, MTL_SESSION_PORT_P);
+  }
+  /* R replays the same packets -- legitimate redundancy. */
+  for (int i = 0; i < 5; i++) {
+    feed_via(static_cast<uint16_t>(i), 1000 + i, /*marker=*/1, MTL_SESSION_PORT_R);
+  }
+
+  /* All 5 R packets must be filtered as redundant. */
+  EXPECT_GT(ut40_stat_redundant(ctx_), 0u)
+      << "the redundancy filter must classify the R replay";
+  /* Redundant packets must NOT be counted as errors. */
+  EXPECT_EQ(err_r(), 0u) << "redundant-filtered packets must not be classified as errors";
+}
+
+TEST_F(St40RxErrPacketsTest, HealthyRedundantStreamHasZeroUnexplainedErrors) {
+  for (int i = 0; i < 5; i++) {
+    feed_via(static_cast<uint16_t>(i), 1000 + i, 1, MTL_SESSION_PORT_P);
+    feed_via(static_cast<uint16_t>(i), 1000 + i, 1, MTL_SESSION_PORT_R);
+  }
+  uint64_t reasons = ut40_stat_wrong_pt(ctx_) + ut40_stat_wrong_ssrc(ctx_) +
+                     ut40_stat_wrong_interlace(ctx_);
+  EXPECT_EQ(reasons, 0u) << "no real error reasons in a healthy stream";
+  EXPECT_EQ(err_r(), 0u)
+      << "redundant-port err_packets must be zero when there are no real errors";
+  EXPECT_EQ(err_p(), 0u);
+}
+
+/* Per stats_guide.md: a redundant packet lands in port[].packets (pre-redundancy)
+ * and stat_pkts_redundant, but NOT in err_packets. */
+TEST_F(St40RxErrPacketsTest, RedundantPacketCountedExactlyOnce) {
+  /* prime session state on P */
+  feed_via(0, 2000, 1, MTL_SESSION_PORT_P);
+  /* one redundant packet on R (old timestamp + low seq → filtered) */
+  feed_via(0, 1000, 1, MTL_SESSION_PORT_R);
+
+  EXPECT_GT(ut40_stat_redundant(ctx_), 0u) << "the R packet must be filtered";
+  EXPECT_EQ(pkts_r(), 1u) << "redundant packet counts in pre-redundancy port[].packets";
+  EXPECT_EQ(err_r(), 0u) << "redundant packet must not be counted as error";
+  EXPECT_EQ(pkts_r() + err_r(), 1u) << "counted exactly once, not double-counted as err";
+}

--- a/tests/unit/session/st40/f_bits_test.cpp
+++ b/tests/unit/session/st40/f_bits_test.cpp
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * RFC 8331 F-bit / interlace handling:
+ * progressive vs interlaced, field counters, cross-port F-bit divergence,
+ * interlace-auto detection.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxFBitsTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxFBitsTest : public St40RxBaseTest {};
+
+/* Invalid F-bits packets are dropped and counted in wrong_interlace stat. */
+TEST_F(St40RxFBitsTest, InvalidFBitsDropped) {
+  ut40_feed_pkt_fbits(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 0x1);
+  ut40_feed_pkt_fbits(ctx_, 1, 1001, 0, MTL_SESSION_PORT_P, 0x1);
+
+  EXPECT_EQ(wrong_interlace(), 2u);
+  EXPECT_EQ(received(), 0u);
+}
+
+/* Progressive F-bits (0b00) are accepted without incrementing interlace counters. */
+TEST_F(St40RxFBitsTest, ProgressiveFBits) {
+  ut40_feed_pkt_fbits(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 0x0);
+  ut40_feed_pkt_fbits(ctx_, 1, 1001, 0, MTL_SESSION_PORT_P, 0x0);
+
+  EXPECT_EQ(wrong_interlace(), 0u);
+  EXPECT_EQ(interlace_first(), 0u);
+  EXPECT_EQ(interlace_second(), 0u);
+  EXPECT_EQ(received(), 2u);
+}
+
+/* Interlaced fields: F=0b10 (first) and F=0b11 (second) are accepted
+ * and tracked in their respective interlace counters. */
+TEST_F(St40RxFBitsTest, InterlaceFieldCounting) {
+  /* F=0x2 → first field */
+  ut40_feed_pkt_fbits(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 0x2);
+  ut40_feed_pkt_fbits(ctx_, 1, 1001, 0, MTL_SESSION_PORT_P, 0x2);
+  /* F=0x3 → second field */
+  ut40_feed_pkt_fbits(ctx_, 2, 1002, 0, MTL_SESSION_PORT_P, 0x3);
+
+  EXPECT_EQ(interlace_first(), 2u);
+  EXPECT_EQ(interlace_second(), 1u);
+  EXPECT_EQ(wrong_interlace(), 0u);
+  EXPECT_EQ(received(), 3u);
+}
+
+/* Producer-side defect: port P emits F=0x2 (first field) while port R
+ * emits F=0x3 (second field) for the same logical frame.  This is a
+ * SMPTE 2110-40 violation.  MTL currently accepts both polarities
+ * silently; this test pins that behaviour. */
+TEST_F(St40RxFBitsTest, AsymmetricFieldBitsBetweenPorts) {
+  /* P sends F=0x2, R sends F=0x3 for the same ts — disagreement. */
+  ut40_feed_pkt_fbits(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 0x2);
+  ut40_feed_pkt_fbits(ctx_, 1, 1000, 1, MTL_SESSION_PORT_P, 0x2);
+  ut40_feed_pkt_fbits(ctx_, 0, 1000, 0, MTL_SESSION_PORT_R, 0x3);
+  ut40_feed_pkt_fbits(ctx_, 1, 1000, 1, MTL_SESSION_PORT_R, 0x3);
+
+  /* Current behaviour: both polarities are counted, no drop. */
+  EXPECT_EQ(wrong_interlace(), 0u);
+  EXPECT_GE(interlace_first(), 2u);  /* F=0x2 from P */
+  EXPECT_GE(interlace_second(), 2u); /* F=0x3 from R */
+}
+
+/* Mid-stream field-bit flip in interlace_auto mode: producer suddenly
+ * starts emitting progressive packets after a run of interlaced ones.
+ * Detection must re-fire (interlace_detected reset) and progressive
+ * packets must not be counted in either field bucket. */
+TEST_F(St40RxFBitsTest, InterlaceAutoFieldBitFlip) {
+  ut40_ctx_set_interlace_auto(ctx_, true);
+  /* warm up with interlaced first-field (F=0x2) */
+  ut40_feed_pkt_fbits(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 0x2);
+  ut40_feed_pkt_fbits(ctx_, 1, 1001, 0, MTL_SESSION_PORT_P, 0x2);
+  EXPECT_EQ(interlace_first(), 2u);
+  /* now flip to progressive (F=0x0) */
+  ut40_feed_pkt_fbits(ctx_, 2, 1002, 0, MTL_SESSION_PORT_P, 0x0);
+  ut40_feed_pkt_fbits(ctx_, 3, 1003, 0, MTL_SESSION_PORT_P, 0x0);
+  /* progressive packets must NOT bump field counters */
+  EXPECT_EQ(interlace_first(), 2u);
+  EXPECT_EQ(interlace_second(), 0u);
+  EXPECT_EQ(wrong_interlace(), 0u);
+  EXPECT_EQ(received(), 4u);
+}
+
+/* Cross-port F-bit divergence: same timestamp, same seq on each port, but
+ * different F bits. Producer violation of SMPTE 2110-40. */
+TEST_F(St40RxFBitsTest, FieldBitMismatchDetected) {
+  constexpr uint32_t ts = 1000;
+  /* P sends F=0x2, R sends F=0x3 for the same frame (same tmstamp). */
+  ut40_feed_pkt_fbits(ctx_, 0, ts, 1, MTL_SESSION_PORT_P, 0x2);
+  ut40_feed_pkt_fbits(ctx_, 0, ts, 1, MTL_SESSION_PORT_R, 0x3);
+
+  EXPECT_GE(field_bit_mismatch(), 1u) << "Cross-port F-bit divergence must be detected";
+}
+
+/* Matching F bits on both ports must NOT register a mismatch. */
+TEST_F(St40RxFBitsTest, FieldBitsMatchNoMismatch) {
+  constexpr uint32_t ts = 1000;
+  ut40_feed_pkt_fbits(ctx_, 0, ts, 1, MTL_SESSION_PORT_P, 0x2);
+  ut40_feed_pkt_fbits(ctx_, 0, ts, 1, MTL_SESSION_PORT_R, 0x2);
+
+  EXPECT_EQ(field_bit_mismatch(), 0u)
+      << "Matching F bits must not trigger the mismatch counter";
+}
+
+/* F-bit mismatches must be counted per packet — one mismatch per packet. */
+TEST_F(St40RxFBitsTest, FieldBitMismatchMultiple) {
+  uint32_t ts = 1000;
+  for (uint16_t i = 0; i < 5; i++) {
+    ut40_feed_pkt_fbits(ctx_, i, ts, 1, MTL_SESSION_PORT_P, 0x2);
+    ut40_feed_pkt_fbits(ctx_, i, ts, 1, MTL_SESSION_PORT_R, 0x3);
+    ts += 3600;
+  }
+  EXPECT_GE(field_bit_mismatch(), 5u) << "One mismatch per offending packet expected";
+}
+
+/* F-bit check must be scoped to the *same* timestamp: different ts on each
+ * port (intentional skew test) must not produce a mismatch. */
+TEST_F(St40RxFBitsTest, FieldBitMismatchOnlyWhenSameTs) {
+  ut40_feed_pkt_fbits(ctx_, 0, 1000, 1, MTL_SESSION_PORT_P, 0x2);
+  ut40_feed_pkt_fbits(ctx_, 0, 2000, 1, MTL_SESSION_PORT_R, 0x3);
+
+  EXPECT_EQ(field_bit_mismatch(), 0u)
+      << "Different timestamps: F bits belong to different frames, no divergence";
+}

--- a/tests/unit/session/st40/header_validation_test.cpp
+++ b/tests/unit/session/st40/header_validation_test.cpp
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * RFC 8331 / RFC 3550 header validation:
+ * payload type, SSRC and F-bit checks; ReturnValue* contract for the
+ * underlying packet handler.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxHeaderValidationTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxHeaderValidationTest : public St40RxBaseTest {};
+
+/* Accepted packet must return 0. */
+TEST_F(St40RxHeaderValidationTest, ReturnValueAccepted) {
+  int rc = feed(0, 1000, false, MTL_SESSION_PORT_P);
+  EXPECT_EQ(rc, 0);
+}
+
+/* Wrong payload type must return -EINVAL. */
+TEST_F(St40RxHeaderValidationTest, ReturnValueWrongPT) {
+  ut40_ctx_set_pt(ctx_, 96);
+  int rc = ut40_feed_pkt_pt(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 97);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* Wrong SSRC must return -EINVAL. */
+TEST_F(St40RxHeaderValidationTest, ReturnValueWrongSSRC) {
+  ut40_ctx_set_ssrc(ctx_, 1234);
+  int rc = ut40_feed_pkt_ssrc(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 5678);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* Invalid F-bits (0b01) must return -EINVAL. */
+TEST_F(St40RxHeaderValidationTest, ReturnValueInvalidFBits) {
+  int rc = ut40_feed_pkt_fbits(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 0x1);
+  EXPECT_EQ(rc, -EINVAL);
+}
+
+/* Redundant (old-timestamp) packet returns -EAGAIN (not an error). */
+TEST_F(St40RxHeaderValidationTest, ReturnValueRedundant) {
+  feed(0, 2000, true, MTL_SESSION_PORT_P);
+  int rc = feed(0, 1000, false, MTL_SESSION_PORT_P);
+  EXPECT_EQ(rc, -EAGAIN);
+}
+
+/* Wrong PT packets are dropped and counted in wrong_pt stat. */
+TEST_F(St40RxHeaderValidationTest, WrongPayloadTypeDropped) {
+  ut40_ctx_set_pt(ctx_, 96);
+  for (int i = 0; i < 5; i++)
+    ut40_feed_pkt_pt(ctx_, i, 1000 + i, 0, MTL_SESSION_PORT_P, 97);
+
+  EXPECT_EQ(wrong_pt(), 5u);
+  EXPECT_EQ(received(), 0u);
+}
+
+/* Correct PT packets are accepted with zero wrong_pt. */
+TEST_F(St40RxHeaderValidationTest, CorrectPayloadTypeAccepted) {
+  ut40_ctx_set_pt(ctx_, 96);
+  for (int i = 0; i < 4; i++)
+    ut40_feed_pkt_pt(ctx_, i, 1000 + i, 0, MTL_SESSION_PORT_P, 96);
+
+  EXPECT_EQ(wrong_pt(), 0u);
+  EXPECT_EQ(received(), 4u);
+}
+
+/* Wrong SSRC packets are dropped and counted in wrong_ssrc stat. */
+TEST_F(St40RxHeaderValidationTest, WrongSSRCDropped) {
+  ut40_ctx_set_ssrc(ctx_, 0xDEAD);
+  for (int i = 0; i < 3; i++)
+    ut40_feed_pkt_ssrc(ctx_, i, 1000 + i, 0, MTL_SESSION_PORT_P, 0xBEEF);
+
+  EXPECT_EQ(wrong_ssrc(), 3u);
+  EXPECT_EQ(received(), 0u);
+}
+
+/* PT=0 disables the payload type check: any PT value is accepted. */
+TEST_F(St40RxHeaderValidationTest, ZeroPTDisablesCheck) {
+  /* PT=0 by default */
+  ut40_feed_pkt_pt(ctx_, 0, 1000, 0, MTL_SESSION_PORT_P, 99);
+  ut40_feed_pkt_pt(ctx_, 1, 1001, 0, MTL_SESSION_PORT_P, 111);
+
+  EXPECT_EQ(wrong_pt(), 0u);
+  EXPECT_EQ(received(), 2u);
+}

--- a/tests/unit/session/st40/marker_test.cpp
+++ b/tests/unit/session/st40/marker_test.cpp
@@ -1,0 +1,232 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * RTP marker bit preservation across the redundancy filter:
+ * single port, mid-frame switchover, cross-port reorder, threshold bypass
+ * and the bitmap late-arrival path.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxMarkerTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxMarkerTest : public St40RxBaseTest {};
+
+/* Marker preservation when P advances timestamp before R delivers marker.
+ *
+ * Scenario:
+ *   1. P delivers frame N body: seq 0-4, ts=1000, no marker
+ *   2. P delivers frame N+1 first packet: seq 7, ts=2000 — tmstamp advances
+ *   3. R delivers frame N tail: seq 5-6, ts=1000, marker on seq 6
+ *
+ * The redundancy filter must accept R's late packets for the immediately
+ * previous timestamp and preserve the marker bit through to the ring. */
+TEST_F(St40RxMarkerTest, MarkerPreservedAfterTimestampAdvance) {
+  ut40_drain_paused _drain_guard;
+  uint32_t ts_frame_n = 1000;
+  uint32_t ts_frame_n1 = 2000;
+
+  /* P delivers frame N body: seq 0-4, no marker */
+  for (int i = 0; i < 5; i++) feed(i, ts_frame_n, false, MTL_SESSION_PORT_P);
+
+  /* P starts frame N+1 before R delivers frame N's marker */
+  feed(7, ts_frame_n1, false, MTL_SESSION_PORT_P);
+
+  /* R delivers frame N's tail: seq 5 (no marker), seq 6 (MARKER) */
+  feed(5, ts_frame_n, false, MTL_SESSION_PORT_R);
+  feed(6, ts_frame_n, true, MTL_SESSION_PORT_R); /* MARKER */
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+
+  EXPECT_TRUE(has_marker)
+      << "Marker from R must survive when P advances to next frame first";
+}
+
+/* Marker bit on the last packet of a single-port burst survives into the ring. */
+TEST_F(St40RxMarkerTest, MarkerPreservedSinglePort) {
+  ut40_drain_paused _drain_guard;
+  /* 6 packets, marker on last */
+  feed_burst(0, 6, 1000, true, MTL_SESSION_PORT_P);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 6);
+  EXPECT_TRUE(has_marker) << "Marker bit must survive into the ring";
+}
+
+/* Mid-frame port switchover: P sends the body, R sends the tail including marker.
+ * A complete prior frame establishes session history, then P sends seq 7-11
+ * and R sends seq 12-13 with marker on seq 13. The marker-bearing packet from R
+ * must pass the redundancy filter and be enqueued with the marker bit intact. */
+TEST_F(St40RxMarkerTest, MarkerPreservedMidFrameSwitchover) {
+  /* Complete prior frame on P (7 packets) to establish session history */
+  feed_burst(0, 7, 1000, true, MTL_SESSION_PORT_P);
+  ut40_drain_ring();
+  ut40_drain_paused _drain_guard;
+
+  uint32_t ts = 2000;
+  /* P sends body: seq 7-11, no marker */
+  for (int i = 7; i <= 11; i++) feed(i, ts, false, MTL_SESSION_PORT_P);
+  /* R sends tail: seq 12-13, marker on seq 13 */
+  feed(12, ts, false, MTL_SESSION_PORT_R);
+  feed(13, ts, true, MTL_SESSION_PORT_R);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 7);
+  EXPECT_TRUE(has_marker) << "Marker from R port must survive mid-frame switchover";
+}
+
+/* Cross-port reorder with bitmap: R delivers seq 7-11 (marker on 11) before
+ * P's late-arriving seq 5-6.  A warm-up frame establishes session_seq so the
+ * bitmap base covers the late arrivals.  The marker from R must survive. */
+TEST_F(St40RxMarkerTest, MarkerPreservedCrossPortReorder) {
+  /* Previous frame to set session_seq_id=4, so bitmap base for next frame = 5 */
+  feed_burst(0, 5, 2999, true, MTL_SESSION_PORT_P);
+  ut40_drain_ring();
+  ut40_drain_paused _drain_guard;
+
+  uint32_t ts = 3000;
+  /* R sends seq 7-10 (no marker), then seq 11 (marker) */
+  for (int i = 7; i <= 10; i++) feed(i, ts, false, MTL_SESSION_PORT_R);
+  feed(11, ts, true, MTL_SESSION_PORT_R);
+  /* P's late arrivals: seq 5-6, same timestamp, no marker */
+  feed(5, ts, false, MTL_SESSION_PORT_P);
+  feed(6, ts, false, MTL_SESSION_PORT_P);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 7);
+  EXPECT_TRUE(has_marker) << "Marker must survive cross-port reorder";
+}
+
+/* Negative test: no marker set on any packet, verify has_marker is false.
+ * Guards against false positives in the test infrastructure. */
+TEST_F(St40RxMarkerTest, MarkerAbsentWhenNotSet) {
+  ut40_drain_paused _drain_guard;
+  /* 6 packets, NO marker on any */
+  feed_burst(0, 6, 1000, false, MTL_SESSION_PORT_P);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 6);
+  EXPECT_FALSE(has_marker) << "No packet had marker=1, has_marker must be false";
+}
+
+/* Marker on the first packet (not last) of a frame.  Verifies position-
+ * independence: the handler must never strip the marker regardless of
+ * where it appears in the sequence. */
+TEST_F(St40RxMarkerTest, MarkerOnFirstPacket) {
+  ut40_drain_paused _drain_guard;
+  uint32_t ts = 4000;
+  /* First packet carries the marker */
+  feed(0, ts, true, MTL_SESSION_PORT_P);
+  for (int i = 1; i < 6; i++) feed(i, ts, false, MTL_SESSION_PORT_P);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 6);
+  EXPECT_TRUE(has_marker) << "Marker on first packet must survive into ring";
+}
+
+/* Late arrival via bitmap carries the marker.  R advances the session seq,
+ * then P's late packet (carrying the marker) is accepted through the bitmap
+ * path (goto accept_pkt).  The marker must survive this alternate code path. */
+TEST_F(St40RxMarkerTest, MarkerOnBitmapLateArrival) {
+  /* Warm-up frame to establish session_seq = 4 */
+  feed_burst(0, 5, 4999, true, MTL_SESSION_PORT_P);
+  ut40_drain_ring();
+  ut40_drain_paused _drain_guard;
+
+  uint32_t ts = 5000;
+  /* R sends seq 7-10, no marker */
+  for (int i = 7; i <= 10; i++) feed(i, ts, false, MTL_SESSION_PORT_R);
+  /* P's late arrivals: seq 5 (no marker), seq 6 (MARKER) */
+  feed(5, ts, false, MTL_SESSION_PORT_P);
+  feed(6, ts, true, MTL_SESSION_PORT_P);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 6);
+  EXPECT_TRUE(has_marker) << "Marker on bitmap-accepted late arrival must survive";
+}
+
+/* Both P and R send the same marker packet (same seq, same ts, both with marker=1).
+ * P's packet is accepted, R's duplicate is filtered as redundant.
+ * The accepted packet must carry the marker into the ring. */
+TEST_F(St40RxMarkerTest, MarkerDuplicateFromBothPorts) {
+  ut40_drain_paused _drain_guard;
+  uint32_t ts = 1000;
+  /* P sends 4 packets, marker on seq 3 */
+  for (int i = 0; i < 3; i++) feed(i, ts, false, MTL_SESSION_PORT_P);
+  feed(3, ts, true, MTL_SESSION_PORT_P);
+  /* R sends same 4 packets (duplicates), marker on seq 3 too — all filtered */
+  for (int i = 0; i < 3; i++) feed(i, ts, false, MTL_SESSION_PORT_R);
+  feed(3, ts, true, MTL_SESSION_PORT_R);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 4) << "Only P's packets should be accepted, R's are redundant";
+  EXPECT_TRUE(has_marker) << "Marker from P's accepted packet must survive";
+}
+
+/* Marker on a packet accepted via the threshold bypass path.
+ * After 20+ consecutive redundant rejections on ALL ports, the filter
+ * force-accepts the next packet.  The marker must survive this path. */
+TEST_F(St40RxMarkerTest, MarkerSurvivesThresholdBypass) {
+  constexpr uint32_t ts_new = 6000;
+  constexpr uint32_t ts_old = 5000;
+
+  /* Establish state with newer timestamp */
+  feed_burst(0, 4, ts_new, true, MTL_SESSION_PORT_P);
+  feed_burst(0, 4, ts_new, true, MTL_SESSION_PORT_R);
+  ut40_drain_ring();
+  ut40_drain_paused _drain_guard;
+
+  /* Send 20 old-ts packets on BOTH ports (below threshold, all rejected) */
+  for (int i = 0; i < 20; i++) {
+    feed(50 + i, ts_old, false, MTL_SESSION_PORT_P);
+    feed(50 + i, ts_old, false, MTL_SESSION_PORT_R);
+  }
+
+  /* 21st pair: R goes first so its marker-bearing packet triggers the bypass.
+   * The bypass resets R's error counter, so P's packet will be rejected
+   * (P's counter is still >= threshold, but R's is now 0 < threshold).
+   * Only R's marker packet gets accepted. */
+  feed(70, ts_old, true, MTL_SESSION_PORT_R); /* marker — triggers bypass */
+  feed(70, ts_old, false, MTL_SESSION_PORT_P);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_GT(count, 0) << "At least one packet must be accepted via threshold bypass";
+  EXPECT_TRUE(has_marker)
+      << "Marker on threshold-bypass-accepted packet must survive into ring";
+}
+
+/* Frame consisting of only a single marker packet (degenerate but
+ * legal — e.g. an ANC frame with one ADF payload).  Must be delivered
+ * cleanly to the ring with marker bit preserved. */
+TEST_F(St40RxMarkerTest, SinglePacketFrameMarkerOnly) {
+  ut40_drain_paused _drain_guard;
+  feed(0, 1000, true, MTL_SESSION_PORT_P);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  EXPECT_EQ(count, 1);
+  EXPECT_TRUE(has_marker);
+  EXPECT_EQ(unrecovered(), 0u);
+}

--- a/tests/unit/session/st40/prev_window_test.cpp
+++ b/tests/unit/session/st40/prev_window_test.cpp
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Previous-timestamp acceptance window:
+ * late packets for the immediately previous frame are accepted; packets
+ * two frames back are rejected; bitmap dedup still applies.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxPrevWindowTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxPrevWindowTest : public St40RxBaseTest {};
+
+/* After tmstamp advances from N to N+1, packets for timestamp N (the immediately
+ * previous frame) must still be accepted by the redundancy filter.  This enables
+ * the pipeline layer to receive late-arriving packets from the redundant port
+ * and resolve pending frames with the correct marker bit. */
+TEST_F(St40RxPrevWindowTest, PrevTimestampPacketsAccepted) {
+  ut40_drain_paused _drain_guard;
+  uint32_t ts_n = 1000;
+  uint32_t ts_n1 = 2000;
+
+  /* P delivers frame N body: seq 0-2, ts=1000 */
+  for (int i = 0; i < 3; i++) feed(i, ts_n, false, MTL_SESSION_PORT_P);
+  /* P advances to frame N+1: seq 3, ts=2000 → tmstamp now 2000 */
+  feed(3, ts_n1, false, MTL_SESSION_PORT_P);
+  /* R delivers late packets for frame N: seq 4-5, ts=1000 */
+  feed(4, ts_n, false, MTL_SESSION_PORT_R);
+  feed(5, ts_n, true, MTL_SESSION_PORT_R); /* marker */
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+
+  /* All 6 packets should be accepted: the filter must recognize ts=1000
+   * as the immediately previous frame and accept R's late packets. */
+  EXPECT_EQ(count, 6) << "Late prev-frame packets from R must be accepted";
+  EXPECT_TRUE(has_marker) << "Late marker from R for prev_tmstamp must reach the ring";
+}
+
+/* Packets two frames back (tmstamp - 2) must still be rejected.
+ * Only the immediately previous timestamp gets the acceptance window. */
+TEST_F(St40RxPrevWindowTest, TwoFramesBackRejected) {
+  ut40_drain_paused _drain_guard;
+  uint32_t ts_old = 1000;
+  uint32_t ts_mid = 2000;
+  uint32_t ts_cur = 3000;
+
+  /* Advance through two frames: 1000 → 2000 → 3000 */
+  feed(0, ts_old, false, MTL_SESSION_PORT_P);
+  feed(1, ts_mid, false, MTL_SESSION_PORT_P); /* completes ts_old */
+  feed(2, ts_cur, false, MTL_SESSION_PORT_P); /* completes ts_mid */
+
+  /* Try sending a late packet for ts_old (two frames back) */
+  feed(3, ts_old, false, MTL_SESSION_PORT_R);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  /* Only 3 packets should be accepted (one per each ts advance).
+   * The late ts_old packet must be rejected — it's 2 frames behind. */
+  EXPECT_EQ(count, 3) << "Packets two timestamps behind must be rejected";
+}
+
+/* Late prev_tmstamp duplicates (same seq already accepted from P) must
+ * still be filtered as redundant.  The prev_tmstamp acceptance window
+ * must not bypass the bitmap deduplication. */
+TEST_F(St40RxPrevWindowTest, PrevTimestampDuplicatesFiltered) {
+  ut40_drain_paused _drain_guard;
+  uint32_t ts_n = 1000;
+  uint32_t ts_n1 = 2000;
+
+  /* P delivers full frame N: seq 0-3, marker on 3 */
+  for (int i = 0; i < 3; i++) feed(i, ts_n, false, MTL_SESSION_PORT_P);
+  feed(3, ts_n, true, MTL_SESSION_PORT_P);
+  /* P starts frame N+1 → tmstamp advances to 2000 */
+  feed(4, ts_n1, false, MTL_SESSION_PORT_P);
+  /* R sends duplicates for frame N (same seq, same ts) */
+  for (int i = 0; i < 3; i++) feed(i, ts_n, false, MTL_SESSION_PORT_R);
+  feed(3, ts_n, true, MTL_SESSION_PORT_R);
+
+  int count = 0;
+  bool has_marker = false;
+  ASSERT_EQ(ut40_ring_dequeue_markers(&count, &has_marker), 0);
+  /* Only 5 unique packets: 4 from P (ts=1000) + 1 from P (ts=2000).
+   * R's 4 duplicates must be filtered out by the bitmap dedup. */
+  EXPECT_EQ(count, 5) << "Late prev-frame duplicates from R must be filtered";
+}
+
+/* Port R lags by more than the prev_tmstamp window (1 frame).  Once R
+ * catches up, its packets for the long-stale frame should be filtered
+ * as redundant — neither delivered nor counted as unrecovered.  This
+ * documents the current 1-frame acceptance window depth. */
+TEST_F(St40RxPrevWindowTest, PortRLagsBeyondPrevTimestampWindow) {
+  /* P advances through frames N, N+1, N+2 */
+  feed(0, 1000, true, MTL_SESSION_PORT_P);
+  feed(1, 2000, true, MTL_SESSION_PORT_P);
+  feed(2, 3000, true, MTL_SESSION_PORT_P);
+
+  uint64_t redundant_before = redundant();
+  /* R now arrives with frame N data — 2 frames stale, outside the
+   * prev_tmstamp window.  Must be filtered as redundant. */
+  feed(0, 1000, true, MTL_SESSION_PORT_R);
+
+  EXPECT_GT(redundant(), redundant_before)
+      << "stale packets beyond prev-tmstamp window must be filtered as redundant";
+}
+
+/* The prev-frame acceptance window matches via
+ *   `tmstamp == (uint32_t)s->prev_tmstamp`
+ * which must work across the 32-bit RTP timestamp wrap. Frame N at
+ * ts=0xFFFFFFF0 advances to frame N+1 at ts=0x00000010 (a real wrap). A
+ * late marker for frame N on the redundant port must still be accepted
+ * via the prev_window path; a wrap-broken comparison would reject it. */
+TEST_F(St40RxPrevWindowTest, PrevTimestampWindowAcrossTsWrap) {
+  constexpr uint32_t ts_n = 0xFFFFFFF0;
+  constexpr uint32_t ts_n1 = 0x00000010; /* wraps over UINT32_MAX */
+
+  /* frame N: only seqs 0 and 1 on P (no marker yet); seq 2 is missing */
+  feed(0, ts_n, false, MTL_SESSION_PORT_P);
+  feed(1, ts_n, false, MTL_SESSION_PORT_P);
+
+  /* frame N+1 starts on P, advances session ts past the wrap */
+  feed(3, ts_n1, false, MTL_SESSION_PORT_P);
+  feed(4, ts_n1, true, MTL_SESSION_PORT_P);
+
+  /* late marker for frame N (seq 2, never delivered) arrives on R — must be
+   * accepted via prev_window despite prev_tmstamp having wrapped */
+  uint64_t recv_before = received();
+  int rc = feed(2, ts_n, true, MTL_SESSION_PORT_R);
+
+  EXPECT_GE(rc, 0)
+      << "late prev-frame marker across the 32-bit ts wrap must be accepted, not -EIO";
+  EXPECT_EQ(received(), recv_before + 1)
+      << "prev_window match must work when prev_tmstamp wrapped via UINT32_MAX";
+}

--- a/tests/unit/session/st40/redundancy_test.cpp
+++ b/tests/unit/session/st40/redundancy_test.cpp
@@ -1,0 +1,405 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Core RX redundancy/dispatch:
+ * normal redundancy, port switchover, threshold bypass, frame assembly,
+ * sequence/timestamp wrap, hitless-merge loss patterns, intra-frame reorder.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxRedundancyTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxRedundancyTest : public St40RxBaseTest {};
+
+/* Same packets sent on both ports, P first. Duplicates on R are filtered.
+ * Expects zero unrecovered. */
+TEST_F(St40RxRedundancyTest, NormalRedundancy) {
+  constexpr uint32_t ts1 = 1000;
+  constexpr uint32_t ts2 = 2500;
+
+  /* frame 1: 6 packets, port 0 then port 1 */
+  feed_burst(0, 6, ts1, true, MTL_SESSION_PORT_P);
+  feed_burst(0, 6, ts1, true, MTL_SESSION_PORT_R);
+
+  /* frame 2: 7 packets, port 0 then port 1 */
+  feed_burst(6, 7, ts2, true, MTL_SESSION_PORT_P);
+  feed_burst(6, 7, ts2, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 13u);
+}
+
+/* Clean burst switchover: P sends the first part of a frame, R sends
+ * the remainder with the marker bit. P's queue drains first.
+ * Expects zero unrecovered. */
+TEST_F(St40RxRedundancyTest, BurstSwitchoverClean) {
+  constexpr uint32_t ts_prev = 500;
+  constexpr uint32_t ts_cur = 1000;
+
+  /* establish history: one complete frame on port 0 */
+  feed_burst(0, 6, ts_prev, true, MTL_SESSION_PORT_P);
+
+  /* switchover frame: first 5 pkts from port 0, last 2 from port 1 */
+  feed_burst(6, 5, ts_cur, false, MTL_SESSION_PORT_P);
+  feed_burst(11, 2, ts_cur, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* Reordered burst switchover: R's newer packets are processed before P's
+ * late arrivals for the same frame (same timestamp). The filter must accept
+ * late packets from P that fill gaps rather than rejecting them as redundant.
+ * Expects zero unrecovered. */
+TEST_F(St40RxRedundancyTest, BurstSwitchoverReordered) {
+  constexpr uint16_t N = 100;
+  constexpr uint32_t ts_prev = 5000;
+  constexpr uint32_t ts_cur = 6500;
+
+  /* establish history: complete frame ending with seq N-1 */
+  feed_burst(N - 6, 6, ts_prev, true, MTL_SESSION_PORT_P);
+
+  ASSERT_EQ(session_seq(), N - 1);
+  ASSERT_EQ(unrecovered(), 0u);
+
+  /* Simulate reordering: R is processed first */
+
+  /* R delivers seq N+2…N+5 while P's queue is empty */
+  feed_burst(N + 2, 4, ts_cur, true, MTL_SESSION_PORT_R);
+
+  /* P's late arrivals: seq N, N+1 */
+  feed(N, ts_cur, false, MTL_SESSION_PORT_P);
+  feed(N + 1, ts_cur, false, MTL_SESSION_PORT_P);
+
+  /* All 6 packets belong to the same frame. Late arrivals from P
+   * should be accepted despite R delivering its portion first. */
+  EXPECT_EQ(unrecovered(), 0u)
+      << "Late packets from port 0 should be accepted, not filtered as redundant.";
+}
+
+/* Multiple consecutive reordered switchovers. Each frame has its tail
+ * processed from R before P's late head arrives.
+ * Verifies cumulative unrecovered remains zero across all switchovers. */
+TEST_F(St40RxRedundancyTest, MultipleSwitchoversReordered) {
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  constexpr int kFramePkts = 6;
+  constexpr uint32_t kTsDelta = 1501;
+
+  /* 10 normal frames on port 0 */
+  for (int f = 0; f < 10; f++) {
+    feed_burst(seq, kFramePkts, ts, true, MTL_SESSION_PORT_P);
+    seq += kFramePkts;
+    ts += kTsDelta;
+  }
+  ASSERT_EQ(unrecovered(), 0u);
+
+  int switchovers = 0;
+  constexpr int kLateCount = 2;
+
+  /* 5 switchover frames: port 1 first, then port 0 late */
+  for (int f = 0; f < 5; f++) {
+    uint16_t frame_start = seq;
+    feed_burst(frame_start + kLateCount, kFramePkts - kLateCount, ts, true,
+               MTL_SESSION_PORT_R);
+    feed_burst(frame_start, kLateCount, ts, false, MTL_SESSION_PORT_P);
+    switchovers++;
+    seq += kFramePkts;
+    ts += kTsDelta;
+  }
+
+  EXPECT_EQ(unrecovered(), 0u)
+      << "Late packets from port 0 should be accepted across all switchovers.";
+}
+
+/* Mid-frame port change without reordering: P sends the first half,
+ * R sends the second half in sequence order.
+ * Expects zero unrecovered and zero redundant. */
+TEST_F(St40RxRedundancyTest, MidFrameSwitchoverNoReorder) {
+  constexpr uint32_t ts = 1000;
+
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P);
+  feed(2, ts, false, MTL_SESSION_PORT_P);
+
+  feed(3, ts, false, MTL_SESSION_PORT_R);
+  feed(4, ts, false, MTL_SESSION_PORT_R);
+  feed(5, ts, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+}
+
+/* Single-port baseline: only one port configured, no redundancy filtering.
+ * All packets accepted, zero redundant. */
+TEST_F(St40RxRedundancyTest, SinglePortBaseline) {
+  ut40_ctx_destroy(ctx_);
+  ctx_ = ut40_ctx_create(1); /* re-create with 1 port */
+  ASSERT_NE(ctx_, nullptr);
+
+  feed_burst(0, 6, 1000, true, MTL_SESSION_PORT_P);
+  feed_burst(6, 7, 2500, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(received(), 13u);
+}
+
+/* Duplicate packet on the same port: same seq+ts resent.
+ * The duplicate must be filtered as redundant. */
+TEST_F(St40RxRedundancyTest, DuplicatePacketSamePort) {
+  constexpr uint32_t ts = 1000;
+
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P);
+  feed(2, ts, false, MTL_SESSION_PORT_P);
+  feed(3, ts, false, MTL_SESSION_PORT_P);
+  feed(4, ts, false, MTL_SESSION_PORT_P);
+  feed(5, ts, true, MTL_SESSION_PORT_P);
+
+  /* duplicate: send seq 5 again with same ts on same port */
+  feed(5, ts, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(redundant(), 1u);
+  EXPECT_EQ(received(), 6u);
+}
+
+/* Duplicate packet across ports: same seq+ts sent on P then R.
+ * The cross-port duplicate must be filtered as redundant. */
+TEST_F(St40RxRedundancyTest, DuplicatePacketCrossPort) {
+  constexpr uint32_t ts = 1000;
+
+  feed_burst(0, 6, ts, true, MTL_SESSION_PORT_P);
+
+  /* port 1 sends the same last packet */
+  feed(5, ts, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(redundant(), 1u);
+  EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* Redundancy error threshold bypass: after 20+ consecutive redundant
+ * rejections on ALL ports (ST_SESSION_REDUNDANT_ERROR_THRESHOLD = 20),
+ * the filter force-accepts the next packet.
+ * Also verifies the invariant: each packet must be counted as EITHER
+ * received OR redundant, never both. */
+TEST_F(St40RxRedundancyTest, ThresholdBypass) {
+  constexpr uint32_t ts_new = 2000;
+  constexpr uint32_t ts_old = 1000;
+
+  /* establish state with newer timestamp */
+  feed_burst(0, 4, ts_new, true, MTL_SESSION_PORT_P);
+  /* also feed port 1 to reset its error counter */
+  feed_burst(0, 4, ts_new, true, MTL_SESSION_PORT_R);
+
+  /* now send 21 packets with old timestamp on BOTH ports to exceed threshold */
+  for (int i = 0; i < 21; i++) {
+    feed(50 + i, ts_old, false, MTL_SESSION_PORT_P);
+    feed(50 + i, ts_old, false, MTL_SESSION_PORT_R);
+  }
+
+  /* the 21st pair should have been accepted (threshold = 20 per port) */
+  uint64_t recv_after = received();
+  EXPECT_GT(recv_after, 4u)
+      << "After exceeding threshold on both ports, packets should be force-accepted";
+
+  /* A bypass-accepted packet must be counted as EITHER received OR redundant.
+   * 8 setup pkts + 42 old-ts pkts = 50 total valid pkts. */
+  EXPECT_EQ(received() + redundant(), 50u)
+      << "Each packet must be counted as EITHER received OR redundant, never both";
+}
+
+/* Partial threshold: only P exceeds the redundancy error threshold while
+ * R remains below it. The filter must NOT bypass until ALL ports exceed
+ * the threshold. Expects no extra packets accepted. */
+TEST_F(St40RxRedundancyTest, ThresholdBypassPerPort) {
+  constexpr uint32_t ts_new = 2000;
+  constexpr uint32_t ts_old = 1000;
+
+  /* establish state */
+  feed_burst(0, 4, ts_new, true, MTL_SESSION_PORT_P);
+  /* feed port 1 — these 4 pkts are filtered as redundant (session_seq already 3),
+   * so port R's redundant_error_cnt reaches 4, which is still below threshold=20. */
+  feed_burst(0, 4, ts_new, true, MTL_SESSION_PORT_R);
+
+  /* send 25 old-ts packets on port 0 ONLY */
+  for (int i = 0; i < 25; i++) {
+    int rc = feed(50 + i, ts_old, false, MTL_SESSION_PORT_P);
+    /* all should be rejected: port R counter is 4, still below threshold */
+    EXPECT_LT(rc, 0)
+        << "Should not bypass threshold when port R only has 4 errors (< 20)";
+  }
+
+  /* nothing extra should have been received */
+  EXPECT_EQ(received(), 4u);
+}
+
+/* Interleaved ports: P sends even seqs, R sends odd seqs, all with the
+ * same timestamp. No packet reordering, just alternating sources.
+ * Expects zero unrecovered, zero redundant, and correct per-port OOO
+ * counts reflecting the per-port sequence gaps. */
+TEST_F(St40RxRedundancyTest, InterleavedPorts) {
+  constexpr uint32_t ts = 1000;
+
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_R);
+  feed(2, ts, false, MTL_SESSION_PORT_P);
+  feed(3, ts, false, MTL_SESSION_PORT_R);
+  feed(4, ts, false, MTL_SESSION_PORT_P);
+  feed(5, ts, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(received(), 6u);
+
+  /* Per-port OOO for interleaved ports: P sees seqs 0,2,4 (two gaps of 1),
+   * R sees seqs 1,3,5 (two gaps of 1). Each port should have 2 OOO events. */
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), 2u) << "Port P sees seq 0,2,4 — two gaps of 1";
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_R), 2u) << "Port R sees seq 1,3,5 — two gaps of 1";
+}
+
+/* Reordered switchover with a larger gap: R delivers 5 packets before
+ * P's 3 late arrivals for the same frame. Expects zero unrecovered. */
+TEST_F(St40RxRedundancyTest, BurstSwitchoverLargeGap) {
+  constexpr uint16_t N = 50;
+  constexpr uint32_t ts_prev = 3000;
+  constexpr uint32_t ts_cur = 4500;
+
+  /* history frame */
+  feed_burst(N - 4, 4, ts_prev, true, MTL_SESSION_PORT_P);
+  ASSERT_EQ(session_seq(), N - 1);
+
+  /* port 1 processed first: seq N+3..N+7 (5 pkts) */
+  feed_burst(N + 3, 5, ts_cur, true, MTL_SESSION_PORT_R);
+  /* port 0 late: seq N, N+1, N+2 */
+  feed(N, ts_cur, false, MTL_SESSION_PORT_P);
+  feed(N + 1, ts_cur, false, MTL_SESSION_PORT_P);
+  feed(N + 2, ts_cur, false, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 0u)
+      << "3 late packets from port 0 should be accepted, not lost.";
+}
+
+/* Full gap then late arrival: R has only the tail of a new frame,
+ * P's entire contribution arrives late. The late packets must be
+ * accepted. Expects zero unrecovered. */
+TEST_F(St40RxRedundancyTest, FullGapThenLateArrival) {
+  constexpr uint16_t N = 200;
+  constexpr uint32_t ts_prev = 7000;
+  constexpr uint32_t ts_cur = 8500;
+
+  feed_burst(N - 6, 6, ts_prev, true, MTL_SESSION_PORT_P);
+
+  /* port 1: seq N+3..N+5 (marker on N+5) — processed first */
+  feed_burst(N + 3, 3, ts_cur, true, MTL_SESSION_PORT_R);
+
+  /* port 0: seq N..N+2 — arrives late */
+  feed_burst(N, 3, ts_cur, false, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 0u)
+      << "First half of frame from port 0 arriving late should not be lost.";
+}
+
+/* Stale replay after switchover: after a clean port switch, R replays
+ * packets from an earlier frame. All replayed packets should be filtered
+ * as redundant. */
+TEST_F(St40RxRedundancyTest, RedundantAfterSwitchover) {
+  constexpr uint32_t ts1 = 1000;
+  constexpr uint32_t ts2 = 2500;
+
+  /* frame 1 from port 0 */
+  feed_burst(0, 6, ts1, true, MTL_SESSION_PORT_P);
+
+  /* frame 2: clean switchover, port 0 first half, port 1 second half */
+  feed_burst(6, 3, ts2, false, MTL_SESSION_PORT_P);
+  feed_burst(9, 3, ts2, true, MTL_SESSION_PORT_R);
+
+  /* port 1 now replays frame 1's packets (stale) */
+  feed_burst(0, 6, ts1, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 6u) << "All 6 stale frame-1 packets should be redundant";
+}
+
+/* True correlated loss: same seq missing on BOTH ports.  This is the
+ * only condition that should produce unrecovered > 0 in a redundant
+ * session. */
+TEST_F(St40RxRedundancyTest, CorrelatedLossBothPorts) {
+  /* Frame N: deliver seq 0,1,3,4 on both ports — seq 2 is lost on both. */
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(1, 1000, false, MTL_SESSION_PORT_P);
+  /* gap: seq 2 missing on P */
+  feed(3, 1000, false, MTL_SESSION_PORT_P);
+  feed(4, 1000, true, MTL_SESSION_PORT_P);
+
+  feed(0, 1000, false, MTL_SESSION_PORT_R);
+  feed(1, 1000, false, MTL_SESSION_PORT_R);
+  /* gap: seq 2 missing on R as well */
+  feed(3, 1000, false, MTL_SESSION_PORT_R);
+  feed(4, 1000, true, MTL_SESSION_PORT_R);
+
+  /* Per-port gap counted on each port. */
+  EXPECT_GE(port_ooo(MTL_SESSION_PORT_P), 1u);
+  EXPECT_GE(port_ooo(MTL_SESSION_PORT_R), 1u);
+  /* And — the meaningful number — true unrecovered loss. */
+  EXPECT_GE(unrecovered(), 1u) << "seq lost on both ports must produce unrecovered > 0";
+}
+
+/* Healthy redundancy: each port loses different packets, the merged
+ * stream is intact.  Asserts that the per-port loss counter rises
+ * while the merged stream sees zero unrecovered loss. */
+TEST_F(St40RxRedundancyTest, UncorrelatedLossOnePortAtATime) {
+  /* P loses even seqs (2,4,6,8); R loses odd seqs (1,3,5,7).
+   * Together every seq 0..9 is delivered exactly once. */
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(1, 1000, false, MTL_SESSION_PORT_P);
+  feed(3, 1000, false, MTL_SESSION_PORT_P);
+  feed(5, 1000, false, MTL_SESSION_PORT_P);
+  feed(7, 1000, false, MTL_SESSION_PORT_P);
+  feed(9, 1000, true, MTL_SESSION_PORT_P);
+
+  feed(0, 1000, false, MTL_SESSION_PORT_R);
+  feed(2, 1000, false, MTL_SESSION_PORT_R);
+  feed(4, 1000, false, MTL_SESSION_PORT_R);
+  feed(6, 1000, false, MTL_SESSION_PORT_R);
+  feed(8, 1000, false, MTL_SESSION_PORT_R);
+
+  /* Both ports report per-port loss (gap counter rises). */
+  EXPECT_GT(port_ooo(MTL_SESSION_PORT_P), 0u);
+  EXPECT_GT(port_ooo(MTL_SESSION_PORT_R), 0u);
+  /* But redundancy covers everything -> no unrecovered loss. */
+  EXPECT_EQ(unrecovered(), 0u)
+      << "per-port loss covered by the other port must not show as unrecovered";
+}
+
+/* Deterministic high per-port loss with full redundancy: ~25% per-port
+ * loss, complementary, so the merged stream is complete.  Every
+ * per-port drop must be counted as a per-port gap exactly once, and
+ * the merged stream must have zero unrecovered loss. */
+TEST_F(St40RxRedundancyTest, HighPerLegLossRedundancySaves) {
+  constexpr uint32_t ts = 1000;
+  constexpr int kPkts = 100;
+  /* P drops every 4th seq (i%4==3); R supplies those interleaved so the
+   * rescue lands inside the bitmap / prev_tmstamp window. */
+  int p_drops = 0;
+  for (int i = 0; i < kPkts; i++) {
+    if (i % 4 == 3) {
+      p_drops++;
+      feed(i, ts, false, MTL_SESSION_PORT_R); /* R covers immediately */
+      continue;
+    }
+    feed(i, ts, false, MTL_SESSION_PORT_P);
+  }
+  /* Close the trailing per-port gap on P (i==99 was a hole that has no
+   * follow-up P packet to expose it).  Forward gaps are observations —
+   * a hole is only counted when a later packet on the same port arrives
+   * past it, so we deliver one more packet at seq=kPkts. */
+  feed(kPkts, ts, true, MTL_SESSION_PORT_P);
+  /* Each per-port drop must show as a per-port gap on P. */
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), (uint64_t)p_drops);
+  /* The merged stream must be intact — every seq delivered once. */
+  EXPECT_EQ(unrecovered(), 0u) << "complementary per-port loss must be fully recovered";
+}

--- a/tests/unit/session/st40/reorder_test.cpp
+++ b/tests/unit/session/st40/reorder_test.cpp
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Per-port reorder and same-port duplicate accounting:
+ * the per-port reordered_packets and duplicates_same_port counters,
+ * their interaction with cross-port redundancy, and behaviour at the
+ * 16-bit seq wrap boundary.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxReorderTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxReorderTest : public St40RxBaseTest {};
+
+/* Backward seq on the same port (never seen on the other port) is a real
+ * intra-port reorder and must bump reordered_packets, NOT lost_packets.
+ * The bitmap path must accept the late arrival, cancelling any pending
+ * unrecovered count from the forward gap. */
+TEST_F(St40RxReorderTest, ReorderedPacketsCounted) {
+  constexpr uint32_t ts = 1000;
+  /* feed 0, 2, 1, 3 on port P only. Order 0-2 creates a forward gap (lost=1).
+   * When seq 1 then arrives, the old "late" packet is a same-port reorder. */
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(2, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P); /* backward — reorder */
+  feed(3, ts, true, MTL_SESSION_PORT_P);
+
+  EXPECT_GE(port_reordered(MTL_SESSION_PORT_P), 1u)
+      << "Backward seq on same port must be counted as reordered";
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 0u) << "Reorder is not a duplicate";
+  EXPECT_GE(port_ooo(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(unrecovered(), 0u)
+      << "intra-frame backward arrival should cancel the pending unrecovered count";
+}
+
+/* Exact same seq seen twice on the *same* port is a same-port duplicate
+ * (e.g. switch/cable loop). It must NOT be confused with the cross-port
+ * redundant copy tracked by stat_pkts_redundant. */
+TEST_F(St40RxReorderTest, DuplicateSamePortCounted) {
+  constexpr uint32_t ts = 1000;
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P); /* true same-port dup */
+  feed(2, ts, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u);
+}
+
+/* Backward arrival must NOT inflate lost_packets (lost is forward-gap only). */
+TEST_F(St40RxReorderTest, ReorderDoesNotInflateLostPackets) {
+  constexpr uint32_t ts = 1000;
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P);
+  feed(2, ts, false, MTL_SESSION_PORT_P);
+  uint64_t lost_before = port_ooo(MTL_SESSION_PORT_P);
+
+  /* Pure reorder: 1 arrives again-as-backward (after 2). No forward gap. */
+  feed(1, ts, false, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), lost_before)
+      << "A backward arrival must not bump lost_packets";
+  EXPECT_GE(port_reordered(MTL_SESSION_PORT_P), 1u);
+}
+
+/* Multiple same-port duplicates must each be counted. */
+TEST_F(St40RxReorderTest, DuplicateSamePortMultiple) {
+  constexpr uint32_t ts = 1000;
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P); /* dup #1 */
+  feed(1, ts, false, MTL_SESSION_PORT_P); /* dup #2 */
+  feed(1, ts, true, MTL_SESSION_PORT_P);  /* dup #3 */
+
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 3u)
+      << "Every same-port re-arrival of the same seq must be counted";
+}
+
+/* Cross-port "normal" redundancy must NOT bump reordered_packets / duplicates_same_port
+ * on either port. The counter is strictly for same-port repetitions. */
+TEST_F(St40RxReorderTest, CrossPortRedundantIsNotSamePortDuplicate) {
+  constexpr uint32_t ts = 1000;
+  feed_burst(0, 4, ts, true, MTL_SESSION_PORT_P);
+  feed_burst(0, 4, ts, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_R), 0u);
+  EXPECT_GE(redundant(), 1u) << "Cross-port redundancy must still count as redundant";
+}
+
+/* Reorder at the seq-wrap boundary: a small-value seq arriving after a
+ * near-max seq must NOT be counted as reorder — mt_seq16_greater treats
+ * the small value as the *forward* next wrap. */
+TEST_F(St40RxReorderTest, SeqWrapNotCountedAsReorder) {
+  constexpr uint32_t ts = 1000;
+  feed(65534, ts, false, MTL_SESSION_PORT_P);
+  feed(65535, ts, false, MTL_SESSION_PORT_P);
+  uint64_t reord_before = port_reordered(MTL_SESSION_PORT_P);
+
+  feed(0, ts, false, MTL_SESSION_PORT_P); /* wraps forward, not backward */
+  feed(1, ts, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), reord_before)
+      << "Wrap-around must be seen as forward, not reorder";
+}
+
+/* Same-port duplicate at seq-wrap boundary must still be counted. */
+TEST_F(St40RxReorderTest, DuplicateSamePortAtSeqWrap) {
+  constexpr uint32_t ts = 1000;
+  feed(65534, ts, false, MTL_SESSION_PORT_P);
+  feed(65535, ts, false, MTL_SESSION_PORT_P);
+  feed(65535, ts, false, MTL_SESSION_PORT_P); /* dup right at boundary */
+
+  EXPECT_EQ(port_duplicates(MTL_SESSION_PORT_P), 1u);
+}

--- a/tests/unit/session/st40/st40_rx_test_base.h
+++ b/tests/unit/session/st40/st40_rx_test_base.h
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Shared gtest fixture for the per-feature ST 2110-40 RX session tests
+ * under tests/unit/session/st40/.
+ *
+ * Each per-feature .cpp derives a thin subclass:
+ *
+ *   class St40RxMarkerTest : public St40RxBaseTest {};
+ *
+ * so that --gtest_filter='St40RxMarkerTest.*' selects only that feature's
+ * tests, while all setup/teardown and stat-accessor wrappers live here in
+ * one place.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "session/st40_harness.h"
+
+class St40RxBaseTest : public ::testing::Test {
+ protected:
+  ut_test_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut40_init(), 0) << "EAL init failed";
+    ut40_drain_ring();
+    ctx_ = ut40_ctx_create(2); /* 2 ports = redundant */
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  void TearDown() override {
+    ut40_drain_ring();
+    ut40_ctx_destroy(ctx_);
+    ctx_ = nullptr;
+  }
+
+  /* convenience wrappers */
+  int feed(uint16_t seq, uint32_t ts, bool marker, enum mtl_session_port port) {
+    return ut40_feed_pkt(ctx_, seq, ts, marker ? 1 : 0, port);
+  }
+
+  void feed_burst(uint16_t seq_start, int count, uint32_t ts, bool last_marker,
+                  enum mtl_session_port port) {
+    ut40_feed_burst(ctx_, seq_start, count, ts, last_marker ? 1 : 0, port);
+  }
+
+  uint64_t unrecovered() {
+    return ut40_stat_unrecovered(ctx_);
+  }
+  uint64_t redundant() {
+    return ut40_stat_redundant(ctx_);
+  }
+  uint64_t received() {
+    return ut40_stat_received(ctx_);
+  }
+  uint64_t ooo() {
+    return ut40_stat_lost_pkts(ctx_);
+  }
+  int session_seq() {
+    return ut40_session_seq_id(ctx_);
+  }
+
+  uint64_t port_pkts(enum mtl_session_port p) {
+    return ut40_stat_port_pkts(ctx_, p);
+  }
+  uint64_t port_bytes(enum mtl_session_port p) {
+    return ut40_stat_port_bytes(ctx_, p);
+  }
+  uint64_t port_ooo(enum mtl_session_port p) {
+    return ut40_stat_port_lost(ctx_, p);
+  }
+  uint64_t port_frames(enum mtl_session_port p) {
+    return ut40_stat_port_frames(ctx_, p);
+  }
+  uint64_t port_reordered(enum mtl_session_port p) {
+    return ut40_stat_port_reordered(ctx_, p);
+  }
+  uint64_t port_duplicates(enum mtl_session_port p) {
+    return ut40_stat_port_duplicates(ctx_, p);
+  }
+  uint64_t field_bit_mismatch() {
+    return ut40_stat_field_bit_mismatch(ctx_);
+  }
+  uint64_t wrong_pt() {
+    return ut40_stat_wrong_pt(ctx_);
+  }
+  uint64_t wrong_ssrc() {
+    return ut40_stat_wrong_ssrc(ctx_);
+  }
+  uint64_t wrong_interlace() {
+    return ut40_stat_wrong_interlace(ctx_);
+  }
+  uint64_t interlace_first() {
+    return ut40_stat_interlace_first(ctx_);
+  }
+  uint64_t interlace_second() {
+    return ut40_stat_interlace_second(ctx_);
+  }
+  uint64_t enqueue_fail() {
+    return ut40_stat_enqueue_fail(ctx_);
+  }
+  int frames_received() {
+    return ut40_frames_received(ctx_);
+  }
+};

--- a/tests/unit/session/st40/stats_test.cpp
+++ b/tests/unit/session/st40/stats_test.cpp
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * Per-port and session-wide stats invariants:
+ * sequence-gap accounting (lost_packets), per-port packet/OOO/reorder/duplicate
+ * counters and the global lost==sum(per-port-lost) invariant.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxStatsTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxStatsTest : public St40RxBaseTest {};
+
+/* Sequence gap produces exact unrecovered count (3 missing between 1 and 5). */
+TEST_F(St40RxStatsTest, SeqGapExactCount) {
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(1, 1000, false, MTL_SESSION_PORT_P);
+  feed(5, 1001, false, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 3u);
+}
+
+/* Large sequence gap: 99 packets missing between seq 0 and seq 100. */
+TEST_F(St40RxStatsTest, SeqGapLargeCount) {
+  feed(0, 1000, true, MTL_SESSION_PORT_P);
+  feed(100, 2000, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 99u);
+  EXPECT_EQ(received(), 2u);
+}
+
+/* Multiple sequence gaps produce correct cumulative unrecovered count. */
+TEST_F(St40RxStatsTest, SeqGapMultipleHoles) {
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(3, 1001, false, MTL_SESSION_PORT_P);
+  feed(6, 1002, false, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 4u); /* gap of 2 + gap of 2 */
+}
+
+/* Consecutive packets with no gap produce zero unrecovered. */
+TEST_F(St40RxStatsTest, NoGapNoUnrecovered) {
+  feed_burst(0, 4, 1000, true, MTL_SESSION_PORT_P);
+  EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* Per-port packet counters track packets received on each port independently. */
+TEST_F(St40RxStatsTest, PortPacketCount) {
+  feed_burst(0, 5, 1000, false, MTL_SESSION_PORT_P);
+  feed_burst(5, 3, 1001, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_P), 5u);
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_R), 3u);
+}
+
+/* Per-port OOO: gap on P only, R is sequential. OOO must be isolated. */
+TEST_F(St40RxStatsTest, PortOOOPerPort) {
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(5, 1001, false, MTL_SESSION_PORT_P); /* gap of 4 on P */
+  feed(6, 1002, false, MTL_SESSION_PORT_R);
+  feed(7, 1003, false, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), 4u);
+  /* port R has no prior history → first pkt sets latest_seq_id, no gap */
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_R), 0u);
+}
+
+/* Backward sequence arrival on the same port must not inflate the per-port
+ * OOO counter due to unsigned 16-bit wrapping. */
+TEST_F(St40RxStatsTest, PerPortOOOBackwardSeq) {
+  /* establish port P latest_seq_id = 5 */
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(5, 1001, false, MTL_SESSION_PORT_P);
+
+  uint64_t ooo_before = port_ooo(MTL_SESSION_PORT_P);
+
+  /* now feed seq 3 (backward) with a new timestamp so it's not filtered as redundant */
+  feed(3, 1002, false, MTL_SESSION_PORT_P);
+
+  /* The backward seq should NOT add ~65533 phantom OOO events.
+   * A correct implementation would add 0 or at most a small value. */
+  EXPECT_LE(port_ooo(MTL_SESSION_PORT_P), ooo_before + 10u)
+      << "Backward seq arrival should not add ~65533 phantom OOO";
+}
+
+/* Per stats_guide.md step 3: port[i].packets is pre-redundancy and includes
+ * filtered duplicates. The redundant packet must also appear in stat_pkts_redundant. */
+TEST_F(St40RxStatsTest, RedundantStillCountsPerPort) {
+  /* 4 packets on port P accepted */
+  feed_burst(0, 4, 1000, true, MTL_SESSION_PORT_P);
+  /* 4 duplicate packets on port R filtered as redundant */
+  feed_burst(0, 4, 1000, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(received(), 4u);
+  EXPECT_EQ(redundant(), 4u);
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_P), 4u);
+  /* R's per-port packets count what arrived on the wire (pre-redundancy). */
+  EXPECT_EQ(port_pkts(MTL_SESSION_PORT_R), 4u);
+}
+
+/* Duplicate seq_id on the same port must not inflate per-port OOO counter
+ * due to unsigned 16-bit wrapping (gap should be 0, not 65535). */
+TEST_F(St40RxStatsTest, DuplicateSeqPortOOOWrapping) {
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(5, 1001, false, MTL_SESSION_PORT_P);
+
+  uint64_t ooo_before = port_ooo(MTL_SESSION_PORT_P);
+
+  /* re-feed seq 5 with same ts → filtered as redundant */
+  feed(5, 1001, false, MTL_SESSION_PORT_P);
+
+  /* A duplicate seq should NOT inflate OOO. The gap is logically 0,
+   * but uint16_t wrapping makes it 65535. */
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), ooo_before)
+      << "Duplicate seq on same port should not inflate OOO counter";
+}
+
+/* Long accumulation: feed > 1000 packets with a regular gap pattern
+ * to ensure the per-port OOO counter accumulates monotonically and
+ * does not wrap.  Logically: the counter equals the number of
+ * injected gap events.
+ * Regression guard: per-port OOO counter must not wrap at uint16 boundary. */
+TEST_F(St40RxStatsTest, PerPortOOOLargeAccumulation) {
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  int gap_events = 0;
+  for (int i = 0; i < 1000; i++) {
+    feed(seq, ts, false, MTL_SESSION_PORT_P);
+    seq++;
+    if (i % 5 == 4) {
+      seq++; /* skip one -> 1-pkt forward gap */
+      gap_events++;
+    }
+    if (i % 50 == 49) ts++;
+  }
+  /* Close the trailing forward gap created on the last iteration: forward
+   * gaps are only counted when a later packet exposes them, so deliver one
+   * more packet at the post-skip seq. */
+  feed(seq, ts, false, MTL_SESSION_PORT_P);
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P), (uint64_t)gap_events);
+}
+
+/* Invariant: stat_lost_packets == port[0].lost + port[1].lost at all times. */
+TEST_F(St40RxStatsTest, LostPacketsInvariant) {
+  constexpr uint32_t ts = 1000;
+  /* Induce forward gap on each port, interleaved. */
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(2, ts, false, MTL_SESSION_PORT_P); /* gap of 1 */
+  feed(0, ts, false, MTL_SESSION_PORT_R);
+  feed(3, ts, false, MTL_SESSION_PORT_R); /* gap of 2 */
+
+  EXPECT_EQ(ooo(), port_ooo(MTL_SESSION_PORT_P) + port_ooo(MTL_SESSION_PORT_R))
+      << "stat_lost_packets must equal the sum of per-port lost_packets";
+}
+
+/* Gap calculation across the 16-bit RTP seq wrap boundary. The lib computes
+ * the per-port gap as `(uint16_t)(seq - latest - 1)`, which must wrap modulo
+ * 2^16. With latest=65534 and seq=1, the true forward gap is 2 (seq 65535
+ * and 0 missed). A signed-promotion or naive subtraction bug would inflate
+ * the counter to ~65535. Regression for the uint16-cast contract. */
+TEST_F(St40RxStatsTest, PortLostNotInflatedAtSeqWrap) {
+  constexpr uint32_t ts1 = 1000;
+  constexpr uint32_t ts2 = 1001;
+
+  /* establish latest_seq_id[P] = 65534 */
+  feed(65533, ts1, false, MTL_SESSION_PORT_P);
+  feed(65534, ts1, true, MTL_SESSION_PORT_P);
+  uint64_t lost_before = port_ooo(MTL_SESSION_PORT_P);
+
+  /* forward jump across the wrap: gap = 2 (seq 65535 and 0 missing) */
+  feed(1, ts2, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(port_ooo(MTL_SESSION_PORT_P) - lost_before, 2u)
+      << "per-port lost gap across seq wrap must be the true forward gap (2),"
+         " not a phantom ~65535 from naive subtraction";
+}
+
+/* The `LostPacketsInvariant` (stat_lost == sum-of-per-port-lost) must hold
+ * across a 16-bit seq wrap. Both ports cross the wrap with independent
+ * gaps; verify the merged invariant survives the modular arithmetic. */
+TEST_F(St40RxStatsTest, LostPacketsInvariantAcrossSeqWrap) {
+  /* P: latest=65534, then 1 (gap 2) */
+  feed(65533, 1000, false, MTL_SESSION_PORT_P);
+  feed(65534, 1000, true, MTL_SESSION_PORT_P);
+  feed(1, 1001, true, MTL_SESSION_PORT_P);
+
+  /* R: latest=65530, then 0 (gap 5) */
+  feed(65529, 1000, false, MTL_SESSION_PORT_R);
+  feed(65530, 1000, true, MTL_SESSION_PORT_R);
+  feed(0, 1001, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(ooo(), port_ooo(MTL_SESSION_PORT_P) + port_ooo(MTL_SESSION_PORT_R))
+      << "sum-of-per-port-lost invariant must hold across seq wrap";
+}
+
+/* The `_handle_pkt` path decrements `stat_pkts_unrecovered` when a late
+ * arrival fills a previously-counted gap. The decrement is guarded by
+ * `if (> 0)`. Drive a sequence where multiple late arrivals could try to
+ * decrement the same logical gap; the counter must never underflow. */
+TEST_F(St40RxStatsTest, UnrecoveredDoesNotUnderflow) {
+  constexpr uint32_t ts = 1000;
+
+  /* P delivers seq 0 then jumps to 5 (gap of 4 -> unrecovered += 4) */
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(5, ts, true, MTL_SESSION_PORT_P);
+  uint64_t unrec_after_gap = unrecovered();
+  ASSERT_GE(unrec_after_gap, 4u);
+
+  /* R now delivers seq 1,2,3,4 — same frame, same ts. Each lands inside
+   * anc_window_cur and decrements unrecovered. Then re-deliver them again
+   * (now bitmap bits already set, so no further decrement should happen). */
+  for (int i = 1; i <= 4; i++) feed(i, ts, false, MTL_SESSION_PORT_R);
+  for (int i = 1; i <= 4; i++) feed(i, ts, false, MTL_SESSION_PORT_R);
+
+  /* unrecovered may be 0 (gap healed) or >0 (some late arrivals classified
+   * as redundant), but it must NEVER wrap to a huge number. */
+  EXPECT_LE(unrecovered(), unrec_after_gap)
+      << "stat_pkts_unrecovered must not underflow when late arrivals re-fire the "
+         "decrement path";
+}

--- a/tests/unit/session/st40/timestamp_test.cpp
+++ b/tests/unit/session/st40/timestamp_test.cpp
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Sequence and timestamp boundary behavior:
+ * 16-bit seq wrap (with and without redundancy), 32-bit timestamp wrap,
+ * backward-timestamp rejection, back-to-back frames.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40RxTimestampTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st40/st40_rx_test_base.h"
+
+class St40RxTimestampTest : public St40RxBaseTest {};
+
+/* 16-bit sequence number wraparound (65533 → 65535 → 0 → 1).
+ * All packets in order on a single port. Expects zero unrecovered. */
+TEST_F(St40RxTimestampTest, SeqWrapAround) {
+  constexpr uint32_t ts1 = 1000;
+  constexpr uint32_t ts2 = 2000;
+
+  /* first frame ends at 65535 */
+  feed(65533, ts1, false, MTL_SESSION_PORT_P);
+  feed(65534, ts1, false, MTL_SESSION_PORT_P);
+  feed(65535, ts1, true, MTL_SESSION_PORT_P);
+
+  /* second frame wraps to 0 */
+  feed(0, ts2, false, MTL_SESSION_PORT_P);
+  feed(1, ts2, false, MTL_SESSION_PORT_P);
+  feed(2, ts2, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(received(), 6u);
+}
+
+/* Sequence wraparound with redundancy: both ports send the same packets
+ * across the 16-bit seq_id boundary. Expects correct redundant count. */
+TEST_F(St40RxTimestampTest, SeqWrapAroundRedundant) {
+  constexpr uint32_t ts = 1000;
+
+  /* port 0: seq 65534,65535,0 */
+  feed(65534, ts, false, MTL_SESSION_PORT_P);
+  feed(65535, ts, false, MTL_SESSION_PORT_P);
+  feed(0, ts, true, MTL_SESSION_PORT_P);
+
+  /* port 1: same packets */
+  feed(65534, ts, false, MTL_SESSION_PORT_R);
+  feed(65535, ts, false, MTL_SESSION_PORT_R);
+  feed(0, ts, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 3u);
+}
+
+/* 32-bit timestamp wraparound from near UINT32_MAX to near zero.
+ * Expects all packets received with zero unrecovered. */
+TEST_F(St40RxTimestampTest, TimestampWrapAround) {
+  constexpr uint32_t ts1 = 0xFFFFFFF0;
+  constexpr uint32_t ts2 = 0x00000010; /* wraps around */
+
+  feed_burst(0, 4, ts1, true, MTL_SESSION_PORT_P);
+  feed_burst(4, 4, ts2, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(received(), 8u);
+}
+
+/* Backward timestamp with advancing seq: a newer-ts frame is followed by
+ * a packet with an older timestamp but higher seq_id.
+ * The filter must reject based on the stale timestamp. */
+TEST_F(St40RxTimestampTest, OldTimestampNewSeq) {
+  constexpr uint32_t ts_new = 2000;
+  constexpr uint32_t ts_old = 1000;
+
+  /* first frame with newer timestamp */
+  feed_burst(0, 4, ts_new, true, MTL_SESSION_PORT_P);
+
+  /* second "frame" has older timestamp but advancing seq — should be filtered */
+  int rc = feed(4, ts_old, true, MTL_SESSION_PORT_P);
+  EXPECT_LT(rc, 0) << "Packet with old timestamp should be rejected";
+  EXPECT_EQ(redundant(), 1u);
+}
+
+/* Back-to-back frames on a single port: 10 frames × 4 packets each.
+ * No gaps, no redundancy. Expects exact received count of 40. */
+TEST_F(St40RxTimestampTest, BackToBackFrames) {
+  ut40_ctx_destroy(ctx_);
+  ctx_ = ut40_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  for (int f = 0; f < 10; f++) {
+    feed_burst(seq, 4, ts, true, MTL_SESSION_PORT_P);
+    seq += 4;
+    ts += 1501;
+  }
+
+  EXPECT_EQ(unrecovered(), 0u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(received(), 40u);
+}

--- a/tests/unit/session/st40_harness.c
+++ b/tests/unit/session/st40_harness.c
@@ -1,0 +1,326 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C harness for ST40 RX redundancy unit tests (session layer).
+ * Wraps internal MTL functions that cannot be called directly from C++
+ * (internal headers use C keywords like "new" as identifiers).
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Include the production .c directly so that all static functions
+ * (rx_ancillary_session_handle_pkt, rx_ancillary_session_reset, etc.)
+ * become visible in this translation unit.  Non-static symbols will
+ * duplicate those in libmtl; the linker flag --allow-multiple-definition
+ * is used to resolve this safely (identical code).
+ * Disable USDT to avoid linker references to probe semaphores.
+ */
+#undef MTL_HAS_USDT
+#include "common/ut_common.h"
+#include "st2110/st_rx_ancillary_session.c"
+
+/* ── define the opaque context ────────────────────────────────────────── */
+
+struct ut_test_ctx {
+  struct mtl_main_impl impl;
+  struct st_rx_ancillary_sessions_mgr mgr;
+  struct st_rx_ancillary_session_impl session;
+};
+
+/* pull in the header after the struct definition so types resolve */
+#include "session/st40_harness.h"
+
+/* ── globals ──────────────────────────────────────────────────────────── */
+
+static struct rte_ring* g_ring;
+static bool g_skip_drain; /* when true, notify_rtp_ready does not drain the ring */
+
+/* ── RTP ready callback ──────────────────────────────────────────────── */
+
+static int ut_notify_rtp_ready(void* priv) {
+  (void)priv;
+  if (!g_skip_drain) ut_ring_drain(g_ring);
+  return 0;
+}
+
+/* ── init (delegates to common) ───────────────────────────────────────── */
+
+int ut40_init(void) {
+  if (ut_eal_init() < 0) return -1;
+
+  if (!g_ring) {
+    g_ring = ut_ring_create("st40_ring", UT_RING_SIZE);
+    if (!g_ring) return -1;
+  }
+  return 0;
+}
+
+/* ── context create / destroy ─────────────────────────────────────────── */
+
+ut_test_ctx* ut40_ctx_create(int num_port) {
+  ut_test_ctx* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx) return NULL;
+
+  mt_stat_u64_init(&ctx->session.stat_time);
+
+  ctx->impl.type = MT_HANDLE_MAIN;
+  ctx->impl.tsc_hz = rte_get_tsc_hz();
+
+  ctx->mgr.parent = &ctx->impl;
+  ctx->mgr.idx = 0;
+
+  ctx->session.idx = 0;
+  ctx->session.socket_id = rte_socket_id();
+  ctx->session.mgr = &ctx->mgr;
+  ctx->session.packet_ring = g_ring;
+  ctx->session.attached = true;
+  ctx->session.ops.num_port = num_port;
+  ctx->session.ops.payload_type = 0;
+  ctx->session.ops.interlaced = false;
+  ctx->session.ops.rtp_ring_size = UT_RING_SIZE;
+  ctx->session.ops.notify_rtp_ready = ut_notify_rtp_ready;
+  ctx->session.ops.priv = &ctx->session;
+  ctx->session.ops.name = "unit_test";
+  ctx->session.interlace_auto = false;
+
+  for (int i = 0; i < MTL_SESSION_PORT_MAX; i++) {
+    ctx->session.priv[i].session = &ctx->session;
+    ctx->session.priv[i].impl = &ctx->impl;
+    ctx->session.priv[i].s_port = (enum mtl_session_port)i;
+  }
+
+  rx_ancillary_session_reset(&ctx->session, false);
+  return ctx;
+}
+
+void ut40_ctx_destroy(ut_test_ctx* ctx) {
+  free(ctx);
+}
+
+void ut40_drain_ring(void) {
+  ut_ring_drain(g_ring);
+}
+
+/* ── mbuf builder (internal) ──────────────────────────────────────────── */
+
+static struct rte_mbuf* make_anc_mbuf_full(uint16_t seq, uint32_t ts, int marker,
+                                           uint8_t pt, uint32_t ssrc, uint8_t f_bits) {
+  struct rte_mbuf* m = rte_pktmbuf_alloc(ut_pool());
+  if (!m) return NULL;
+
+  size_t hdr_offset = sizeof(struct st_rfc3550_hdr) - sizeof(struct st_rfc3550_rtp_hdr);
+  size_t total = hdr_offset + sizeof(struct st40_rfc8331_rtp_hdr);
+
+  if (rte_pktmbuf_tailroom(m) < total) {
+    rte_pktmbuf_free(m);
+    return NULL;
+  }
+
+  uint8_t* buf = rte_pktmbuf_mtod(m, uint8_t*);
+  memset(buf, 0, total);
+
+  struct st40_rfc8331_rtp_hdr* rtp = (struct st40_rfc8331_rtp_hdr*)(buf + hdr_offset);
+  rtp->base.version = 2;
+  rtp->base.seq_number = htons(seq);
+  rtp->base.tmstamp = htonl(ts);
+  rtp->base.ssrc = htonl(ssrc);
+  rtp->base.payload_type = pt;
+  rtp->base.marker = marker ? 1 : 0;
+
+  /* pack anc_count=1 and f_bits into the chunk that gets ntohl'd */
+  uint32_t chunk = ((uint32_t)1) << 24; /* anc_count = 1 */
+  chunk |= ((uint32_t)(f_bits & 0x3)) << 22;
+  rtp->swapped_first_hdr_chunk = htonl(chunk);
+
+  m->data_len = total;
+  m->pkt_len = total;
+  return m;
+}
+
+static struct rte_mbuf* make_anc_mbuf(uint16_t seq, uint32_t ts, int marker) {
+  return make_anc_mbuf_full(seq, ts, marker, 0, 0, 0);
+}
+
+/* ── feed functions ───────────────────────────────────────────────────── */
+
+int ut40_feed_pkt(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                  enum mtl_session_port port) {
+  struct rte_mbuf* m = make_anc_mbuf(seq, ts, marker);
+  if (!m) return -1;
+  int rc = rx_ancillary_session_handle_pkt(&ctx->impl, &ctx->session, m, port);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+void ut40_feed_burst(ut_test_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
+                     int last_marker, enum mtl_session_port port) {
+  for (int i = 0; i < count; i++) {
+    int marker = last_marker && (i == count - 1);
+    ut40_feed_pkt(ctx, seq_start + i, ts, marker, port);
+  }
+}
+
+int ut40_feed_spec(ut_test_ctx* ctx, struct ut40_pkt_spec spec) {
+  struct rte_mbuf* m = make_anc_mbuf_full(spec.seq, spec.ts, spec.marker,
+                                          spec.payload_type, spec.ssrc, spec.f_bits);
+  if (!m) return -1;
+  int rc = rx_ancillary_session_handle_pkt(&ctx->impl, &ctx->session, m, spec.port);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut40_feed_pkt_pt(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                     enum mtl_session_port port, uint8_t payload_type) {
+  struct ut40_pkt_spec spec = {
+      .seq = seq, .ts = ts, .marker = marker, .port = port, .payload_type = payload_type};
+  return ut40_feed_spec(ctx, spec);
+}
+
+int ut40_feed_pkt_ssrc(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                       enum mtl_session_port port, uint32_t ssrc) {
+  struct ut40_pkt_spec spec = {
+      .seq = seq, .ts = ts, .marker = marker, .port = port, .ssrc = ssrc};
+  return ut40_feed_spec(ctx, spec);
+}
+
+int ut40_feed_pkt_fbits(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                        enum mtl_session_port port, uint8_t f_bits) {
+  struct ut40_pkt_spec spec = {
+      .seq = seq, .ts = ts, .marker = marker, .port = port, .f_bits = f_bits};
+  return ut40_feed_spec(ctx, spec);
+}
+
+int ut40_feed_spec_via_wrapper(ut_test_ctx* ctx, struct ut40_pkt_spec spec) {
+  struct rte_mbuf* m = make_anc_mbuf_full(spec.seq, spec.ts, spec.marker,
+                                          spec.payload_type, spec.ssrc, spec.f_bits);
+  if (!m) return -1;
+  struct rte_mbuf* mbufs[1] = {m};
+  int rc = rx_ancillary_session_handle_mbuf(&ctx->session.priv[spec.port], mbufs, 1);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+/* ── config setters ───────────────────────────────────────────────────── */
+
+void ut40_ctx_set_pt(ut_test_ctx* ctx, uint8_t pt) {
+  ctx->session.ops.payload_type = pt;
+}
+
+void ut40_ctx_set_ssrc(ut_test_ctx* ctx, uint32_t ssrc) {
+  ctx->session.ops.ssrc = ssrc;
+}
+
+void ut40_ctx_set_interlace_auto(ut_test_ctx* ctx, bool enable) {
+  ctx->session.interlace_auto = enable;
+}
+
+/* ── stat accessors ───────────────────────────────────────────────────── */
+
+uint64_t ut40_stat_unrecovered(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_unrecovered;
+}
+
+uint64_t ut40_stat_redundant(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_redundant;
+}
+
+uint64_t ut40_stat_received(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_received;
+}
+
+uint64_t ut40_stat_lost_pkts(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_lost_packets;
+}
+
+int ut40_session_seq_id(const ut_test_ctx* ctx) {
+  return ctx->session.session_seq_id;
+}
+
+uint64_t ut40_stat_port_pkts(const ut_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].packets;
+}
+
+uint64_t ut40_stat_port_bytes(const ut_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].bytes;
+}
+
+uint64_t ut40_stat_port_lost(const ut_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].lost_packets;
+}
+
+uint64_t ut40_stat_port_frames(const ut_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].frames;
+}
+
+uint64_t ut40_stat_port_reordered(const ut_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].reordered_packets;
+}
+
+uint64_t ut40_stat_port_duplicates(const ut_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].duplicates_same_port;
+}
+
+uint64_t ut40_stat_port_err_packets(const ut_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].err_packets;
+}
+
+uint64_t ut40_stat_field_bit_mismatch(const ut_test_ctx* ctx) {
+  return ctx->session.stat_internal_field_bit_mismatch;
+}
+
+uint64_t ut40_stat_wrong_pt(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_wrong_pt_dropped;
+}
+
+uint64_t ut40_stat_wrong_ssrc(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_wrong_ssrc_dropped;
+}
+
+uint64_t ut40_stat_wrong_interlace(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_wrong_interlace_dropped;
+}
+
+uint64_t ut40_stat_interlace_first(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_interlace_first_field;
+}
+
+uint64_t ut40_stat_interlace_second(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_interlace_second_field;
+}
+
+uint64_t ut40_stat_enqueue_fail(const ut_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_enqueue_fail;
+}
+
+int ut40_frames_received(const ut_test_ctx* ctx) {
+  return rte_atomic32_read(&ctx->session.stat_frames_received);
+}
+
+/* ── ring marker inspection ───────────────────────────────────────────── */
+
+void ut40_set_skip_drain(bool skip) {
+  g_skip_drain = skip;
+}
+
+void ut40_session_reset(ut_test_ctx* ctx) {
+  rx_ancillary_session_reset(&ctx->session, false);
+}
+
+int ut40_ring_dequeue_markers(int* out_count, bool* out_has_marker) {
+  *out_count = 0;
+  *out_has_marker = false;
+  if (!g_ring) return -1;
+
+  struct rte_mbuf* pkt = NULL;
+  while (rte_ring_sc_dequeue(g_ring, (void**)&pkt) == 0) {
+    size_t hdr_offset = sizeof(struct st_rfc3550_hdr) - sizeof(struct st_rfc3550_rtp_hdr);
+    struct st_rfc3550_rtp_hdr* rtp =
+        rte_pktmbuf_mtod_offset(pkt, struct st_rfc3550_rtp_hdr*, hdr_offset);
+    if (rtp->marker) *out_has_marker = true;
+    (*out_count)++;
+    rte_pktmbuf_free(pkt);
+  }
+  return 0;
+}

--- a/tests/unit/session/st40_harness.h
+++ b/tests/unit/session/st40_harness.h
@@ -1,0 +1,200 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2025 Intel Corporation
+ *
+ * C harness API for the ST 2110-40 (ancillary) RX session unit tests.
+ *
+ * The harness wraps a single `st_rx_ancillary_session_impl`. Accepted
+ * packets are placed onto a real DPDK ring (so the production frame-assembly
+ * code can dequeue them); the ring is drained between feeds by default and
+ * can be inspected directly via the `ut40_drain_paused` RAII guard plus
+ * `ut40_ring_dequeue_markers()`.
+ *
+ * Two feeder families are exposed:
+ *
+ *   ut40_feed_*                — call the per-packet handler directly.
+ *                                Use to assert on filter/state behaviour.
+ *   ut40_feed_*_via_wrapper    — call the public `_handle_mbuf` wrapper
+ *                                the production tasklet uses. Use whenever
+ *                                the test asserts on per-port `err_packets`
+ *                                or `packets` accounting.
+ */
+
+#ifndef _ST40_SESSION_HARNESS_H_
+#define _ST40_SESSION_HARNESS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "mtl_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ut_test_ctx ut_test_ctx;
+
+/* Initialise the shared DPDK EAL, mempool, and ANC ring. Idempotent —
+ * safe to call once per gtest fixture SetUp(). Returns 0 on success. */
+int ut40_init(void);
+
+/* Create a context with `num_port` enabled (1 = single-port, 2 = redundant).
+ * Caller owns the returned pointer and must free it with ut40_ctx_destroy(). */
+ut_test_ctx* ut40_ctx_create(int num_port);
+void ut40_ctx_destroy(ut_test_ctx* ctx);
+
+/* Drain every accepted packet currently on the ANC ring. The harness
+ * normally drains automatically inside each feeder; call this explicitly
+ * after `ut40_drain_paused` scope ends, or in TearDown() to reset shared
+ * state between tests. */
+void ut40_drain_ring(void);
+
+/* Build and feed one RFC 8331 ancillary packet directly to the per-packet
+ * handler. `marker` sets the RTP marker bit (1 = end of frame, 0 = mid).
+ * Returns the production handler's return code (0 = accepted, < 0 = error
+ * reason; e.g. -EIO for redundancy filtering). */
+int ut40_feed_pkt(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                  enum mtl_session_port port);
+
+/* Convenience: feed `count` consecutive packets starting at `seq_start`,
+ * all with the same `ts`. The marker bit is set only on the last packet
+ * if `last_marker` is non-zero. */
+void ut40_feed_burst(ut_test_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
+                     int last_marker, enum mtl_session_port port);
+
+/* Negative-test feeders: override one RTP / payload field while keeping
+ * the others at session defaults. */
+int ut40_feed_pkt_pt(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                     enum mtl_session_port port, uint8_t payload_type);
+int ut40_feed_pkt_ssrc(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                       enum mtl_session_port port, uint32_t ssrc);
+int ut40_feed_pkt_fbits(ut_test_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                        enum mtl_session_port port, uint8_t f_bits);
+
+/* Designated-initializer-friendly packet description for ut40_feed_spec().
+ * Fields are in the order tests overwhelmingly use; defaults (0) match the
+ * thin wrappers above so callers only set what they want to override. */
+struct ut40_pkt_spec {
+  uint16_t seq;
+  uint32_t ts;
+  int marker;
+  enum mtl_session_port port;
+  uint8_t payload_type; /* 0 = use session default */
+  uint32_t ssrc;        /* 0 = use session default */
+  uint8_t f_bits;       /* 0 = progressive */
+};
+
+/* Feed a packet described by `spec` directly to the per-packet handler.
+ * Equivalent to the typed feeders above but lets a test override several
+ * fields in one call without an explosion of parameters. */
+int ut40_feed_spec(ut_test_ctx* ctx, struct ut40_pkt_spec spec);
+
+/* Configure the session's expected RTP fields. Call after ut40_ctx_create()
+ * and before feeding any packet. */
+void ut40_ctx_set_pt(ut_test_ctx* ctx, uint8_t pt);
+void ut40_ctx_set_ssrc(ut_test_ctx* ctx, uint32_t ssrc);
+
+/* Toggle interlace auto-detection. When enabled the session derives the
+ * field bit from the first interlaced packet seen; when disabled the
+ * session enforces its configured value. */
+void ut40_ctx_set_interlace_auto(ut_test_ctx* ctx, bool enable);
+
+/* Wrapper feeder — drives the production `_handle_mbuf` wrapper instead of
+ * the per-packet handler. Use this whenever the test asserts on per-port
+ * `err_packets` or per-port `packets`. */
+int ut40_feed_spec_via_wrapper(ut_test_ctx* ctx, struct ut40_pkt_spec spec);
+
+/* Per-port counter accessors. */
+uint64_t ut40_stat_port_err_packets(const ut_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut40_stat_port_pkts(const ut_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut40_stat_port_bytes(const ut_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut40_stat_port_lost(const ut_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut40_stat_port_frames(const ut_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut40_stat_port_reordered(const ut_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut40_stat_port_duplicates(const ut_test_ctx* ctx, enum mtl_session_port port);
+
+/* Session-wide counters. `unrecovered` counts gaps the redundancy filter
+ * could not heal; `redundant` counts cross-port duplicates dropped by the
+ * filter; `received` counts accepted packets after filtering. */
+uint64_t ut40_stat_unrecovered(const ut_test_ctx* ctx);
+uint64_t ut40_stat_redundant(const ut_test_ctx* ctx);
+uint64_t ut40_stat_received(const ut_test_ctx* ctx);
+uint64_t ut40_stat_lost_pkts(const ut_test_ctx* ctx);
+
+/* Last accepted RTP sequence number (a.k.a. session "watermark"). */
+int ut40_session_seq_id(const ut_test_ctx* ctx);
+
+/* Internal field-bit mismatch counter, bumped when ports disagree on
+ * the F-bit value within the same timestamp. */
+uint64_t ut40_stat_field_bit_mismatch(const ut_test_ctx* ctx);
+
+/* Per-reason drop counters. */
+uint64_t ut40_stat_wrong_pt(const ut_test_ctx* ctx);
+uint64_t ut40_stat_wrong_ssrc(const ut_test_ctx* ctx);
+uint64_t ut40_stat_wrong_interlace(const ut_test_ctx* ctx);
+
+/* Per-field interlace counters (incremented when the session accepts a
+ * packet for the corresponding field of an interlaced frame). */
+uint64_t ut40_stat_interlace_first(const ut_test_ctx* ctx);
+uint64_t ut40_stat_interlace_second(const ut_test_ctx* ctx);
+
+/* Counts ring-enqueue failures (e.g. ring full) — useful when validating
+ * back-pressure paths. */
+uint64_t ut40_stat_enqueue_fail(const ut_test_ctx* ctx);
+
+/* Number of frames delivered since session reset. */
+int ut40_frames_received(const ut_test_ctx* ctx);
+
+/* Pause or resume the auto-drain that runs inside every feeder. While
+ * paused, accepted packets accumulate on the ring so the test can inspect
+ * them with ut40_ring_dequeue_markers(). Prefer the `ut40_drain_paused`
+ * RAII guard below over calling this directly. */
+void ut40_set_skip_drain(bool skip);
+
+/* Reset the session's per-packet state (sequence watermark, prev_tmstamp,
+ * threshold counters) without destroying the context. Use to start a fresh
+ * sub-scenario inside a test. */
+void ut40_session_reset(ut_test_ctx* ctx);
+
+/* Dequeue every packet currently on the ANC ring, counting them and
+ * reporting whether any of them carried the RTP marker bit.
+ *   *out_count       — total number of packets dequeued.
+ *   *out_has_marker  — true iff at least one of them had marker == 1.
+ * Returns 0 on success, < 0 if the ring is not initialised.
+ *
+ * Typical use:
+ *   {
+ *     ut40_drain_paused guard;
+ *     // ... feed packets ...
+ *     int n; bool m;
+ *     ut40_ring_dequeue_markers(&n, &m);
+ *     EXPECT_TRUE(m);
+ *   }
+ */
+int ut40_ring_dequeue_markers(int* out_count, bool* out_has_marker);
+
+#ifdef __cplusplus
+}
+
+/* RAII guard: pause ring drain for the lifetime of the guard. Use in tests
+ * that need to inspect queued packets directly. Restores the previous state
+ * on scope exit (including via gtest assertion failures). */
+class ut40_drain_paused {
+ public:
+  ut40_drain_paused() {
+    ut40_set_skip_drain(true);
+  }
+  ~ut40_drain_paused() {
+    ut40_set_skip_drain(false);
+  }
+  ut40_drain_paused(const ut40_drain_paused&) = delete;
+  ut40_drain_paused& operator=(const ut40_drain_paused&) = delete;
+};
+
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST40_SESSION_HARNESS_H_ */


### PR DESCRIPTION
## API changes (header / ABI)

- **New common frame-level counters** on `st_rx_user_stats` / `st_tx_user_stats`: `stat_frames_received`, `stat_frames_dropped`, `stat_frames_corrupted` (RX) and `stat_frames_sent`, `stat_frames_dropped` (TX). Populated by all pipeline RX/TX (ST20p / ST30p / ST40p).
- **ST20p RX** now emits `stat_frames_corrupted` (frames with checksum/integrity errors).
- **New per-port RX counters** in `st_rx_port_stats`: `frames`, `err_packets`, `lost_packets`, `reordered_packets`, `duplicates_same_port`.
- **RX stats rename** (deconflict overloaded names; old names preserved in doxygen + trailing comments for ctrl-f migration):
  - `port[i].incomplete_frames` (was on common, video-only) → moved to `st20_rx_user_stats::frames_partial[i]`
  - `st20_rx_user_stats::incomplete_frames_cnt` and the duplicate transport-level `st20_rx_user_stats::stat_frames_dropped` → merged into `st20_rx_user_stats::stat_frames_incomplete`
  - `common.stat_frames_dropped` (= pipeline back-pressure) and `common.stat_frames_corrupted` are unchanged.

## Bug fixes (correctness, all RX side)

- **ST40 RX**: marker loss in redundant sessions; cross-port late arrival rejection (per-frame bitmap); bitmap reset clears stale state.
- **ST30 RX**: missing `redundant_error_cnt` increment.
- **ST20 video**: OOO counter underflow on backward `pkt_idx`.
- **ST30 / ST40 RX**: per-port OOO counter `uint16` wraparound; phantom unrecovered count on backward seq jump.
- **All RX**: threshold bypass double-counted packets as redundant + received.

## New component tests (200 tests)

## Refactors

- **Periodic stat log lines** (ST20/ST30/ST40 RX) clarified and made consistent across media types.
- **Per-stat-call framebuffer-queue log** lowered from `info` to `dbg` to reduce noise.
- **ST40 RX bitmap consolidation**: collapsed 8 parallel `anc_bitmap_*` / `anc_prev_bitmap_*` fields into `struct anc_window` (2 instances); replaced hardcoded `64` with `ST_RX_ANC_BITMAP_BITS` macro.

## Hot path

No throughput-impacting changes. Counter bumps that were added/moved are all in already-existing slow paths (frame completion, validation rejects). The new pipeline frame counters are relaxed atomics on the same code paths that already update wire stats.

## Docs

- `doc/stats_guide.md` rewritten end-to-end (RX + TX pipeline diagrams, frame-level counter section, troubleshooting table).
- `st_api.h` / `st20_api.h` doxygen expanded for every renamed/added field.
- Unit-test `README.md` rewritten; markdownlint warnings fixed.

## RxTxApp

- ST20p/ST30p/ST40p result line now queries `get_session_stats()` and prints a one-line wire-stats reconciliation with cause classification (bilateral loss / protocol violation / receiver too slow / healed by redundancy).
