### PR TITLE
Ci: batch update from open dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,41 +3,41 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "Ci: "
 
   - package-ecosystem: pip
     directory: /tests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "Ci: "
 
   - package-ecosystem: pip
     directory: /python
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "Ci: "
 
   - package-ecosystem: cargo
     directory: /rust
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "Ci: "
 
   - package-ecosystem: docker
     directory: /manager
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "Ci: "
 
   - package-ecosystem: docker
     directory: /docker
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "Ci: "

--- a/.github/workflows/base_build.yml
+++ b/.github/workflows/base_build.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: 'upload release build artifacts'
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mtl-release-bin
           path: '${{ github.workspace }}/build/'
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 90
     steps:
     - name: 'Harden Runner'
-      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
       with:
         egress-policy: audit
 
@@ -57,7 +57,7 @@ jobs:
         build_platform: 'linux64'
         working-directory: '${{ github.workspace }}'
         command: ./build.sh 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@v7.0.1
       with:
         name: coverity-reports
         path: '${{ github.workspace }}/cov-int'

--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: dpdk
     steps:
       - name: Harden-Runner
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Checkout MTL
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Harden-Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Set current date
@@ -54,7 +54,7 @@ jobs:
         with:
           ref: "${{ github.ref }}"
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build-${{ github.sha }}
       - name: Make build artifacts executable
@@ -116,7 +116,7 @@ jobs:
           LD_LIBRARY_PATH: ${{ github.workspace }}/build/lib
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "custom-test-report-${{ env.CURRENT_DATE }}"
           path: ./tests/validation/report.html

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -46,7 +46,7 @@ jobs:
       packages: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Checkout repository
@@ -92,7 +92,7 @@ jobs:
       DOCKER_IMAGE_NAME: mtl-manager
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/github_pages_update.yml
+++ b/.github/workflows/github_pages_update.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Secure the runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
@@ -48,7 +48,7 @@ jobs:
         run:  make -C doc/sphinx html
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: ./doc/_build/html
 

--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Harden Runner
         if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -44,7 +44,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/nightly-combined-report.yml
+++ b/.github/workflows/nightly-combined-report.yml
@@ -58,7 +58,7 @@ jobs:
       both_completed: ${{ steps.check-status.outputs.both_completed }}
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
@@ -245,7 +245,7 @@ jobs:
             console.log(`GTest Run #${run.data.run_number}, Branch: ${run.data.head_branch}, Date: ${run.data.created_at}`);
 
       - name: Download pytest artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: nightly-test-report-*
           path: pytest-reports
@@ -254,7 +254,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download gtest artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: nightly-gtest-report-*
           path: gtest-reports
