### PR TITLE
Add: extra pix_fmts to mtl_st20p ffmpeg plugin

### DIFF
--- a/ecosystem/ffmpeg_plugin/README.md
+++ b/ecosystem/ffmpeg_plugin/README.md
@@ -107,9 +107,18 @@ Reading from a yuv stream from a local file and sending a ST 2110-20 10-bit YUV4
 ffmpeg -stream_loop -1 -video_size 1920x1080 -f rawvideo -pix_fmt yuv422p10le -i yuv422p10le_1080p.yuv -filter:v fps=59.94 -p_port 0000:af:01.1 -p_sip 192.168.96.3 -p_tx_ip 239.168.85.20 -udp_port 20000 -payload_type 96 -f mtl_st20p -
 ```
 
-### 2.3. y210 format
+### 2.3. Supported pixel formats
 
-The y210 format is not supported by the MTL Plugin for FFmpeg.
+The `mtl_st20p` plugin maps the following FFmpeg `pix_fmt` values to MTL frame
+formats. The same `-pix_fmt` must be used on TX and RX.
+
+| `-pix_fmt`    | Wire format                   | ST 2110-20:2022 §6.2 compliant |
+| ------------- | ----------------------------- | ------------------------------ |
+| `yuv422p10le` | YUV 4:2:2 10-bit RFC 4175 PG2BE10 | yes (Table 2)              |
+| `y210le`      | YUV 4:2:2 10-bit RFC 4175 PG2BE10 | yes (Table 2)              |
+| `yuv444p10le` | YUV 4:4:4 10-bit RFC 4175 PG4BE10 | yes (Table 1)              |
+| `gbrp10le`    | RGB 10-bit RFC 4175 PG4BE10       | yes (Table 1)              |
+| `yuv420p`     | Planar I420 passthrough (`ST_FRAME_FMT_YUV420CUSTOM8`) | **no** — MTL-to-MTL only, not interoperable with third-party receivers |
 
 ## 3. ST22 compressed video run guide
 

--- a/ecosystem/ffmpeg_plugin/mtl_st20p_rx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st20p_rx.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <mtl/st_convert_api.h>
-
 #include "mtl_common.h"
 #ifdef MTL_GPU_DIRECT_ENABLED
 #include <mtl_gpu_direct/gpu.h>
@@ -122,15 +120,30 @@ static int mtl_st20p_read_header(AVFormatContext* ctx) {
       ops_rx.transport_fmt = ST20_FMT_YUV_422_10BIT;
       ops_rx.output_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
       break;
-    case AV_PIX_FMT_Y210LE: /* This format is not supported by MTL plugin.
-                               This is workaround
-                               for Intel(R) Tiber(TM) Broadcast Suite */
+    case AV_PIX_FMT_Y210LE:
       ops_rx.transport_fmt = ST20_FMT_YUV_422_10BIT;
       ops_rx.output_fmt = ST_FRAME_FMT_Y210;
       break;
     case AV_PIX_FMT_RGB24:
       ops_rx.transport_fmt = ST20_FMT_RGB_8BIT;
       ops_rx.output_fmt = ST_FRAME_FMT_RGB8;
+      break;
+    case AV_PIX_FMT_YUV444P10LE:
+      ops_rx.transport_fmt = ST20_FMT_YUV_444_10BIT;
+      ops_rx.output_fmt = ST_FRAME_FMT_YUV444PLANAR10LE;
+      break;
+    case AV_PIX_FMT_GBRP10LE:
+      ops_rx.transport_fmt = ST20_FMT_RGB_10BIT;
+      ops_rx.output_fmt = ST_FRAME_FMT_GBRPLANAR10LE;
+      break;
+    case AV_PIX_FMT_YUV420P:
+      /* MTL-to-MTL passthrough only: YUV420CUSTOM8 receives the raw
+       * ST20_FMT_YUV_420_8BIT payload straight as planar I420 with no RFC4175
+       * conversion. The wire bytes are NOT a SMPTE ST 2110-20:2022 §6.2.5
+       * Table 3 pgroup, so this only round-trips correctly when both peers
+       * are MTL endpoints using YUV420CUSTOM8. */
+      ops_rx.transport_fmt = ST20_FMT_YUV_420_8BIT;
+      ops_rx.output_fmt = ST_FRAME_FMT_YUV420CUSTOM8;
       break;
     default:
       err(ctx, "%s, unsupported pixel format: %s\n", __func__, pix_fmt_desc->name);
@@ -263,17 +276,6 @@ static int mtl_st20p_read_packet(AVFormatContext* ctx, AVPacket* pkt) {
     err(ctx, "%s(%d), av_new_packet failed with %d\n", __func__, s->idx, ret);
     st20p_rx_put_frame(s->rx_handle, frame);
     return ret;
-  }
-
-  /* This format is not supported by MTL plugin.
-     This is workaround for Intel(R) Tiber(TM) Broadcast Suite */
-  if (s->pixel_format == AV_PIX_FMT_Y210LE) {
-    ret = st20_rfc4175_422be10_to_y210((struct st20_rfc4175_422_10_pg2_be*)frame,
-                                       (uint16_t*)pkt->data, s->width, s->height);
-    if (ret != 0) {
-      av_log(ctx, AV_LOG_ERROR, "st20_rfc4175_422be10_to_y210le failed with %d\n", ret);
-      return ret;
-    }
   }
 
   /* todo: zero copy with external frame mode */

--- a/ecosystem/ffmpeg_plugin/mtl_st20p_tx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st20p_tx.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <mtl/st_convert_api.h>
-
 #include "mtl_common.h"
 
 typedef struct mtlSt20pMuxerContext {
@@ -96,15 +94,32 @@ static int mtl_st20p_write_header(AVFormatContext* ctx) {
       ops_tx.input_fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
       ops_tx.transport_fmt = ST20_FMT_YUV_422_10BIT;
       break;
-    case AV_PIX_FMT_Y210LE: /* This format is not supported by MTL plugin.
-                               This is workaround
-                               for Intel(R) Tiber(TM) Broadcast Suite */
-      ops_tx.transport_fmt = ST20_FMT_YUV_422_10BIT;
+    case AV_PIX_FMT_Y210LE:
       ops_tx.input_fmt = ST_FRAME_FMT_Y210;
+      ops_tx.transport_fmt = ST20_FMT_YUV_422_10BIT;
       break;
     case AV_PIX_FMT_RGB24:
       ops_tx.input_fmt = ST_FRAME_FMT_RGB8;
       ops_tx.transport_fmt = ST20_FMT_RGB_8BIT;
+      break;
+    case AV_PIX_FMT_YUV444P10LE:
+      ops_tx.input_fmt = ST_FRAME_FMT_YUV444PLANAR10LE;
+      ops_tx.transport_fmt = ST20_FMT_YUV_444_10BIT;
+      break;
+    case AV_PIX_FMT_GBRP10LE:
+      ops_tx.input_fmt = ST_FRAME_FMT_GBRPLANAR10LE;
+      ops_tx.transport_fmt = ST20_FMT_RGB_10BIT;
+      break;
+    case AV_PIX_FMT_YUV420P:
+      /* MTL-to-MTL passthrough only: YUV420CUSTOM8 sends the planar I420
+       * buffer straight onto the wire as ST20_FMT_YUV_420_8BIT payload
+       * without any conversion (st_frame_fmt_equal_transport() returns true).
+       * The wire bytes are NOT a SMPTE ST 2110-20:2022 §6.2.5 Table 3
+       * pgroup (which mandates 6-octet/4-pixel Y'00-Y'01-Y'10-Y'11-CB'00-CR'00
+       * interleaving), so this format is not interoperable with third-party
+       * ST 2110-20 receivers. Use only for MTL-to-MTL transport. */
+      ops_tx.input_fmt = ST_FRAME_FMT_YUV420CUSTOM8;
+      ops_tx.transport_fmt = ST20_FMT_YUV_420_8BIT;
       break;
     default:
       err(ctx, "%s, unsupported pixel format: %d\n", __func__, s->pixel_format);
@@ -160,14 +175,6 @@ static int mtl_st20p_write_packet(AVFormatContext* ctx, AVPacket* pkt) {
     return AVERROR(EIO);
   }
   dbg(ctx, "%s(%d), st20p_tx_get_frame: %p\n", __func__, s->idx, frame);
-
-  /* This format is not supported by MTL plugin.
-     This is workaround for Intel(R) Tiber(TM) Broadcast Suite */
-  if (s->pixel_format == AV_PIX_FMT_Y210LE) {
-    st20_y210_to_rfc4175_422be10((uint16_t*)pkt->data,
-                                 (struct st20_rfc4175_422_10_pg2_be*)(frame->addr[0]),
-                                 s->width, s->height);
-  }
 
   /* todo: zero copy with external frame mode */
   mtl_memcpy(frame->addr[0], pkt->data, s->frame_size);

--- a/tests/validation/common/integrity/video_integrity.py
+++ b/tests/validation/common/integrity/video_integrity.py
@@ -48,6 +48,15 @@ def calculate_yuv_frame_size(width: int, height: int, file_format: str) -> int:
             pixel_size = 2.5
         case "YUV422PLANAR10LE" | "yuv422p10le":
             pixel_size = 4
+        case "yuv444p10le" | "gbrp10le":
+            # 3 planes (Y/U/V or G/B/R), 10-bit samples padded to 2 bytes each
+            pixel_size = 6
+        case "yuv420p":
+            # I420: full Y plane + quarter-size U + quarter-size V
+            pixel_size = 1.5
+        case "y210le":
+            # Packed 4:2:2 10-bit, 2 samples per pixel × 2 bytes per sample
+            pixel_size = 4
         case _:
             logging.error(f"Size of {file_format} pixel is not known")
             raise ValueError(f"Size of {file_format} pixel is not known")

--- a/tests/validation/mtl_engine/ffmpeg_app.py
+++ b/tests/validation/mtl_engine/ffmpeg_app.py
@@ -235,11 +235,26 @@ def execute_test(
     output_format: str,
     multiple_sessions: bool = False,
     tx_is_ffmpeg: bool = True,
+    pix_fmt: str = "yuv422p10le",
+    keep_output: bool = False,
 ):
+    """Execute FFmpeg loopback (or FFmpeg<->RxTxApp) ST2110-20 test.
+
+    When ``keep_output=True`` the output file(s) are NOT deleted after
+    validation and the function returns ``(passed, output_files[0])`` instead
+    of ``passed``. Use this when a follow-up integrity check needs the file.
+
+    ``pix_fmt`` controls FFmpeg input/output pixel format on both sides; the
+    ``video_url`` source must already be in that pix_fmt and ``-filter:v fps=``
+    is dropped to preserve byte-exact frame parity.
+    """
     case_id = os.environ.get("PYTEST_CURRENT_TEST", "ffmpeg_test")
     case_id = case_id[: case_id.rfind("(") - 1] if "(" in case_id else case_id
 
     video_size, fps = decode_video_format_16_9(video_format)
+    # When caller pre-converted the source to a non-default pix_fmt (typical
+    # for integrity tests), skip the fps filter so frames stay byte-identical.
+    tx_filter = "" if pix_fmt != "yuv422p10le" else f"-filter:v fps={fps} "
     match output_format:
         case "yuv":
             ffmpeg_rx_f_flag = "-f rawvideo"
@@ -251,7 +266,7 @@ def execute_test(
             f"{FFMPEG_EXE} -p_port {nic_port_list[0]} "
             f"-p_sip {ip_pools.rx[0]} "
             f"-p_rx_ip {ip_pools.rx_multicast[0]} -udp_port 20000 "
-            f"-payload_type 112 -fps {fps} -pix_fmt yuv422p10le "
+            f"-payload_type 112 -fps {fps} -pix_fmt {pix_fmt} "
             f"-video_size {video_size} -f mtl_st20p -i k "
             f"-init_retry 20 "
             f"{ffmpeg_rx_f_flag} {output_files[0]} -y"
@@ -259,8 +274,8 @@ def execute_test(
         if tx_is_ffmpeg:
             tx_cmd = (
                 f"{FFMPEG_EXE} -stream_loop -1 -video_size {video_size} -f rawvideo "
-                f"-pix_fmt yuv422p10le -i {video_url} "
-                f"-filter:v fps={fps} -p_port {nic_port_list[1]} "
+                f"-pix_fmt {pix_fmt} -i {video_url} "
+                f"{tx_filter}-p_port {nic_port_list[1]} "
                 f"-p_sip {ip_pools.tx[0]} "
                 f"-p_tx_ip {ip_pools.rx_multicast[0]} -udp_port 20000 "
                 f"-payload_type 112 -f mtl_st20p -"
@@ -276,11 +291,11 @@ def execute_test(
             f"{FFMPEG_EXE} -p_sip {ip_pools.rx[0]} "
             f"-p_port {nic_port_list[0]} "
             f"-p_rx_ip {ip_pools.rx_multicast[0]} -udp_port 20000 "
-            f"-payload_type 112 -fps {fps} -pix_fmt yuv422p10le "
+            f"-payload_type 112 -fps {fps} -pix_fmt {pix_fmt} "
             f"-video_size {video_size} -f mtl_st20p -i 1 "
             f"-p_port {nic_port_list[0]} "
             f"-p_rx_ip {ip_pools.rx_multicast[0]} -udp_port 20002 "
-            f"-payload_type 112 -fps {fps} -pix_fmt yuv422p10le "
+            f"-payload_type 112 -fps {fps} -pix_fmt {pix_fmt} "
             f"-video_size {video_size} -f mtl_st20p -i 2 "
             f"-map 0:0 {ffmpeg_rx_f_flag} {output_files[0]} -y "
             f"-map 1:0 {ffmpeg_rx_f_flag} {output_files[1]} -y"
@@ -288,8 +303,8 @@ def execute_test(
         if tx_is_ffmpeg:
             tx_cmd = (
                 f"{FFMPEG_EXE} -stream_loop -1 -video_size {video_size} -f rawvideo "
-                f"-pix_fmt yuv422p10le -i {video_url} "
-                f"-filter:v fps={fps} -p_port {nic_port_list[1]} "
+                f"-pix_fmt {pix_fmt} -i {video_url} "
+                f"{tx_filter}-p_port {nic_port_list[1]} "
                 f"-p_sip {ip_pools.tx[0]} "
                 f"-p_tx_ip {ip_pools.rx_multicast[0]} -udp_port 20000 "
                 f"-payload_type 112 -f mtl_st20p -"
@@ -365,14 +380,18 @@ def execute_test(
             passed = check_output_video_h264(
                 output_files[0], video_size, host, build, video_url
             )
-    # Clean up output files after validation
-    try:
-        for output_file in output_files:
-            run(f"rm -f {output_file}", host=host)
-    except Exception as e:
-        logger.info(f"Could not remove output files: {e}")
+    # Clean up output files after validation (unless caller wants to keep them
+    # for follow-up checks like integrity validation).
+    if not keep_output:
+        try:
+            for output_file in output_files:
+                run(f"rm -f {output_file}", host=host)
+        except Exception as e:
+            logger.info(f"Could not remove output files: {e}")
     if not passed:
         log_fail("test failed")
+    if keep_output:
+        return passed, output_files[0]
     return passed
 
 
@@ -739,6 +758,33 @@ def decode_video_format_16_9(video_format: str) -> tuple:
     else:
         log_fail("Invalid video format")
         return None
+
+
+def generate_reference_file(
+    host,
+    build: str,
+    src_url: str,
+    video_size: str,
+    src_pix_fmt: str,
+    dst_pix_fmt: str,
+) -> str:
+    """Transcode a raw YUV source into a reference file in ``dst_pix_fmt``.
+
+    Used by integrity tests to obtain a byte-exact reference matching the
+    pix_fmt that the FFmpeg MTL plugin will both send and receive.
+    Returns the path of the generated reference file on ``host``.
+    """
+    test_name = sanitize_filename(get_case_id())
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    ref_file = f"{build}/tests/{test_name}_{timestamp}_ref_{dst_pix_fmt}.yuv"
+    cmd = (
+        f"{FFMPEG_EXE} -y -f rawvideo -pix_fmt {src_pix_fmt} "
+        f"-video_size {video_size} -i {src_url} "
+        f"-pix_fmt {dst_pix_fmt} -f rawvideo {ref_file}"
+    )
+    logger.info(f"Generating reference file: {ref_file}")
+    run(cmd, cwd=build, timeout=300, testcmd=False, host=host)
+    return ref_file
 
 
 def generate_rxtxapp_rx_config(

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_pix_fmt.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_pix_fmt.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2024-2026 Intel Corporation
+
+import logging
+import os
+
+import pytest
+from common.integrity.integrity_runner import FileVideoIntegrityRunner
+from common.nicctl import InterfaceSetup
+from mtl_engine import ffmpeg_app
+from mtl_engine.execute import log_fail, run
+from mtl_engine.media_files import yuv_files_422p10le
+
+logger = logging.getLogger(__name__)
+
+# Pixel formats supported by the mtl_st20p FFmpeg plugin.
+# yuv422p10le pre-existing; yuv444p10le, gbrp10le, yuv420p, y210le added by this PR.
+#
+# Wire-format compliance vs SMPTE ST 2110-20:2022 §6.2:
+#   yuv422p10le, y210le -> 4:2:2 10b RFC4175 PG2BE10  (Table 2)  compliant
+#   yuv444p10le         -> 4:4:4 10b RFC4175 PG4BE10  (Table 1)  compliant
+#   gbrp10le            -> RGB   10b RFC4175 PG4BE10  (Table 1)  compliant
+#   yuv420p             -> ST_FRAME_FMT_YUV420CUSTOM8 passthrough, NON-compliant:
+#                          MTL memcpys planar I420 straight to the wire instead of
+#                          the §6.2.5 Table 3 pgroup (Y'00-Y'01-Y'10-Y'11-CB'00-CR'00).
+#                          MTL<->MTL only; not interoperable with third-party receivers.
+PIX_FMTS = [
+    "yuv422p10le",
+    "yuv444p10le",
+    "gbrp10le",
+    "yuv420p",
+    "y210le",
+]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("pix_fmt", PIX_FMTS)
+@pytest.mark.parametrize(
+    "video_format, media_file",
+    [("i1080p25", yuv_files_422p10le["Penguin_1080p"])],
+    indirect=["media_file"],
+    ids=["Penguin_1080p"],
+)
+def test_rx_ffmpeg_tx_ffmpeg_pix_fmt(
+    hosts,
+    test_time,
+    mtl_path,
+    setup_interfaces: InterfaceSetup,
+    video_format,
+    pix_fmt,
+    test_config,
+    media_file,
+):
+    """FFmpeg TX -> FFmpeg RX loopback with frame-by-frame integrity check.
+
+    Validates every pixel format supported by the mtl_st20p FFmpeg plugin
+    end-to-end:
+
+    1. Pre-generates a reference file in the target ``pix_fmt`` from the
+       canonical YUV422P10LE source (skipped when source already matches).
+    2. Runs FFmpeg TX -> mtl_st20p -> FFmpeg RX loopback using that reference.
+    3. Runs ``FileVideoIntegrityRunner`` to MD5-compare every received frame
+       against the reference. Catches plane-layout / converter regressions
+       that a simple "output > 0 bytes" check would miss.
+    """
+    media_file_info, media_file_path = media_file
+    host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
+    video_size, _ = ffmpeg_app.decode_video_format_16_9(video_format)
+
+    # 1. Reference file in target pix_fmt (skip transcoding for the canonical fmt).
+    if pix_fmt == "yuv422p10le":
+        ref_file = media_file_path
+        cleanup_ref = False
+    else:
+        ref_file = ffmpeg_app.generate_reference_file(
+            host=host,
+            build=mtl_path,
+            src_url=media_file_path,
+            video_size=video_size,
+            src_pix_fmt="yuv422p10le",
+            dst_pix_fmt=pix_fmt,
+        )
+        cleanup_ref = True
+
+    rx_output = None
+    try:
+        # 2. TX/RX loopback. keep_output=True so integrity runner can read it.
+        passed, rx_output = ffmpeg_app.execute_test(
+            test_time=test_time,
+            build=mtl_path,
+            host=host,
+            nic_port_list=interfaces_list,
+            type_="frame",
+            video_format=video_format,
+            pg_format=media_file_info["format"],
+            video_url=ref_file,
+            output_format="yuv",
+            pix_fmt=pix_fmt,
+            keep_output=True,
+        )
+        if not passed:
+            log_fail(f"loopback failed for pix_fmt={pix_fmt}")
+            return
+
+        # 3. Frame-by-frame MD5 integrity check.
+        logger.info(f"Running video integrity check for pix_fmt={pix_fmt}")
+        integrity = FileVideoIntegrityRunner(
+            host=host,
+            test_repo_path=mtl_path,
+            src_url=ref_file,
+            out_name=os.path.basename(rx_output),
+            resolution=video_size,
+            file_format=pix_fmt,
+            out_path=os.path.dirname(rx_output),
+            delete_file=False,
+            integrity_path=os.path.join(
+                mtl_path, "tests", "validation", "common", "integrity"
+            ),
+        )
+        if not integrity.run():
+            log_fail(f"integrity check failed for pix_fmt={pix_fmt}")
+    finally:
+        # Best-effort cleanup of files we created.
+        if rx_output:
+            run(f"rm -f {rx_output}", host=host)
+        if cleanup_ref:
+            run(f"rm -f {ref_file}", host=host)


### PR DESCRIPTION
Adds yuv444p10le, gbrp10le, yuv420p, and y210le on top of the existing yuv422p10le pixel format support in the mtl_st20p ffmpeg plugin.

New ST 2110-20 pipeline integrity test
tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_pix_fmt.py covers the added formats end-to-end with frame-by-frame MD5 verification.

yuv420p uses ST_FRAME_FMT_YUV420CUSTOM8 passthrough (planar I420 on the wire); not SMPTE ST 2110-20:2022 §6.2.5 compliant — MTL-to-MTL only. The other formats are converted to standard RFC 4175 pgroups.