### PR TITLE
Ci: fix path resolution for ci caching

### DIFF
--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -454,6 +454,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		pushd "${root_folder}/tests/tools/gstreamer_tools/" >/dev/null || exit 1
 		meson setup builddir
 		ninja -C builddir/
+
 		# Copy test tool .so files alongside gstreamer plugins
 		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
 			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,6 @@
 name: Linter
 
-on: [push, pull_request]
+on: [pull_request]
 
 permissions:
   contents: read

--- a/script/hash_sources_dpdk.env
+++ b/script/hash_sources_dpdk.env
@@ -1,6 +1,9 @@
 # Paths that affect the DPDK build artifact.
 # One path per line (glob-free). Relative to repository root.
 
+# CICD dependency
+.github/scripts/setup_environment.sh
+
 # sanity check
 script/hash_sources_dpdk.rc
 

--- a/script/hash_sources_ffmpeg.env
+++ b/script/hash_sources_ffmpeg.env
@@ -1,6 +1,9 @@
 # Paths that affect the FFmpeg plugin build artifact.
 # One path per line (glob-free). Relative to repository root.
 
+# CICD dependency
+.github/scripts/setup_environment.sh
+
 # Sanity check
 script/hash_sources_ffmpeg.rc
 

--- a/script/hash_sources_gstreamer.env
+++ b/script/hash_sources_gstreamer.env
@@ -1,6 +1,9 @@
 # Paths that affect the GStreamer plugin build artifact.
 # One path per line (glob-free). Relative to repository root.
 
+# CICD dependency
+.github/scripts/setup_environment.sh
+
 # Sanity check
 script/hash_sources_gstreamer.rc
 

--- a/script/hash_sources_mtl.env
+++ b/script/hash_sources_mtl.env
@@ -1,6 +1,9 @@
 # Paths that affect the MTL (libmtl) build artifact.
 # One path per line (glob-free). Relative to repository root.
 
+# CICD dependency
+.github/scripts/setup_environment.sh
+
 # Sanity check
 script/hash_sources_mtl.rc
 

--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -28,6 +28,7 @@ from mtl_engine.const import (
     FFMPEG_LIB_PATH,
     FFMPEG_PATH,
     FRAMES_CAPTURE,
+    GSTREAMER_LIB_PATH,
     LOG_FOLDER,
     MTL_LIB_PATH,
     PERF_LOG_FOLDER,
@@ -1224,6 +1225,7 @@ def _register_local_libs(hosts, mtl_path):
         os.path.join(mtl_path, MTL_LIB_PATH.removeprefix("./")),
         os.path.join(mtl_path, DPDK_LIB_PATH.removeprefix("./")),
         os.path.join(mtl_path, FFMPEG_LIB_PATH.removeprefix("./")),
+        os.path.join(mtl_path, GSTREAMER_LIB_PATH.removeprefix("./")),
     ]
     conf = "\\n".join(lib_dirs)
     ffmpeg_bin = os.path.join(mtl_path, FFMPEG_PATH.removeprefix("./"))

--- a/tests/validation/mtl_engine/GstreamerApp.py
+++ b/tests/validation/mtl_engine/GstreamerApp.py
@@ -144,6 +144,7 @@ def setup_gstreamer_plugins_paths(build):
         os.environ.get(
             "GST_PLUGIN_PATH", f"{build}/.local_install/gstreamer/gstreamer-1.0"
         ),
+        f"{build}/.local_install/gstreamer",
         f"{build}/ecosystem/gstreamer_plugin/builddir",
         f"{build}/tests/tools/gstreamer_tools/builddir",
     ]

--- a/tests/validation/mtl_engine/const.py
+++ b/tests/validation/mtl_engine/const.py
@@ -15,7 +15,7 @@ MTL_MANAGER_EXE = f"{RXTXAPP_PATH}/MtlManager"
 MTL_LIB_PATH = f"{PREFIX}/mtl/lib/x86_64-linux-gnu"
 DPDK_LIB_PATH = f"{PREFIX}/dpdk/lib/x86_64-linux-gnu"
 FFMPEG_LIB_PATH = f"{PREFIX}/ffmpeg/lib"
-GSTREAMER_LIB_PATH = f"{PREFIX}/gstreamer"
+GSTREAMER_LIB_PATH = f"{PREFIX}/gstreamer/gstreamer-1.0"
 
 
 LD_LIB_PATH_REL = (


### PR DESCRIPTION
This patch includes fixes for the paths resolution of the gstreamer tool plugins (tools used to test gstreamer were not in the path) and the hash sources scripts (which are used to determine if a build artifact needs to be rebuilt) were missing the setup_environment.sh. Also added the gstreamer library path to the conftest.py which is used gstreamer plugins to find the gst_common library.

Remove the unnecessary linter activation trigger.