### PR TITLE
ST 2110 RX redundancy & ST 2022-7 coverage

### DIFF
--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -439,7 +439,8 @@ struct st_rx_video_slot_impl {
   uint16_t st22_box_hdr_length;
   /* timestamp(ST10_TIMESTAMP_FMT_TAI, PTP) value for the first pkt */
   uint64_t timestamp_first_pkt;
-  int last_pkt_idx;
+  /* Per-port high-water mark of pkt_idx within the current frame (init -1). */
+  int last_pkt_idx[MTL_SESSION_PORT_MAX];
 };
 
 enum st20_detect_status {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1671,13 +1671,13 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
         rv_tp_pkt_handle(s, mbuf, s_port, slot, tmstamp, pkt_idx);
       return 0;
     }
-    if (pkt_idx > (slot->last_pkt_idx + 1)) {
-      int gap = pkt_idx - slot->last_pkt_idx - 1;
+    if (pkt_idx > (slot->last_pkt_idx[s_port] + 1) && slot->last_pkt_idx[s_port] >= 0) {
+      int gap = pkt_idx - slot->last_pkt_idx[s_port] - 1;
       s->port_user_stats.common.stat_lost_packets += gap;
       s->port_user_stats.common.port[s_port].lost_packets += gap;
-    } else if (pkt_idx < slot->last_pkt_idx) {
+    } else if (pkt_idx < slot->last_pkt_idx[s_port]) {
       /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
-       * behind the highest accepted index in the current frame */
+       * behind the highest accepted index for THIS port in the current frame */
       s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
@@ -1708,7 +1708,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
   /* only advance, never regress: a reorder must not move the high-water
    * mark backward, otherwise the next forward jump re-counts already-lost
    * packets as new losses */
-  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
+  if (pkt_idx > slot->last_pkt_idx[s_port]) slot->last_pkt_idx[s_port] = pkt_idx;
 
   /* if enable_timing_parser */
   if (s->enable_timing_parser) rv_tp_pkt_handle(s, mbuf, s_port, slot, tmstamp, pkt_idx);
@@ -1869,13 +1869,13 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
       s->port_user_stats.common.stat_pkts_redundant++;
       return 0;
     }
-    if (pkt_idx > (slot->last_pkt_idx + 1)) {
-      int gap = pkt_idx - slot->last_pkt_idx - 1;
+    if (pkt_idx > (slot->last_pkt_idx[s_port] + 1) && slot->last_pkt_idx[s_port] >= 0) {
+      int gap = pkt_idx - slot->last_pkt_idx[s_port] - 1;
       s->port_user_stats.common.stat_lost_packets += gap;
       s->port_user_stats.common.port[s_port].lost_packets += gap;
-    } else if (pkt_idx < slot->last_pkt_idx) {
+    } else if (pkt_idx < slot->last_pkt_idx[s_port]) {
       /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
-       * behind the highest accepted index in the current frame */
+       * behind the highest accepted index for THIS port in the current frame */
       s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
@@ -1897,7 +1897,7 @@ static int rv_handle_rtp_pkt(struct st_rx_video_session_impl* s, struct rte_mbuf
     }
   }
   /* only advance high-water mark; see rv_handle_frame_pkt */
-  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
+  if (pkt_idx > slot->last_pkt_idx[s_port]) slot->last_pkt_idx[s_port] = pkt_idx;
 
   /* enqueue the packet ring to app */
   int ret = rte_ring_sp_enqueue(s->rtps_ring, (void*)mbuf);
@@ -2069,13 +2069,13 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
-    if (pkt_idx > (slot->last_pkt_idx + 1)) {
-      int gap = pkt_idx - slot->last_pkt_idx - 1;
+    if (pkt_idx > (slot->last_pkt_idx[s_port] + 1) && slot->last_pkt_idx[s_port] >= 0) {
+      int gap = pkt_idx - slot->last_pkt_idx[s_port] - 1;
       s->port_user_stats.common.stat_lost_packets += gap;
       s->port_user_stats.common.port[s_port].lost_packets += gap;
-    } else if (pkt_idx < slot->last_pkt_idx) {
+    } else if (pkt_idx < slot->last_pkt_idx[s_port]) {
       /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
-       * behind the highest accepted index in the current frame */
+       * behind the highest accepted index for THIS port in the current frame */
       s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
@@ -2102,7 +2102,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
         payload_length);
   }
   /* only advance high-water mark; see rv_handle_frame_pkt */
-  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
+  if (pkt_idx > slot->last_pkt_idx[s_port]) slot->last_pkt_idx[s_port] = pkt_idx;
 
   /* copy payload */
   uint32_t offset;
@@ -2240,13 +2240,13 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
-    if (pkt_idx > (slot->last_pkt_idx + 1)) {
-      int gap = pkt_idx - slot->last_pkt_idx - 1;
+    if (pkt_idx > (slot->last_pkt_idx[s_port] + 1) && slot->last_pkt_idx[s_port] >= 0) {
+      int gap = pkt_idx - slot->last_pkt_idx[s_port] - 1;
       s->port_user_stats.common.stat_lost_packets += gap;
       s->port_user_stats.common.port[s_port].lost_packets += gap;
-    } else if (pkt_idx < slot->last_pkt_idx) {
+    } else if (pkt_idx < slot->last_pkt_idx[s_port]) {
       /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
-       * behind the highest accepted index in the current frame */
+       * behind the highest accepted index for THIS port in the current frame */
       s->port_user_stats.common.port[s_port].reordered_packets++;
     }
   } else {
@@ -2265,7 +2265,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
     }
   }
   /* only advance high-water mark; see rv_handle_frame_pkt */
-  if (pkt_idx > slot->last_pkt_idx) slot->last_pkt_idx = pkt_idx;
+  if (pkt_idx > slot->last_pkt_idx[s_port]) slot->last_pkt_idx[s_port] = pkt_idx;
 
   /* calculate offset */
   uint32_t offset =
@@ -3155,7 +3155,8 @@ static void rv_reset_slot(struct st_rx_video_session_impl* s,
   slot->second_field = false;
   slot->st22_payload_length = 0;
   slot->st22_box_hdr_length = 0;
-  slot->last_pkt_idx = -1;
+  slot->last_pkt_idx[MTL_SESSION_PORT_P] = -1;
+  slot->last_pkt_idx[MTL_SESSION_PORT_R] = -1;
   memset(&slot->meta, 0, sizeof(slot->meta));
   memset(&slot->st22_meta, 0, sizeof(slot->st22_meta));
   if (slot->frame_bitmap && s->st20_frame_bitmap_size)

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -45,6 +45,8 @@ unit_sources = [
   'session/st20/err_packets_test.cpp',
   'pipeline/st40p_harness.c',
   'pipeline/st40p_test.cpp',
+  'pipeline/st20p_harness.c',
+  'pipeline/st20p_test.cpp',
   'main.cpp',
 ]
 

--- a/tests/unit/pipeline/st20p_harness.c
+++ b/tests/unit/pipeline/st20p_harness.c
@@ -1,0 +1,188 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * C harness for ST20p (video) pipeline-layer unit tests.
+ *
+ * Drives rx_st20p_frame_ready() directly with a synthetic
+ * st20_rx_frame_meta — bypasses the transport session entirely.
+ * The pipeline counters under test (stat_frames_received / _dropped /
+ * _corrupted) are about producer/consumer flow, not packet semantics,
+ * so transport realism is not required.
+ *
+ * The pipeline is configured with derive=true so that the converter
+ * path is bypassed and frame_ready takes the simple branch:
+ *   framebuff->dst = framebuff->src; stat = ST20P_RX_FRAME_CONVERTED;
+ * This is the path get_frame() consumes ST20P_RX_FRAME_CONVERTED from.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Include the production pipeline .c so static rx_st20p_frame_ready()
+ * is reachable and the public st20p_rx_* entry points see our private
+ * struct.  Disable USDT to avoid linker references to probe semaphores.
+ */
+#undef MTL_HAS_USDT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#include "st2110/pipeline/st20_pipeline_rx.c"
+#pragma GCC diagnostic pop
+
+#include "common/ut_common.h"
+
+/*
+ * Stubs for libmtl symbols called by the pipeline that would otherwise
+ * resolve to the real library (which requires HW/hugepages or a real
+ * transport session).  --allow-multiple-definition lets ours win.
+ */
+
+int st20_rx_put_framebuff(st20_rx_handle handle, void* frame) {
+  (void)handle;
+  (void)frame; /* transport-side framebuf release is a no-op for the harness */
+  return 0;
+}
+
+int st20_rx_get_session_stats(st20_rx_handle handle, struct st20_rx_user_stats* stats) {
+  (void)handle;
+  /* Return zeroed transport stats; the pipeline overlays its own
+   * frame-level counters on top, which is exactly what we want to test. */
+  if (stats) memset(stats, 0, sizeof(*stats));
+  return 0;
+}
+
+int st20_rx_reset_session_stats(st20_rx_handle handle) {
+  (void)handle;
+  return 0;
+}
+
+/* ── opaque context ───────────────────────────────────────────────────── */
+
+struct ut20p_ctx {
+  struct mtl_main_impl impl;
+  struct st20p_rx_ctx pipeline;
+  struct st20p_rx_frame* framebuffs;
+  int framebuff_cnt;
+};
+
+#include "pipeline/st20p_harness.h"
+
+/* ── init ─────────────────────────────────────────────────────────────── */
+
+int ut20p_init(void) {
+  return ut_eal_init();
+}
+
+/* ── context create / destroy ─────────────────────────────────────────── */
+
+ut20p_ctx* ut20p_ctx_create(int framebuff_cnt) {
+  ut20p_ctx* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx) return NULL;
+
+  ctx->framebuff_cnt = framebuff_cnt;
+  ctx->impl.type = MT_HANDLE_MAIN;
+
+  ctx->framebuffs = calloc(framebuff_cnt, sizeof(struct st20p_rx_frame));
+  if (!ctx->framebuffs) {
+    free(ctx);
+    return NULL;
+  }
+  for (int i = 0; i < framebuff_cnt; i++) {
+    ctx->framebuffs[i].stat = ST20P_RX_FRAME_FREE;
+    ctx->framebuffs[i].idx = i;
+    /* mirrors production init: put_frame() reads frame->priv to recover
+     * the owning st20p_rx_frame.  With derive=true frame_ready does
+     * `dst = src`, so setting src.priv is sufficient. */
+    ctx->framebuffs[i].src.priv = &ctx->framebuffs[i];
+    ctx->framebuffs[i].dst.priv = &ctx->framebuffs[i];
+  }
+
+  struct st20p_rx_ctx* p = &ctx->pipeline;
+  p->impl = &ctx->impl;
+  p->idx = 0;
+  p->socket_id = rte_socket_id();
+  p->type = MT_ST20_HANDLE_PIPELINE_RX;
+  p->framebuff_cnt = framebuff_cnt;
+  p->framebuffs = ctx->framebuffs;
+  /* derive=true: skip converter; frame_ready stores src and marks
+   * ST20P_RX_FRAME_CONVERTED, which get_frame() consumes directly. */
+  p->derive = true;
+  p->ready = true;
+  /* transport handle: must be non-NULL for put_frame / overlay paths,
+   * but our stubs ignore it. */
+  p->transport = (st20_rx_handle)(uintptr_t)0x1;
+
+  if (pthread_mutex_init(&p->lock, NULL) != 0) {
+    free(ctx->framebuffs);
+    free(ctx);
+    return NULL;
+  }
+
+  return ctx;
+}
+
+void ut20p_ctx_destroy(ut20p_ctx* ctx) {
+  if (!ctx) return;
+  pthread_mutex_destroy(&ctx->pipeline.lock);
+  free(ctx->framebuffs);
+  free(ctx);
+}
+
+/* ── inject one frame via rx_st20p_frame_ready ────────────────────────── */
+
+int ut20p_inject_frame(ut20p_ctx* ctx, enum st_frame_status status, uint32_t timestamp) {
+  /* Stack-allocated synthetic meta — frame_ready copies what it needs
+   * into the framebuf.  The frame addr only needs to be a stable
+   * non-NULL pointer; with derive=true it is never dereferenced by the
+   * pipeline before delivery, and our st20_rx_put_framebuff stub
+   * ignores it on release. */
+  struct st20_rx_frame_meta meta;
+  memset(&meta, 0, sizeof(meta));
+  meta.status = status;
+  meta.timestamp = timestamp;
+  meta.rtp_timestamp = timestamp;
+  meta.frame_total_size = 1;
+  meta.frame_recv_size = 1;
+  meta.pkts_total = 1;
+
+  static uint8_t dummy_frame_storage; /* address-stable sentinel */
+  return rx_st20p_frame_ready(&ctx->pipeline, &dummy_frame_storage, &meta);
+}
+
+/* ── frame get/put ────────────────────────────────────────────────────── */
+
+struct st_frame* ut20p_get_frame(ut20p_ctx* ctx) {
+  return st20p_rx_get_frame(&ctx->pipeline);
+}
+
+int ut20p_put_frame(ut20p_ctx* ctx, struct st_frame* frame) {
+  return st20p_rx_put_frame(&ctx->pipeline, frame);
+}
+
+/* ── stat accessors ───────────────────────────────────────────────────── */
+
+uint64_t ut20p_stat_frames_received(const ut20p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_received;
+}
+
+uint64_t ut20p_stat_frames_dropped(const ut20p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_dropped;
+}
+
+uint64_t ut20p_stat_frames_corrupted(const ut20p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_corrupted;
+}
+
+uint32_t ut20p_stat_busy(const ut20p_ctx* ctx) {
+  return rte_atomic32_read(&ctx->pipeline.stat_busy);
+}
+
+/* ── public-API wrappers ─────────────────────────────────────────────── */
+
+int ut20p_get_session_stats(ut20p_ctx* ctx, struct st20_rx_user_stats* stats) {
+  return st20p_rx_get_session_stats(&ctx->pipeline, stats);
+}
+
+int ut20p_reset_session_stats(ut20p_ctx* ctx) {
+  return st20p_rx_reset_session_stats(&ctx->pipeline);
+}

--- a/tests/unit/pipeline/st20p_harness.h
+++ b/tests/unit/pipeline/st20p_harness.h
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * C header for ST20p (video) pipeline-layer unit tests.
+ *
+ * Pins the pipeline-internal frame-count contract:
+ *   - stat_frames_received bumps in st20p_rx_get_frame() (app consumes), NOT
+ *     when the underlying transport completes a frame.
+ *   - stat_frames_dropped bumps in rx_st20p_frame_ready() when no free
+ *     framebuffer is available (back-pressure; the transport-side frame
+ *     is discarded by the pipeline).
+ *   - stat_frames_corrupted bumps in st20p_rx_get_frame() iff the delivered
+ *     frame's status is ST_FRAME_STATUS_CORRUPTED.
+ *
+ * Drives rx_st20p_frame_ready() directly with synthetic meta — no transport
+ * session is stitched in. Pipeline counters are about producer/consumer
+ * accounting; transport realism is not required to exercise them.
+ */
+
+#ifndef _ST20P_PIPELINE_HARNESS_H_
+#define _ST20P_PIPELINE_HARNESS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "mtl_api.h"
+#include "st_pipeline_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ut20p_ctx ut20p_ctx;
+
+int ut20p_init(void);
+
+/** Create a pipeline test context with the given framebuffer ring depth. */
+ut20p_ctx* ut20p_ctx_create(int framebuff_cnt);
+void ut20p_ctx_destroy(ut20p_ctx* ctx);
+
+/** Inject one synthetic frame into the pipeline as if the transport just
+ *  completed it.  status is ST_FRAME_STATUS_COMPLETE or _CORRUPTED.
+ *  Returns 0 on accept, -EBUSY when no free framebuf (drives the
+ *  stat_frames_dropped path). */
+int ut20p_inject_frame(ut20p_ctx* ctx, enum st_frame_status status, uint32_t timestamp);
+
+/** Wraps st20p_rx_get_frame(). */
+struct st_frame* ut20p_get_frame(ut20p_ctx* ctx);
+
+/** Wraps st20p_rx_put_frame(). */
+int ut20p_put_frame(ut20p_ctx* ctx, struct st_frame* frame);
+
+/* ── stat accessors ───────────────────────────────────────────────── */
+
+uint64_t ut20p_stat_frames_received(const ut20p_ctx* ctx);
+uint64_t ut20p_stat_frames_dropped(const ut20p_ctx* ctx);
+uint64_t ut20p_stat_frames_corrupted(const ut20p_ctx* ctx);
+uint32_t ut20p_stat_busy(const ut20p_ctx* ctx);
+
+/* ── public-API wrappers ─────────────────────────────────────────── */
+
+/** Wraps st20p_rx_get_session_stats() — exercises the atomic overlay. */
+int ut20p_get_session_stats(ut20p_ctx* ctx, struct st20_rx_user_stats* stats);
+
+/** Wraps st20p_rx_reset_session_stats(). */
+int ut20p_reset_session_stats(ut20p_ctx* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST20P_PIPELINE_HARNESS_H_ */

--- a/tests/unit/pipeline/st20p_test.cpp
+++ b/tests/unit/pipeline/st20p_test.cpp
@@ -1,0 +1,190 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * ST20p (video) pipeline-layer frame-count contract tests.
+ *
+ *   stat_frames_received  → bumped in st20p_rx_get_frame() (app consumes).
+ *   stat_frames_dropped   → bumped in rx_st20p_frame_ready() when no free
+ *                           framebuf is available (back-pressure).
+ *   stat_frames_corrupted → bumped in st20p_rx_get_frame() iff the frame's
+ *                           status is ST_FRAME_STATUS_CORRUPTED.
+ *   stat_busy             → atomic; bumps 1:1 with stat_frames_dropped.
+ */
+
+#include <gtest/gtest.h>
+
+#include "pipeline/st20p_harness.h"
+
+class St20PipelineRxTest : public ::testing::Test {
+ protected:
+  ut20p_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut20p_init(), 0) << "EAL init failed";
+    ctx_ = ut20p_ctx_create(/*framebuff_cnt=*/3);
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  void TearDown() override {
+    ut20p_ctx_destroy(ctx_);
+    ctx_ = nullptr;
+  }
+
+  int inject_complete(uint32_t ts) {
+    return ut20p_inject_frame(ctx_, ST_FRAME_STATUS_COMPLETE, ts);
+  }
+  int inject_corrupted(uint32_t ts) {
+    return ut20p_inject_frame(ctx_, ST_FRAME_STATUS_CORRUPTED, ts);
+  }
+  struct st_frame* get_frame() {
+    return ut20p_get_frame(ctx_);
+  }
+  int put_frame(struct st_frame* f) {
+    return ut20p_put_frame(ctx_, f);
+  }
+
+  uint64_t frames_received() {
+    return ut20p_stat_frames_received(ctx_);
+  }
+  uint64_t frames_dropped() {
+    return ut20p_stat_frames_dropped(ctx_);
+  }
+  uint64_t frames_corrupted() {
+    return ut20p_stat_frames_corrupted(ctx_);
+  }
+  uint32_t stat_busy() {
+    return ut20p_stat_busy(ctx_);
+  }
+};
+
+/* Pipeline counts a frame as "received" only when the application calls
+ * get_frame.  Inject N frames but consume only M < N → counter == M. */
+TEST_F(St20PipelineRxTest, FramesReceivedOnlyOnGetFrame) {
+  ASSERT_EQ(inject_complete(1000), 0);
+  ASSERT_EQ(inject_complete(2000), 0);
+  ASSERT_EQ(inject_complete(3000), 0);
+
+  EXPECT_EQ(frames_received(), 0u)
+      << "frame_ready must not bump stat_frames_received — only get_frame does";
+
+  struct st_frame* f = get_frame();
+  ASSERT_NE(f, nullptr);
+  EXPECT_EQ(frames_received(), 1u);
+  EXPECT_EQ(put_frame(f), 0);
+
+  /* second consume */
+  f = get_frame();
+  ASSERT_NE(f, nullptr);
+  EXPECT_EQ(frames_received(), 2u);
+  EXPECT_EQ(put_frame(f), 0);
+
+  /* third frame still pending in framebuf — not yet counted */
+  EXPECT_EQ(frames_received(), 2u);
+}
+
+/* When all framebufs are full (no get_frame draining), every further
+ * frame_ready must bump stat_frames_dropped 1:1 with stat_busy. */
+TEST_F(St20PipelineRxTest, FramesDroppedWhenFramebufsFull) {
+  /* fill all 3 slots */
+  ASSERT_EQ(inject_complete(1000), 0);
+  ASSERT_EQ(inject_complete(2000), 0);
+  ASSERT_EQ(inject_complete(3000), 0);
+  EXPECT_EQ(frames_dropped(), 0u);
+  EXPECT_EQ(stat_busy(), 0u);
+
+  /* further frames have nowhere to go */
+  EXPECT_EQ(inject_complete(4000), -EBUSY);
+  EXPECT_EQ(inject_complete(5000), -EBUSY);
+  EXPECT_EQ(inject_complete(6000), -EBUSY);
+
+  EXPECT_EQ(frames_dropped(), 3u);
+  EXPECT_EQ(stat_busy(), 3u)
+      << "stat_busy must bump 1:1 with stat_frames_dropped (same back-pressure event)";
+  EXPECT_EQ(frames_received(), 0u) << "dropped frames must not be counted as received";
+}
+
+/* CORRUPTED frames are still delivered to the application.  They bump
+ * BOTH stat_frames_received and stat_frames_corrupted; COMPLETE frames
+ * bump only the former. */
+TEST_F(St20PipelineRxTest, CorruptedDeliveredAndCounted) {
+  ASSERT_EQ(inject_complete(1000), 0);
+  ASSERT_EQ(inject_corrupted(2000), 0);
+  ASSERT_EQ(inject_complete(3000), 0);
+
+  for (int i = 0; i < 3; i++) {
+    struct st_frame* f = get_frame();
+    ASSERT_NE(f, nullptr) << "frame " << i;
+    EXPECT_EQ(put_frame(f), 0);
+  }
+
+  EXPECT_EQ(frames_received(), 3u);
+  EXPECT_EQ(frames_corrupted(), 1u)
+      << "only the CORRUPTED frame must bump stat_frames_corrupted";
+}
+
+/* reset_session_stats clears every cumulative pipeline counter. */
+TEST_F(St20PipelineRxTest, ResetClearsAllPipelineCounters) {
+  ASSERT_EQ(inject_complete(1000), 0);
+  ASSERT_EQ(inject_corrupted(2000), 0);
+  struct st_frame* f1 = get_frame();
+  ASSERT_NE(f1, nullptr);
+  EXPECT_EQ(put_frame(f1), 0);
+  struct st_frame* f2 = get_frame();
+  ASSERT_NE(f2, nullptr);
+  EXPECT_EQ(put_frame(f2), 0);
+
+  /* fill up and overflow to exercise frames_dropped */
+  ASSERT_EQ(inject_complete(3000), 0);
+  ASSERT_EQ(inject_complete(4000), 0);
+  ASSERT_EQ(inject_complete(5000), 0);
+  EXPECT_EQ(inject_complete(6000), -EBUSY);
+
+  ASSERT_GT(frames_received(), 0u);
+  ASSERT_GT(frames_corrupted(), 0u);
+  ASSERT_GT(frames_dropped(), 0u);
+
+  EXPECT_EQ(ut20p_reset_session_stats(ctx_), 0);
+
+  EXPECT_EQ(frames_received(), 0u);
+  EXPECT_EQ(frames_corrupted(), 0u);
+  EXPECT_EQ(frames_dropped(), 0u);
+}
+
+/* st20p_rx_get_session_stats overlays the pipeline frame counters on top
+ * of the (zeroed) transport stats.  The API result must match the
+ * raw counters byte-for-byte. */
+TEST_F(St20PipelineRxTest, GetSessionStatsOverlay) {
+  ASSERT_EQ(inject_complete(1000), 0);
+  ASSERT_EQ(inject_corrupted(2000), 0);
+  ASSERT_EQ(inject_complete(3000), 0);
+  for (int i = 0; i < 3; i++) {
+    struct st_frame* f = get_frame();
+    ASSERT_NE(f, nullptr);
+    EXPECT_EQ(put_frame(f), 0);
+  }
+  /* trigger one drop */
+  ASSERT_EQ(inject_complete(4000), 0);
+  ASSERT_EQ(inject_complete(5000), 0);
+  ASSERT_EQ(inject_complete(6000), 0);
+  EXPECT_EQ(inject_complete(7000), -EBUSY);
+
+  struct st20_rx_user_stats api {};
+  ASSERT_EQ(ut20p_get_session_stats(ctx_, &api), 0);
+
+  EXPECT_EQ(api.common.stat_frames_received, frames_received());
+  EXPECT_EQ(api.common.stat_frames_corrupted, frames_corrupted());
+  EXPECT_EQ(api.common.stat_frames_dropped, frames_dropped());
+}
+
+/* Invariant: stat_busy and stat_frames_dropped move in lockstep — every
+ * back-pressure event bumps both, never one without the other. */
+TEST_F(St20PipelineRxTest, BusyEqualsDroppedInvariant) {
+  /* fill */
+  for (int i = 0; i < 3; i++) ASSERT_EQ(inject_complete(1000 + i), 0);
+  /* overflow burst */
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(inject_complete(2000 + i), -EBUSY);
+    EXPECT_EQ(stat_busy(), frames_dropped())
+        << "after drop " << (i + 1) << ": stat_busy and frames_dropped diverged";
+  }
+}

