### PR TITLE
Test: remove nightly marker from legacy RxTxApp-based tests

### DIFF
--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24.py
@@ -7,7 +7,6 @@ from mtl_engine import ffmpeg_app
 from mtl_engine.media_files import yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "video_format, test_time_mutlipler, media_file",
     [

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_ffmpeg_rgb24_multiple.py
@@ -7,7 +7,6 @@ from mtl_engine import ffmpeg_app
 from mtl_engine.media_files import yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "video_format_1, video_format_2, test_time_mutlipler, media_file",
     [

--- a/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_rxtxapp.py
+++ b/tests/validation/tests/single/ffmpeg/test_rx_ffmpeg_tx_rxtxapp.py
@@ -7,7 +7,6 @@ from mtl_engine import ffmpeg_app
 from mtl_engine.media_files import yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "video_format, multiple_sessions, test_time_multipler, media_file",
     [

--- a/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo/test_kernel_lo.py
@@ -31,7 +31,6 @@ from mtl_engine.media_files import (
 )
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("test_mode", ["kernel"])
 @pytest.mark.parametrize(
     "media_file",

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st20p/test_kernel_lo_st20p.py
@@ -25,7 +25,6 @@ import pytest
 from mtl_engine.media_files import yuv_files_422p10le
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("test_mode", ["kernel"])
 @pytest.mark.parametrize(
     "media_file",

--- a/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
+++ b/tests/validation/tests/single/kernel_socket/kernel_lo_st22p/test_kernel_lo_st22p.py
@@ -27,7 +27,6 @@ import pytest
 from mtl_engine.media_files import parse_fps_to_pformat, yuv_files_422rfc10
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("test_mode", ["kernel"])
 @pytest.mark.parametrize(
     "media_file",

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/mixed/test_pmd_kernel_mixed.py
@@ -60,7 +60,6 @@ from mtl_engine.media_files import (
 )
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("test_mode", ["multicast"])
 @pytest.mark.parametrize(
     "media_file",

--- a/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
+++ b/tests/validation/tests/single/kernel_socket/pmd_kernel/video/test_pmd_kernel_video.py
@@ -45,7 +45,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import parse_fps_to_pformat, yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("test_mode", ["multicast"])
 @pytest.mark.parametrize(
     "media_file",

--- a/tests/validation/tests/single/ptp/st20_interfaces_mix/test_st20_interfaces_mix.py
+++ b/tests/validation/tests/single/ptp/st20_interfaces_mix/test_st20_interfaces_mix.py
@@ -23,7 +23,6 @@ def _is_supported_runner() -> bool:
     return workflow.endswith(":e810") or workflow.endswith(":e830")
 
 
-@pytest.mark.nightly
 @pytest.mark.ptp
 @pytest.mark.skipif(
     not _is_supported_runner(),

--- a/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
+++ b/tests/validation/tests/single/rss_mode/audio/test_rss_mode_audio.py
@@ -13,7 +13,6 @@ from mtl_engine.media_files import audio_files
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
+++ b/tests/validation/tests/single/rss_mode/video/test_rss_mode_video.py
@@ -7,7 +7,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/rx_timing/mixed/test_mode.py
+++ b/tests/validation/tests/single/rx_timing/mixed/test_mode.py
@@ -8,7 +8,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import anc_files, audio_files, yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("test_mode", ["unicast", "multicast"])
 def test_rx_timing_mode(
     hosts,

--- a/tests/validation/tests/single/rx_timing/video/test_video_format.py
+++ b/tests/validation/tests/single/rx_timing/video/test_video_format.py
@@ -8,7 +8,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "video_format",
     [

--- a/tests/validation/tests/single/st20p/format/test_format.py
+++ b/tests/validation/tests/single/st20p/format/test_format.py
@@ -7,7 +7,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le, yuv_files_422rfc10
 
 
-@pytest.mark.nightly
 @pytest.mark.verified
 @pytest.mark.parametrize(
     "media_file",
@@ -96,7 +95,6 @@ convert1_formats = dict(
 )
 
 
-@pytest.mark.nightly
 @pytest.mark.verified
 @pytest.mark.parametrize(
     "media_file",
@@ -244,7 +242,6 @@ def test_tx_rx_conversion(
     )
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [yuv_files_422rfc10["test_8K"]],

--- a/tests/validation/tests/single/st20p/fps/test_fps.py
+++ b/tests/validation/tests/single/st20p/fps/test_fps.py
@@ -9,7 +9,6 @@ from mtl_engine.media_files import yuv_files_422rfc10
 pytestmark = pytest.mark.verified
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [yuv_files_422rfc10["ParkJoy_1080p"]],

--- a/tests/validation/tests/single/st20p/integrity/test_integrity.py
+++ b/tests/validation/tests/single/st20p/integrity/test_integrity.py
@@ -18,16 +18,12 @@ pytestmark = pytest.mark.verified
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [
         yuv_files_422rfc10["Penguin_720p"],
         yuv_files_422rfc10["Penguin_1080p"],
-        pytest.param(
-            yuv_files_422p10le["Penguin_720p"],
-            marks=pytest.mark.nightly,
-        ),
+        yuv_files_422p10le["Penguin_720p"],
         yuv_files_422p10le["Penguin_1080p"],
     ],
     indirect=["media_file"],

--- a/tests/validation/tests/single/st20p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st20p/interlace/test_interlace.py
@@ -9,7 +9,6 @@ from mtl_engine.media_files import yuv_files_interlace
 pytestmark = pytest.mark.verified
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     list(yuv_files_interlace.values()),

--- a/tests/validation/tests/single/st20p/pacing/test_pacing.py
+++ b/tests/validation/tests/single/st20p/pacing/test_pacing.py
@@ -9,7 +9,6 @@ from mtl_engine.media_files import yuv_files_422rfc10
 pytestmark = pytest.mark.verified
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("pacing", ["narrow", "wide", "linear"])
 @pytest.mark.parametrize(
     "media_file",

--- a/tests/validation/tests/single/st20p/packing/test_packing.py
+++ b/tests/validation/tests/single/st20p/packing/test_packing.py
@@ -9,7 +9,6 @@ from mtl_engine.media_files import yuv_files_422rfc10
 pytestmark = pytest.mark.verified
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize("packing", ["GPM_SL", "GPM"])
 @pytest.mark.parametrize(
     "media_file",

--- a/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
+++ b/tests/validation/tests/single/st20p/resolutions/test_resolutions.py
@@ -9,7 +9,6 @@ from mtl_engine.media_files import yuv_files_422rfc10
 pytestmark = pytest.mark.verified
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st20p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st20p/test_mode/test_multicast.py
@@ -9,7 +9,6 @@ from mtl_engine.media_files import yuv_files_422rfc10
 pytestmark = pytest.mark.verified
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st22p/codec/test_codec.py
+++ b/tests/validation/tests/single/st22p/codec/test_codec.py
@@ -8,7 +8,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [yuv_files_422p10le["Penguin_1080p"]],

--- a/tests/validation/tests/single/st22p/format/test_format.py
+++ b/tests/validation/tests/single/st22p/format/test_format.py
@@ -8,7 +8,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     list(yuv_files_422p10le.values()),

--- a/tests/validation/tests/single/st22p/fps/test_fps.py
+++ b/tests/validation/tests/single/st22p/fps/test_fps.py
@@ -8,7 +8,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [yuv_files_422p10le["Penguin_1080p"]],
@@ -20,7 +19,7 @@ from mtl_engine.media_files import yuv_files_422p10le
     [
         "p23",
         "p24",
-        pytest.param("p25", marks=pytest.mark.nightly),
+        pytest.param("p25"),
         "p29",
         "p30",
         "p50",

--- a/tests/validation/tests/single/st22p/interlace/test_interlace.py
+++ b/tests/validation/tests/single/st22p/interlace/test_interlace.py
@@ -8,7 +8,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_interlace
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     list(yuv_files_interlace.values()),

--- a/tests/validation/tests/single/st22p/quality/test_quality.py
+++ b/tests/validation/tests/single/st22p/quality/test_quality.py
@@ -8,7 +8,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [yuv_files_422p10le["Penguin_1080p"]],

--- a/tests/validation/tests/single/st22p/test_mode/test_unicast.py
+++ b/tests/validation/tests/single/st22p/test_mode/test_unicast.py
@@ -7,7 +7,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files_422p10le
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [yuv_files_422p10le["Penguin_1080p"]],

--- a/tests/validation/tests/single/st30p/integrity/test_integrity.py
+++ b/tests/validation/tests/single/st30p/integrity/test_integrity.py
@@ -16,7 +16,6 @@ from mtl_engine.media_files import audio_files
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
+++ b/tests/validation/tests/single/st30p/st30p_channel/test_st30p_channel.py
@@ -18,7 +18,6 @@ _AUDIO_CHANNELS = ["M", "DM", "ST", "LtRt", "51", "71", "222", "SGRP"]
 _SMOKE_CASE = ("PCM16", "M")
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     ("media_file", "audio_channel"),
     [

--- a/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
+++ b/tests/validation/tests/single/st30p/st30p_format/test_st30p_format.py
@@ -13,7 +13,6 @@ from mtl_engine.media_files import audio_files
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
+++ b/tests/validation/tests/single/st30p/st30p_ptime/test_st30p_ptime.py
@@ -13,7 +13,6 @@ from mtl_engine.media_files import audio_files
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
+++ b/tests/validation/tests/single/st30p/st30p_sampling/test_st30p_sampling.py
@@ -13,7 +13,6 @@ from mtl_engine.media_files import audio_files
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st30p/test_mode/test_multicast.py
+++ b/tests/validation/tests/single/st30p/test_mode/test_multicast.py
@@ -9,7 +9,6 @@ from mtl_engine.execute import LOG_FOLDER
 from mtl_engine.media_files import audio_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st40p/basic/test_basic.py
+++ b/tests/validation/tests/single/st40p/basic/test_basic.py
@@ -12,7 +12,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import anc_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [
@@ -60,7 +59,6 @@ def test_st40p_basic(
     )
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [anc_files["text_p59"]],

--- a/tests/validation/tests/single/st40p/multicast_with_compliance/test_multicast_with_compliance.py
+++ b/tests/validation/tests/single/st40p/multicast_with_compliance/test_multicast_with_compliance.py
@@ -14,7 +14,6 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import anc_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [

--- a/tests/validation/tests/single/st41/dit/test_dit.py
+++ b/tests/validation/tests/single/st41/dit/test_dit.py
@@ -22,7 +22,6 @@ k_bit_mapping = {
 }
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [st41_files["st41_p29_long_file"]],

--- a/tests/validation/tests/single/st41/fps/test_fps.py
+++ b/tests/validation/tests/single/st41/fps/test_fps.py
@@ -22,7 +22,6 @@ k_bit_mapping = {
 }
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [st41_files["st41_p29_long_file"]],

--- a/tests/validation/tests/single/st41/k_bit/test_k_bit.py
+++ b/tests/validation/tests/single/st41/k_bit/test_k_bit.py
@@ -22,7 +22,6 @@ k_bit_mapping = {
 }
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [st41_files["st41_p29_long_file"]],

--- a/tests/validation/tests/single/st41/no_chain/test_no_chain.py
+++ b/tests/validation/tests/single/st41/no_chain/test_no_chain.py
@@ -22,7 +22,6 @@ k_bit_mapping = {
 }
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [st41_files["st41_p29_long_file"]],

--- a/tests/validation/tests/single/st41/payload_type/test_payload_type.py
+++ b/tests/validation/tests/single/st41/payload_type/test_payload_type.py
@@ -21,7 +21,6 @@ k_bit_mapping = {
 }
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [st41_files["st41_p29_long_file"]],

--- a/tests/validation/tests/single/st41/type_mode/test_type_mode.py
+++ b/tests/validation/tests/single/st41/type_mode/test_type_mode.py
@@ -22,7 +22,6 @@ k_bit_mapping = {
 }
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file",
     [st41_files["st41_p29_long_file"]],

--- a/tests/validation/tests/single/virtio_user/test_virtio_user.py
+++ b/tests/validation/tests/single/virtio_user/test_virtio_user.py
@@ -6,14 +6,13 @@ from common.nicctl import InterfaceSetup
 from mtl_engine.media_files import yuv_files
 
 
-@pytest.mark.nightly
 @pytest.mark.parametrize(
     "media_file, replicas",
     [
-        pytest.param(yuv_files["i1080p60"], 1, marks=pytest.mark.nightly),
+        pytest.param(yuv_files["i1080p60"], 1),
         (yuv_files["i1080p60"], 3),
         (yuv_files["i1080p60"], 30),
-        pytest.param(yuv_files["i2160p60"], 1, marks=pytest.mark.nightly),
+        pytest.param(yuv_files["i2160p60"], 1),
         (yuv_files["i2160p60"], 3),
         (yuv_files["i2160p60"], 9),
     ],


### PR DESCRIPTION
Refactored versions of these tests already exist and are marked with the nightly marker. Only the refactored tests should run in the nightly pipeline.