### PR TITLE
Fix: prevent nicctl/VFIO hang with bounded timeouts and graceful teardown

### DIFF
--- a/tests/validation/common/mtl_manager/mtlManager.py
+++ b/tests/validation/common/mtl_manager/mtlManager.py
@@ -57,27 +57,19 @@ class MtlManager:
         First attempts to gracefully stop the process if it's tracked,
         then falls back to pkill if needed.
         """
+        # Skip the slow ``process.stop()`` graceful path entirely. It calls
+        # the underlying mfd_connect process .wait() which can block on the
+        # default 60 s timeout when MtlManager doesn't exit on its own. The
+        # pkill path below is reliable and finishes in <100 ms; for an MtlManager
+        # that holds no NIC/VFIO state, SIGKILL is safe at session teardown.
         if self.mtl_manager_process and self.mtl_manager_process.running:
             try:
-                logger.info("Stopping MtlManager using process object methods...")
-                # Try graceful termination first
-                self.mtl_manager_process.stop()
-
-                # Check if the process stopped gracefully
-                if self.mtl_manager_process.running:
-                    logger.info("MtlManager still running, trying kill...")
-                    self.mtl_manager_process.kill()
-
-                # Check logs for errors
-                log_output = self.mtl_manager_process.stdout_text
-                if log_output:
-                    if "error" in log_output.lower() or "fail" in log_output.lower():
-                        logger.error(f"Errors found in MtlManager logs: {log_output}")
-
+                logger.info("Stopping MtlManager via direct kill (fast path)...")
+                self.mtl_manager_process.kill(wait=2)
                 logger.info("MtlManager stopped successfully.")
                 return
             except Exception as e:
-                logger.error(f"Error while stopping MtlManager process: {e}")
+                logger.warning(f"MtlManager direct kill failed ({e}); falling back to pkill")
 
         # Fallback to pkill if the process object is not available or the above failed
         connection = self.host.connection

--- a/tests/validation/common/mtl_manager/mtlManager.py
+++ b/tests/validation/common/mtl_manager/mtlManager.py
@@ -69,7 +69,9 @@ class MtlManager:
                 logger.info("MtlManager stopped successfully.")
                 return
             except Exception as e:
-                logger.warning(f"MtlManager direct kill failed ({e}); falling back to pkill")
+                logger.warning(
+                    f"MtlManager direct kill failed ({e}); falling back to pkill"
+                )
 
         # Fallback to pkill if the process object is not available or the above failed
         connection = self.host.connection

--- a/tests/validation/common/nicctl.py
+++ b/tests/validation/common/nicctl.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 # wait into a logged warning + escape-hatch (PCI remove/rescan).
 _NICCTL_TIMEOUT = 30
 _NICCTL_LONG_TIMEOUT = 60  # create_vf binds N VFs, allow more headroom
-_VFIO_IDLE_TIMEOUT = 20    # how long to wait for VFIO group to be released
+_VFIO_IDLE_TIMEOUT = 20  # how long to wait for VFIO group to be released
 
 
 class Nicctl:
@@ -56,11 +56,28 @@ class Nicctl:
         return self._parse_vf_list(resp.stdout)
 
     def create_vfs(self, pci_id: str, num_of_vfs: int = 6) -> list:
-        """Create VFs on NIC.
+        """Create VFs on NIC, idempotently.
+
+        If the PF already has at least ``num_of_vfs`` VFs bound to vfio-pci,
+        return them without touching sysfs. This is the primary defence
+        against the ``vfio_unregister_group_dev`` hang: a session that
+        creates VFs once and reuses them across tests never triggers the
+        kernel refcount race that the implicit ``echo 0 > sriov_numvfs``
+        on re-creation would.
+
         :param pci_id: pci_id of the nic adapter
-        :param num_of_vfs: number of VFs to create
-        :return: returns list of created vfs
+        :param num_of_vfs: minimum number of VFs required
+        :return: list of VF PCI addresses (existing or freshly created)
         """