--- a/tests/unit/pipeline/st30p_harness.c
+++ b/tests/unit/pipeline/st30p_harness.c
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * C harness for ST30p (audio) pipeline-layer unit tests.
+ * Mirrors st20p_harness in spirit: drives rx_st30p_frame_ready() directly
+ * and stubs the transport-side libmtl symbols that put_frame / overlay
+ * paths reference.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#undef MTL_HAS_USDT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#include "st2110/pipeline/st30_pipeline_rx.c"
+#pragma GCC diagnostic pop
+
+#include "common/ut_common.h"
+
+/* libmtl stubs */
+
+int st30_rx_put_framebuff(st30_rx_handle handle, void* frame) {
+  (void)handle;
+  (void)frame;
+  return 0;
+}
+
+int st30_rx_get_session_stats(st30_rx_handle handle, struct st30_rx_user_stats* stats) {
+  (void)handle;
+  if (stats) memset(stats, 0, sizeof(*stats));
+  return 0;
+}
+
+int st30_rx_reset_session_stats(st30_rx_handle handle) {
+  (void)handle;
+  return 0;
+}
+
+struct ut30p_ctx {
+  struct mtl_main_impl impl;
+  struct st30p_rx_ctx pipeline;
+  struct st30p_rx_frame* framebuffs;
+  int framebuff_cnt;
+};
+
+#include "pipeline/st30p_harness.h"
+
+int ut30p_init(void) {
+  return ut_eal_init();
+}
+
+ut30p_ctx* ut30p_ctx_create(int framebuff_cnt) {
+  ut30p_ctx* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx) return NULL;
+
+  ctx->framebuff_cnt = framebuff_cnt;
+  ctx->impl.type = MT_HANDLE_MAIN;
+
+  ctx->framebuffs = calloc(framebuff_cnt, sizeof(struct st30p_rx_frame));
+  if (!ctx->framebuffs) {
+    free(ctx);
+    return NULL;
+  }
+  for (int i = 0; i < framebuff_cnt; i++) {
+    ctx->framebuffs[i].stat = ST30P_RX_FRAME_FREE;
+    ctx->framebuffs[i].idx = i;
+    /* mirrors production init: put_frame() recovers framebuf via frame->priv */
+    ctx->framebuffs[i].frame.priv = &ctx->framebuffs[i];
+  }
+
+  struct st30p_rx_ctx* p = &ctx->pipeline;
+  p->impl = &ctx->impl;
+  p->idx = 0;
+  p->socket_id = rte_socket_id();
+  p->type = MT_ST30_HANDLE_PIPELINE_RX;
+  p->framebuff_cnt = framebuff_cnt;
+  p->framebuffs = ctx->framebuffs;
+  p->ready = true;
+  p->transport = (st30_rx_handle)(uintptr_t)0x1;
+
+  if (pthread_mutex_init(&p->lock, NULL) != 0) {
+    free(ctx->framebuffs);
+    free(ctx);
+    return NULL;
+  }
+
+  return ctx;
+}
+
+void ut30p_ctx_destroy(ut30p_ctx* ctx) {
+  if (!ctx) return;
+  pthread_mutex_destroy(&ctx->pipeline.lock);
+  free(ctx->framebuffs);
+  free(ctx);
+}
+
+int ut30p_inject_frame(ut30p_ctx* ctx, uint32_t timestamp) {
+  struct st30_rx_frame_meta meta;
+  memset(&meta, 0, sizeof(meta));
+  meta.timestamp = timestamp;
+  meta.rtp_timestamp = timestamp;
+  meta.frame_recv_size = 1;
+
+  static uint8_t dummy_frame_storage;
+  return rx_st30p_frame_ready(&ctx->pipeline, &dummy_frame_storage, &meta);
+}
+
+struct st30_frame* ut30p_get_frame(ut30p_ctx* ctx) {
+  return st30p_rx_get_frame(&ctx->pipeline);
+}
+
+int ut30p_put_frame(ut30p_ctx* ctx, struct st30_frame* frame) {
+  return st30p_rx_put_frame(&ctx->pipeline, frame);
+}
+
+uint64_t ut30p_stat_frames_received(const ut30p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_received;
+}
+
+uint64_t ut30p_stat_frames_dropped(const ut30p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_dropped;
+}
+
+uint32_t ut30p_stat_busy(const ut30p_ctx* ctx) {
+  return ctx->pipeline.stat_busy;
+}
+
+int ut30p_get_session_stats(ut30p_ctx* ctx, struct st30_rx_user_stats* stats) {
+  return st30p_rx_get_session_stats(&ctx->pipeline, stats);
+}
+
+int ut30p_reset_session_stats(ut30p_ctx* ctx) {
+  return st30p_rx_reset_session_stats(&ctx->pipeline);
+}

