### PR TITLE
Fix #1506: st40p RX miscomputes ANC payload stride for non-byte-aligned UDW counts

### DIFF
--- a/lib/src/st2110/pipeline/st40_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.c
@@ -275,8 +275,10 @@ static int rx_st40p_rtp_ready(void* priv) {
     meta_entry->udw_offset = frame_info->udw_buffer_fill;
 
     uint32_t total_bits = (3 + udw_words + 1) * 10;
-    /* Match TX padding: floor to bytes then pad to the next 4-byte multiple */
-    uint32_t total_size = total_bits / 8;
+    /* SMPTE ST 2110-40 / RFC 8331 packs the 10-bit fields (DID, SDID, DC,
+     * UDW[], checksum) bit-contiguously. Round the total bit count up to
+     * whole bytes, then 4-byte align per the RFC. */
+    uint32_t total_size = (total_bits + 7) / 8;
     uint32_t total_size_aligned = (total_size + 3) & ~0x3U;
     uint32_t anc_packet_bytes =
         sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size_aligned;

--- a/tests/unit/pipeline/st40p_harness.c
+++ b/tests/unit/pipeline/st40p_harness.c
@@ -228,6 +228,86 @@ static struct rte_mbuf* make_pipeline_mbuf(uint16_t seq, uint32_t ts, int marker
   return m;
 }
 
+static uint32_t ut40p_anc_payload_bytes(uint16_t udw_size) {
+  uint32_t total_bits = (uint32_t)(3 + udw_size + 1) * 10;
+  uint32_t total_size = (total_bits + 7) / 8;
+  total_size = (total_size + 3) & ~0x3U;
+  return sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size;
+}
+
+static struct rte_mbuf* make_multi_anc_mbuf(uint16_t seq, uint32_t ts, int marker,
+                                            uint16_t dpdk_port_id,
+                                            const uint16_t* udw_sizes,
+                                            uint8_t anc_count) {
+  if (!udw_sizes || !anc_count || anc_count > ST40_MAX_META) return NULL;
+
+  size_t payload_len = 0;
+  for (uint8_t anc_idx = 0; anc_idx < anc_count; anc_idx++)
+    payload_len += ut40p_anc_payload_bytes(udw_sizes[anc_idx]);
+
+  size_t rtp_len = sizeof(struct st40_rfc8331_rtp_hdr) + payload_len;
+  size_t total = UT40P_L234_HDR_LEN + rtp_len;
+
+  struct rte_mbuf* m = rte_pktmbuf_alloc(ut_pool());
+  if (!m) return NULL;
+
+  if (rte_pktmbuf_tailroom(m) < total) {
+    rte_pktmbuf_free(m);
+    return NULL;
+  }
+
+  uint8_t* buf = rte_pktmbuf_mtod(m, uint8_t*);
+  memset(buf, 0, total);
+
+  struct st40_rfc8331_rtp_hdr* rtp =
+      (struct st40_rfc8331_rtp_hdr*)(buf + UT40P_L234_HDR_LEN);
+  rtp->base.version = 2;
+  rtp->base.seq_number = htons(seq);
+  rtp->base.tmstamp = htonl(ts);
+  rtp->base.marker = marker ? 1 : 0;
+  rtp->length = htons(payload_len);
+  rtp->first_hdr_chunk.anc_count = anc_count;
+  rtp->first_hdr_chunk.f = 0b00;
+  /* The RTP first_hdr_chunk is host-order on entry to the pipeline: the
+   * session layer byte-swaps it in place before passing the mbuf up. The
+   * per-ANC payload headers below stay in network order; the pipeline
+   * ntohl()'s them itself. */
+
+  uint8_t* payload = (uint8_t*)(rtp + 1);
+  for (uint8_t anc_idx = 0; anc_idx < anc_count; anc_idx++) {
+    uint16_t udw_size = udw_sizes[anc_idx];
+    struct st40_rfc8331_payload_hdr* payload_hdr =
+        (struct st40_rfc8331_payload_hdr*)payload;
+
+    payload_hdr->first_hdr_chunk.c = 0;
+    payload_hdr->first_hdr_chunk.line_number = 10 + anc_idx;
+    payload_hdr->first_hdr_chunk.horizontal_offset = 0;
+    payload_hdr->first_hdr_chunk.s = 0;
+    payload_hdr->first_hdr_chunk.stream_num = 0;
+    payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x45);
+    payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x01);
+    payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
+
+    payload_hdr->swapped_first_hdr_chunk = htonl(payload_hdr->swapped_first_hdr_chunk);
+    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
+
+    uint8_t* udw_dst = (uint8_t*)&payload_hdr->second_hdr_chunk;
+    for (uint16_t udw_idx = 0; udw_idx < udw_size; udw_idx++) {
+      uint8_t v = (uint8_t)(((uint16_t)(anc_idx + 1) * 17 + udw_idx) & 0xff);
+      st40_set_udw(udw_idx + 3, st40_add_parity_bits(v), udw_dst);
+    }
+    uint16_t checksum = st40_calc_checksum(3 + udw_size, udw_dst);
+    st40_set_udw(udw_size + 3, checksum, udw_dst);
+
+    payload += ut40p_anc_payload_bytes(udw_size);
+  }
+
+  m->data_len = total;
+  m->pkt_len = total;
+  m->port = dpdk_port_id;
+  return m;
+}
+
 /* ── enqueue functions ────────────────────────────────────────────────── */
 
 int ut40p_enqueue_pkt(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
@@ -255,6 +335,22 @@ void ut40p_enqueue_burst(ut40p_ctx* ctx, uint16_t seq_start, int count, uint32_t
     int marker = last_marker && (i == count - 1);
     ut40p_enqueue_pkt(ctx, seq_start + i, ts, marker, port);
   }
+}
+
+int ut40p_enqueue_multi_anc_pkt(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                                enum mtl_session_port port, const uint16_t* udw_sizes,
+                                uint8_t anc_count) {
+  (void)ctx;
+  uint16_t dpdk_port_id = (port == MTL_SESSION_PORT_R) ? 1 : 0;
+  struct rte_mbuf* m =
+      make_multi_anc_mbuf(seq, ts, marker, dpdk_port_id, udw_sizes, anc_count);
+  if (!m) return -1;
+
+  if (rte_ring_sp_enqueue(g_mock_ring, m) != 0) {
+    rte_pktmbuf_free(m);
+    return -1;
+  }
+  return 0;
 }
 
 /* ── process functions ────────────────────────────────────────────────── */

