### PR TITLE
ci: trigger build workflow before custom pytest runs

### DIFF
--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -19,12 +19,22 @@ on:
         required: true
         type: string
         default: tests
+      shadow_host:
+        description: 'Path to shadow host credentials file (IP/USER). Leave empty to use secret.'
+        required: false
+        type: string
+        default: ''
+      enable_shadow_host:
+        description: 'Enable shadow host sync'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
-  build-artifacts:
+  build:
     runs-on: dpdk
     steps:
       - name: Harden-Runner
@@ -39,9 +49,9 @@ jobs:
         id: validate
         uses: ./.github/actions/validate-host
         with:
-          shadow_host: '${{ secrets.SHADOW_HOST }}'
+          shadow_host: ${{ inputs.enable_shadow_host && (inputs.shadow_host || secrets.SHADOW_HOST) || '' }}
   run-pytest:
-    needs: build-artifacts
+    needs: build
     runs-on: "${{ inputs.nic }}"
     timeout-minutes: 720
     steps:

--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -32,24 +32,14 @@ on:
 
 permissions:
   contents: read
+  checks: read
 
 jobs:
   build:
-    runs-on: dpdk
-    steps:
-      - name: Harden-Runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-      - name: Checkout MTL
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.ref }}
-      - name: Validate host and download artifacts
-        id: validate
-        uses: ./.github/actions/validate-host
-        with:
-          shadow_host: ${{ inputs.enable_shadow_host && (inputs.shadow_host || secrets.SHADOW_HOST) || '' }}
+    uses: ./.github/workflows/build.yml
+    with:
+      skip_linter_check: true
+
   run-pytest:
     needs: build
     runs-on: "${{ inputs.nic }}"
@@ -65,14 +55,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "${{ github.ref }}"
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8.0.1
+      - name: Validate host and download stashes
+        id: validate
+        uses: ./.github/actions/validate-host
         with:
-          name: build-${{ github.sha }}
-      - name: Make build artifacts executable
-        run: |
-          chmod +x ./ecosystem/ffmpeg_plugin/FFmpeg-release-7.0/ffmpeg
-          chmod +x ./tests/tools/RxTxApp/build/RxTxApp
+          shadow_host: ${{ inputs.enable_shadow_host && (inputs.shadow_host || secrets.SHADOW_HOST) || '' }}
       - name: Install pytest dependencies
         working-directory: ./tests/validation
         run: |


### PR DESCRIPTION
Call `build.yml` as a reusable workflow in `custom-pytest` so that DPDK, MTL, FFmpeg and GStreamer are built (or restored from cache) on the `dpdk` runner before the test job starts.

### Changes
- Add `build` job using `workflow_call` to `.github/workflows/build.yml` with `skip_linter_check: true` (manual dispatch — no linter gate needed)
- Make `run-pytest` depend on `build` via `needs: build`
- Add `checks: read` permission required by the build workflow
- Use `validate-host` action to download stashes on the test runner