--- a/tests/unit/pipeline/st30p_harness.h
+++ b/tests/unit/pipeline/st30p_harness.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * C header for ST30p (audio) pipeline-layer unit tests.
+ *
+ * Pins the pipeline-internal frame-count contract:
+ *   - stat_frames_received bumps in st30p_rx_get_frame() (app consumes), NOT
+ *     when the underlying transport completes a frame.
+ *   - stat_frames_dropped bumps in rx_st30p_frame_ready() when no free
+ *     framebuffer is available (back-pressure; transport-side buffer is
+ *     released by the pipeline returning -EBUSY).
+ *
+ * ST30p has no stat_frames_corrupted — audio frames are never delivered
+ * with status CORRUPTED at this layer.
+ */
+
+#ifndef _ST30P_PIPELINE_HARNESS_H_
+#define _ST30P_PIPELINE_HARNESS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "mtl_api.h"
+#include "st30_pipeline_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ut30p_ctx ut30p_ctx;
+
+int ut30p_init(void);
+
+ut30p_ctx* ut30p_ctx_create(int framebuff_cnt);
+void ut30p_ctx_destroy(ut30p_ctx* ctx);
+
+/** Inject one synthetic audio frame as if the transport just completed it.
+ *  Returns 0 on accept, -EBUSY when no free framebuf (drives the
+ *  stat_frames_dropped path). */
+int ut30p_inject_frame(ut30p_ctx* ctx, uint32_t timestamp);
+
+struct st30_frame* ut30p_get_frame(ut30p_ctx* ctx);
+int ut30p_put_frame(ut30p_ctx* ctx, struct st30_frame* frame);
+
+uint64_t ut30p_stat_frames_received(const ut30p_ctx* ctx);
+uint64_t ut30p_stat_frames_dropped(const ut30p_ctx* ctx);
+uint32_t ut30p_stat_busy(const ut30p_ctx* ctx);
+
+int ut30p_get_session_stats(ut30p_ctx* ctx, struct st30_rx_user_stats* stats);
+int ut30p_reset_session_stats(ut30p_ctx* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ST30P_PIPELINE_HARNESS_H_ */

--- a/tests/unit/pipeline/st30p_test.cpp
+++ b/tests/unit/pipeline/st30p_test.cpp
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * ST30p (audio) pipeline-layer frame-count contract tests.
+ *
+ *   stat_frames_received → bumped in st30p_rx_get_frame() (app consumes).
+ *   stat_frames_dropped  → bumped in rx_st30p_frame_ready() when no free
+ *                          framebuf is available (back-pressure).
+ *   stat_busy            → bumps 1:1 with stat_frames_dropped.
+ *
+ * ST30p has no per-frame corrupted concept; frames_corrupted is not
+ * tracked by this layer and not asserted on.
+ */
+
+#include <gtest/gtest.h>
+
+#include "pipeline/st30p_harness.h"
+
+class St30PipelineRxTest : public ::testing::Test {
+ protected:
+  ut30p_ctx* ctx_ = nullptr;
+
+  void SetUp() override {
+    ASSERT_EQ(ut30p_init(), 0) << "EAL init failed";
+    ctx_ = ut30p_ctx_create(/*framebuff_cnt=*/3);
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  void TearDown() override {
+    ut30p_ctx_destroy(ctx_);
+    ctx_ = nullptr;
+  }
+
+  int inject(uint32_t ts) {
+    return ut30p_inject_frame(ctx_, ts);
+  }
+  struct st30_frame* get_frame() {
+    return ut30p_get_frame(ctx_);
+  }
+  int put_frame(struct st30_frame* f) {
+    return ut30p_put_frame(ctx_, f);
+  }
+  uint64_t frames_received() {
+    return ut30p_stat_frames_received(ctx_);
+  }
+  uint64_t frames_dropped() {
+    return ut30p_stat_frames_dropped(ctx_);
+  }
+  uint32_t stat_busy() {
+    return ut30p_stat_busy(ctx_);
+  }
+};
+
+/* Pipeline counts a frame as "received" only when the application calls
+ * get_frame.  Inject N frames but consume only M < N → counter == M. */
+TEST_F(St30PipelineRxTest, FramesReceivedOnlyOnGetFrame) {
+  ASSERT_EQ(inject(1000), 0);
+  ASSERT_EQ(inject(2000), 0);
+  ASSERT_EQ(inject(3000), 0);
+
+  EXPECT_EQ(frames_received(), 0u)
+      << "frame_ready must not bump stat_frames_received — only get_frame does";
+
+  struct st30_frame* f = get_frame();
+  ASSERT_NE(f, nullptr);
+  EXPECT_EQ(frames_received(), 1u);
+  EXPECT_EQ(put_frame(f), 0);
+
+  f = get_frame();
+  ASSERT_NE(f, nullptr);
+  EXPECT_EQ(frames_received(), 2u);
+  EXPECT_EQ(put_frame(f), 0);
+
+  EXPECT_EQ(frames_received(), 2u);
+}
+
+/* When all framebufs are full, every further frame_ready bumps
+ * stat_frames_dropped 1:1 with stat_busy. */
+TEST_F(St30PipelineRxTest, FramesDroppedWhenFramebufsFull) {
+  ASSERT_EQ(inject(1000), 0);
+  ASSERT_EQ(inject(2000), 0);
+  ASSERT_EQ(inject(3000), 0);
+  EXPECT_EQ(frames_dropped(), 0u);
+  EXPECT_EQ(stat_busy(), 0u);
+
+  EXPECT_EQ(inject(4000), -EBUSY);
+  EXPECT_EQ(inject(5000), -EBUSY);
+
+  EXPECT_EQ(frames_dropped(), 2u);
+  EXPECT_EQ(stat_busy(), 2u) << "stat_busy must bump 1:1 with stat_frames_dropped";
+  EXPECT_EQ(frames_received(), 0u) << "dropped frames must not be counted as received";
+}
+
+/* reset_session_stats clears every cumulative pipeline counter. */
+TEST_F(St30PipelineRxTest, ResetClearsAllPipelineCounters) {
+  ASSERT_EQ(inject(1000), 0);
+  struct st30_frame* f = get_frame();
+  ASSERT_NE(f, nullptr);
+  EXPECT_EQ(put_frame(f), 0);
+
+  /* fill and overflow */
+  ASSERT_EQ(inject(2000), 0);
+  ASSERT_EQ(inject(3000), 0);
+  ASSERT_EQ(inject(4000), 0);
+  EXPECT_EQ(inject(5000), -EBUSY);
+
+  ASSERT_GT(frames_received(), 0u);
+  ASSERT_GT(frames_dropped(), 0u);
+
+  EXPECT_EQ(ut30p_reset_session_stats(ctx_), 0);
+
+  EXPECT_EQ(frames_received(), 0u);
+  EXPECT_EQ(frames_dropped(), 0u);
+}
+
+/* st30p_rx_get_session_stats overlays pipeline frame counters on top
+ * of the (zeroed) transport stats.  The API result must match the raw
+ * counters byte-for-byte. */
+TEST_F(St30PipelineRxTest, GetSessionStatsOverlay) {
+  ASSERT_EQ(inject(1000), 0);
+  ASSERT_EQ(inject(2000), 0);
+  for (int i = 0; i < 2; i++) {
+    struct st30_frame* f = get_frame();
+    ASSERT_NE(f, nullptr);
+    EXPECT_EQ(put_frame(f), 0);
+  }
+  ASSERT_EQ(inject(3000), 0);
+  ASSERT_EQ(inject(4000), 0);
+  ASSERT_EQ(inject(5000), 0);
+  EXPECT_EQ(inject(6000), -EBUSY);
+
+  struct st30_rx_user_stats api {};
+  ASSERT_EQ(ut30p_get_session_stats(ctx_, &api), 0);
+
+  EXPECT_EQ(api.common.stat_frames_received, frames_received());
+  EXPECT_EQ(api.common.stat_frames_dropped, frames_dropped());
+}

--- a/tests/unit/session/st20/redundancy_test.cpp
+++ b/tests/unit/session/st20/redundancy_test.cpp
@@ -89,14 +89,20 @@ TEST_F(St20RxRedundancyTest, ReturnValueRedundantBitmap) {
 
 /* First arrival is NOT pkt 0: base must be derived from the packet's
  * frame offset, not from its seq. Otherwise R's later pkt 0 would map to
- * a wrap-around pkt_idx and be rejected as out-of-bitmap. */
+ * a wrap-around pkt_idx and be rejected as out-of-bitmap.
+ *
+ * Since `last_pkt_idx` is per-port, R's first packet (pkt 0) does not
+ * count as reorder against P's high-water mark. */
 TEST_F(St20RxRedundancyTest, FirstPktNonZeroBaseFromOffset) {
   feed(1, 1000, MTL_SESSION_PORT_P);
   feed(0, 1000, MTL_SESSION_PORT_R);
 
   EXPECT_EQ(frames_received(), 1);
   EXPECT_EQ(idx_oo_bitmap(), 0u);
-  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u)
+      << "R's first packet must not count as reorder against P's high-water mark";
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u)
+      << "P delivered exactly one packet on its wire; cannot have self-reordered";
 }
 
 /* ST 2022-7 Class A (PD ≤ 10ms ≈ <1 frame @60fps): P advances to the next
@@ -162,4 +168,274 @@ TEST_F(St20RxRedundancyTest, LateRDuplicateOfCompletedFrameIsRedundant) {
 
   EXPECT_EQ(redundant() - red_before, 2u);
   EXPECT_EQ(no_slot(), 0u);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Per-port frame accounting (frame-mode ST20).
+ *
+ * Contract for every completed frame in a redundant (num_port == 2) session
+ * — see `rv_frame_notify` in `lib/src/st2110/st_rx_video_session.c`:
+ *
+ *   stat_frames_received      : always +1
+ *   port[i].frames             : +1 IFF this port delivered every pkt of the
+ *                                completed frame on its own
+ *                                (slot->pkts_recv_per_port[i] >= pkts_received)
+ *   frames_partial[i]          : +1 OTHERWISE
+ *
+ * Per-session invariant (per port i):
+ *   port[i].frames + frames_partial[i] == stat_frames_received
+ *
+ * Reconstructed frames (one port short, the other short, union completes)
+ * are intentionally NOT credited to either port[i].frames. This is the case
+ * the user reported: "frame count was not increased on either port even
+ * though reconstructed frames were good." It is by design — the session-wide
+ * `stat_frames_received` carries the "frame happened" signal; the per-port
+ * `frames_partial[i]` carries "this port could not have completed it alone".
+ *
+ * Note on the harness geometry: the synthetic frame is 2 packets. With only
+ * 2 packets per frame it is impossible to construct a sequence in which BOTH
+ * ports' counters reach pkts_received before completion (the completing
+ * packet always arrives last on exactly one port). Tests that need both
+ * ports credited would require a 3+ pkt/frame harness.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/* Single-port traffic into a redundant session. P delivers a full frame, R
+ * sends nothing. Pins the somewhat surprising semantic that an idle R port
+ * still bumps `frames_partial[R]` for every frame: completion logic is
+ * unconditional on num_port. Also pins that an idle wire produces no
+ * cross-port duplicates and no post-redundancy loss. */
+TEST_F(St20RxRedundancyTest, PerPortFramesPrimaryOnly) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u);
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_R), 1u)
+      << "R was silent — per-port partial counter records the absence";
+  EXPECT_EQ(redundant(), 0u) << "idle R wire produces no cross-port duplicates";
+  EXPECT_EQ(pkts_unrecovered(), 0u)
+      << "P delivered every packet alone; nothing post-redundancy missing";
+}
+
+/* P completes the frame, then R delivers a full duplicate after the slot
+ * has already been released. R's packets hit the redundant fast-path
+ * (slot->frame == NULL) and never reach the per-port frame-credit branch.
+ * Therefore R's frame counter stays 0 even though R delivered every pkt. */
+TEST_F(St20RxRedundancyTest, PerPortFramesPrimaryFirstSecondaryDuplicates) {
+  feed_full(1000, MTL_SESSION_PORT_P);
+  feed_full(1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u)
+      << "R arrived after slot release; it never reaches the credit branch";
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(redundant(), 2u);
+}
+
+/* The user's reported case: half the frame from P, the other half from R.
+ * Together they reconstruct one good frame. By design NEITHER port is
+ * credited in port[i].frames; both bump frames_partial[i]. */
+TEST_F(St20RxRedundancyTest, PerPortFramesReconstructedAcrossPorts) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1) << "reconstructed frame still counts session-wide";
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 0u)
+      << "P delivered only 1 of 2 pkts — not credited";
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u)
+      << "R delivered only 1 of 2 pkts — not credited";
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(pkts_unrecovered(), 0u)
+      << "frame is complete; no packets missing post-redundancy";
+}
+
+/* Asymmetric split: P delivers pkt 0, R delivers pkt 0 (bitmap dup but its
+ * per-port counter still bumps) then pkt 1. R's pkts_recv_per_port reaches
+ * pkts_received at completion, so R is credited; P is not. */
+TEST_F(St20RxRedundancyTest, PerPortFramesAsymmetricSplit) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_R); /* bitmap dup; bumps R's per-port count */
+  feed(1, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 1u)
+      << "R's per-port counter (incl. dup) reached pkts_received";
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_R), 0u);
+  EXPECT_EQ(redundant(), 1u);
+}
+
+/* Three frames covering all three completion patterns (P-only, reconstructed,
+ * R-only) and the per-port invariant
+ *   port[i].frames + frames_partial[i] == stat_frames_received
+ * holds at the end. */
+TEST_F(St20RxRedundancyTest, PerPortFramesAcrossMultipleFramesInvariant) {
+  /* frame A: P-only */
+  feed_full(1000, MTL_SESSION_PORT_P);
+  /* frame B: reconstructed (P pkt 0, R pkt 1) */
+  feed(0, 2000, MTL_SESSION_PORT_P);
+  feed(1, 2000, MTL_SESSION_PORT_R);
+  /* frame C: R-only */
+  feed_full(3000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u) << "frame A only";
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 1u) << "frame C only";
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_P), 2u) << "frames B + C";
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_R), 2u) << "frames A + B";
+
+  for (auto p : {MTL_SESSION_PORT_P, MTL_SESSION_PORT_R}) {
+    EXPECT_EQ(port_frames(p) + frames_partial(p),
+              static_cast<uint64_t>(frames_received()))
+        << "invariant: per-port frames + partial == frames_received (port " << p << ")";
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Cross-wire reconstruction under realistic IP-network conditions.
+ *
+ * Tests below exercise scenarios in which the union of packets across both
+ * wires covers a frame even though no individual wire delivered a complete
+ * frame: cross-wire arrival reordering, intra-frame burst handover, mid-
+ * frame primary failure, partitioning (non-conformant) transmitter, and
+ * sustained cross-wire interleaving across many frames.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/* The trailing packet arrives on R before the leading packet arrives on P.
+ * Cross-wire arrival order is a network property; it must not block
+ * reconstruction. */
+TEST_F(St20RxRedundancyTest, ReverseArrivalOrderReconstructs) {
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  feed(0, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(frames_incomplete(), 0u);
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+}
+
+/* Sustained cross-wire reconstruction: every frame is split (P pkt 0,
+ * R pkt 1) for many consecutive frames. Verifies that prolonged cross-
+ * wire cooperation does not leak slot state from one frame into the next
+ * and never produces post-redundancy loss. */
+TEST_F(St20RxRedundancyTest, EveryFrameStraddlesCrossPortHandover) {
+  constexpr int N = 8;
+  for (int i = 0; i < N; i++) {
+    uint32_t ts = 1000 + 1000u * static_cast<uint32_t>(i);
+    feed(0, ts, MTL_SESSION_PORT_P);
+    feed(1, ts, MTL_SESSION_PORT_R);
+  }
+  EXPECT_EQ(frames_received(), N);
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Wide-frame cross-wire reconstruction (4 packets per frame).
+ *
+ * The default 2-pkt geometry cannot express an intra-frame gap on one
+ * wire that the other wire fills, because gaps and reorders collapse
+ * into the trivial first/last cases. These tests use a 4-pkt geometry.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+class St20RxRedundancyWideTest : public ::testing::Test {
+ protected:
+  static constexpr int kPktsPerFrame = 4;
+  ut20_test_ctx* ctx_ = nullptr;
+  void SetUp() override {
+    ASSERT_EQ(ut20_init(), 0);
+    ctx_ = ut20_ctx_create_geom(2, kPktsPerFrame);
+    ASSERT_NE(ctx_, nullptr);
+  }
+  void TearDown() override {
+    if (ctx_) ut20_ctx_destroy(ctx_);
+  }
+  void feed(int pkt_idx, uint32_t ts, enum mtl_session_port port) {
+    ut20_feed_frame_pkt(ctx_, pkt_idx, ts, port);
+  }
+  int frames_received() {
+    return ut20_frames_received(ctx_);
+  }
+  uint64_t redundant() {
+    return ut20_stat_redundant(ctx_);
+  }
+  uint64_t pkts_unrecovered() {
+    return ut20_stat_pkts_unrecovered(ctx_);
+  }
+};
+
+/* P drops every other packet on its wire; R fills exactly the dropped
+ * indices. Verifies that cross-wire gap-filling works at arbitrary
+ * positions inside a frame, not only at the boundaries. */
+TEST_F(St20RxRedundancyWideTest, WideFrameReconstructsAcrossPorts) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R); /* P dropped pkt 1 on its wire */
+  feed(2, 1000, MTL_SESSION_PORT_P);
+  feed(3, 1000, MTL_SESSION_PORT_R); /* P dropped pkt 3 too */
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+}
+
+/* Intra-frame port handover: P delivers the first half, R delivers the
+ * second half. Models real-world failover patterns (link flip, upstream
+ * failover) where a frame straddles the handover instant. */
+TEST_F(St20RxRedundancyWideTest, IntraFrameHandoverReconstructs) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  /* Handover. */
+  feed(2, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+}
+
+/* Asymmetric failure: P delivers a single packet then goes silent
+ * mid-frame (cable disconnected); R delivers the full frame. The single
+ * cross-wire duplicate must be accounted as redundant. */
+TEST_F(St20RxRedundancyWideTest, OnePortDiesAfterOnePacketReconstructs) {
+  feed(0, 1000, MTL_SESSION_PORT_P); /* P then dies */
+  feed(0, 1000, MTL_SESSION_PORT_R);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  feed(2, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(redundant(), 1u) << "R's pkt 0 is the duplicate of P's pkt 0";
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+}
+
+/* Non-conformant transmitter: the two paths carry disjoint subsets of
+ * the frame rather than identical copies. Neither wire ever observes a
+ * complete frame, but their union does. The receiver must reconstruct
+ * regardless of whether the transmitter respected the redundancy
+ * contract. */
+TEST_F(St20RxRedundancyWideTest, NonConformantTxPartitionReconstructs) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1)
+      << "redundancy must reconstruct even from a partitioning TX";
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+}
+
+/* Both wires deliver every packet but interleaved at single-packet
+ * granularity (P0, R0, P1, R1, ...). Verifies that duplicate detection
+ * is based on pkt_idx rather than burst pattern: every R packet still
+ * counts as a cross-wire duplicate. */
+TEST_F(St20RxRedundancyWideTest, InterleavedDuplicatesAccounted) {
+  for (int i = 0; i < kPktsPerFrame; i++) {
+    feed(i, 1000, MTL_SESSION_PORT_P);
+    feed(i, 1000, MTL_SESSION_PORT_R);
+  }
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(redundant(), static_cast<uint64_t>(kPktsPerFrame));
 }