@@ -285,7 +285,7 @@ jobs:
           ls -lh ./*.log || echo "No gtest logs found"
 
       - name: Download system info artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: system-info-*
@@ -295,7 +295,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Also download system info from gtest run
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: system-info-*
@@ -315,7 +315,7 @@ jobs:
 
       - name: Download baseline pytest artifacts
         if: needs.wait-for-both-workflows.outputs.baseline_pytest_run_id != ''
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: nightly-test-report-*
@@ -326,7 +326,7 @@ jobs:
 
       - name: Download baseline gtest artifacts
         if: needs.wait-for-both-workflows.outputs.baseline_gtest_run_id != ''
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: nightly-gtest-report-*
@@ -454,14 +454,14 @@ jobs:
 
       - name: Upload combined Excel report
         if: steps.combine.outputs.reports_generated == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-combined-report-excel
           path: combined_nightly_report.xlsx
 
       - name: Upload combined HTML report
         if: steps.combine.outputs.reports_generated == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-combined-report-html
           path: combined_nightly_report.html

--- a/.github/workflows/nightly-gtest.yml
+++ b/.github/workflows/nightly-gtest.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 300
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
@@ -63,7 +63,7 @@ jobs:
       - name: "upload report gtest"
         if: always()
         id: upload-report-gtest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-gtest-report-${{ matrix.nic }}
           path: |
@@ -71,7 +71,7 @@ jobs:
       
       - name: "upload system info"
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: system-info-${{ matrix.nic }}
           path: system-info-${{ matrix.nic }}/

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: dpdk
     steps:
       - name: Harden-Runner
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Checkout MTL
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
@@ -57,7 +57,7 @@ jobs:
         with:
           ref: '${{ github.ref }}'
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build-${{ github.sha }}
       - name: Make build artifacts executable
@@ -130,14 +130,14 @@ jobs:
       - name: "upload report python"
         if: always()
         id: upload-report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-test-report-${{ matrix.nic }}-${{ matrix.dir }}
           path: ./tests/validation/report.html
 
       - name: "upload system info"
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: system-info-${{ matrix.nic }}-${{ matrix.dir }}
           path: ./system-info-${{ matrix.nic }}-${{ matrix.dir }}
@@ -150,7 +150,7 @@ jobs:
       - name: 'preparation: Checkout MTL'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download python report artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: nightly-test-report-*
           path: python-reports  # Downloads all artifacts into this directory
@@ -192,7 +192,7 @@ jobs:
           printf 'report_path=%s\n' "$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
       - name: Upload combined python report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-pytest-combined-report
           path: ${{ steps.combine.outputs.report_path }}

--- a/.github/workflows/perf-pytest.yml
+++ b/.github/workflows/perf-pytest.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Harden-Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Set current date
@@ -116,7 +116,7 @@ jobs:
           fi
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "perf-test-report-${{ runner.name }}-${{ env.CURRENT_DATE }}"
           path: |

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: dpdk
     steps:
       - name: Harden-Runner
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Checkout MTL
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: 'preparation: Harden Runner'
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
@@ -70,7 +70,7 @@ jobs:
           ref: '${{ github.ref }}'
       - name: Download build artifacts
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: build-${{ github.sha }}
       - name: Make build artifacts executable
@@ -134,7 +134,7 @@ jobs:
       - name: "upload report"
         if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
         id: upload-report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoke-test-report-${{ matrix.nic }}
           path: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -53,7 +53,7 @@ jobs:
 
 
       - name: Run Trivy vulnerability scanner with sarif output
-        uses: aquasecurity/trivy-action@0.35.0 # v0.32.0
+        uses: aquasecurity/trivy-action@v0.36.0 # v0.32.0
         with:
           scan-type: config
           scan-ref: ./docker
@@ -91,7 +91,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Run Trivy vulnerability scanner with sarif output
-        uses: aquasecurity/trivy-action@0.35.0 # v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0 # v0.35.0
         with:
           scan-type: config
           scan-ref: ./manager
@@ -127,7 +127,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Run Trivy vulnerability scanner with table output
-        uses: aquasecurity/trivy-action@0.35.0 # v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0 # v0.35.0
         with:
           scan-type: config
           scan-ref: ./docker
@@ -137,7 +137,7 @@ jobs:
           vuln-type: os,library
 
       - name: Run Trivy manager vulnerability scanner with table output
-        uses: aquasecurity/trivy-action@0.35.0 # v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0 # v0.35.0
         with:
           scan-type: config
           scan-ref: ./manager

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -120,7 +120,7 @@ jobs:
       pipenv-activate: ${{ steps.pipenv-install.outputs.VIRTUAL_ENV }}
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
@@ -202,7 +202,7 @@ jobs:
       PYTEST_RETRIES: '3'
     steps:
       - name: 'preparation: Harden Runner'
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
@@ -285,7 +285,7 @@ jobs:
 
       - name: 'cleanup: Validation execution logs'
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: 'validation-execution-logs.tar.gz'
           path: '${{ github.workspace }}/tests/validation/validation-execution-logs.tar.gz'

--- a/tests/doc/requirements.txt
+++ b/tests/doc/requirements.txt
@@ -1,3 +1,3 @@
-sphinx>=5.0
-sphinx_rtd_theme>=1.0
-breathe>=4.35.0
+sphinx>=9.1.0
+sphinx_rtd_theme>=3.1.0
+breathe>=4.36.0


### PR DESCRIPTION
Consolidates updates from dependabot PRs #1537, #1538, #1539, #1540, #1541, #1543, #1544, #1545. PR #1542/#1512 (pytest 8.4.1 -> 9.0.3) is intentionally excluded because pytest-mfd-config 3.25.0 (latest) pins 'pytest<9'.

GitHub Actions:
- step-security/harden-runner: v2.18.0/v2.12.2 -> v2.19.0 (#1541)
- aquasecurity/trivy-action: 0.35.0 -> v0.36.0 (#1540)
- actions/upload-artifact: v7.0.0 / v7 -> v7.0.1 (#1539)
- actions/download-artifact: v7.0.0 / v8 -> v8.0.1 (#1538)
- actions/upload-pages-artifact: v4.0.0 -> v5.0.0 (#1537)

Documentation deps (tests/doc/requirements.txt):
- sphinx: >=5.0 -> >=9.1.0 (#1544)
- sphinx_rtd_theme: >=1.0 -> >=3.1.0 (#1545)
- breathe: >=4.35.0 -> >=4.36.0 (#1543)

Validated tests/validation/requirements.txt resolves cleanly with the existing pytest 8.4.1 pin (pytest 9 conflict noted above).