### PR TITLE
ci: make shadow host configurable in custom-pytest workflow

### DIFF
--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -19,12 +19,22 @@ on:
         required: true
         type: string
         default: tests
+      shadow_host:
+        description: 'Path to shadow host credentials file (IP/USER). Leave empty to use secret.'
+        required: false
+        type: string
+        default: ''
+      enable_shadow_host:
+        description: 'Enable shadow host sync'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
-  build-artifacts:
+  build:
     runs-on: dpdk
     steps:
       - name: Harden-Runner
@@ -39,9 +49,9 @@ jobs:
         id: validate
         uses: ./.github/actions/validate-host
         with:
-          shadow_host: '${{ secrets.SHADOW_HOST }}'
+          shadow_host: ${{ inputs.enable_shadow_host && (inputs.shadow_host || secrets.SHADOW_HOST) || '' }}
   run-pytest:
-    needs: build-artifacts
+    needs: build
     runs-on: "${{ inputs.nic }}"
     timeout-minutes: 720
     steps:


### PR DESCRIPTION
## Summary

Make shadow host sync configurable via workflow dispatch inputs in the custom-pytest workflow.

## Changes

- Add `shadow_host` string input to allow specifying a custom credentials file path
- Add `enable_shadow_host` boolean input to toggle shadow host sync on/off
- Shadow host uses input value if provided, falls back to `secrets.SHADOW_HOST`, or disables entirely based on toggle
- Rename `build-artifacts` job to `build` for consistency