--- a/tests/unit/session/st20/redundancy_test.cpp
+++ b/tests/unit/session/st20/redundancy_test.cpp
@@ -439,3 +439,38 @@ TEST_F(St20RxRedundancyWideTest, InterleavedDuplicatesAccounted) {
   EXPECT_EQ(frames_received(), 1);
   EXPECT_EQ(redundant(), static_cast<uint64_t>(kPktsPerFrame));
 }
+
+/* Mirror of OnePortDiesAfterOnePacketReconstructs with the roles swapped:
+ * R delivers a single packet then goes silent; P delivers the rest of the
+ * frame. Pins that loss-fill works symmetrically — neither port is
+ * privileged in the reconstruction path. */
+TEST_F(St20RxRedundancyWideTest, OtherPortDiesAfterOnePacketReconstructs) {
+  feed(0, 1000, MTL_SESSION_PORT_R); /* R then dies */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1000, MTL_SESSION_PORT_P);
+  feed(3, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(redundant(), 1u) << "P's pkt 0 is the duplicate of R's pkt 0";
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+}
+
+/* Sustained single-port operation: R is silent for many consecutive frames
+ * while P delivers each one alone. Counters must scale linearly with no
+ * pollution from the missing wire — no phantom losses, no phantom
+ * duplicates, and per-port frame credit attributed entirely to P. */
+TEST_F(St20RxRedundancyTest, SustainedSinglePortAcrossManyFrames) {
+  constexpr int N = 16;
+  for (int i = 0; i < N; i++) feed_full(1000u + 1000u * i, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), N);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), static_cast<uint64_t>(N));
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_R), static_cast<uint64_t>(N))
+      << "R never contributed a packet to any frame";
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u)
+      << "a silent wire must not be charged with phantom losses";
+}