--- a/tests/unit/pipeline/st40p_harness.h
+++ b/tests/unit/pipeline/st40p_harness.h
@@ -43,6 +43,11 @@ int ut40p_enqueue_pkt_port_id(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int mar
 void ut40p_enqueue_burst(ut40p_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
                          int last_marker, enum mtl_session_port port);
 
+/** Enqueue one RTP packet carrying multiple RFC 8331 ANC data packets. */
+int ut40p_enqueue_multi_anc_pkt(ut40p_ctx* ctx, uint16_t seq, uint32_t ts, int marker,
+                                enum mtl_session_port port, const uint16_t* udw_sizes,
+                                uint8_t anc_count);
+
 /** Call rx_st40p_rtp_ready() once — processes one mbuf from the ring. */
 int ut40p_process(ut40p_ctx* ctx);
 

--- a/tests/unit/pipeline/st40p_test.cpp
+++ b/tests/unit/pipeline/st40p_test.cpp
@@ -8,9 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include "mtl_api.h"
 #include "pipeline/st40p_harness.h"
-
-/* ── fixture ───────────────────────────────────────────────────────── */
 
 class St40PipelineRxTest : public ::testing::Test {
  protected:
@@ -35,6 +34,13 @@ class St40PipelineRxTest : public ::testing::Test {
   void enqueue_burst(uint16_t seq_start, int count, uint32_t ts, bool last_marker,
                      enum mtl_session_port port) {
     ut40p_enqueue_burst(ctx_, seq_start, count, ts, last_marker ? 1 : 0, port);
+  }
+
+  int enqueue_multi_anc(uint16_t seq, uint32_t ts, bool marker,
+                        enum mtl_session_port port, const uint16_t* udw_sizes,
+                        uint8_t anc_count) {
+    return ut40p_enqueue_multi_anc_pkt(ctx_, seq, ts, marker ? 1 : 0, port, udw_sizes,
+                                       anc_count);
   }
 
   int process() {
@@ -81,6 +87,66 @@ TEST_F(St40PipelineRxTest, SingleFrameCompletion) {
   EXPECT_TRUE(frame->rtp_marker);
   EXPECT_EQ(frame->status, ST_FRAME_STATUS_COMPLETE);
   put_frame(frame);
+}
+
+/* Multiple ANC data packets carried in a single RTP packet (non-split mode).
+ * Validates that the receiver correctly walks the variable-length per-ANC
+ * payload stride when the 10-bit UDW packing of one or more blocks is not
+ * byte-aligned, and recovers the original metadata and user data words for
+ * every ANC packet in the frame.
+ *
+ * Two size patterns are exercised because a wrong stride manifests
+ * differently depending on what the misread bytes decode to:
+ *   {8, 6, 4} — the misread data_count lands on zero padding, so the
+ *               receiver silently produces an empty meta entry. Caught
+ *               here by the per-byte UDW equality check.
+ *   {6, 6, 6} — the misread data_count decodes to a large value that
+ *               overflows the remaining payload room, surfacing as the
+ *               "ANC packet bytes exceed payload" path and a meta_num
+ *               short of anc_count. */
+TEST_F(St40PipelineRxTest, MultiAncInSingleRtpPacket) {
+  const uint16_t patterns[][3] = {{8, 6, 4}, {6, 6, 6}};
+  const uint8_t anc_count = 3;
+  uint32_t ts = 1000;
+
+  for (const auto& udw_sizes : patterns) {
+    ASSERT_EQ(enqueue_multi_anc(0, ts, true, MTL_SESSION_PORT_P, udw_sizes, anc_count),
+              0);
+    process_all();
+
+    auto* frame = get_frame();
+    ASSERT_NE(frame, nullptr);
+    EXPECT_EQ(frame->rtp_timestamp, ts);
+    EXPECT_EQ(frame->pkts_total, 1u);
+    EXPECT_TRUE(frame->rtp_marker);
+    EXPECT_EQ(frame->status, ST_FRAME_STATUS_COMPLETE);
+    ASSERT_EQ(frame->meta_num, anc_count);
+
+    uint16_t expected_offset = 0;
+    for (uint8_t anc_idx = 0; anc_idx < anc_count; anc_idx++) {
+      const auto& meta = frame->meta[anc_idx];
+      EXPECT_EQ(meta.c, 0u);
+      EXPECT_EQ(meta.line_number, 10u + anc_idx);
+      EXPECT_EQ(meta.hori_offset, 0u);
+      EXPECT_EQ(meta.s, 0u);
+      EXPECT_EQ(meta.stream_num, 0u);
+      EXPECT_EQ(meta.did, 0x45u);
+      EXPECT_EQ(meta.sdid, 0x01u);
+      EXPECT_EQ(meta.udw_size, udw_sizes[anc_idx]);
+      EXPECT_EQ(meta.udw_offset, expected_offset);
+
+      for (uint16_t udw_idx = 0; udw_idx < udw_sizes[anc_idx]; udw_idx++) {
+        uint8_t expected = static_cast<uint8_t>(((anc_idx + 1) * 17 + udw_idx) & 0xff);
+        EXPECT_EQ(frame->udw_buff_addr[expected_offset + udw_idx], expected);
+      }
+
+      expected_offset += udw_sizes[anc_idx];
+    }
+    EXPECT_EQ(frame->udw_buffer_fill, expected_offset);
+    put_frame(frame);
+
+    ts += 1000;
+  }
 }
 
 /* Timestamp change completes the previous frame without marker. */


### PR DESCRIPTION
Fixes #1506.

### Root cause

`rx_st40p_rtp_ready()` walked the per-ANC payload stride with `total_bits / 8` (floor), while the TX side uses `(total_bits + 7) / 8` (ceil) as required by SMPTE ST 2110-40 / RFC 8331. Whenever `(4 + udw_count) * 10` is not a multiple of 8, the receiver advances 4 bytes short and misreads the next ANC block's header in a multi-ANC RTP frame.

### Symptom

Spurious `"ANC packet bytes exceed payload"`, `"UDW parity failure"`, or `"checksum mismatch"` warnings; truncated/dropped subsequent ANC blocks; `meta_num` lower than the transmitted ANC count.

### Changes

- `lib/src/st2110/pipeline/st40_pipeline_rx.c` — round total bit count up to whole bytes before the 4-byte alignment.
- `tests/unit/pipeline/st40p_harness.{c,h}` — new `make_multi_anc_mbuf` / `ut40p_enqueue_multi_anc_pkt` builders.
- `tests/unit/pipeline/st40p_test.cpp` — new gtest `St40PipelineRxTest.MultiAncInSingleRtpPacket` exercising two UDW-size patterns: `{8, 6, 4}` (silent-corruption path) and `{6, 6, 6}` (the warning path from the issue). Both fail pre-fix, pass post-fix.