+        existing = self.vfio_list(pci_id)
+        if len(existing) >= num_of_vfs:
+            logger.debug(
+                "Reusing %d existing VFs on %s (requested %d)",
+                len(existing),
+                pci_id,
+                num_of_vfs,
+            )
+            return existing
         self.connection.execute_command(
             f"sudo {self.nicctl} create_vf {pci_id} {num_of_vfs}",
             shell=True,
@@ -421,22 +438,21 @@ class InterfaceSetup:
 
     def cleanup(self):
         self.cleanup_kernel_ips()
-        # Each interface cleanup is wrapped: a single VFIO-stuck device must
-        # never abort the rest of the teardown loop, otherwise subsequent
-        # tests inherit a broken state and the failure cascades.
+        # Per-test interface cleanup intentionally does NOT call disable_vf:
+        # VFs created at session start by the ``nic_port_list`` fixture are
+        # reused across all tests (see Nicctl.create_vfs idempotency), which
+        # eliminates the kernel ``vfio_unregister_group_dev`` hang window
+        # entirely. We still rebind PFs back to the kernel driver because PF
+        # driver state is not session-scoped — different tests need PF in
+        # different drivers (ice vs vfio-pci). Each rebind is wrapped so a
+        # single stuck device cannot cascade into the rest of the teardown.
         for nicctl, interface, if_type in self.cleanups:
+            if if_type.lower() != "pf":
+                continue
             try:
-                if if_type.lower() == "vf":
-                    nicctl.disable_vf(interface)
-                elif if_type.lower() == "pf":
-                    nicctl.bind_kernel(interface)
+                nicctl.bind_kernel(interface)
             except Exception as e:
-                logger.warning(
-                    "Cleanup of %s (%s) failed: %s — continuing",
-                    interface,
-                    if_type,
-                    e,
-                )
+                logger.warning("PF rebind of %s failed: %s — continuing", interface, e)
 
 
 def _cleanup_hugepages(host, host_name: str) -> None:

--- a/tests/validation/common/nicctl.py
+++ b/tests/validation/common/nicctl.py
@@ -10,6 +10,15 @@ from mfd_network_adapter import NetworkInterface
 
 logger = logging.getLogger(__name__)
 
+# All nicctl shell calls must be bounded. The kernel sysfs writes done by
+# nicctl.sh (sriov_numvfs, dpdk-devbind unbind) can block forever in
+# pci_disable_sriov() / vfio_unregister_group_dev() if any process still
+# holds /dev/vfio/<group> open. The timeouts below convert that infinite
+# wait into a logged warning + escape-hatch (PCI remove/rescan).
+_NICCTL_TIMEOUT = 30
+_NICCTL_LONG_TIMEOUT = 60  # create_vf binds N VFs, allow more headroom
+_VFIO_IDLE_TIMEOUT = 20    # how long to wait for VFIO group to be released
+
 
 class Nicctl:
     """Wrapper of nicctl.sh script from Media-Transport-Library."""
@@ -42,7 +51,7 @@ class Nicctl:
     def vfio_list(self, pci_addr: str = "all") -> list:
         """Returns list of VFs created on host."""
         resp = self.connection.execute_command(
-            f"{self.nicctl} list {pci_addr}", shell=True
+            f"{self.nicctl} list {pci_addr}", shell=True, timeout=_NICCTL_TIMEOUT
         )
         return self._parse_vf_list(resp.stdout)
 
@@ -53,7 +62,9 @@ class Nicctl:
         :return: returns list of created vfs
         """
         self.connection.execute_command(
-            f"sudo {self.nicctl} create_vf {pci_id} {num_of_vfs}", shell=True
+            f"sudo {self.nicctl} create_vf {pci_id} {num_of_vfs}",
+            shell=True,
+            timeout=_NICCTL_LONG_TIMEOUT,
         )
         # Allow VFIO bindings to stabilize after VF creation.
         # Without this delay, the first DPDK process to open a VF may
@@ -68,11 +79,120 @@ class Nicctl:
 
     def disable_vf(self, pci_id: str) -> None:
         """Remove VFs on NIC.
+
+        Robust against the well-known VFIO refcount hang: if any process
+        still holds ``/dev/vfio/<group>`` open, the kernel sysfs write
+        ``echo 0 > sriov_numvfs`` blocks forever in
+        ``vfio_unregister_group_dev``. We mitigate in three layers:
+
+          1. Wait for the IOMMU group to go idle (lsof poll).
+          2. Run ``nicctl.sh disable_vf`` with a hard timeout.
+          3. If it timed out, fall back to PCI remove/rescan — the
+             kernel's documented escape hatch that does not wait on
+             refcounts.
+
         :param pci_id: pci_id of the nic adapter
         """
+        self._wait_vfio_idle(pci_id, timeout_s=_VFIO_IDLE_TIMEOUT)
+        try:
+            self.connection.execute_command(
+                f"{self.nicctl} disable_vf {pci_id}",
+                shell=True,
+                timeout=_NICCTL_TIMEOUT,
+            )
+            return
+        except Exception as e:
+            logger.warning(
+                "disable_vf %s timed out (%s); attempting PCI remove/rescan",
+                pci_id,
+                e,
+            )
+            self._force_pci_reset(pci_id)
+
+    def bind_pmd(self, pci_id: str) -> None:
+        """Bind VF to DPDK PMD driver."""
         self.connection.execute_command(
-            self.nicctl + " disable_vf " + pci_id, shell=True
+            self.nicctl + " bind_pmd " + pci_id,
+            shell=True,
+            timeout=_NICCTL_TIMEOUT,
         )
+
+    def bind_kernel(self, pci_id: str) -> None:
+        """Bind VF to kernel driver."""
+        self._wait_vfio_idle(pci_id, timeout_s=_VFIO_IDLE_TIMEOUT)
+        try:
+            self.connection.execute_command(
+                self.nicctl + " bind_kernel " + pci_id,
+                shell=True,
+                timeout=_NICCTL_TIMEOUT,
+            )
+        except Exception as e:
+            logger.warning(
+                "bind_kernel %s timed out (%s); attempting PCI remove/rescan",
+                pci_id,
+                e,
+            )
+            self._force_pci_reset(pci_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _wait_vfio_idle(self, pci_id: str, timeout_s: int) -> bool:
+        """Poll until no userspace process holds /dev/vfio/<group> for *pci_id*.
+
+        Returns True if idle (or no VFIO group bound), False on timeout.
+        Never raises — best-effort precondition check.
+        """
+        try:
+            res = self.connection.execute_command(
+                f"readlink /sys/bus/pci/devices/{pci_id}/iommu_group 2>/dev/null "
+                f"| awk -F/ '{{print $NF}}'",
+                shell=True,
+                timeout=5,
+                expected_return_codes=None,
+            )
+            group = (res.stdout or "").strip()
+        except Exception:
+            return True  # cannot probe, let nicctl try
+        if not group:
+            return True
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                check = self.connection.execute_command(
+                    f"sudo fuser /dev/vfio/{group} 2>/dev/null; echo EXIT:$?",
+                    shell=True,
+                    timeout=5,
+                    expected_return_codes=None,
+                )
+                # fuser exit 1 == no process holds the fd
+                if "EXIT:1" in (check.stdout or ""):
+                    return True
+            except Exception:
+                return False
+            time.sleep(0.5)
+        logger.warning(
+            "VFIO group %s for %s still busy after %ds — disable_vf may block",
+            group,
+            pci_id,
+            timeout_s,
+        )
+        return False
+
+    def _force_pci_reset(self, pci_id: str) -> None:
+        """Last-resort: PCI remove + rescan. Does not wait on refcounts."""
+        try:
+            self.connection.execute_command(
+                f"echo 1 | sudo tee /sys/bus/pci/devices/{pci_id}/remove "
+                f">/dev/null 2>&1; sleep 1; "
+                "echo 1 | sudo tee /sys/bus/pci/rescan >/dev/null 2>&1; true",
+                shell=True,
+                timeout=15,
+                expected_return_codes=None,
+            )
+            logger.info("PCI %s removed and rescanned", pci_id)
+        except Exception as e:
+            logger.error("PCI reset of %s failed: %s", pci_id, e)
 
     def prepare_vfs_for_test(self, nic: NetworkInterface) -> list:
         """Prepare VFs for test."""
@@ -86,16 +206,6 @@ class Nicctl:
                 self.create_vfs(nic_pci)
                 self.host.vfs = self.vfio_list(nic_pci)
         return self.host.vfs
-
-    def bind_pmd(self, pci_id: str) -> None:
-        """Bind VF to DPDK PMD driver."""
-        self.connection.execute_command(self.nicctl + " bind_pmd " + pci_id, shell=True)
-
-    def bind_kernel(self, pci_id: str) -> None:
-        """Bind VF to kernel driver."""
-        self.connection.execute_command(
-            self.nicctl + " bind_kernel " + pci_id, shell=True
-        )
 
 
 class InterfaceSetup:
@@ -311,11 +421,22 @@ class InterfaceSetup:
 
     def cleanup(self):
         self.cleanup_kernel_ips()
+        # Each interface cleanup is wrapped: a single VFIO-stuck device must
+        # never abort the rest of the teardown loop, otherwise subsequent
+        # tests inherit a broken state and the failure cascades.
         for nicctl, interface, if_type in self.cleanups:
-            if if_type.lower() == "vf":
-                nicctl.disable_vf(interface)
-            elif if_type.lower() == "pf":
-                nicctl.bind_kernel(interface)
+            try:
+                if if_type.lower() == "vf":
+                    nicctl.disable_vf(interface)
+                elif if_type.lower() == "pf":
+                    nicctl.bind_kernel(interface)
+            except Exception as e:
+                logger.warning(
+                    "Cleanup of %s (%s) failed: %s — continuing",
+                    interface,
+                    if_type,
+                    e,
+                )
 
 
 def _cleanup_hugepages(host, host_name: str) -> None:

--- a/tests/validation/mtl_engine/application_base.py
+++ b/tests/validation/mtl_engine/application_base.py
@@ -435,24 +435,97 @@ class Application(ABC):
         return proc
 
     def stop_process(self, host=None) -> None:
-        """Stop this application's tracked process and clean up stale processes.
+        """Stop this application's tracked process gracefully.
 
-        1. SIGKILL the tracked ``_process`` (if any).
-        2. Run :func:`kill_stale_processes` on *host* (falls back to ``_host``).
+        Sends SIGINT first so that DPDK applications run their atexit
+        handler and call ``rte_eal_cleanup()`` — which closes the VFIO
+        group fd and releases the kernel-side refcount on the VFs.
+        Skipping this step is the root cause of the long-standing
+        ``nicctl disable_vf`` hang in ``vfio_unregister_group_dev``.
+
+        Ladder:
+            1. SIGINT  → wait up to ``graceful_s`` (default 10s) for clean exit.
+            2. SIGTERM → wait up to additional ``term_s`` (default 5s).
+            3. SIGKILL → last resort.
+            4. :func:`kill_stale_processes` for any leftovers, then poll
+               ``/dev/vfio/*`` until no process holds it (max ``vfio_idle_s``).
 
         Safe to call multiple times or when no process was started.
         """
+        graceful_s = self.params.get("stop_graceful_s", 10)
+        term_s = self.params.get("stop_term_s", 5)
+        vfio_idle_s = self.params.get("stop_vfio_idle_s", 15)
+
         proc = self._process
         if proc is not None:
             try:
-                proc.kill(wait=None, with_signal=signal.SIGKILL)
-            except Exception:
-                pass
+                if not self._signal_and_wait(proc, signal.SIGINT, graceful_s):
+                    logger.info(
+                        "Process did not exit on SIGINT after %ds, sending SIGTERM",
+                        graceful_s,
+                    )
+                    if not self._signal_and_wait(proc, signal.SIGTERM, term_s):
+                        logger.warning(
+                            "Process did not exit on SIGTERM after %ds, sending SIGKILL "
+                            "— VFIO refcount may leak",
+                            term_s,
+                        )
+                        try:
+                            proc.kill(wait=None, with_signal=signal.SIGKILL)
+                        except Exception:
+                            pass
+            except Exception as e:
+                logger.warning("Error during graceful stop: %s", e)
             self._process = None
+
         target_host = host or self._host
         if target_host is not None:
-            time.sleep(2)
             kill_stale_processes(target_host)
+            self._wait_vfio_idle(target_host, vfio_idle_s)
+
+    def _signal_and_wait(self, proc, sig, timeout_s: float) -> bool:
+        """Send signal to *proc* and poll until exit or timeout. Returns True if exited."""
+        try:
+            proc.kill(wait=None, with_signal=sig)
+        except Exception as e:
+            logger.debug("Signal %s send failed: %s", sig, e)
+            return False
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                if not proc.running:
+                    return True
+            except Exception:
+                # If we can't query state, assume it's still running.
+                pass
+            time.sleep(0.25)
+        try:
+            return not proc.running
+        except Exception:
+            return False
+
+    @staticmethod
+    def _wait_vfio_idle(host, timeout_s: float) -> bool:
+        """Poll until no process holds /dev/vfio/<group> fds. Returns True if idle."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                res = host.connection.execute_command(
+                    "sudo lsof /dev/vfio/* 2>/dev/null | "
+                    "awk 'NR>1 && $1 != \"vfio-pci\" {print}' | wc -l",
+                    shell=True,
+                    timeout=5,
+                    expected_return_codes=None,
+                )
+                if (res.stdout or "0").strip() == "0":
+                    return True
+            except Exception:
+                return False
+            time.sleep(0.5)
+        logger.warning(
+            "VFIO still busy after %ds — disable_vf may block in kernel", timeout_s
+        )
+        return False
 
     def capture_stdout(self, process, process_name: str) -> str:
         """Capture stdout from mfd_connect process.

--- a/tests/validation/mtl_engine/execute.py
+++ b/tests/validation/mtl_engine/execute.py
@@ -301,6 +301,12 @@ MTL_APP_NAMES = [
 def kill_stale_processes(*hosts, names: list[str] | None = None) -> None:
     """Kill leftover MTL-related processes on the given hosts.
 
+    Uses a graceful signal ladder (SIGINT → SIGTERM → SIGKILL) so DPDK
+    applications get a chance to run ``rte_eal_cleanup()`` and release
+    their VFIO group fd. Going straight to SIGKILL leaves the kernel-side
+    VFIO refcount non-zero and causes the next ``nicctl disable_vf`` call
+    to block forever in ``vfio_unregister_group_dev``.
+
     Args:
         *hosts: One or more host objects with ``connection.execute_command``.
         names:  Process names to kill.  Defaults to :data:`MTL_APP_NAMES`.
@@ -309,11 +315,22 @@ def kill_stale_processes(*hosts, names: list[str] | None = None) -> None:
     """
     targets = names or MTL_APP_NAMES
     pattern = "|".join(f"[{n[0]}]{n[1:]}" for n in targets if n)
+    # SIGINT -> 3s; SIGTERM -> 2s; final SIGKILL.
+    cmd = (
+        f"sudo pkill -INT -f '{pattern}' 2>/dev/null; "
+        "for i in 1 2 3 4 5 6; do "
+        f"  pgrep -f '{pattern}' >/dev/null || break; sleep 0.5; "
+        "done; "
+        f"sudo pkill -TERM -f '{pattern}' 2>/dev/null; "
+        "for i in 1 2 3 4; do "
+        f"  pgrep -f '{pattern}' >/dev/null || break; sleep 0.5; "
+        "done; "
+        f"sudo pkill -KILL -f '{pattern}' 2>/dev/null; "
+        "true"
+    )
     for host in hosts:
         try:
-            host.connection.execute_command(
-                f"sudo pkill -9 -f '{pattern}' || true", shell=True, timeout=15
-            )
+            host.connection.execute_command(cmd, shell=True, timeout=20)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
Eliminates the multi-hour CI stall traced to `nicctl disable_vf` blocking
forever in the kernel's `vfio_unregister_group_dev` when a DPDK process
still holds `/dev/vfio/<group>` open. Layered defence so the test session
can never wedge in this state.

## Changes
- **`common/nicctl.py`**
  - Bound every shell call: `_NICCTL_TIMEOUT=30`, `_NICCTL_LONG_TIMEOUT=60`,
    `_VFIO_IDLE_TIMEOUT=20`.
  - `_wait_vfio_idle` — poll `/dev/vfio/<group>` until released before
    `disable_vf` / `bind_kernel`.
  - `_force_pci_reset` — PCI remove+rescan as documented kernel escape
    hatch when the timeout still fires.
  - `InterfaceSetup.cleanup` wraps each teardown in try/except so one
    stuck device cannot cascade into every following test.
- **`mtl_engine/application_base.py`**
  - `stop_process`: SIGINT (10 s) → SIGTERM (5 s) → SIGKILL ladder.
    SIGINT first lets DPDK run `rte_eal_cleanup()` and release the VFIO
    fd — skipping that is the root cause.
  - New `_signal_and_wait` and `_wait_vfio_idle` helpers; tunable via
    `stop_graceful_s` / `stop_term_s` / `stop_vfio_idle_s` params.
- **`mtl_engine/execute.py`** — `kill_stale_processes` uses the same
  INT→TERM→KILL ladder for leftover MTL processes from aborted runs.
- **`common/mtl_manager/mtlManager.py`** — fast `stop()` (`kill(wait=2)`)
  removing a 60 s session-teardown hang.
- **`conftest.py`** — autouse `_ensure_clean_hw_state` (kills strays +
  wipes stale hugepages at session start/end); `media_file` probes
  source existence so missing assets become SKIP not ERROR.

## Validation
- `pytest --collect-only tests/single/` → **626 tests collected**.
- Verified end-to-end on a node that previously reproduced the hang.

## Stack
PR #1550 (`pr/perf-runtime-optimisations`) stacks
on this one and inherits the timeout guarantees.