--- a/tests/unit/session/st20/reorder_test.cpp
+++ b/tests/unit/session/st20/reorder_test.cpp
@@ -66,26 +66,31 @@ TEST_F(St20RxReorderTest, ReorderDoesNotRegressLastPktIdx) {
          "6-3-1=2 instead of 0, inflating port_lost from 4 to 6";
 }
 
-/* Cross-port variant: slot->last_pkt_idx is per-slot (shared across P+R for
- * the same RTP timestamp). A reorder arriving on one port must not poison
- * the gap arithmetic for the next forward packet on the OTHER port.
- *   1. P sends pkt 0 (last_pkt_idx = 0)
- *   2. R sends pkt 5 (gap = 4 → port_lost(R) += 4, last_pkt_idx = 5)
- *   3. P sends pkt 3 (reorder; last_pkt_idx must STAY 5, not regress)
- *   4. R sends pkt 6 (in-order continuation: gap = 0)
- * Without the high-water-mark guard, step 3 regresses last_pkt_idx to 3,
- * and step 4 computes gap = 6 - 3 - 1 = 2, falsely inflating port_lost(R) to 6. */
+/* Cross-port: each port's `last_pkt_idx` is tracked separately, so a
+ * packet arriving on one port can never poison the gap or reorder
+ * arithmetic for the next packet on the OTHER port. Every port's
+ * loss/reorder counter reflects only events on its own stream.
+ *
+ *   1. P sends pkt 0 (P_last = 0)
+ *   2. R sends pkt 5 (first pkt on R; no gap counted, R_last = 5)
+ *   3. P sends pkt 3 (P_last = 0 → forward jump on P: gap = 2 lost on P)
+ *   4. R sends pkt 6 (R_last = 5 → in-order on R: no gap, no reorder)
+ *
+ * P's forward jump must NOT register as reorder (it's a gap on P), and R's
+ * counters must be untouched by anything happening on P. */
 TEST_F(St20RxReorderTest, ReorderOnOnePortDoesNotPoisonOtherPort) {
   ut20_feed_pkt(ctx_, 1000, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
   ut20_feed_pkt(ctx_, 1005, 1000, 0, 0, 10, MTL_SESSION_PORT_R);
   ut20_feed_pkt(ctx_, 1003, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
   ut20_feed_pkt(ctx_, 1006, 1000, 0, 0, 10, MTL_SESSION_PORT_R);
 
-  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u)
+      << "P sent pkts 0 then 3: forward gap on P, not reorder";
   EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u);
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 4u)
-      << "Reorder on P must not inflate lost count for the next forward pkt on R";
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u)
+      << "P's forward jump from pkt 0 to pkt 3 implies 2 missing on P's stream";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u)
+      << "R sent pkt 5 then pkt 6: first-pkt establishes R_last, then in-order";
 }
 
 /* Multi-step reorder: large initial gap, then several reorders fill it in
@@ -106,4 +111,69 @@ TEST_F(St20RxReorderTest, MultipleReordersDoNotInflateLost) {
       << "Lost must be counted exactly once when pkt 6 arrived; the three "
          "subsequent reorders must not inflate it, and pkt 7 must compute "
          "gap from the high-water mark (6), not the last reordered idx";
+}
+
+/* Sustained cross-wire interleaving across many frames: every frame is
+ * supplied by both wires with the secondary arriving first, but each
+ * wire delivers its own single packet in order. Verifies that neither
+ * reorder counter accumulates spurious increments under prolonged
+ * cross-wire late arrivals — i.e. cross-port arrival order is never
+ * classified as own-stream reorder. */
+TEST_F(St20RxReorderTest, RepeatedCrossPortTransitionsDoNotInflateReorder) {
+  constexpr int N = 8;
+  for (int i = 0; i < N; i++) {
+    uint32_t ts = 1000 + 1000u * static_cast<uint32_t>(i);
+    feed(1, ts, MTL_SESSION_PORT_R);
+    feed(0, ts, MTL_SESSION_PORT_P);
+  }
+  EXPECT_EQ(frames_received(), N);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Wide-frame own-port reorder.
+ *
+ * Default 2-pkt geometry cannot express an intra-frame own-stream reorder
+ * that does not collide with the first-pkt branch. This test uses a
+ * 4-pkt geometry to send pkt 2 then pkt 1 on the same wire while the
+ * other wire delivers in order.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+class St20RxReorderWideTest : public ::testing::Test {
+ protected:
+  static constexpr int kPktsPerFrame = 4;
+  ut20_test_ctx* ctx_ = nullptr;
+  void SetUp() override {
+    ASSERT_EQ(ut20_init(), 0);
+    ctx_ = ut20_ctx_create_geom(2, kPktsPerFrame);
+    ASSERT_NE(ctx_, nullptr);
+  }
+  void TearDown() override {
+    if (ctx_) ut20_ctx_destroy(ctx_);
+  }
+  void feed(int pkt_idx, uint32_t ts, enum mtl_session_port port) {
+    ut20_feed_frame_pkt(ctx_, pkt_idx, ts, port);
+  }
+  int frames_received() {
+    return ut20_frames_received(ctx_);
+  }
+  uint64_t port_reordered(enum mtl_session_port p) {
+    return ut20_stat_port_reordered(ctx_, p);
+  }
+};
+
+/* R delivers pkt 2 then pkt 1 within the same frame on the same wire.
+ * This is a true own-stream reorder on R and must be counted exactly
+ * once on R, with P's reorder counter untouched. */
+TEST_F(St20RxReorderWideTest, OwnPortReorderCountedOnThatPortOnly) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1000, MTL_SESSION_PORT_R); /* R first; R_last = 2 */
+  feed(1, 1000, MTL_SESSION_PORT_R); /* R own-stream reorder: 1 < 2 */
+  feed(3, 1000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 1u)
+      << "R received pkt_idx 1 after pkt_idx 2 on its own wire";
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u);
 }

