### PR TITLE
Ci: combine dependabot dependency updates v2

### DIFF
--- a/.github/workflows/base_build.yml
+++ b/.github/workflows/base_build.yml
@@ -43,9 +43,9 @@ jobs:
       manager_build: ${{ steps.filter.outputs.manager_build == 'true' }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: .github/path_filters.yml
@@ -57,11 +57,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build Release
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: 'upload release build artifacts'
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: mtl-release-bin
           path: '${{ github.workspace }}/build/'
@@ -81,11 +81,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: ebpf-xdp build
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,11 +21,11 @@ jobs:
     timeout-minutes: 90
     steps:
     - name: 'Harden Runner'
-      uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
           ref: main
       
@@ -57,7 +57,7 @@ jobs:
         build_platform: 'linux64'
         working-directory: '${{ github.workspace }}'
         command: ./build.sh 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: coverity-reports
         path: '${{ github.workspace }}/cov-int'

--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -29,13 +29,13 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Harden-Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
       - name: Set current date
         run: echo "CURRENT_DATE=$(date '+%y%m%d-%H%M%S')" >> "$GITHUB_ENV"
       - name: Checkout MTL
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{ github.ref }}"
       - uses: ./.github/actions/build
@@ -90,7 +90,7 @@ jobs:
             "./${{ inputs.dir }}"
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: "custom-test-report-${{ env.CURRENT_DATE }}"
           path: ./tests/validation/report.html

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: 'Checkout Repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -30,9 +30,9 @@ jobs:
       ubuntu_build: ${{ steps.filter.outputs.ubuntu_build == 'true' }}
       manager_build: ${{ steps.filter.outputs.manager_build == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: .github/path_filters.yml
@@ -46,11 +46,11 @@ jobs:
       packages: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -60,7 +60,7 @@ jobs:
           driver-opts: memory=14Gib,memory-swap=25Gib,env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000,env.BUILDKIT_STEP_LOG_MAX_SPEED=10000000
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: ${{ env.DOCKER_REGISTRY_LOGIN == 'true' }}
         id: dockerLoginStep
         continue-on-error: true
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build image
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: "${{ env.DOCKER_REGISTRY_LOGIN == 'true' && steps.dockerLoginStep.outcome == 'SUCCESS' && github.ref == 'refs/heads/main' }}"
           context: "${{ github.workspace }}"
@@ -92,12 +92,12 @@ jobs:
       DOCKER_IMAGE_NAME: mtl-manager
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -112,7 +112,7 @@ jobs:
         run: echo "VERSION=$(cat VERSION)">> "$GITHUB_OUTPUT"
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: ${{ env.DOCKER_REGISTRY_LOGIN == 'true' }}
         id: dockerLoginStep
         continue-on-error: true
@@ -123,7 +123,7 @@ jobs:
 
       - name: Build manager image
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: "${{ env.DOCKER_REGISTRY_LOGIN == 'true' && steps.dockerLoginStep.outcome == 'SUCCESS' && github.ref == 'refs/heads/main' }}"
           context: "${{ github.workspace }}/manager"

--- a/.github/workflows/github_pages_update.yml
+++ b/.github/workflows/github_pages_update.yml
@@ -29,12 +29,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Secure the runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare operating system for documentation build
         run: |

--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -33,9 +33,9 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.linux_tests == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: .github/path_filters.yml
@@ -54,13 +54,13 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: Checkout MTL
         if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ inputs.branch-to-checkout || github.sha || github.ref }}'
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full git history is needed to get a proper
           # list of changed files within `super-linter`

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -21,9 +21,9 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.msys2_build == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: .github/path_filters.yml
@@ -44,7 +44,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
@@ -76,10 +76,10 @@ jobs:
           cp npcap-sdk/Lib/x64/* ${MSYSTEM_PREFIX}/lib/
 
       - name: Checkout IMTL code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout mman-win32 code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: 'alitrack/mman-win32'
           ref: master
@@ -106,14 +106,14 @@ jobs:
 
       - name: Cache DPDK
         id: cache-dpdk
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: dpdk
           key: dpdk-${{ matrix.dpdk }}-${{ matrix.sys }}-${{ steps.hash-patches.outputs.hash }}
 
       - name: Checkout DPDK code
         if: ${{ steps.cache-dpdk.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: 'DPDK/dpdk'
           ref: v${{matrix.dpdk}}

--- a/.github/workflows/nightly-combined-report.yml
+++ b/.github/workflows/nightly-combined-report.yml
@@ -58,13 +58,13 @@ jobs:
       both_completed: ${{ steps.check-status.outputs.both_completed }}
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: Wait for both workflows to complete
         id: get-runs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const workflows = ['nightly-gtest', 'nightly-pytest'];
@@ -201,16 +201,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get pytest run metadata
         id: pytest-metadata
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = ${{ needs.wait-for-both-workflows.outputs.pytest_run_id }};
@@ -228,7 +228,7 @@ jobs:
 
       - name: Get gtest run metadata
         id: gtest-metadata
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = ${{ needs.wait-for-both-workflows.outputs.gtest_run_id }};
@@ -366,7 +366,7 @@ jobs:
       - name: Get baseline pytest run metadata
         id: baseline-pytest-metadata
         if: needs.wait-for-both-workflows.outputs.baseline_pytest_run_id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = ${{ needs.wait-for-both-workflows.outputs.baseline_pytest_run_id }};
@@ -385,7 +385,7 @@ jobs:
       - name: Get baseline gtest run metadata
         id: baseline-gtest-metadata
         if: needs.wait-for-both-workflows.outputs.baseline_gtest_run_id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runId = ${{ needs.wait-for-both-workflows.outputs.baseline_gtest_run_id }};
@@ -454,14 +454,14 @@ jobs:
 
       - name: Upload combined Excel report
         if: steps.combine.outputs.reports_generated == 'true'
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-combined-report-excel
           path: combined_nightly_report.xlsx
 
       - name: Upload combined HTML report
         if: steps.combine.outputs.reports_generated == 'true'
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-combined-report-html
           path: combined_nightly_report.html

--- a/.github/workflows/nightly-gtest.yml
+++ b/.github/workflows/nightly-gtest.yml
@@ -22,11 +22,11 @@ jobs:
     timeout-minutes: 300
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ github.ref }}'
       - uses: ./.github/actions/build
@@ -63,7 +63,7 @@ jobs:
       - name: "upload report gtest"
         if: always()
         id: upload-report-gtest
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-gtest-report-${{ matrix.nic }}
           path: |
@@ -71,7 +71,7 @@ jobs:
       
       - name: "upload system info"
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: system-info-${{ matrix.nic }}
           path: system-info-${{ matrix.nic }}/

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -35,11 +35,11 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ github.ref }}'
       - uses: ./.github/actions/build
@@ -107,14 +107,14 @@ jobs:
       - name: "upload report python"
         if: always()
         id: upload-report
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-test-report-${{ matrix.nic }}-${{ matrix.dir }}
           path: ./tests/validation/report.html
 
       - name: "upload system info"
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: system-info-${{ matrix.nic }}-${{ matrix.dir }}
           path: ./system-info-${{ matrix.nic }}-${{ matrix.dir }}
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download python report artifacts
         uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
         with:
@@ -169,7 +169,7 @@ jobs:
           printf 'report_path=%s\n' "$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
       - name: Upload combined python report
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-pytest-combined-report
           path: ${{ steps.combine.outputs.report_path }}

--- a/.github/workflows/perf-pytest.yml
+++ b/.github/workflows/perf-pytest.yml
@@ -40,13 +40,13 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Harden-Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
       - name: Set current date
         run: echo "CURRENT_DATE=$(date '+%y%m%d-%H%M%S')" >> "$GITHUB_ENV"
       - name: Checkout MTL
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ inputs.branch || github.ref }}'
           fetch-depth: 0
@@ -116,7 +116,7 @@ jobs:
           fi
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: "perf-test-report-${{ runner.name }}-${{ env.CURRENT_DATE }}"
           path: |

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -32,17 +32,17 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,9 +19,9 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.linux_tests == 'true' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: .github/path_filters.yml
@@ -44,12 +44,12 @@ jobs:
     steps:
       - name: 'preparation: Harden Runner'
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ github.ref }}'
       - uses: ./.github/actions/build
@@ -107,7 +107,7 @@ jobs:
       - name: "upload report"
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
         id: upload-report
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: smoke-test-report-${{ matrix.nic }}
           path: |

--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Sync upstream changes
         id: sync

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -120,7 +120,7 @@ jobs:
       pipenv-activate: ${{ steps.pipenv-install.outputs.VIRTUAL_ENV }}
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
@@ -131,12 +131,12 @@ jobs:
           env | grep TEST_ || true
 
       - name: 'preparation: Checkout MTL'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: '${{ inputs.branch-to-checkout }}'
 
       - name: 'preparation: Checkout DPDK'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: env.DPDK_REBUILD == 'true'
         with:
           repository: 'DPDK/dpdk'
@@ -202,7 +202,7 @@ jobs:
       PYTEST_RETRIES: '3'
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
         with:
           egress-policy: audit
 
@@ -285,7 +285,7 @@ jobs:
 
       - name: 'cleanup: Validation execution logs'
         if: always()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: 'validation-execution-logs.tar.gz'
           path: '${{ github.workspace }}/tests/validation/validation-execution-logs.tar.gz'

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -6,7 +6,7 @@
 # Please review and modify as necessary before using in a production environment.
 
 # Build stage, ubuntu 22.04
-FROM ubuntu@sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7ca37 AS builder
+FROM ubuntu@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS builder
 
 LABEL maintainer="andrzej.wilczynski@intel.com,dawid.wesierski@intel.com,marek.kasiewicz@intel.com"
 
@@ -41,7 +41,7 @@ RUN meson setup build && \
     DESTDIR=/install meson install -C build
 
 # Runtime stage, ubuntu 22.04
-FROM ubuntu@sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7ca37
+FROM ubuntu@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 # Install runtime dependencies
 RUN apt-get update -y && \

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,4 +21,4 @@ version = "^0.1.0"
 ctrlc = "3.4.4"
 memmap2 = "0.9.4"
 clap = { version = "4.5.4", features = ["derive"] }
-sdl2 = "0.36.0"
+sdl2 = "0.38.0"

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -7,7 +7,7 @@ blinker==1.9.0
 certifi==2025.7.14
 cffi==2.0.0
 charset-normalizer==3.4.2
-click==8.3.1
+click==8.3.2
 cryptography==46.0.7
 dlipower==1.0.176
 docutils==0.21.2
@@ -15,8 +15,8 @@ exceptiongroup==1.3.0
 Flask==3.1.3
 funcy==1.18
 htmlmin2==0.1.13
-idna==3.10
-iniconfig==2.1.0
+idna==3.11
+iniconfig==2.3.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 jinja2-workarounds==0.1.0
@@ -60,7 +60,7 @@ packaging==25.0
 paramiko==3.4.0
 pexpect==4.8.0
 pluggy==1.6.0
-plumbum==1.9.0
+plumbum==1.10.0
 psutil==5.9.8
 ptyprocess==0.7.0
 pyasn1==0.6.3
@@ -71,7 +71,7 @@ pyftpdlib==1.5.10
 Pygments==2.20.0
 PyNaCl==1.6.2
 pyserial==3.5
-pysnmp==7.1.21
+pysnmp==7.1.23
 pyspnego==0.11.2
 pytest==8.4.1
 pytest-check==2.5.3


### PR DESCRIPTION
## Combined Dependabot Dependency Updates v2

This PR combines all open Dependabot PRs into a single update. Supersedes #1509.

### GitHub Actions updates (17 workflow files)
| Dependency | Old | New | PR |
|---|---|---|---|
| step-security/harden-runner | v2.13.0 | v2.18.0 | #1520 |
| dorny/paths-filter | v3.0.2 | v4.0.1 | #1519 |
| docker/build-push-action | v7.0.0 | v7.1.0 | #1522 |
| actions/cache | v4.2.3 | v5.0.5 | #1521 |
| actions/checkout | v4.2.2 | v6.0.2 | #1509 |
| actions/upload-artifact | v4 | v7 | #1509 |
| docker/login-action | v3.5.0 | v4.1.0 | #1509 |
| actions/dependency-review-action | v4.7.3 | v4.9.0 | #1509 |
| actions/github-script | v7 | v9 | #1518 |
| ossf/scorecard-action | v2.4.2 | v2.4.3 | #1509 |

### Python requirements updates
| Package | Old | New | PR |
|---|---|---|---|
| click | 8.3.1 | 8.3.2 | #1509 |
| idna | 3.10 | 3.11 | #1509 |
| iniconfig | 2.1.0 | 2.3.0 | #1525 |
| plumbum | 1.9.0 | 1.10.0 | #1509 |
| pysnmp | 7.1.21 | 7.1.23 | #1526 |

### Other updates
| File | Change | PR |
|---|---|---|
| manager/Dockerfile | Ubuntu digest update | #1523 |
| rust/Cargo.toml | sdl2 0.36.0 → 0.38.0 | #1509 |

### Skipped (dependency conflicts)
These packages could not be updated due to version pinning by `mfd-connect 7.15.0` or `pytest-mfd-config 3.25.0`:

| Package | Wanted | Blocker | PR |
|---|---|---|---|
| paramiko | 4.0.0 | mfd-connect requires ==3.4.0 | #1527 |
| scp | 0.15.0 | mfd-connect requires ~=0.13.4 | #1527 |
| pexpect | 4.9.0 | mfd-connect requires ~=4.8.0 | #1499 |
| funcy | 2.0 | mfd-connect requires ~=1.14 | #1524 |
| pytest | 9.0.3 | pytest-mfd-config requires <9 | #1512 |

### Testing
- ✅ `./build.sh` passed (24/24 compilation steps)
- ✅ `pip install -r requirements.txt` passed in a clean venv

### PRs included
Covers: #1527, #1526, #1525, #1524, #1523, #1522, #1521, #1520, #1519, #1518, #1512, #1509, #1499