### PR TITLE
CI: auto-discover pkg-config and library paths for local installs

### DIFF
--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -55,6 +55,30 @@ nproc=$(nproc 2>/dev/null || echo 50)
 # shellcheck disable=SC1091
 . "${root_folder}/script/common.sh"
 
+# Discover and export pkg-config / library paths from a local install prefix
+# so that downstream builds (MTL → FFmpeg → GStreamer) can find each other's
+# headers and libraries without hardcoding directory layouts.
+_export_local_paths() {
+	local prefix="$1"
+	[ -d "$prefix" ] || return 0
+
+	# pkg-config (.pc files)
+	while IFS= read -r -d '' pcdir; do
+		case ":${PKG_CONFIG_PATH:-}:" in
+		*":${pcdir}:"*) ;;
+		*) export PKG_CONFIG_PATH="${pcdir}${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" ;;
+		esac
+	done < <(find "$prefix" -name '*.pc' -exec dirname {} \; | sort -u | tr '\n' '\0')
+
+	# shared libraries
+	while IFS= read -r -d '' libdir; do
+		case ":${LD_LIBRARY_PATH:-}:" in
+		*":${libdir}:"*) ;;
+		*) export LD_LIBRARY_PATH="${libdir}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;;
+		esac
+	done < <(find "$prefix" -name '*.so' -exec dirname {} \; | sort -u | tr '\n' '\0')
+}
+
 # Before MTL build install
 function setup_ubuntu_install_dependencies() {
 	echo "1.1. Install the build dependency from OS software store"
@@ -225,6 +249,16 @@ function setup_ubuntu_install_dependencies() {
 # Allow sourcing of the script.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
+	# Bootstrap: discover paths from any pre-existing local installs (e.g.
+	# restored from CI cache) so downstream builds can find their deps.
+	if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+		local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
+		for _comp in dpdk mtl ffmpeg gstreamer; do
+			_export_local_paths "${local_base}/${_comp}"
+		done
+		unset _comp
+	fi
+
 	if [ "$SETUP_ENVIRONMENT" == "1" ]; then
 		echo "$STEP Environment setup."
 
@@ -295,7 +329,13 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
 	if [ "${SETUP_BUILD_AND_INSTALL_DPDK}" == "1" ]; then
 		echo "$STEP DPDK build and install"
-		bash "${root_folder}/script/build_dpdk.sh" -f
+		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
+			MTL_INSTALL_PREFIX="${local_base}/dpdk" bash "${root_folder}/script/build_dpdk.sh" -f
+			_export_local_paths "${local_base}/dpdk"
+		else
+			bash "${root_folder}/script/build_dpdk.sh" -f
+		fi
 		STEP=$((STEP + 1))
 	fi
 
@@ -381,6 +421,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		pushd "${root_folder}" >/dev/null || exit 1
 		./build.sh "${mtl_build_options}"
 		popd >/dev/null
+		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+			_export_local_paths "${MTL_INSTALL_PREFIX}"
+		fi
 		STEP=$((STEP + 1))
 	fi
 
@@ -426,11 +469,21 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		fi
 
 		bash "${root_folder}/ecosystem/ffmpeg_plugin/build.sh" "${enable_gpu}"
+		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
+			_export_local_paths "${local_base}/ffmpeg"
+		fi
 		STEP=$((STEP + 1))
 	fi
 
 	if [ "${ECOSYSTEM_BUILD_AND_INSTALL_GSTREAMER_PLUGIN}" == "1" ]; then
 		echo "$STEP Ecosystem GStreamer plugin build and install"
+
+		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
+			_export_local_paths "${local_base}/dpdk"
+			_export_local_paths "${MTL_INSTALL_PREFIX}"
+		fi
 
 		pushd "${root_folder}/ecosystem/gstreamer_plugin" >/dev/null || exit 1
 		bash build.sh


### PR DESCRIPTION
## Problem

When building with `MTL_INSTALL_PREFIX` (local-install mode), downstream builds like GStreamer cannot find `mtl.pc` or DPDK headers because `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` are either hardcoded to a specific `libdir` layout or not propagated between build steps.

## Solution

Add `_export_local_paths()` helper to `setup_environment.sh` that dynamically discovers `.pc` files and shared libraries under a given prefix and exports the correct paths.

**Key changes:**
- **Bootstrap block** at script start — picks up paths from pre-existing/cached installs so downstream builds work even when upstream components were cache-hits (not rebuilt)
- **Per-build exports** after DPDK, MTL, FFmpeg — ensures each subsequent build inherits correct paths
- **Pre-GStreamer exports** — explicitly ensures `mtl.pc` and DPDK pkgconfig are discoverable before the GStreamer meson build
- **DPDK local-install** — routes DPDK build to `${local_base}/dpdk` when `MTL_INSTALL_PREFIX` is set

This eliminates the need to hardcode `lib/x86_64-linux-gnu` vs `lib64` paths and makes the build robust across different system layouts.