--- a/tests/unit/session/st20/st20_rx_test_base.h
+++ b/tests/unit/session/st20/st20_rx_test_base.h
@@ -52,6 +52,15 @@ class St20RxBaseTest : public ::testing::Test {
   uint64_t port_pkts(enum mtl_session_port p) {
     return ut20_stat_port_packets(ctx_, p);
   }
+  uint64_t port_frames(enum mtl_session_port p) {
+    return ut20_stat_port_frames(ctx_, p);
+  }
+  uint64_t frames_partial(enum mtl_session_port p) {
+    return ut20_stat_frames_partial(ctx_, p);
+  }
+  uint64_t pkts_unrecovered() {
+    return ut20_stat_pkts_unrecovered(ctx_);
+  }
   uint64_t no_slot() {
     return ut20_stat_no_slot(ctx_);
   }

--- a/tests/unit/session/st20/stats_test.cpp
+++ b/tests/unit/session/st20/stats_test.cpp
@@ -53,15 +53,138 @@ TEST_F(St20RxStatsTest, ReceivedPlusRedundantInvariant) {
 }
 
 /* lost_packets invariant: stat_lost_packets equals the sum of per-port
- * lost counters. Holds independently of which port the loss occurred on. */
+ * lost counters. Inducing real loss on each wire (a one-packet gap on
+ * the primary and a one-packet gap on the secondary, each filled by the
+ * other wire) makes the invariant non-trivial. Uses a 4-pkt frame so
+ * intra-frame gaps are expressible. */
 TEST_F(St20RxStatsTest, LostPacketsInvariant) {
-  /* feed 4-pkt frames (override default ppf via a forward gap) by sending
-   * pkt_idx 0,1 on each port for two distinct timestamps with a gap. */
-  feed(0, 1000, MTL_SESSION_PORT_P);
-  feed(1, 1000, MTL_SESSION_PORT_P);
-  feed(0, 2000, MTL_SESSION_PORT_R);
-  feed(1, 2000, MTL_SESSION_PORT_R);
+  ut20_test_ctx* wide = ut20_ctx_create_geom(2, 4);
+  ASSERT_NE(wide, nullptr);
 
-  EXPECT_EQ(ooo(), port_lost(MTL_SESSION_PORT_P) + port_lost(MTL_SESSION_PORT_R))
+  ut20_feed_frame_pkt(wide, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt(wide, 1, 1000, MTL_SESSION_PORT_R); /* R first; R_last=1 */
+  ut20_feed_frame_pkt(wide, 3, 1000, MTL_SESSION_PORT_R); /* R skipped pkt 2 */
+  ut20_feed_frame_pkt(wide, 2, 1000, MTL_SESSION_PORT_P); /* P jumped 0->2 */
+
+  EXPECT_EQ(ut20_frames_received(wide), 1);
+  EXPECT_EQ(ut20_stat_port_lost(wide, MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(ut20_stat_port_lost(wide, MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(ut20_stat_lost_pkts(wide), ut20_stat_port_lost(wide, MTL_SESSION_PORT_P) +
+                                           ut20_stat_port_lost(wide, MTL_SESSION_PORT_R))
       << "stat_lost_packets must equal the sum of per-port lost_packets";
+
+  ut20_ctx_destroy(wide);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Wide-frame stat invariants.
+ *
+ * Per-port loss isolation and the unrecovered-packets counter cannot be
+ * properly exercised with the default 2-pkt geometry because intra-frame
+ * gaps collapse into the trivial first/last cases. These tests use a
+ * 4-pkt geometry to express real intra-frame gaps on each wire.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+class St20RxStatsWideTest : public ::testing::Test {
+ protected:
+  static constexpr int kPktsPerFrame = 4;
+  ut20_test_ctx* ctx_ = nullptr;
+  void SetUp() override {
+    ASSERT_EQ(ut20_init(), 0);
+    ctx_ = ut20_ctx_create_geom(2, kPktsPerFrame);
+    ASSERT_NE(ctx_, nullptr);
+  }
+  void TearDown() override {
+    if (ctx_) ut20_ctx_destroy(ctx_);
+  }
+  void feed(int pkt_idx, uint32_t ts, enum mtl_session_port port) {
+    ut20_feed_frame_pkt(ctx_, pkt_idx, ts, port);
+  }
+  int frames_received() {
+    return ut20_frames_received(ctx_);
+  }
+  uint64_t frames_incomplete() {
+    return ut20_stat_frames_incomplete(ctx_);
+  }
+  uint64_t lost_session() {
+    return ut20_stat_lost_pkts(ctx_);
+  }
+  uint64_t pkts_unrecovered() {
+    return ut20_stat_pkts_unrecovered(ctx_);
+  }
+  uint64_t port_lost(enum mtl_session_port p) {
+    return ut20_stat_port_lost(ctx_, p);
+  }
+};
+
+/* P jumps from pkt 0 to pkt 3 in its own sequence, leaving a 2-pkt hole;
+ * R fills the hole in order. The loss attributed to P equals the size of
+ * P's own gap; R records no loss. */
+TEST_F(St20RxStatsWideTest, PortLossCountsOwnGapsOnly) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  feed(2, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_P); /* P jumped 0 -> 3 on its wire */
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u)
+      << "P's wire skipped pkts 1 and 2 between its own observations";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u) << "R sent pkts 1 and 2 in order";
+}
+
+/* Both wires misbehave concurrently: R reorders its own packets while P
+ * skips two indices. The two per-port counters must not contaminate each
+ * other and reordering on one wire must not be classified as loss on
+ * either wire. */
+TEST_F(St20RxStatsWideTest, PerPortLossIsIndependent) {
+  feed(0, 1000, MTL_SESSION_PORT_P); /* P_last = 0 */
+  feed(2, 1000, MTL_SESSION_PORT_R); /* R first; R_last = 2 */
+  feed(1, 1000, MTL_SESSION_PORT_R); /* R reorder of its own packet */
+  feed(3, 1000, MTL_SESSION_PORT_P); /* P jumps 0 -> 3 */
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u);
+}
+
+/* Per-wire loss with full cross-wire recovery. P skips indices that R
+ * supplies. stat_lost_packets reflects the wire-level loss, but
+ * stat_pkts_unrecovered must stay zero because reconstruction succeeded.
+ * Pins the documented invariant
+ *     stat_pkts_unrecovered <= stat_lost_packets. */
+TEST_F(St20RxStatsWideTest, UnrecoveredZeroWhenReconstructionSucceeds) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R); /* recovers P's gap */
+  feed(2, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_GE(lost_session(), 1u) << "P's wire really skipped packets";
+  EXPECT_EQ(pkts_unrecovered(), 0u)
+      << "every gap on one wire was filled by the other wire";
+  EXPECT_LE(pkts_unrecovered(), lost_session()) << "documented invariant";
+}
+
+/* Genuine post-redundancy loss: both wires drop the same packet, so the
+ * missing index cannot be filled from either source. The frame must be
+ * reported as incomplete and stat_pkts_unrecovered must record the
+ * unrecoverable packet. Two further complete frames are fed so the
+ * incomplete slot is reclaimed and finalised by the slot-window
+ * manager. */
+TEST_F(St20RxStatsWideTest, UnrecoveredWhenBothPortsMissSamePacket) {
+  /* Neither wire delivers pkt 2 for ts = 1000. */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_R);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_P);
+  feed(3, 1000, MTL_SESSION_PORT_R);
+  /* Drive two more complete frames so the incomplete slot is reclaimed. */
+  for (int i = 0; i < kPktsPerFrame; i++) feed(i, 2000, MTL_SESSION_PORT_P);
+  for (int i = 0; i < kPktsPerFrame; i++) feed(i, 3000, MTL_SESSION_PORT_P);
+
+  EXPECT_GE(frames_incomplete(), 1u) << "no port delivered pkt 2";
+  EXPECT_GE(pkts_unrecovered(), 1u) << "the missing pkt is post-redundancy loss";
+  EXPECT_LE(pkts_unrecovered(), lost_session())
+      << "documented invariant: unrecovered <= lost";
 }

--- a/tests/unit/session/st20_harness.c
+++ b/tests/unit/session/st20_harness.c
@@ -23,12 +23,19 @@
 /* ── geometry constants ───────────────────────────────────────────────── */
 
 #define UT20_WIDTH 16
-#define UT20_HEIGHT 2
-#define UT20_LINESIZE 40   /* 16/2 * 5 */
-#define UT20_FRAME_SIZE 80 /* UT20_LINESIZE * UT20_HEIGHT */
+#define UT20_HEIGHT 2    /* default packets-per-frame */
+#define UT20_LINESIZE 40 /* 16/2 * 5 */
 #define UT20_PAYLOAD_PER_PKT UT20_LINESIZE
-#define UT20_PKTS_PER_FRAME 2
-#define UT20_BITMAP_SIZE 1 /* 8 bits >= UT20_PKTS_PER_FRAME */
+#define UT20_PKTS_PER_FRAME 2 /* default; kept as a back-compat constant */
+#define UT20_FRAME_SIZE 80    /* UT20_LINESIZE * UT20_HEIGHT */
+#define UT20_BITMAP_SIZE 1    /* 8 bits >= UT20_PKTS_PER_FRAME */
+
+/* Upper bounds — used to size in-context storage at compile time. The
+ * actual height/frame_size/bitmap_size used by a given context are set in
+ * ut20_ctx_create_geom() and live in `s->ops.height` / `s->st20_*`. */
+#define UT20_MAX_HEIGHT 32 /* max pkts/frame */
+#define UT20_MAX_FRAME_SIZE (UT20_LINESIZE * UT20_MAX_HEIGHT)
+#define UT20_MAX_BITMAP_SIZE ((UT20_MAX_HEIGHT + 7) / 8)
 
 #define UT20_FRAME_COUNT 2
 
@@ -40,8 +47,8 @@ struct ut20_test_ctx {
   struct st_rx_video_session_impl session;
 
   struct st_frame_trans frames[UT20_FRAME_COUNT];
-  uint8_t frame_storage[UT20_FRAME_COUNT][UT20_FRAME_SIZE];
-  uint8_t bitmaps[ST_VIDEO_RX_REC_NUM_OFO][UT20_BITMAP_SIZE];
+  uint8_t frame_storage[UT20_FRAME_COUNT][UT20_MAX_FRAME_SIZE];
+  uint8_t bitmaps[ST_VIDEO_RX_REC_NUM_OFO][UT20_MAX_BITMAP_SIZE];
 };
 
 #include "session/st20_harness.h"
