### PR TITLE
ci: add harden-runner with egress-policy audit to all workflow jobs

### DIFF
--- a/.github/workflows/base_build.yml
+++ b/.github/workflows/base_build.yml
@@ -43,6 +43,11 @@ jobs:
       manager_build: ${{ steps.filter.outputs.manager_build == 'true' }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Linter
         uses: ./.github/actions/wait-for-workflow
@@ -59,6 +64,11 @@ jobs:
       ffmpeg: ${{ steps.sums.outputs.ffmpeg }}
       gstreamer: ${{ steps.sums.outputs.gstreamer }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: sums
@@ -70,6 +80,11 @@ jobs:
     runs-on: dpdk
     timeout-minutes: 60
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Clean workspace (handle root-owned files)
         run: sudo rm -rf "${{ github.workspace }}/.local_install" || true && sudo chown -R "$USER:$USER" "${{ github.workspace }}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -30,6 +30,11 @@ jobs:
       ubuntu_build: ${{ steps.filter.outputs.ubuntu_build == 'true' }}
       manager_build: ${{ steps.filter.outputs.manager_build == 'true' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -35,6 +35,11 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.linux_tests == 'true' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Clean workspace (handle root-owned files)
         run: sudo rm -rf "${{ github.workspace }}/.local_install" || true && sudo chown -R "$USER:$USER" "${{ github.workspace }}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -50,6 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Build workflow
         uses: ./.github/actions/wait-for-workflow

--- a/.github/workflows/msys2_build.yml
+++ b/.github/workflows/msys2_build.yml
@@ -21,6 +21,11 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.msys2_build == 'true' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -136,6 +136,11 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: 'preparation: Checkout MTL'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download python report artifacts

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -21,6 +21,11 @@ jobs:
     outputs:
       changed: ${{ steps.filter.outputs.linux_tests == 'true' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -33,6 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Build workflow
         uses: ./.github/actions/wait-for-workflow

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,6 +34,11 @@ jobs:
     permissions:
         security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 23 * * *'
         uses: actions/checkout@v4
@@ -73,6 +78,11 @@ jobs:
     permissions:
         security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 23 * * *'
         uses: actions/checkout@v4
@@ -109,6 +119,11 @@ jobs:
     name: table output scan
     runs-on: ubuntu-22.04
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         if: github.event_name == 'schedule' && github.event.schedule == '0 23 * * *'
         uses: actions/checkout@v4

--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -17,6 +17,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout target repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
Several workflow jobs were missing step-security/harden-runner, leaving gaps in egress monitoring. Without egress-policy: audit on every job, compromised dependencies or runner attacks can exfiltrate data undetected.

Add harden-runner (v2.19.0, pinned by SHA) with egress-policy: audit as the first step in every job that was missing it:

- build.yml: wait-for-linter, checksums, build
- trivy.yml: triv-security-tab, triv-security-tab-manager, trivy-stdout
- upstream_sync.yml: sync_latest_from_upstream
- base_build.yml: changes
- docker_build.yml: changes
- gtest-bare-metal.yml: gtest-check-for-changes, build
- msys2_build.yml: changes
- nightly-pytest.yml: aggregate-python-reports
- smoke-tests.yml: smoke-check-for-changes, build