### PR TITLE
Test: turbo boost optimization and VF/PF report fix for performance tests

### DIFF
--- a/tests/validation/common/generate_report.py
+++ b/tests/validation/common/generate_report.py
@@ -123,7 +123,7 @@ RE_REDUNDANT_MODE = re.compile(
     r"Redundant mode:\s*interfaces=\[(.+?)\],\s*direction=(\w+)"
 )
 RE_NICCTL_CMD = re.compile(
-    r"Executing\s+>[\d.]+\.(\d+)>\s+'[^']*nicctl\.sh\s+list\s+([\da-fA-F:.]+)'"
+    r"Executing\s+>(?:[\d.]+\.(\d+)|\S+)>\s+'[^']*nicctl\.sh\s+list\s+([\da-fA-F:.]+)'"
 )
 RE_PCI_LINE = re.compile(r"^([\da-fA-F]{4}:[\da-fA-F]{2}:[\da-fA-F]{2}\.\d+)\s*$")
 RE_LOG_PREFIX = re.compile(
@@ -237,7 +237,8 @@ def _parse_log_file(log_path: str, dir_name: str = ""):
             # ── nicctl PF→VF mapping ──
             m = RE_NICCTL_CMD.search(line)
             if m:
-                nicctl_suffix, nicctl_pf = m.group(1), m.group(2)
+                nicctl_suffix = m.group(1)  # None when IP is masked (e.g. ***)
+                nicctl_pf = m.group(2) if nicctl_suffix else None
                 collecting_vfs = False
                 continue
             if nicctl_pf and "stdout>>" in line:
@@ -488,10 +489,12 @@ def scan_logs(log_root: str):
                 log_files.extend(
                     os.path.join(root, fn) for fn in files if fn.endswith(".log")
                 )
-        if not log_files:
-            lp = os.path.join(dp, "pytest.log")
-            if os.path.exists(lp):
-                log_files.append(lp)
+        # Also parse pytest.log for fixture/setup data (nicctl PF→VF
+        # mapping, VF creation, DMA setup) that is NOT in per-test logs.
+        # Sweep tests found here are harmless duplicates (overwritten by key).
+        pytest_log = os.path.join(dp, "pytest.log")
+        if os.path.exists(pytest_log):
+            log_files.append(pytest_log)
         if not log_files:
             continue
 
@@ -527,23 +530,48 @@ def scan_logs(log_root: str):
     all_tests = [t for t in best.values() if not (t.tested_side == "TX" and t.dma)]
     hosts = _extract_hosts(all_tests, vf_map)
 
+    # Build a VF map from rxtxapp_config interfaces for DUT host.
+    # This is the most reliable source: the captured JSON config always
+    # contains the VF PCI address used by the measured (DUT) application.
+    config_vf_map: dict[str, str] = {}  # {hostname: vf_addr}
+    for t in all_tests:
+        cfg = t.rxtxapp_config
+        if not cfg:
+            continue
+        ifaces = cfg.get("interfaces", [])
+        if not ifaces:
+            continue
+        vf_from_cfg = ifaces[0].get("name", "")
+        if not vf_from_cfg:
+            continue
+        # Determine DUT hostname from host_assignment
+        ha = RE_HOST_ASSIGN.search(t.host_assignment or "")
+        if ha:
+            dut_name = ha.group(1)
+            config_vf_map.setdefault(dut_name, vf_from_cfg)
+
     # Enrich hosts with NIC/DMA info
     for h in hosts:
         nd = nic_dma_map.get(h.name)
         if nd:
             h.nic_dma = nd
-        # Companion: use "redundant port VFs" as authoritative VF source
-        if h.role != "dut":
-            host_vfs = vf_map.get(h.name, [])
-            if host_vfs:
-                h.nic_dma.vf_addr = host_vfs[0]
-                if not h.nic_dma.pf_addr:
-                    suffix_m = re.search(r"_(\d+)$", h.name)
-                    if suffix_m:
-                        for pf, pf_vfs in all_pf_vf.get(suffix_m.group(1), {}).items():
-                            if h.nic_dma.vf_addr in pf_vfs:
-                                h.nic_dma.pf_addr = pf
-                                break
+        # Use "redundant port VFs" as authoritative VF source (all hosts)
+        host_vfs = vf_map.get(h.name, [])
+        if host_vfs and not h.nic_dma.vf_addr:
+            h.nic_dma.vf_addr = host_vfs[0]
+        # Fallback: use VF from rxtxapp_config interfaces
+        if not h.nic_dma.vf_addr:
+            cfg_vf = config_vf_map.get(h.name, "")
+            if cfg_vf:
+                h.nic_dma.vf_addr = cfg_vf
+        # Resolve PF from nicctl output
+        if h.nic_dma.vf_addr and not h.nic_dma.pf_addr:
+            suffix_m = re.search(r"_(\d+)$", h.name)
+            if suffix_m:
+                for pf, pf_vfs in all_pf_vf.get(suffix_m.group(1), {}).items():
+                    if h.nic_dma.vf_addr in pf_vfs:
+                        h.nic_dma.pf_addr = pf
+                        break
         # Default single PF/VF pair
         if not h.nic_dma.pf_vf_pairs and h.nic_dma.pf_addr and h.nic_dma.vf_addr:
             h.nic_dma.pf_vf_pairs = [(h.nic_dma.pf_addr, h.nic_dma.vf_addr)]

--- a/tests/validation/common/host_setup.py
+++ b/tests/validation/common/host_setup.py
@@ -104,8 +104,7 @@ def ensure_turbo_boost_enabled(host) -> None:
         val = (result.stdout or "").strip()
         if val == "0":
             host.connection.execute_command(
-                "echo 1 | sudo tee"
-                " /sys/devices/system/cpu/cpufreq/boost >/dev/null",
+                "echo 1 | sudo tee" " /sys/devices/system/cpu/cpufreq/boost >/dev/null",
                 shell=True,
             )
             logger.info(f"Host {host.name}: turbo boost enabled (cpufreq)")

--- a/tests/validation/common/host_setup.py
+++ b/tests/validation/common/host_setup.py
@@ -165,6 +165,100 @@ def check_cpu_isolation(host) -> None:
         logger.warning(f"Host {host.name}: could not check CPU isolation: {e}")
 
 
+def optimize_cpu_cores_for_turbo(host, isolcpus: str | None = None) -> str | None:
+    """Offline unused CPU cores to maximize turbo frequency on active cores.
+
+    On high-core-count servers (e.g. 256 logical CPUs), all cores staying
+    in C0 limits turbo boost to the all-core frequency (~3600 MHz on GNR).
+    By offlining unused cores, the remaining cores can reach higher turbo
+    bins (e.g. 3800-3900 MHz with ~21 active cores).
+
+    Keeps CPUs 0 through max(isolcpus) online and offlines the rest.
+    Returns the original online CPU range string for later restoration,
+    or None if no changes were made.
+    """
+    try:
+        result = host.connection.execute_command(
+            "cat /sys/devices/system/cpu/online", shell=True
+        )
+        original_online = (result.stdout or "").strip()
+
+        # Determine max CPU to keep online from isolcpus range
+        max_cpu = 20  # default fallback
+        if isolcpus:
+            for part in isolcpus.replace(",", "-").split("-"):
+                try:
+                    max_cpu = max(max_cpu, int(part))
+                except ValueError:
+                    pass
+
+        result = host.connection.execute_command("nproc --all", shell=True)
+        total_cpus = int((result.stdout or "1").strip())
+        if total_cpus <= max_cpu + 1:
+            return None  # already few enough cores
+
+        # Offline CPUs beyond the needed range
+        host.connection.execute_command(
+            f"for c in $(seq {max_cpu + 1} {total_cpus - 1}); do "
+            f"echo 0 > /sys/devices/system/cpu/cpu$c/online 2>/dev/null; done",
+            shell=True,
+        )
+        # Ensure performance governor on remaining cores
+        host.connection.execute_command(
+            f"for c in $(seq 0 {max_cpu}); do "
+            "echo performance > /sys/devices/system/cpu/cpu$c/cpufreq/"
+            "scaling_governor 2>/dev/null; done",
+            shell=True,
+        )
+
+        result = host.connection.execute_command(
+            "cat /sys/devices/system/cpu/online", shell=True
+        )
+        new_online = (result.stdout or "").strip()
+        logger.info(
+            f"Host {host.name}: optimized turbo — "
+            f"online CPUs: {new_online} (was {original_online})"
+        )
+        return original_online
+    except Exception as e:
+        logger.warning(f"Host {host.name}: could not optimize cores for turbo: {e}")
+        return None
+
+
+def restore_cpu_cores(host, original_online: str) -> None:
+    """Bring all CPU cores back online after turbo optimization."""
+    try:
+        # Extract max CPU from original range (e.g. "0-255" -> 255)
+        max_cpu = 0
+        for part in original_online.replace(",", "-").split("-"):
+            try:
+                max_cpu = max(max_cpu, int(part))
+            except ValueError:
+                pass
+
+        host.connection.execute_command(
+            f"for c in $(seq 0 {max_cpu}); do "
+            f"echo 1 > /sys/devices/system/cpu/cpu$c/online 2>/dev/null; done",
+            shell=True,
+        )
+        # Restore performance governor on all cores
+        host.connection.execute_command(
+            f"for c in $(seq 0 {max_cpu}); do "
+            "echo performance > /sys/devices/system/cpu/cpu$c/cpufreq/"
+            "scaling_governor 2>/dev/null; done",
+            shell=True,
+        )
+        result = host.connection.execute_command(
+            "cat /sys/devices/system/cpu/online", shell=True
+        )
+        logger.info(
+            f"Host {host.name}: restored CPU cores — "
+            f"online: {(result.stdout or '').strip()}"
+        )
+    except Exception as e:
+        logger.warning(f"Host {host.name}: could not restore CPU cores: {e}")
+
+
 def ensure_pf_up(host, pf_pci: str) -> None:
     """Bring the PF interface UP if it is not already.
 

--- a/tests/validation/common/host_setup.py
+++ b/tests/validation/common/host_setup.py
@@ -78,6 +78,42 @@ def ensure_hugepage_access(host) -> None:
         logger.warning(f"Host {host.name}: could not ensure hugepage access: {e}")
 
 
+def ensure_turbo_boost_enabled(host) -> None:
+    """Enable turbo boost if it is currently disabled."""
+    try:
+        result = host.connection.execute_command(
+            "cat /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null",
+            shell=True,
+        )
+        val = (result.stdout or "").strip()
+        if val == "1":
+            host.connection.execute_command(
+                "echo 0 | sudo tee"
+                " /sys/devices/system/cpu/intel_pstate/no_turbo >/dev/null",
+                shell=True,
+            )
+            logger.info(f"Host {host.name}: turbo boost enabled (intel_pstate)")
+            return
+        if val == "0":
+            return
+
+        result = host.connection.execute_command(
+            "cat /sys/devices/system/cpu/cpufreq/boost 2>/dev/null",
+            shell=True,
+        )
+        val = (result.stdout or "").strip()
+        if val == "0":
+            host.connection.execute_command(
+                "echo 1 | sudo tee"
+                " /sys/devices/system/cpu/cpufreq/boost >/dev/null",
+                shell=True,
+            )
+            logger.info(f"Host {host.name}: turbo boost enabled (cpufreq)")
+            return
+    except Exception as e:
+        logger.warning(f"Host {host.name}: could not enable turbo boost: {e}")
+
+
 def ensure_cpu_performance_governor(host) -> None:
     """Set the CPU frequency scaling governor to 'performance' on all cores."""
     try:

--- a/tests/validation/tests/dual/performance/conftest.py
+++ b/tests/validation/tests/dual/performance/conftest.py
@@ -9,7 +9,11 @@ depends on ``nic_port_list``.
 """
 
 import pytest
-from common.host_setup import check_cpu_isolation, ensure_cpu_performance_governor
+from common.host_setup import (
+    check_cpu_isolation,
+    ensure_cpu_performance_governor,
+    ensure_turbo_boost_enabled,
+)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -17,4 +21,5 @@ def performance_host_setup(hosts: dict) -> None:
     """One-time host tuning for performance tests only."""
     for host in hosts.values():
         ensure_cpu_performance_governor(host)
+        ensure_turbo_boost_enabled(host)
         check_cpu_isolation(host)

--- a/tests/validation/tests/dual/performance/test_vf_perf_dualhost.py
+++ b/tests/validation/tests/dual/performance/test_vf_perf_dualhost.py
@@ -682,9 +682,7 @@ def _run_session_sweep(
     measured_host = tx_host if is_tx else rx_host
     if is_tx and single_core:
         isolcpus = _get_isolcpus(measured_host)
-        original_online_cpus = optimize_cpu_cores_for_turbo(
-            measured_host, isolcpus
-        )
+        original_online_cpus = optimize_cpu_cores_for_turbo(measured_host, isolcpus)
 
     def _is_crash(detail: str) -> bool:
         """Return True if the detail indicates a crash requiring VF FLR."""

--- a/tests/validation/tests/dual/performance/test_vf_perf_dualhost.py
+++ b/tests/validation/tests/dual/performance/test_vf_perf_dualhost.py
@@ -11,6 +11,7 @@ import time
 import traceback
 
 import pytest
+from common.host_setup import optimize_cpu_cores_for_turbo, restore_cpu_cores
 from common.nicctl import ensure_vfio_bound, reset_vfio_bindings
 from conftest import get_host_mtl_path, is_host_sut
 from mfd_common_libs.log_levels import TEST_PASS
@@ -673,6 +674,18 @@ def _run_session_sweep(
     reset_vfio_bindings(rx_host, rx_host.name, presweep_rx_vfs)
     time.sleep(5)
 
+    # ── Turbo boost optimization for TX single-core tests ──
+    # On high-core-count servers, offline unused cores on the SUT so the
+    # active cores reach higher turbo bins (e.g. 3800 MHz vs 3600 MHz).
+    # Only safe for TX (no DPDK flow/queue issues from offlining).
+    original_online_cpus: str | None = None
+    measured_host = tx_host if is_tx else rx_host
+    if is_tx and single_core:
+        isolcpus = _get_isolcpus(measured_host)
+        original_online_cpus = optimize_cpu_cores_for_turbo(
+            measured_host, isolcpus
+        )
+
     def _is_crash(detail: str) -> bool:
         """Return True if the detail indicates a crash requiring VF FLR."""
         crash_codes = (
@@ -837,12 +850,17 @@ def _run_session_sweep(
         logger.info(f"{'═' * 70}\n")
 
         if not passed:
+            if original_online_cpus:
+                restore_cpu_cores(measured_host, original_online_cpus)
             pytest.fail(
                 f"Fixed run FAILED: {num_sessions} sessions for "
                 f"{mode_tag}{direction.upper()} "
                 f"{'SC' if single_core else 'MC'}{dma_label} "
                 f"@ {fps}fps / {resolution}"
             )
+
+        if original_online_cpus:
+            restore_cpu_cores(measured_host, original_online_cpus)
 
         logger.log(
             TEST_PASS,
@@ -927,12 +945,17 @@ def _run_session_sweep(
         logger.info(f"{'═' * 70}\n")
 
         if max_passing == 0:
+            if original_online_cpus:
+                restore_cpu_cores(measured_host, original_online_cpus)
             pytest.fail(
                 f"Sweep FAILED: no sessions passed for "
                 f"{mode_tag}{direction.upper()} "
                 f"{'SC' if single_core else 'MC'}{dma_label} "
                 f"@ {fps}fps / {resolution}"
             )
+
+        if original_online_cpus:
+            restore_cpu_cores(measured_host, original_online_cpus)
 
         logger.log(
             TEST_PASS,


### PR DESCRIPTION
Improve single-core TX performance test reliability and fix NIC address reporting in HTML performance reports.

Turbo boost & core optimization

- Add ensure_turbo_boost_enabled() to enable turbo boost on SUT before performance tests — without it, single-core TX capacity drops ~26%, causing test failures
- Offline unused CPU cores during TX single-core tests so active cores reach higher turbo bins (3800 MHz vs 3600 MHz on GNR); restore cores after test completes or on failure

Performance report VF/PF fix

- Fix DUT VF enrichment — was incorrectly skipped for DUT hosts, leaving VF address as "N/A"
- Add fallback VF extraction from rxtxapp_config interfaces field
- Update RE_NICCTL_CMD regex to handle GitHub Actions masked IPs (***)
- Always parse pytest.log for fixture data (nicctl PF→VF mapping) alongside per-test logs