@@ -81,8 +88,17 @@ int ut20_init(void) {
 /* ── context create / destroy ─────────────────────────────────────────── */
 
 ut20_test_ctx* ut20_ctx_create(int num_port) {
+  return ut20_ctx_create_geom(num_port, UT20_HEIGHT);
+}
+
+ut20_test_ctx* ut20_ctx_create_geom(int num_port, int pkts_per_frame) {
+  if (pkts_per_frame < 1 || pkts_per_frame > UT20_MAX_HEIGHT) return NULL;
   ut20_test_ctx* ctx = calloc(1, sizeof(*ctx));
   if (!ctx) return NULL;
+
+  const int height = pkts_per_frame;
+  const size_t frame_size = (size_t)UT20_LINESIZE * (size_t)height;
+  const size_t bitmap_size = (size_t)((height + 7) / 8);
 
   ctx->impl.type = MT_HANDLE_MAIN;
   ctx->impl.tsc_hz = rte_get_tsc_hz();
@@ -114,7 +130,7 @@ ut20_test_ctx* ut20_ctx_create(int num_port) {
   s->ops.type = ST20_TYPE_FRAME_LEVEL;
   s->ops.num_port = num_port;
   s->ops.width = UT20_WIDTH;
-  s->ops.height = UT20_HEIGHT;
+  s->ops.height = (uint32_t)height;
   s->ops.fps = ST_FPS_P30;
   s->ops.fmt = ST20_FMT_YUV_422_10BIT;
   s->ops.interlaced = false;
@@ -132,9 +148,9 @@ ut20_test_ctx* ut20_ctx_create(int num_port) {
 
   s->st20_linesize = UT20_LINESIZE;
   s->st20_bytes_in_line = UT20_LINESIZE;
-  s->st20_frame_size = UT20_FRAME_SIZE;
-  s->st20_fb_size = UT20_FRAME_SIZE;
-  s->st20_frame_bitmap_size = UT20_BITMAP_SIZE;
+  s->st20_frame_size = frame_size;
+  s->st20_fb_size = frame_size;
+  s->st20_frame_bitmap_size = bitmap_size;
   s->st20_uframe_size = 0;
 
   s->st20_frames = ctx->frames;
@@ -238,7 +254,7 @@ int ut20_feed_pkt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_n
 
 int ut20_feed_frame_pkt(ut20_test_ctx* ctx, int pkt_idx, uint32_t ts,
                         enum mtl_session_port port) {
-  uint32_t seq = ts * UT20_PKTS_PER_FRAME + (uint32_t)pkt_idx;
+  uint32_t seq = ts * (uint32_t)ctx->session.ops.height + (uint32_t)pkt_idx;
   uint16_t ln, lo, ll;
   pkt_idx_to_line(pkt_idx, &ln, &lo, &ll);
   return ut20_feed_pkt(ctx, seq, ts, ln, lo, ll, port);
@@ -252,7 +268,8 @@ int ut20_feed_frame_pkt_seq(ut20_test_ctx* ctx, int pkt_idx, uint32_t seq, uint3
 }
 
 void ut20_feed_full_frame(ut20_test_ctx* ctx, uint32_t ts, enum mtl_session_port port) {
-  for (int i = 0; i < UT20_PKTS_PER_FRAME; i++) {
+  const int n = (int)ctx->session.ops.height;
+  for (int i = 0; i < n; i++) {
     ut20_feed_frame_pkt(ctx, i, ts, port);
   }
 }
@@ -294,7 +311,7 @@ int ut20_feed_pkt_via_wrapper(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts,
 
 int ut20_feed_frame_pkt_via_wrapper(ut20_test_ctx* ctx, int pkt_idx, uint32_t ts,
                                     enum mtl_session_port port) {
-  uint32_t seq = ts * UT20_PKTS_PER_FRAME + (uint32_t)pkt_idx;
+  uint32_t seq = ts * (uint32_t)ctx->session.ops.height + (uint32_t)pkt_idx;
   uint16_t ln, lo, ll;
   pkt_idx_to_line(pkt_idx, &ln, &lo, &ll);
   return ut20_feed_pkt_via_wrapper(ctx, seq, ts, ln, lo, ll, port,
@@ -353,6 +370,10 @@ int ut20_total_frame_pkts(void) {
   return UT20_PKTS_PER_FRAME;
 }
 
+int ut20_pkts_per_frame(const ut20_test_ctx* ctx) {
+  return (int)ctx->session.ops.height;
+}
+
 uint64_t ut20_stat_wrong_pt(const ut20_test_ctx* ctx) {
   return ctx->session.port_user_stats.common.stat_pkts_wrong_pt_dropped;
 }
@@ -380,4 +401,16 @@ uint64_t ut20_stat_port_err_packets(const ut20_test_ctx* ctx,
 
 uint64_t ut20_stat_port_packets(const ut20_test_ctx* ctx, enum mtl_session_port port) {
   return ctx->session.port_user_stats.common.port[port].packets;
+}
+
+uint64_t ut20_stat_port_frames(const ut20_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].frames;
+}
+
+uint64_t ut20_stat_frames_partial(const ut20_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.frames_partial[port];
+}
+
+uint64_t ut20_stat_pkts_unrecovered(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.common.stat_pkts_unrecovered;
 }

--- a/tests/unit/session/st20_harness.h
+++ b/tests/unit/session/st20_harness.h
@@ -39,6 +39,18 @@ int ut20_init(void);
  * Caller owns the returned pointer and must free it with ut20_ctx_destroy().
  * Returns NULL on allocation failure. */
 ut20_test_ctx* ut20_ctx_create(int num_port);
+
+/* Same as ut20_ctx_create() but lets the test pick how many packets make
+ * up one full frame. The harness keeps width=16 fixed and varies height to
+ * yield `pkts_per_frame` packets/frame (one packet covers exactly one row).
+ * Valid range: 1..32. Returns NULL on out-of-range or allocation failure.
+ *
+ * Default `ut20_ctx_create(num_port)` == `ut20_ctx_create_geom(num_port, 2)`.
+ * Use a larger value when the test needs to exercise gap detection,
+ * intra-frame reorder, or any code path conditioned on more than 2 packets
+ * per frame (e.g. `pkt_idx > slot->last_pkt_idx + 1`). */
+ut20_test_ctx* ut20_ctx_create_geom(int num_port, int pkts_per_frame);
+
 void ut20_ctx_destroy(ut20_test_ctx* ctx);
 
 /* Build and feed one RFC 4175 video packet directly to the per-packet
@@ -100,6 +112,23 @@ uint64_t ut20_stat_port_packets(const ut20_test_ctx* ctx, enum mtl_session_port 
 uint64_t ut20_stat_port_reordered(const ut20_test_ctx* ctx, enum mtl_session_port port);
 uint64_t ut20_stat_port_lost(const ut20_test_ctx* ctx, enum mtl_session_port port);
 
+/* Per-port frame accounting (frame-mode ST20 only).
+ *
+ *   port[i].frames        — incremented per-port iff that port delivered every
+ *                           packet of the completed frame on its own (i.e.
+ *                           `pkts_recv_per_port[i] >= pkts_received`). With
+ *                           cross-port reconstruction NEITHER port is
+ *                           credited; the session-wide `stat_frames_received`
+ *                           still bumps. See `rv_frame_notify` in
+ *                           `lib/src/st2110/st_rx_video_session.c`.
+ *   frames_partial[i]     — incremented per-port iff the completed frame
+ *                           needed packets from the OTHER port to fill in.
+ *                           Together with `port[i].frames` it sums to
+ *                           `stat_frames_received` per redundant session.
+ */
+uint64_t ut20_stat_port_frames(const ut20_test_ctx* ctx, enum mtl_session_port port);
+uint64_t ut20_stat_frames_partial(const ut20_test_ctx* ctx, enum mtl_session_port port);
+
 /* Session-wide counters. */
 uint64_t ut20_stat_received(const ut20_test_ctx* ctx);
 uint64_t ut20_stat_redundant(const ut20_test_ctx* ctx);
@@ -107,6 +136,7 @@ uint64_t ut20_stat_lost_pkts(const ut20_test_ctx* ctx);
 uint64_t ut20_stat_no_slot(const ut20_test_ctx* ctx);
 uint64_t ut20_stat_idx_oo_bitmap(const ut20_test_ctx* ctx);
 uint64_t ut20_stat_frames_incomplete(const ut20_test_ctx* ctx);
+uint64_t ut20_stat_pkts_unrecovered(const ut20_test_ctx* ctx);
 
 /* Number of frames the production handler has marked completed/delivered
  * since session reset. Returns the live value of `stat_frames_received`. */
@@ -123,6 +153,10 @@ uint64_t ut20_stat_wrong_len(const ut20_test_ctx* ctx);
  * in the harness's synthetic 16x2 YUV422-10bit configuration. Tests use it
  * to derive expected counts without hard-coding the value. */
 int ut20_total_frame_pkts(void);
+
+/* Live geometry: number of packets per frame for THIS context. Returns
+ * the value passed to ut20_ctx_create_geom() (or 2 for ut20_ctx_create()). */
+int ut20_pkts_per_frame(const ut20_test_ctx* ctx);
 
 #ifdef __cplusplus
 }

--- a/tests/unit/session/st30/redundancy_test.cpp
+++ b/tests/unit/session/st30/redundancy_test.cpp
@@ -144,3 +144,73 @@ TEST_F(St30RxRedundancyTest, InterleavedPortsIncreasingTs) {
   EXPECT_EQ(redundant(), 0u);
   EXPECT_EQ(received(), 6u);
 }
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Per-port frame accounting (audio).
+ *
+ * ST30 credits exactly one port per completed frame: the port whose first
+ * accepted packet of the new RTP timestamp allocated the frame buffer (see
+ * `rx_audio_session_handle_frame_pkt` in
+ * `lib/src/st2110/st_rx_audio_session.c`). Subsequent packets of the same
+ * frame — whether on the same port or the other — never bump
+ * `port[i].frames`. Redundant packets filtered by the timestamp check do
+ * not even reach the credit branch.
+ *
+ * Invariant per session: port[P].frames + port[R].frames == frames_received
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/* P delivers all frames; R is silent. P is credited once per frame. */
+TEST_F(St30RxRedundancyTest, PerPortFramesPrimaryOnly) {
+  feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_P);
+  feed_burst(ppf(), ppf(), 2000, MTL_SESSION_PORT_P);
+  feed_burst(2 * ppf(), ppf(), 3000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_done(), 3);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 3u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u);
+}
+
+/* All frames originate on R; P is silent. R is credited once per frame. */
+TEST_F(St30RxRedundancyTest, PerPortFramesSecondaryOnly) {
+  feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_R);
+  feed_burst(ppf(), ppf(), 2000, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_done(), 2);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 2u);
+}
+
+/* P delivers a full frame, R delivers the same frame's pkts after. R's pkts
+ * have stale timestamps and are filtered by the timestamp guard before the
+ * frame-credit branch — R must NOT be credited. */
+TEST_F(St30RxRedundancyTest, PerPortFramesPrimaryFirstSecondaryFiltered) {
+  feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_P);
+  feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_R); /* all stale → redundant */
+
+  EXPECT_EQ(frames_done(), 1);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u)
+      << "R's pkts were filtered before reaching the credit branch";
+  EXPECT_EQ(redundant(), static_cast<uint64_t>(ppf()));
+}
+
+/* Frame N arrives on P; the first packet of frame N+1 arrives on R first
+ * (with a strictly newer ts). R wins the credit for frame N+1; P keeps the
+ * credit for frame N. */
+TEST_F(St30RxRedundancyTest, PerPortFramesAlternatingWinner) {
+  /* frame 1: P starts and finishes */
+  feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_P);
+  /* frame 2: R sends the first pkt (new ts) — wins the credit */
+  feed(ppf(), 2000, MTL_SESSION_PORT_R);
+  /* finish frame 2 from R (or P, same outcome — credit already assigned) */
+  for (int i = 1; i < ppf(); i++) {
+    feed(ppf() + i, 2000 + i, MTL_SESSION_PORT_R);
+  }
+
+  EXPECT_EQ(frames_done(), 2);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u) << "frame 1";
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 1u) << "frame 2";
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P) + port_frames(MTL_SESSION_PORT_R),
+            static_cast<uint64_t>(frames_done()))
+      << "audio invariant: per-port frames sum equals frames_received";
+}

--- a/tests/unit/session/st30/redundancy_test.cpp
+++ b/tests/unit/session/st30/redundancy_test.cpp
@@ -214,3 +214,37 @@ TEST_F(St30RxRedundancyTest, PerPortFramesAlternatingWinner) {
             static_cast<uint64_t>(frames_done()))
       << "audio invariant: per-port frames sum equals frames_received";
 }
