### PR TITLE
Fix: return -EIO from MT_HANDLE_GUARD in int-returning APIs

### DIFF
--- a/lib/src/st2110/pipeline/st20_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_rx.c
@@ -1202,7 +1202,7 @@ int st20p_rx_get_queue_meta(st20p_rx_handle handle, struct st_queue_meta* meta) 
   struct st20p_rx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st20_rx_get_queue_meta(ctx->transport, meta);
   MT_HANDLE_RELEASE(ctx);
@@ -1213,7 +1213,7 @@ int st20p_rx_get_sch_idx(st20p_rx_handle handle) {
   struct st20p_rx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st20_rx_get_sch_idx(ctx->transport);
   MT_HANDLE_RELEASE(ctx);
@@ -1229,7 +1229,7 @@ int st20p_rx_get_session_stats(st20p_rx_handle handle, struct st20_rx_user_stats
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st20_rx_get_session_stats(ctx->transport, stats);
   if (ret < 0) goto out;
@@ -1255,7 +1255,7 @@ int st20p_rx_reset_session_stats(st20p_rx_handle handle) {
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   __atomic_store_n(&ctx->stat_frames_received, 0, __ATOMIC_RELAXED);
   __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
@@ -1269,7 +1269,7 @@ int st20p_rx_update_source(st20p_rx_handle handle, struct st_rx_source_info* src
   struct st20p_rx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st20_rx_update_source(ctx->transport, src);
   MT_HANDLE_RELEASE(ctx);
@@ -1281,7 +1281,7 @@ int st20p_rx_timing_parser_critical(st20p_rx_handle handle,
   struct st20p_rx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st20_rx_timing_parser_critical(ctx->transport, pass);
   MT_HANDLE_RELEASE(ctx);
@@ -1291,7 +1291,7 @@ int st20p_rx_timing_parser_critical(st20p_rx_handle handle,
 int st20p_rx_wake_block(st20p_rx_handle handle) {
   struct st20p_rx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   if (ctx->block_get) rx_st20p_block_wake(ctx);
 
@@ -1302,7 +1302,7 @@ int st20p_rx_wake_block(st20p_rx_handle handle) {
 int st20p_rx_set_block_timeout(st20p_rx_handle handle, uint64_t timedwait_ns) {
   struct st20p_rx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_RX, -EIO);
 
   ctx->block_timeout_ns = timedwait_ns;
   MT_HANDLE_RELEASE(ctx);

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -1189,7 +1189,7 @@ int st20p_tx_get_sch_idx(st20p_tx_handle handle) {
   struct st20p_tx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, -EIO);
 
   ret = st20_tx_get_sch_idx(ctx->transport);
   MT_HANDLE_RELEASE(ctx);
@@ -1223,7 +1223,7 @@ int st20p_tx_get_session_stats(st20p_tx_handle handle, struct st20_tx_user_stats
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, -EIO);
 
   ret = st20_tx_get_session_stats(ctx->transport, stats);
   if (ret < 0) goto out;
@@ -1247,7 +1247,7 @@ int st20p_tx_reset_session_stats(st20p_tx_handle handle) {
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, -EIO);
 
   __atomic_store_n(&ctx->stat_frames_sent, 0, __ATOMIC_RELAXED);
   __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
@@ -1260,7 +1260,7 @@ int st20p_tx_update_destination(st20p_tx_handle handle, struct st_tx_dest_info* 
   struct st20p_tx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, -EIO);
 
   ret = st20_tx_update_destination(ctx->transport, dst);
   MT_HANDLE_RELEASE(ctx);
@@ -1270,7 +1270,7 @@ int st20p_tx_update_destination(st20p_tx_handle handle, struct st_tx_dest_info* 
 int st20p_tx_wake_block(st20p_tx_handle handle) {
   struct st20p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, -EIO);
 
   if (ctx->block_get) tx_st20p_block_wake(ctx);
 
@@ -1281,7 +1281,7 @@ int st20p_tx_wake_block(st20p_tx_handle handle) {
 int st20p_tx_set_block_timeout(st20p_tx_handle handle, uint64_t timedwait_ns) {
   struct st20p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST20_HANDLE_PIPELINE_TX, -EIO);
 
   ctx->block_timeout_ns = timedwait_ns;
   MT_HANDLE_RELEASE(ctx);

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -898,7 +898,7 @@ int st22p_rx_get_queue_meta(st22p_rx_handle handle, struct st_queue_meta* meta) 
   struct st22p_rx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st22_rx_get_queue_meta(ctx->transport, meta);
   MT_HANDLE_RELEASE(ctx);
@@ -931,7 +931,7 @@ int st22p_rx_update_source(st22p_rx_handle handle, struct st_rx_source_info* src
 int st22p_rx_wake_block(st22p_rx_handle handle) {
   struct st22p_rx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_RX, -EIO);
 
   if (ctx->block_get) rx_st22p_block_wake(ctx);
 
@@ -942,7 +942,7 @@ int st22p_rx_wake_block(st22p_rx_handle handle) {
 int st22p_rx_set_block_timeout(st22p_rx_handle handle, uint64_t timedwait_ns) {
   struct st22p_rx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_RX, -EIO);
 
   ctx->block_timeout_ns = timedwait_ns;
   MT_HANDLE_RELEASE(ctx);

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -1116,7 +1116,7 @@ int st22p_tx_update_destination(st22p_tx_handle handle, struct st_tx_dest_info* 
   struct st22p_tx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_TX, -EIO);
 
   ret = st22_tx_update_destination(ctx->transport, dst);
   MT_HANDLE_RELEASE(ctx);
@@ -1126,7 +1126,7 @@ int st22p_tx_update_destination(st22p_tx_handle handle, struct st_tx_dest_info* 
 int st22p_tx_wake_block(st22p_tx_handle handle) {
   struct st22p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_TX, -EIO);
 
   if (ctx->block_get) tx_st22p_block_wake(ctx);
 
@@ -1137,7 +1137,7 @@ int st22p_tx_wake_block(st22p_tx_handle handle) {
 int st22p_tx_set_block_timeout(st22p_tx_handle handle, uint64_t timedwait_ns) {
   struct st22p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST22_HANDLE_PIPELINE_TX, -EIO);
 
   ctx->block_timeout_ns = timedwait_ns;
   MT_HANDLE_RELEASE(ctx);

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.c
@@ -546,7 +546,7 @@ int st30p_rx_get_queue_meta(st30p_rx_handle handle, struct st_queue_meta* meta) 
   struct st30p_rx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st30_rx_get_queue_meta(ctx->transport, meta);
   MT_HANDLE_RELEASE(ctx);
@@ -562,7 +562,7 @@ int st30p_rx_get_session_stats(st30p_rx_handle handle, struct st30_rx_user_stats
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st30_rx_get_session_stats(ctx->transport, stats);
   if (ret < 0) goto out;
@@ -588,7 +588,7 @@ int st30p_rx_reset_session_stats(st30p_rx_handle handle) {
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, -EIO);
 
   __atomic_store_n(&ctx->stat_frames_received, 0, __ATOMIC_RELAXED);
   __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
@@ -602,7 +602,7 @@ int st30p_rx_update_source(st30p_rx_handle handle, struct st_rx_source_info* src
   struct st30p_rx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, -EIO);
 
   ret = st30_rx_update_source(ctx->transport, src);
   MT_HANDLE_RELEASE(ctx);
@@ -612,7 +612,7 @@ int st30p_rx_update_source(st30p_rx_handle handle, struct st_rx_source_info* src
 int st30p_rx_wake_block(st30p_rx_handle handle) {
   struct st30p_rx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, -EIO);
 
   if (ctx->block_get) rx_st30p_block_wake(ctx);
 
@@ -623,7 +623,7 @@ int st30p_rx_wake_block(st30p_rx_handle handle) {
 int st30p_rx_set_block_timeout(st30p_rx_handle handle, uint64_t timedwait_ns) {
   struct st30p_rx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_RX, -EIO);
 
   ctx->block_timeout_ns = timedwait_ns;
   MT_HANDLE_RELEASE(ctx);

--- a/lib/src/st2110/pipeline/st30_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_tx.c
@@ -703,7 +703,7 @@ int st30p_tx_update_destination(st30p_tx_handle handle, struct st_tx_dest_info* 
   struct st30p_tx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, -EIO);
 
   ret = st30_tx_update_destination(ctx->transport, dst);
   MT_HANDLE_RELEASE(ctx);
@@ -713,7 +713,7 @@ int st30p_tx_update_destination(st30p_tx_handle handle, struct st_tx_dest_info* 
 int st30p_tx_wake_block(st30p_tx_handle handle) {
   struct st30p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, -EIO);
 
   if (ctx->block_get) tx_st30p_block_wake(ctx);
 
@@ -724,7 +724,7 @@ int st30p_tx_wake_block(st30p_tx_handle handle) {
 int st30p_tx_set_block_timeout(st30p_tx_handle handle, uint64_t timedwait_ns) {
   struct st30p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, -EIO);
 
   ctx->block_timeout_ns = timedwait_ns;
   MT_HANDLE_RELEASE(ctx);
@@ -816,7 +816,7 @@ int st30p_tx_reset_session_stats(st30p_tx_handle handle) {
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST30_HANDLE_PIPELINE_TX, -EIO);
 
   __atomic_store_n(&ctx->stat_frames_sent, 0, __ATOMIC_RELAXED);
   __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);

--- a/lib/src/st2110/pipeline/st40_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_tx.c
@@ -692,7 +692,7 @@ int st40p_tx_update_destination(st40p_tx_handle handle, struct st_tx_dest_info* 
   struct st40p_tx_ctx* ctx = handle;
   int ret;
 
-  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, -EIO);
 
   ret = st40_tx_update_destination(ctx->transport, dst);
   MT_HANDLE_RELEASE(ctx);
@@ -702,7 +702,7 @@ int st40p_tx_update_destination(st40p_tx_handle handle, struct st_tx_dest_info* 
 int st40p_tx_wake_block(st40p_tx_handle handle) {
   struct st40p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, -EIO);
 
   if (ctx->block_get) tx_st40p_block_wake(ctx);
 
@@ -713,7 +713,7 @@ int st40p_tx_wake_block(st40p_tx_handle handle) {
 int st40p_tx_set_block_timeout(st40p_tx_handle handle, uint64_t timedwait_ns) {
   struct st40p_tx_ctx* ctx = handle;
 
-  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, -EIO);
 
   ctx->block_timeout_ns = timedwait_ns;
   MT_HANDLE_RELEASE(ctx);
@@ -802,7 +802,7 @@ int st40p_tx_reset_session_stats(st40p_tx_handle handle) {
     return -EINVAL;
   }
 
-  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, 0);
+  MT_HANDLE_GUARD(ctx, MT_ST40_HANDLE_PIPELINE_TX, -EIO);
 
   __atomic_store_n(&ctx->stat_frames_sent, 0, __ATOMIC_RELAXED);
   __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);


### PR DESCRIPTION
All pipeline public APIs that return int used errret=0 in MT_HANDLE_GUARD, falsely reporting success when the handle is being destroyed. Callers that check ret < 0 to detect teardown never saw the error and could keep using a stale handle.

Change errret from 0 to -EIO for every int-returning function. The 10 size_t-returning sites (frame_size, max_udw_buff_size) correctly keep 0 since no negative is representable in size_t.

Fixes: b8b6cf51e40c ("Fix: serialize public session-handle APIs against *_free")