### PR TITLE
 Ci: bump actions/download-artifact to v7.0.0 for Node.js 24

### DIFF
--- a/.github/workflows/nightly-combined-report.yml
+++ b/.github/workflows/nightly-combined-report.yml
@@ -245,7 +245,7 @@ jobs:
             console.log(`GTest Run #${run.data.run_number}, Branch: ${run.data.head_branch}, Date: ${run.data.created_at}`);
 
       - name: Download pytest artifacts
-        uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: nightly-test-report-*
           path: pytest-reports
@@ -254,7 +254,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download gtest artifacts
-        uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: nightly-gtest-report-*
           path: gtest-reports
@@ -285,7 +285,7 @@ jobs:
           ls -lh ./*.log || echo "No gtest logs found"
 
       - name: Download system info artifacts
-        uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         continue-on-error: true
         with:
           pattern: system-info-*
@@ -295,7 +295,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Also download system info from gtest run
-        uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         continue-on-error: true
         with:
           pattern: system-info-*
@@ -315,7 +315,7 @@ jobs:
 
       - name: Download baseline pytest artifacts
         if: needs.wait-for-both-workflows.outputs.baseline_pytest_run_id != ''
-        uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         continue-on-error: true
         with:
           pattern: nightly-test-report-*
@@ -326,7 +326,7 @@ jobs:
 
       - name: Download baseline gtest artifacts
         if: needs.wait-for-both-workflows.outputs.baseline_gtest_run_id != ''
-        uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         continue-on-error: true
         with:
           pattern: nightly-gtest-report-*

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -150,7 +150,7 @@ jobs:
       - name: 'preparation: Checkout MTL'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download python report artifacts
-        uses: actions/download-artifact@f093f21ca4cfa7c75ccbbc2be54da76a0c7e1f05 # v4.4.3
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: nightly-test-report-*
           path: python-reports  # Downloads all artifacts into this directory


### PR DESCRIPTION
bump actions/download-artifact to v7.0.0 for Node.js 24