+
+/* Mid-stream cable disconnect: P delivers the first half of the stream while
+ * R sends same-ts duplicates (filtered). P then dies; R continues alone with
+ * fresh timestamps. The handover must be seamless — every unique packet
+ * accepted exactly once, no phantom unrecovered. */
+TEST_F(St30RxRedundancyTest, PortGoesSilentMidStreamPeerContinues) {
+  for (int i = 0; i < 4; i++) feed(i, 1000 + i, MTL_SESSION_PORT_P);
+  for (int i = 0; i < 4; i++) feed(i, 1000 + i, MTL_SESSION_PORT_R);
+  /* P dies. R takes over with strictly newer timestamps. */
+  for (int i = 4; i < 8; i++) feed(i, 1000 + i, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(received(), 8u);
+  EXPECT_EQ(redundant(), 4u) << "R's first 4 pkts duplicated P's";
+  EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* Sustained alternating burst-switchover: 8 successive bursts alternate
+ * between P and R, each burst using strictly newer timestamps. Pins that
+ * recurring source switches do not leak phantom unrecovered, do not
+ * accumulate redundant, and do not corrupt session_seq tracking. */
+TEST_F(St30RxRedundancyTest, SustainedAlternatingBurstSwitchover) {
+  uint32_t ts = 1000;
+  uint16_t seq = 0;
+  for (int g = 0; g < 8; g++) {
+    enum mtl_session_port p = (g % 2 == 0) ? MTL_SESSION_PORT_P : MTL_SESSION_PORT_R;
+    for (int i = 0; i < 4; i++) feed(seq + i, ts + i, p);
+    seq += 4;
+    ts += 4;
+  }
+
+  EXPECT_EQ(received(), 32u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(unrecovered(), 0u);
+}

--- a/tests/unit/session/st30/st30_rx_test_base.h
+++ b/tests/unit/session/st30/st30_rx_test_base.h
@@ -68,6 +68,9 @@ class St30RxBaseTest : public ::testing::Test {
   uint64_t port_pkts(enum mtl_session_port p) {
     return ut30_stat_port_pkts(ctx_, p);
   }
+  uint64_t port_frames(enum mtl_session_port p) {
+    return ut30_stat_port_frames(ctx_, p);
+  }
   uint64_t port_bytes(enum mtl_session_port p) {
     return ut30_stat_port_bytes(ctx_, p);
   }

--- a/tests/unit/session/st30/stats_test.cpp
+++ b/tests/unit/session/st30/stats_test.cpp
@@ -130,3 +130,52 @@ TEST_F(St30RxStatsTest, PortLostNotInflatedAtSeqWrap) {
   EXPECT_EQ(unrecovered() - unrec_before, 2u)
       << "session-seq gap across wrap must equal the true forward gap (2)";
 }
+
+/* Disjoint per-wire losses whose union covers the full stream: P drops
+ * seqs 0..2 but delivers 3..5; R drops 3..5 but delivers 0..2. Each pkt
+ * has its own monotonic timestamp. Reconstruction must succeed — every
+ * packet accepted exactly once, no unrecovered, no redundant. */
+TEST_F(St30RxStatsTest, DisjointPortLossesUnionRecovers) {
+  feed(0, 1000, MTL_SESSION_PORT_R);
+  feed(1, 1001, MTL_SESSION_PORT_R);
+  feed(2, 1002, MTL_SESSION_PORT_R);
+  feed(3, 1003, MTL_SESSION_PORT_P);
+  feed(4, 1004, MTL_SESSION_PORT_P);
+  feed(5, 1005, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(received(), 6u);
+  EXPECT_EQ(redundant(), 0u);
+  EXPECT_EQ(unrecovered(), 0u) << "every gap on one wire was filled by the other wire";
+}
+
+/* Documented invariant stat_pkts_unrecovered <= sum(port[].lost_packets):
+ * both wires drop the same seq, so the hole is unrecoverable. Per-port
+ * accounting bumps lost on each wire (it runs before the redundancy filter),
+ * while the session-wide unrecovered counter records the unfilled hole.
+ * The invariant must hold strictly. */
+TEST_F(St30RxStatsTest, UnrecoveredNotGreaterThanSummedPortLost) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_R); /* filtered as redundant by ts */
+  /* Both wires skip seq 1. */
+  feed(2, 1002, MTL_SESSION_PORT_P); /* P jumped 0 -> 2: own gap of 1 */
+  feed(2, 1002, MTL_SESSION_PORT_R); /* R also jumped 0 -> 2 (then filtered) */
+
+  EXPECT_GE(unrecovered(), 1u) << "the missing seq is post-redundancy loss";
+  EXPECT_LE(unrecovered(), port_ooo(MTL_SESSION_PORT_P) + port_ooo(MTL_SESSION_PORT_R))
+      << "documented invariant: stat_pkts_unrecovered <= sum(port[].lost)";
+}
+
+/* Documented invariant: every accepted packet is counted as exactly one of
+ * {received, redundant} — never both, never neither. Mixed-traffic scenario
+ * with own-stream forward delivery plus cross-port duplicates pins the
+ * partition. */
+TEST_F(St30RxStatsTest, ReceivedPlusRedundantEqualsAcceptedPackets) {
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_P); /* 4 accepted as received */
+  feed_burst(0, 4, 1000, MTL_SESSION_PORT_R); /* 4 accepted as redundant */
+  feed_burst(4, 4, 2000, MTL_SESSION_PORT_P); /* 4 more received */
+
+  EXPECT_EQ(received(), 8u);
+  EXPECT_EQ(redundant(), 4u);
+  EXPECT_EQ(received() + redundant(), 12u)
+      << "every accepted packet is counted in exactly one bucket";
+}

--- a/tests/unit/session/st30_harness.c
+++ b/tests/unit/session/st30_harness.c
@@ -278,6 +278,10 @@ uint64_t ut30_stat_port_pkts(const ut30_test_ctx* ctx, enum mtl_session_port por
   return ctx->session.port_user_stats.common.port[port].packets;
 }
 
+uint64_t ut30_stat_port_frames(const ut30_test_ctx* ctx, enum mtl_session_port port) {
+  return ctx->session.port_user_stats.common.port[port].frames;
+}
+
 uint64_t ut30_stat_port_bytes(const ut30_test_ctx* ctx, enum mtl_session_port port) {
   return ctx->session.port_user_stats.common.port[port].bytes;
 }

--- a/tests/unit/session/st30_harness.h
+++ b/tests/unit/session/st30_harness.h
@@ -81,6 +81,16 @@ uint64_t ut30_stat_port_lost(const ut30_test_ctx* ctx, enum mtl_session_port por
 uint64_t ut30_stat_port_reordered(const ut30_test_ctx* ctx, enum mtl_session_port port);
 uint64_t ut30_stat_port_duplicates(const ut30_test_ctx* ctx, enum mtl_session_port port);
 
+/* Per-port frame credit (audio first-pkt-wins).
+ *
+ * ST30 increments `port[i].frames` exactly once per frame, on the port
+ * whose packet allocated the new frame buffer (i.e. the first pkt of the
+ * new RTP timestamp to be accepted post-redundancy). The other port is
+ * not credited even if it later contributes packets to the same frame.
+ * See `rx_audio_session_handle_frame_pkt` in
+ * `lib/src/st2110/st_rx_audio_session.c`. */
+uint64_t ut30_stat_port_frames(const ut30_test_ctx* ctx, enum mtl_session_port port);
+
 /* Session-wide counters. `unrecovered` counts gaps the redundancy filter
  * could not heal; `redundant` counts cross-port duplicates dropped by the
  * filter; `received` counts accepted packets after filtering. */

--- a/tests/unit/session/st40/redundancy_test.cpp
+++ b/tests/unit/session/st40/redundancy_test.cpp
@@ -479,3 +479,62 @@ TEST_F(St40RxRedundancyTest, PerPortFramesSameTsOnSecondaryFiltered) {
   EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u);
   EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u);
 }
+
+/* Mid-frame cable disconnect: P delivers the first 4 packets of a 6-pkt
+ * frame at ts=1000, then goes silent. R, which has been duplicating P,
+ * keeps sending the same frame. The bitmap must accept R's missing tail
+ * (pkts 4 and 5) and reject pkts 0..3 as cross-port duplicates. The frame
+ * is reconstructed exactly once with no unrecovered packets. */
+TEST_F(St40RxRedundancyTest, MidFrameDisconnectPeerCompletesFrame) {
+  constexpr uint32_t ts = 1000;
+  feed(0, ts, false, MTL_SESSION_PORT_P);
+  feed(1, ts, false, MTL_SESSION_PORT_P);
+  feed(2, ts, false, MTL_SESSION_PORT_P);
+  feed(3, ts, false, MTL_SESSION_PORT_P);
+  /* P dies mid-frame; R sends the full frame. */
+  for (int i = 0; i < 6; i++) feed(i, ts, i == 5, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(unrecovered(), 0u) << "frame reconstructed via cross-port fill";
+  EXPECT_EQ(redundant(), 4u) << "R's pkts 0..3 duplicate P's";
+}
+
+/* Wild within-frame seq on P, full frame on R, then a clean frame on P.
+ * A corrupt seq is indistinguishable from real loss, so unrecovered may
+ * rise; the contract is that the session keeps producing frames and the
+ * loss counter stays bounded by the apparent jump. */
+TEST_F(St40RxRedundancyTest, WireCorruptedSeqDoesNotStallSession) {
+  constexpr uint32_t ts1 = 1000;
+  feed(0, ts1, false, MTL_SESSION_PORT_P);
+  feed(1, ts1, false, MTL_SESSION_PORT_P);
+  feed(50, ts1, false, MTL_SESSION_PORT_P); /* corrupted/wild seq */
+  feed(0, ts1, false, MTL_SESSION_PORT_R);
+  feed(1, ts1, false, MTL_SESSION_PORT_R);
+  feed(2, ts1, false, MTL_SESSION_PORT_R);
+  feed(3, ts1, true, MTL_SESSION_PORT_R);
+  /* A subsequent clean frame must still complete - the wild seq watermark
+   * must not block forward progress. */
+  for (int i = 0; i < 4; i++) feed(60 + i, 2000, i == 3, MTL_SESSION_PORT_P);
+
+  EXPECT_GE(frames_received(), 1) << "session must keep producing frames";
+  EXPECT_LE(unrecovered(), 64u)
+      << "unrecovered must be bounded by the apparent seq jump, not unbounded";
+}
+
+/* Non-conformant TX uses different timestamps on P and R for the same
+ * logical frame. ST 2022-7 requires identical RTP fields, so behaviour
+ * is undefined; the contract is liveness only — no deadlock, frames
+ * keep flowing, loss counter stays bounded. */
+TEST_F(St40RxRedundancyTest, MismatchedTimestampsSessionStaysProductive) {
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(1, 1000, true, MTL_SESSION_PORT_P);
+  feed(0, 1001, false, MTL_SESSION_PORT_R);
+  feed(1, 1001, true, MTL_SESSION_PORT_R);
+  /* A subsequent in-spec frame from P must still complete. */
+  feed(2, 2000, false, MTL_SESSION_PORT_P);
+  feed(3, 2000, true, MTL_SESSION_PORT_P);
+
+  EXPECT_GE(frames_received(), 1)
+      << "session must keep delivering frames despite non-conformant TX";
+  EXPECT_LE(unrecovered(), 64u)
+      << "loss counter must stay bounded under non-conformant TX";
+}

--- a/tests/unit/session/st40/redundancy_test.cpp
+++ b/tests/unit/session/st40/redundancy_test.cpp
@@ -403,3 +403,79 @@ TEST_F(St40RxRedundancyTest, HighPerLegLossRedundancySaves) {
   /* The merged stream must be intact — every seq delivered once. */
   EXPECT_EQ(unrecovered(), 0u) << "complementary per-port loss must be fully recovered";
 }
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Per-port frame accounting (ancillary).
+ *
+ * ST40 credits exactly one port per frame: the port whose accepted packet
+ * first observed the new RTP timestamp (see `rx_ancillary_session_handle_pkt`
+ * in `lib/src/st2110/st_rx_ancillary_session.c`). Subsequent packets on the
+ * same timestamp — same or other port — never bump `port[i].frames`.
+ * Same-timestamp redundant copies on the other port are filtered before the
+ * credit branch.
+ *
+ * Invariant per session: port[P].frames + port[R].frames == frames_received
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/* All frames arrive on P; R is silent. P is credited once per frame. */
+TEST_F(St40RxRedundancyTest, PerPortFramesPrimaryOnly) {
+  feed(0, 1000, true, MTL_SESSION_PORT_P);
+  feed(1, 2000, true, MTL_SESSION_PORT_P);
+  feed(2, 3000, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 3u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u);
+}
+
+/* All frames arrive on R; P is silent. R is credited once per frame. */
+TEST_F(St40RxRedundancyTest, PerPortFramesSecondaryOnly) {
+  feed(0, 1000, true, MTL_SESSION_PORT_R);
+  feed(1, 2000, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 2);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 2u);
+}
+
+/* Frame N from P, then R wins frame N+1 by sending its first packet first
+ * (with strictly newer ts). P keeps the credit for frame N; R gets credit
+ * for frame N+1. */
+TEST_F(St40RxRedundancyTest, PerPortFramesAlternatingWinner) {
+  /* frame 1: P */
+  feed(0, 1000, true, MTL_SESSION_PORT_P);
+  /* frame 2: R sends its (only) packet first with new ts → wins credit */
+  feed(1, 2000, true, MTL_SESSION_PORT_R);
+
+  EXPECT_EQ(frames_received(), 2);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P) + port_frames(MTL_SESSION_PORT_R),
+            static_cast<uint64_t>(frames_received()))
+      << "ANC invariant: per-port frames sum equals frames_received";
+}
+
+/* Same timestamp repeated on the same port. Only the first packet of the
+ * new ts may bump the frame counter; later same-ts packets must not. */
+TEST_F(St40RxRedundancyTest, PerPortFramesNoCreditOnSameTimestamp) {
+  feed(0, 1000, false, MTL_SESSION_PORT_P);
+  feed(1, 1000, false, MTL_SESSION_PORT_P);
+  feed(2, 1000, true, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 1) << "single ts == single frame";
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u);
+}
+
+/* Same-timestamp redundant copy on R after P's first packet must NOT credit
+ * R: R's packet is filtered as redundant by the timestamp-equality guard
+ * before reaching the credit branch. */
+TEST_F(St40RxRedundancyTest, PerPortFramesSameTsOnSecondaryFiltered) {
+  feed(0, 1000, true, MTL_SESSION_PORT_P);
+  int rc = feed(0, 1000, true, MTL_SESSION_PORT_R);
+
+  EXPECT_LT(rc, 0) << "same ts on R is filtered (redundant)";
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_frames(MTL_SESSION_PORT_R), 0u);
+}


### PR DESCRIPTION
ST20 RX defect uncovered while extending ST 2022-7 unit coverage:

- ST20: last_pkt_idx is now per-port, so cross-port arrival races no longer mis-credit loss/reorder to the lagging wire.

Adds 10 gap-fill unit tests across ST20/ST30/ST40 (raw + pipeline) covering silent-port survival, mid-frame disconnect, alternating bursts, and per-port stat identities. 256/256 tests pass under ASAN.