### PR TITLE
Refactor: Consolidate RFC 8331 ANC encode/decode helpers

### DIFF
--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -447,8 +447,7 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
 
   payload_hdr = (struct st40_rfc8331_payload_hdr*)(&hdr[1]);
   for (int i = 0; i < anc_count; i++) {
-    payload_hdr->swapped_first_hdr_chunk = ntohl(payload_hdr->swapped_first_hdr_chunk);
-    payload_hdr->swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
+    st40_rfc8331_payload_hdr_bswap(payload_hdr);
     if (gst_mtl_st40_rx_check_parity(payload_hdr) != GST_FLOW_OK) {
       for (int j = 0; j < i; j++) free(anc_data[j]);
       return GST_FLOW_ERROR;
@@ -483,6 +482,8 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
       anc_data[i][meta_offset++] = payload_hdr->second_hdr_chunk.data_count & 0xff;
     }
 
+    /* Re-swap second chunk to wire order; the 10-bit UDW/checksum reads below assume
+     * network byte layout. */
     payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
 
     for (int d = 0; d < udw_size; d++) {

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40_rx.c
@@ -130,8 +130,6 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
                                                  void* usrptr);
 static guint gst_mtl_st40_rx_parse_port_arguments(struct st40_rx_ops* ops_rx,
                                                   SessionPortArgs* portArgs);
-static struct st40_rfc8331_payload_hdr* gst_mtl_st40_rx_shift_payload_hdr(
-    struct st40_rfc8331_payload_hdr* payload_hdr, int udw_size);
 
 static gint gst_mtl_st40_rx_mbuff_available(void* priv) {
   Gst_Mtl_St40_Rx* src = (Gst_Mtl_St40_Rx*)priv;
@@ -385,42 +383,10 @@ static void* gst_mtl_st40_rx_get_mbuf_with_timeout(Gst_Mtl_St40_Rx* src,
   return mbuf;
 }
 
-static struct st40_rfc8331_payload_hdr* gst_mtl_st40_rx_shift_payload_hdr(
-    struct st40_rfc8331_payload_hdr* payload_hdr, int udw_size) {
-  gint package_size;
-  gint payload_len;
-
-  package_size = ((WORD_10_BIT_ALIGN + udw_size) * USER_DATA_WORD_BIT_SIZE) / BYTE_SIZE;
-  payload_len = sizeof(struct st40_rfc8331_payload_hdr) -
-                (package_size % WORD_10_BIT_ALIGN) + package_size;
-
-  return (struct st40_rfc8331_payload_hdr*)((uint8_t*)payload_hdr + payload_len);
-}
-
-static GstFlowReturn gst_mtl_st40_rx_check_parity(
-    const struct st40_rfc8331_payload_hdr* payload_hdr) {
-  if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.did)) {
-    GST_ERROR("Parity check failed for DID");
-    return GST_FLOW_ERROR;
-  }
-  if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.sdid)) {
-    GST_ERROR("Parity check failed for SDID");
-    return GST_FLOW_ERROR;
-  }
-  if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.data_count)) {
-    GST_ERROR("Parity check failed for Data Count");
-    return GST_FLOW_ERROR;
-  }
-  return GST_FLOW_OK;
-}
-
 static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer** buffer,
                                                  void* usrptr) {
   struct st40_rfc8331_rtp_hdr* hdr;
-  struct st40_rfc8331_payload_hdr* payload_hdr;
   GstMapInfo dest_info;
-  guint16 data;
-  gint udw_size;
   guint buffer_size = 0, meta_offset, anc_count;
 
   hdr = (struct st40_rfc8331_rtp_hdr*)usrptr;
@@ -445,15 +411,24 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
   guint8* anc_data[anc_count];
   guint8 anc_data_count[anc_count];
 
-  payload_hdr = (struct st40_rfc8331_payload_hdr*)(&hdr[1]);
+  uint8_t* payload = (uint8_t*)&hdr[1];
+  uint32_t payload_offset = 0;
+  uint32_t payload_room = ST40_MAX_META * st40_rfc8331_payload_bytes(255);
+
   for (int i = 0; i < anc_count; i++) {
-    st40_rfc8331_payload_hdr_bswap(payload_hdr);
-    if (gst_mtl_st40_rx_check_parity(payload_hdr) != GST_FLOW_OK) {
+    struct st40_meta meta;
+    uint8_t udw_buf[256];
+    uint32_t consumed = 0;
+    enum st40_rfc8331_decode_result rc = st40_rfc8331_decode_packet(
+        payload + payload_offset, payload_room - payload_offset, &meta, udw_buf,
+        sizeof(udw_buf), &consumed);
+    if (rc != ST40_RFC8331_DECODE_OK) {
+      GST_ERROR("Ancillary decode failed for packet %d, result=%d", i, rc);
       for (int j = 0; j < i; j++) free(anc_data[j]);
       return GST_FLOW_ERROR;
     }
 
-    udw_size = payload_hdr->second_hdr_chunk.data_count & 0xff;
+    int udw_size = meta.udw_size;
     anc_data_count[i] = udw_size;
     meta_offset = 0;
     buffer_size += udw_size;
@@ -472,31 +447,19 @@ static GstFlowReturn gst_mtl_st40_rx_fill_buffer(Gst_Mtl_St40_Rx* src, GstBuffer
     }
 
     if (src->include_metadata_in_buffer) {
-      anc_data[i][meta_offset++] = payload_hdr->first_hdr_chunk.c;
-      anc_data[i][meta_offset++] = payload_hdr->first_hdr_chunk.line_number;
-      anc_data[i][meta_offset++] = payload_hdr->first_hdr_chunk.horizontal_offset;
-      anc_data[i][meta_offset++] = payload_hdr->first_hdr_chunk.s;
-      anc_data[i][meta_offset++] = payload_hdr->first_hdr_chunk.stream_num;
-      anc_data[i][meta_offset++] = payload_hdr->second_hdr_chunk.did & 0xff;
-      anc_data[i][meta_offset++] = payload_hdr->second_hdr_chunk.sdid & 0xff;
-      anc_data[i][meta_offset++] = payload_hdr->second_hdr_chunk.data_count & 0xff;
+      anc_data[i][meta_offset++] = meta.c;
+      anc_data[i][meta_offset++] = meta.line_number;
+      anc_data[i][meta_offset++] = meta.hori_offset;
+      anc_data[i][meta_offset++] = meta.s;
+      anc_data[i][meta_offset++] = meta.stream_num;
+      anc_data[i][meta_offset++] = meta.did;
+      anc_data[i][meta_offset++] = meta.sdid;
+      anc_data[i][meta_offset++] = meta.udw_size;
     }
 
-    /* Re-swap second chunk to wire order; the 10-bit UDW/checksum reads below assume
-     * network byte layout. */
-    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
+    memcpy(anc_data[i] + meta_offset, udw_buf, udw_size);
 
-    for (int d = 0; d < udw_size; d++) {
-      data = st40_get_udw(d + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
-      if (!st40_check_parity_bits(data)) {
-        GST_ERROR("Ancillary data parity bits check failed, data=0x%03x", data & 0x3FF);
-        for (int j = 0; j <= i; j++) free(anc_data[j]);
-        return GST_FLOW_ERROR;
-      }
-      anc_data[i][d + meta_offset] = data & 0xff;
-    }
-
-    payload_hdr = gst_mtl_st40_rx_shift_payload_hdr(payload_hdr, udw_size);
+    payload_offset += consumed;
   }
 
   *buffer = gst_buffer_new_allocate(NULL, buffer_size, NULL);

--- a/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
+++ b/ecosystem/gstreamer_plugin/gst_mtl_st40p_tx.c
@@ -652,10 +652,8 @@ static GstFlowReturn gst_mtl_st40p_tx_parse_8331_anc_words(
     payload_cursor = (uint8_t*)map_info.data + (buffer_size - bytes_left_to_process);
 
     rfc8331_meta.headers[i] = (struct st40_rfc8331_payload_hdr*)payload_cursor;
-    payload_header.swapped_first_hdr_chunk =
-        ntohl(rfc8331_meta.headers[i]->swapped_first_hdr_chunk);
-    payload_header.swapped_second_hdr_chunk =
-        ntohl(rfc8331_meta.headers[i]->swapped_second_hdr_chunk);
+    payload_header = *rfc8331_meta.headers[i];
+    st40_rfc8331_payload_hdr_bswap(&payload_header);
 
     payload_cursor = (uint8_t*)&rfc8331_meta.headers[i]->swapped_second_hdr_chunk;
     /*

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -760,6 +760,43 @@ void st40_rfc8331_rtp_hdr_bswap(struct st40_rfc8331_rtp_hdr* hdr);
 void st40_rfc8331_payload_hdr_bswap(struct st40_rfc8331_payload_hdr* hdr);
 
 /**
+ * Result of st40_rfc8331_decode_packet().
+ */
+enum st40_rfc8331_decode_result {
+  ST40_RFC8331_DECODE_OK = 0,
+  ST40_RFC8331_DECODE_SHORT_BUFFER,
+  ST40_RFC8331_DECODE_PARITY_FAIL,
+  ST40_RFC8331_DECODE_CHECKSUM_FAIL,
+};
+
+/**
+ * Decode one wire-order RFC 8331 ANC sub-packet from @p buf (capacity
+ * @p room), write parsed meta to @p meta and up to @p udw_cap stripped
+ * UDW bytes (low 8 bits per word) to @p udw_out.
+ *
+ * On success @p *consumed is set to the number of bytes occupied on the
+ * wire (post 4-byte alignment) so the caller can advance to the next
+ * sub-packet. @p udw_out may be NULL with @p udw_cap == 0 when the
+ * caller only needs meta and size.
+ */
+enum st40_rfc8331_decode_result st40_rfc8331_decode_packet(
+    const uint8_t* buf, uint32_t room, struct st40_meta* meta, uint8_t* udw_out,
+    uint32_t udw_cap, uint32_t* consumed);
+
+/**
+ * Encode one ANC sub-packet at @p buf (capacity @p room) from @p meta and
+ * @p udw_in (meta->udw_size bytes; may be NULL when meta->udw_size == 0).
+ * On success writes wire-order bytes and sets @p *written to the bytes
+ * occupied on the wire.
+ *
+ * @return
+ *   - 0 on success
+ *   - -ENOSPC if @p room is too small for the packet
+ */
+int st40_rfc8331_encode_packet(uint8_t* buf, uint32_t room, const struct st40_meta* meta,
+                               const uint8_t* udw_in, uint32_t* written);
+
+/**
  * Add parity from st2110-40(ancillary) payload.
  *
  * @param val

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -710,7 +710,7 @@ int st40_rx_get_queue_meta(st40_rx_handle handle, struct st_queue_meta* meta);
  * @return
  *   - udw
  */
-uint16_t st40_get_udw(uint32_t idx, uint8_t* data);
+uint16_t st40_get_udw(uint32_t idx, const uint8_t* data);
 
 /**
  * Set udw from for st2110-40(ancillary) payload.
@@ -734,7 +734,7 @@ void st40_set_udw(uint32_t idx, uint16_t udw, uint8_t* data);
  * @return
  *   - checksum
  */
-uint16_t st40_calc_checksum(uint32_t data_num, uint8_t* data);
+uint16_t st40_calc_checksum(uint32_t data_num, const uint8_t* data);
 
 /**
  * Wire-aligned byte size of one RFC 8331 ANC data packet inside an RTP

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -737,6 +737,17 @@ void st40_set_udw(uint32_t idx, uint16_t udw, uint8_t* data);
 uint16_t st40_calc_checksum(uint32_t data_num, uint8_t* data);
 
 /**
+ * Wire-aligned byte size of one RFC 8331 ANC data packet inside an RTP
+ * payload (4-byte payload header + 10-bit-packed DID/SDID/DC/UDW[]/checksum,
+ * ceil to whole bytes, then rounded up to a 4-byte boundary).
+ *
+ * @param udw_size
+ *   User Data Word count (0..255, the 8-bit DataCount field).
+ * @return byte count to advance per ANC packet on the wire.
+ */
+uint32_t st40_rfc8331_payload_bytes(uint16_t udw_size);
+
+/**
  * Add parity from st2110-40(ancillary) payload.
  *
  * @param val

--- a/include/st40_api.h
+++ b/include/st40_api.h
@@ -748,6 +748,18 @@ uint16_t st40_calc_checksum(uint32_t data_num, uint8_t* data);
 uint32_t st40_rfc8331_payload_bytes(uint16_t udw_size);
 
 /**
+ * Byte-swap the first header chunk of an RFC 8331 RTP header in place
+ * between host and network order.
+ */
+void st40_rfc8331_rtp_hdr_bswap(struct st40_rfc8331_rtp_hdr* hdr);
+
+/**
+ * Byte-swap both header chunks of an RFC 8331 payload header in place
+ * between host and network order.
+ */
+void st40_rfc8331_payload_hdr_bswap(struct st40_rfc8331_payload_hdr* hdr);
+
+/**
  * Add parity from st2110-40(ancillary) payload.
  *
  * @param val

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.c
@@ -258,9 +258,8 @@ static int rx_st40p_rtp_ready(void* priv) {
 
     payload_hdr = (struct st40_rfc8331_payload_hdr*)(payload + payload_offset);
 
-    struct st40_rfc8331_payload_hdr hdr_local = {0};
-    hdr_local.swapped_first_hdr_chunk = ntohl(payload_hdr->swapped_first_hdr_chunk);
-    hdr_local.swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
+    struct st40_rfc8331_payload_hdr hdr_local = *payload_hdr;
+    st40_rfc8331_payload_hdr_bswap(&hdr_local);
 
     uint16_t udw_words = hdr_local.second_hdr_chunk.data_count & 0xFF;
     struct st40_meta* meta_entry = &frame_info->meta[frame_info->meta_num];

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.c
@@ -274,14 +274,7 @@ static int rx_st40p_rtp_ready(void* priv) {
     meta_entry->udw_size = udw_words;
     meta_entry->udw_offset = frame_info->udw_buffer_fill;
 
-    uint32_t total_bits = (3 + udw_words + 1) * 10;
-    /* SMPTE ST 2110-40 / RFC 8331 packs the 10-bit fields (DID, SDID, DC,
-     * UDW[], checksum) bit-contiguously. Round the total bit count up to
-     * whole bytes, then 4-byte align per the RFC. */
-    uint32_t total_size = (total_bits + 7) / 8;
-    uint32_t total_size_aligned = (total_size + 3) & ~0x3U;
-    uint32_t anc_packet_bytes =
-        sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size_aligned;
+    uint32_t anc_packet_bytes = st40_rfc8331_payload_bytes(udw_words);
     if (payload_offset + anc_packet_bytes > payload_room) {
       warn("%s(%d), ANC packet bytes exceed payload (offset=%u, size=%u, room=%u)\n",
            __func__, ctx->idx, payload_offset, anc_packet_bytes, payload_room);

--- a/lib/src/st2110/pipeline/st40_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st40_pipeline_rx.c
@@ -76,7 +76,6 @@ static int rx_st40p_rtp_ready(void* priv) {
   struct st40_frame_info* frame_info = NULL;
   uint32_t anc_count;
   uint8_t* payload;
-  struct st40_rfc8331_payload_hdr* payload_hdr;
   uint32_t payload_offset = 0;
   bool notify_frame = false;
   struct st40p_rx_frame* done_frames[2] = {0};
@@ -256,70 +255,42 @@ static int rx_st40p_rtp_ready(void* priv) {
       break;
     }
 
-    payload_hdr = (struct st40_rfc8331_payload_hdr*)(payload + payload_offset);
+    struct st40_meta parsed = {0};
+    uint32_t udw_room = (frame_info->udw_buffer_fill < frame_info->udw_buffer_size)
+                            ? (frame_info->udw_buffer_size - frame_info->udw_buffer_fill)
+                            : 0;
+    uint32_t anc_packet_bytes = 0;
+    enum st40_rfc8331_decode_result rc = st40_rfc8331_decode_packet(
+        payload + payload_offset, payload_room - payload_offset, &parsed,
+        frame_info->udw_buff_addr + frame_info->udw_buffer_fill, udw_room,
+        &anc_packet_bytes);
 
-    struct st40_rfc8331_payload_hdr hdr_local = *payload_hdr;
-    st40_rfc8331_payload_hdr_bswap(&hdr_local);
-
-    uint16_t udw_words = hdr_local.second_hdr_chunk.data_count & 0xFF;
-    struct st40_meta* meta_entry = &frame_info->meta[frame_info->meta_num];
-    meta_entry->c = hdr_local.first_hdr_chunk.c;
-    meta_entry->line_number = hdr_local.first_hdr_chunk.line_number;
-    meta_entry->hori_offset = hdr_local.first_hdr_chunk.horizontal_offset;
-    meta_entry->s = hdr_local.first_hdr_chunk.s;
-    meta_entry->stream_num = hdr_local.first_hdr_chunk.stream_num;
-    meta_entry->did = hdr_local.second_hdr_chunk.did & 0xFF;
-    meta_entry->sdid = hdr_local.second_hdr_chunk.sdid & 0xFF;
-    meta_entry->udw_size = udw_words;
-    meta_entry->udw_offset = frame_info->udw_buffer_fill;
-
-    uint32_t anc_packet_bytes = st40_rfc8331_payload_bytes(udw_words);
-    if (payload_offset + anc_packet_bytes > payload_room) {
-      warn("%s(%d), ANC packet bytes exceed payload (offset=%u, size=%u, room=%u)\n",
-           __func__, ctx->idx, payload_offset, anc_packet_bytes, payload_room);
+    if (rc == ST40_RFC8331_DECODE_SHORT_BUFFER) {
+      warn("%s(%d), ANC packet does not fit (offset=%u, room=%u)\n", __func__, ctx->idx,
+           payload_offset, payload_room);
+      break;
+    }
+    if (rc == ST40_RFC8331_DECODE_PARITY_FAIL) {
+      warn("%s(%d), parity failure on packet %u\n", __func__, ctx->idx, anc_idx);
+      break;
+    }
+    if (rc == ST40_RFC8331_DECODE_CHECKSUM_FAIL) {
+      warn("%s(%d), checksum mismatch packet %u\n", __func__, ctx->idx, anc_idx);
       break;
     }
 
-    /* If this is an empty ANC frame (udw_words == 0), still preserve and count it */
-    bool meta_valid = true;
-    if (udw_words == 0) {
-      /* Accept and preserve empty ANC frame as valid */
-      meta_valid = true;
-    } else {
-      /* Parse and validate UDW as before */
-      uint8_t* udw_src = (uint8_t*)&payload_hdr->second_hdr_chunk;
-      uint32_t original_fill = frame_info->udw_buffer_fill;
-      for (uint16_t udw_idx = 0; udw_idx < udw_words; udw_idx++) {
-        uint16_t udw = st40_get_udw(udw_idx + 3, udw_src);
-        if (!st40_check_parity_bits(udw)) {
-          warn("%s(%d), UDW parity failure packet %u word %u\n", __func__, ctx->idx,
-               anc_idx, udw_idx);
-          meta_valid = false;
-          break;
-        }
-        if (frame_info->udw_buffer_fill >= frame_info->udw_buffer_size) {
-          warn("%s(%d), UDW buffer overflow for packet %u\n", __func__, ctx->idx,
-               anc_idx);
-          meta_valid = false;
-          break;
-        }
-        frame_info->udw_buff_addr[frame_info->udw_buffer_fill++] = (uint8_t)(udw & 0xFF);
-      }
-      if (meta_valid) {
-        uint16_t checksum_udw = st40_get_udw(udw_words + 3, udw_src);
-        uint16_t checksum_calc = st40_calc_checksum(3 + udw_words, udw_src);
-        if (checksum_udw != checksum_calc) {
-          warn("%s(%d), checksum mismatch packet %u (0x%03x != 0x%03x)\n", __func__,
-               ctx->idx, anc_idx, checksum_udw, checksum_calc);
-          meta_valid = false;
-        }
-      }
-      if (!meta_valid) {
-        frame_info->udw_buffer_fill = original_fill;
-        break;
-      }
-    }
+    struct st40_meta* meta_entry = &frame_info->meta[frame_info->meta_num];
+    meta_entry->c = parsed.c;
+    meta_entry->line_number = parsed.line_number;
+    meta_entry->hori_offset = parsed.hori_offset;
+    meta_entry->s = parsed.s;
+    meta_entry->stream_num = parsed.stream_num;
+    meta_entry->did = parsed.did;
+    meta_entry->sdid = parsed.sdid;
+    meta_entry->udw_size = parsed.udw_size;
+    meta_entry->udw_offset = frame_info->udw_buffer_fill;
 
+    frame_info->udw_buffer_fill += parsed.udw_size;
     frame_info->meta_num++;
     payload_offset += anc_packet_bytes;
   }

--- a/lib/src/st2110/st_ancillary.c
+++ b/lib/src/st2110/st_ancillary.c
@@ -3,6 +3,7 @@
  */
 
 #include "../mt_log.h"
+#include "../mt_platform.h"
 #include "st40_api.h"
 
 typedef union anc_udw_10_6e {
@@ -192,6 +193,15 @@ uint32_t st40_rfc8331_payload_bytes(uint16_t udw_size) {
   uint32_t total_size = (total_bits + 7) / 8;
   total_size = (total_size + 3) & ~0x3U;
   return (uint32_t)(sizeof(struct st40_rfc8331_payload_hdr) - 4) + total_size;
+}
+
+void st40_rfc8331_rtp_hdr_bswap(struct st40_rfc8331_rtp_hdr* hdr) {
+  hdr->swapped_first_hdr_chunk = htonl(hdr->swapped_first_hdr_chunk);
+}
+
+void st40_rfc8331_payload_hdr_bswap(struct st40_rfc8331_payload_hdr* hdr) {
+  hdr->swapped_first_hdr_chunk = htonl(hdr->swapped_first_hdr_chunk);
+  hdr->swapped_second_hdr_chunk = htonl(hdr->swapped_second_hdr_chunk);
 }
 
 uint16_t st40_add_parity_bits(uint16_t val) {

--- a/lib/src/st2110/st_ancillary.c
+++ b/lib/src/st2110/st_ancillary.c
@@ -2,6 +2,9 @@
  * Copyright(c) 2022 Intel Corporation
  */
 
+#include <errno.h>
+#include <string.h>
+
 #include "../mt_log.h"
 #include "../mt_platform.h"
 #include "st40_api.h"
@@ -210,4 +213,89 @@ uint16_t st40_add_parity_bits(uint16_t val) {
 
 int st40_check_parity_bits(uint16_t val) {
   return val == st40_add_parity_bits(val & 0xFF);
+}
+
+int st40_rfc8331_encode_packet(uint8_t* buf, uint32_t room, const struct st40_meta* meta,
+                               const uint8_t* udw_in, uint32_t* written) {
+  /* Note: st_tx_ancillary_session.c intentionally does NOT use this helper;
+   * its per-value TX_ANC_TEST_APPLY_PARITY hook requires direct primitive
+   * access. See st_tx_ancillary_test.h. */
+  uint16_t udw_size = meta->udw_size;
+  uint32_t need = st40_rfc8331_payload_bytes(udw_size);
+  if (room < need) return -ENOSPC;
+
+  /* Zero the body so checksum padding bits are deterministic. */
+  memset(buf, 0, need);
+
+  struct st40_rfc8331_payload_hdr* ph = (struct st40_rfc8331_payload_hdr*)buf;
+  ph->first_hdr_chunk.c = meta->c;
+  ph->first_hdr_chunk.line_number = meta->line_number;
+  ph->first_hdr_chunk.horizontal_offset = meta->hori_offset;
+  ph->first_hdr_chunk.s = meta->s;
+  ph->first_hdr_chunk.stream_num = meta->stream_num;
+  ph->second_hdr_chunk.did = st40_add_parity_bits(meta->did);
+  ph->second_hdr_chunk.sdid = st40_add_parity_bits(meta->sdid);
+  ph->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
+
+  st40_rfc8331_payload_hdr_bswap(ph);
+
+  uint8_t* udw_dst = (uint8_t*)&ph->second_hdr_chunk;
+  for (uint16_t i = 0; i < udw_size; i++) {
+    st40_set_udw(i + 3, st40_add_parity_bits(udw_in[i]), udw_dst);
+  }
+  uint16_t checksum = st40_calc_checksum(3 + udw_size, udw_dst);
+  st40_set_udw(udw_size + 3, checksum, udw_dst);
+
+  *written = need;
+  return 0;
+}
+
+enum st40_rfc8331_decode_result st40_rfc8331_decode_packet(
+    const uint8_t* buf, uint32_t room, struct st40_meta* meta, uint8_t* udw_out,
+    uint32_t udw_cap, uint32_t* consumed) {
+  if (room < sizeof(struct st40_rfc8331_payload_hdr))
+    return ST40_RFC8331_DECODE_SHORT_BUFFER;
+
+  /* Read header without mutating caller memory: copy + bswap a local. */
+  struct st40_rfc8331_payload_hdr hdr_local =
+      *(const struct st40_rfc8331_payload_hdr*)buf;
+  st40_rfc8331_payload_hdr_bswap(&hdr_local);
+
+  if (!st40_check_parity_bits(hdr_local.second_hdr_chunk.did) ||
+      !st40_check_parity_bits(hdr_local.second_hdr_chunk.sdid) ||
+      !st40_check_parity_bits(hdr_local.second_hdr_chunk.data_count))
+    return ST40_RFC8331_DECODE_PARITY_FAIL;
+
+  uint16_t udw_size = hdr_local.second_hdr_chunk.data_count & 0xFF;
+  uint32_t need = st40_rfc8331_payload_bytes(udw_size);
+  if (room < need) return ST40_RFC8331_DECODE_SHORT_BUFFER;
+  if (udw_out && udw_size > udw_cap) return ST40_RFC8331_DECODE_SHORT_BUFFER;
+
+  /* UDW/checksum reads need the second chunk in wire layout; the source
+   * buffer already is, so read directly from it. */
+  const uint8_t* udw_src =
+      (const uint8_t*)&((const struct st40_rfc8331_payload_hdr*)buf)->second_hdr_chunk;
+
+  for (uint16_t i = 0; i < udw_size; i++) {
+    uint16_t udw = st40_get_udw(i + 3, udw_src);
+    if (!st40_check_parity_bits(udw)) return ST40_RFC8331_DECODE_PARITY_FAIL;
+    if (udw_out) udw_out[i] = (uint8_t)(udw & 0xFF);
+  }
+
+  uint16_t checksum_wire = st40_get_udw(udw_size + 3, udw_src);
+  uint16_t checksum_calc = st40_calc_checksum(3 + udw_size, udw_src);
+  if (checksum_wire != checksum_calc) return ST40_RFC8331_DECODE_CHECKSUM_FAIL;
+
+  meta->c = hdr_local.first_hdr_chunk.c;
+  meta->line_number = hdr_local.first_hdr_chunk.line_number;
+  meta->hori_offset = hdr_local.first_hdr_chunk.horizontal_offset;
+  meta->s = hdr_local.first_hdr_chunk.s;
+  meta->stream_num = hdr_local.first_hdr_chunk.stream_num;
+  meta->did = hdr_local.second_hdr_chunk.did & 0xFF;
+  meta->sdid = hdr_local.second_hdr_chunk.sdid & 0xFF;
+  meta->udw_size = udw_size;
+  meta->udw_offset = 0;
+
+  *consumed = need;
+  return ST40_RFC8331_DECODE_OK;
 }

--- a/lib/src/st2110/st_ancillary.c
+++ b/lib/src/st2110/st_ancillary.c
@@ -3,6 +3,7 @@
  */
 
 #include "../mt_log.h"
+#include "st40_api.h"
 
 typedef union anc_udw_10_6e {
   struct {
@@ -183,6 +184,14 @@ uint16_t st40_calc_checksum(uint32_t data_num, uint8_t* data) {
   chks = (~((chks << 1)) & 0x200) | chks;
 
   return chks;
+}
+
+uint32_t st40_rfc8331_payload_bytes(uint16_t udw_size) {
+  /* 10-bit words: DID, SDID, DC, UDW[udw_size], checksum. */
+  uint32_t total_bits = (uint32_t)(3 + udw_size + 1) * 10;
+  uint32_t total_size = (total_bits + 7) / 8;
+  total_size = (total_size + 3) & ~0x3U;
+  return (uint32_t)(sizeof(struct st40_rfc8331_payload_hdr) - 4) + total_size;
 }
 
 uint16_t st40_add_parity_bits(uint16_t val) {

--- a/lib/src/st2110/st_ancillary.c
+++ b/lib/src/st2110/st_ancillary.c
@@ -81,11 +81,11 @@ static inline uint16_t get_parity_bits(uint16_t val) {
   return parity_tab[val & 0xFF];
 }
 
-static uint16_t st_ntohs(uint8_t* data) {
+static uint16_t st_ntohs(const uint8_t* data) {
   return ((data[0] << 8) | (data[1]));
 }
 
-static uint16_t get_10bit_udw(int idx, uint8_t* data) {
+static uint16_t get_10bit_udw(int idx, const uint8_t* data) {
   int byte_offset, bit_offset;
   int total_bits_offset = idx * 10; /*10 bit per field */
   byte_offset = total_bits_offset / 8;
@@ -167,7 +167,7 @@ static void set_10bit_udw(int idx, uint16_t udw, uint8_t* data) {
   data[1] = (uint8_t)(val & 0xFF);
 }
 
-uint16_t st40_get_udw(uint32_t idx, uint8_t* data) {
+uint16_t st40_get_udw(uint32_t idx, const uint8_t* data) {
   return get_10bit_udw(idx, data);
 }
 
@@ -175,7 +175,7 @@ void st40_set_udw(uint32_t idx, uint16_t udw, uint8_t* data) {
   set_10bit_udw(idx, udw, data);
 }
 
-uint16_t st40_calc_checksum(uint32_t data_num, uint8_t* data) {
+uint16_t st40_calc_checksum(uint32_t data_num, const uint8_t* data) {
   uint16_t chks = 0, udw;
   for (uint32_t i = 0; i < data_num; i++) {
     udw = get_10bit_udw(i, data);

--- a/lib/src/st2110/st_rx_ancillary_session.c
+++ b/lib/src/st2110/st_rx_ancillary_session.c
@@ -102,7 +102,7 @@ static int rx_ancillary_session_handle_pkt(struct mtl_main_impl* impl,
   uint16_t seq_id = ntohs(rtp->seq_number);
   uint8_t payload_type = rtp->payload_type;
   struct st40_rfc8331_rtp_hdr* rfc8331 = (struct st40_rfc8331_rtp_hdr*)rtp;
-  rfc8331->swapped_first_hdr_chunk = ntohl(rfc8331->swapped_first_hdr_chunk);
+  st40_rfc8331_rtp_hdr_bswap(rfc8331);
   MTL_MAY_UNUSED(s_port);
   uint32_t pkt_len = mbuf->data_len - sizeof(struct st40_rfc8331_rtp_hdr);
   MTL_MAY_UNUSED(pkt_len);

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -549,13 +549,7 @@ static int tx_ancillary_session_build_packet(struct st_tx_ancillary_session_impl
     checksum = st40_calc_checksum(3 + udw_size, (uint8_t*)&pktBuff->second_hdr_chunk);
     st40_set_udw(i + 3, checksum, (uint8_t*)&pktBuff->second_hdr_chunk);
 
-    /* Compute byte size of 10-bit words
-      (DID, SDID, DC, payload, checksum) and align to 4 */
-    uint32_t total_bits = (uint32_t)(3 + udw_size + 1) * 10; /* words = udw_size + 4 */
-    uint32_t total_size = (total_bits + 7) / 8;              /* ceil(bits/8) */
-    total_size = (total_size + 3) & ~0x3U;                   /* align to 4 bytes */
-    uint32_t size_to_send = (sizeof(struct st40_rfc8331_payload_hdr) - 4) +
-                            total_size; /* Full size of one ANC */
+    uint32_t size_to_send = st40_rfc8331_payload_bytes(udw_size);
     if (s->split_payload && size_to_send > s->max_pkt_len) {
       err("%s(%d), ANC packet too large for MTU (size=%u max=%u)\n", __func__, s->idx,
           size_to_send, s->max_pkt_len);
@@ -648,13 +642,7 @@ static int tx_ancillary_session_build_rtp_packet(struct st_tx_ancillary_session_
     checksum = st40_calc_checksum(3 + udw_size, (uint8_t*)&pktBuff->second_hdr_chunk);
     st40_set_udw(i + 3, checksum, (uint8_t*)&pktBuff->second_hdr_chunk);
 
-    /* Compute byte size of 10-bit words (DID, SDID, DC, payload, checksum)
-       and align to 4 */
-    uint32_t total_bits = (uint32_t)(3 + udw_size + 1) * 10;
-    uint32_t total_size = (total_bits + 7) / 8;
-    total_size = (total_size + 3) & ~0x3U;
-    uint32_t size_to_send = (sizeof(struct st40_rfc8331_payload_hdr) - 4) +
-                            total_size; /* Full size of one ANC */
+    uint32_t size_to_send = st40_rfc8331_payload_bytes(udw_size);
     if (s->split_payload && size_to_send > s->max_pkt_len) {
       err("%s(%d), ANC packet too large for MTU (size=%u max=%u)\n", __func__, s->idx,
           size_to_send, s->max_pkt_len);

--- a/lib/src/st2110/st_tx_ancillary_session.c
+++ b/lib/src/st2110/st_tx_ancillary_session.c
@@ -537,8 +537,7 @@ static int tx_ancillary_session_build_packet(struct st_tx_ancillary_session_impl
     pktBuff->second_hdr_chunk.sdid = tx_ancillary_apply_parity(s, src->meta[idx].sdid);
     pktBuff->second_hdr_chunk.data_count = tx_ancillary_apply_parity(s, udw_size);
 
-    pktBuff->swapped_first_hdr_chunk = htonl(pktBuff->swapped_first_hdr_chunk);
-    pktBuff->swapped_second_hdr_chunk = htonl(pktBuff->swapped_second_hdr_chunk);
+    st40_rfc8331_payload_hdr_bswap(pktBuff);
     int i = 0;
     int offset = src->meta[idx].udw_offset;
     for (; i < udw_size; i++) {
@@ -579,7 +578,7 @@ static int tx_ancillary_session_build_packet(struct st_tx_ancillary_session_impl
   bool last_pkt = (s->st40_total_pkts > 0) ? (s->st40_pkt_idx == (s->st40_total_pkts - 1))
                                            : (idx == anc_count);
   if (!test_no_marker && last_pkt) rtp->base.marker = 1;
-  rtp->swapped_first_hdr_chunk = htonl(rtp->swapped_first_hdr_chunk);
+  st40_rfc8331_rtp_hdr_bswap(rtp);
   dbg("%s(%d), anc_count %d, payload_size %d\n", __func__, s->idx, anc_count,
       payload_size);
 
@@ -630,8 +629,7 @@ static int tx_ancillary_session_build_rtp_packet(struct st_tx_ancillary_session_
     pktBuff->second_hdr_chunk.sdid = tx_ancillary_apply_parity(s, src->meta[idx].sdid);
     pktBuff->second_hdr_chunk.data_count = tx_ancillary_apply_parity(s, udw_size);
 
-    pktBuff->swapped_first_hdr_chunk = htonl(pktBuff->swapped_first_hdr_chunk);
-    pktBuff->swapped_second_hdr_chunk = htonl(pktBuff->swapped_second_hdr_chunk);
+    st40_rfc8331_payload_hdr_bswap(pktBuff);
     int i = 0;
     int offset = src->meta[idx].udw_offset;
     for (; i < udw_size; i++) {
@@ -672,7 +670,7 @@ static int tx_ancillary_session_build_rtp_packet(struct st_tx_ancillary_session_
   bool last_pkt = (s->st40_total_pkts > 0) ? (s->st40_pkt_idx == (s->st40_total_pkts - 1))
                                            : (idx == anc_count);
   if (!test_no_marker && last_pkt) rtp->base.marker = 1;
-  rtp->swapped_first_hdr_chunk = htonl(rtp->swapped_first_hdr_chunk);
+  st40_rfc8331_rtp_hdr_bswap(rtp);
 
   dbg("%s(%d), anc_count %d, payload_size %d\n", __func__, s->idx, anc_count,
       payload_size);
@@ -709,7 +707,7 @@ static int tx_ancillary_session_rtp_update_packet(struct mtl_main_impl* impl,
     if (s->ops.interlaced) {
       struct st40_rfc8331_rtp_hdr* rfc8331 = (struct st40_rfc8331_rtp_hdr*)rtp;
       second_field = (rfc8331->first_hdr_chunk.f == 0b11) ? true : false;
-      rfc8331->swapped_first_hdr_chunk = htonl(rfc8331->swapped_first_hdr_chunk);
+      st40_rfc8331_rtp_hdr_bswap(rfc8331);
     }
     if (s->ops.interlaced) {
       if (second_field) {
@@ -775,7 +773,7 @@ static int tx_ancillary_session_build_packet_chain(struct mtl_main_impl* impl,
         if (s->ops.interlaced) {
           struct st40_rfc8331_rtp_hdr* rfc8331 = (struct st40_rfc8331_rtp_hdr*)&udp[1];
           second_field = (rfc8331->first_hdr_chunk.f == 0b11) ? true : false;
-          rfc8331->swapped_first_hdr_chunk = htonl(rfc8331->swapped_first_hdr_chunk);
+          st40_rfc8331_rtp_hdr_bswap(rfc8331);
         }
         if (s->ops.interlaced) {
           if (second_field) {
@@ -789,7 +787,7 @@ static int tx_ancillary_session_build_packet_chain(struct mtl_main_impl* impl,
                                            ntohl(rtp->base.tmstamp));
       }
       rtp->base.tmstamp = htonl(s->pacing.rtp_time_stamp);
-      rtp->swapped_first_hdr_chunk = htonl(rtp->swapped_first_hdr_chunk);
+      st40_rfc8331_rtp_hdr_bswap(rtp);
     }
   }
 

--- a/tests/integration_tests/noctx/testcases/st40i_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st40i_tests.cpp
@@ -87,12 +87,11 @@ namespace {
 
 static void build_split_rtp_packet(std::vector<uint8_t>& out, uint16_t seq, uint32_t ts,
                                    bool marker, const std::vector<uint8_t>& payload) {
-  out.clear();
-  out.resize(sizeof(st40_rfc8331_rtp_hdr) + sizeof(st40_rfc8331_payload_hdr) - 4 +
-             ((3 + payload.size() + 1) * 10 + 7) / 8);
+  uint32_t payload_bytes =
+      st40_rfc8331_payload_bytes(static_cast<uint16_t>(payload.size()));
+  out.assign(sizeof(st40_rfc8331_rtp_hdr) + payload_bytes, 0);
 
   auto* rtp = reinterpret_cast<st40_rfc8331_rtp_hdr*>(out.data());
-  memset(rtp, 0, sizeof(*rtp));
   rtp->base.version = 2;
   rtp->base.payload_type = 113;
   rtp->base.seq_number = htons(seq);
@@ -100,32 +99,17 @@ static void build_split_rtp_packet(std::vector<uint8_t>& out, uint16_t seq, uint
   rtp->base.tmstamp = htonl(ts);
   rtp->base.marker = marker ? 1 : 0;
   rtp->first_hdr_chunk.anc_count = 1;
-
-  auto* ph = reinterpret_cast<st40_rfc8331_payload_hdr*>(rtp + 1);
-  memset(ph, 0, sizeof(*ph));
-  ph->first_hdr_chunk.c = 0;
-  ph->first_hdr_chunk.line_number = 1;
-  ph->first_hdr_chunk.horizontal_offset = 0;
-  ph->first_hdr_chunk.s = 0;
-  ph->first_hdr_chunk.stream_num = 0;
-  ph->second_hdr_chunk.did = st40_add_parity_bits(0x45);
-  ph->second_hdr_chunk.sdid = st40_add_parity_bits(0x01);
-  ph->second_hdr_chunk.data_count = st40_add_parity_bits(payload.size());
-
-  uint8_t* udw_dst = reinterpret_cast<uint8_t*>(&ph->second_hdr_chunk);
-  for (size_t i = 0; i < payload.size(); i++) {
-    st40_set_udw(static_cast<int>(i + 3), st40_add_parity_bits(payload[i]), udw_dst);
-  }
-  uint16_t checksum = st40_calc_checksum(3 + payload.size(), udw_dst);
-  st40_set_udw(static_cast<int>(payload.size() + 3), checksum, udw_dst);
-
-  uint32_t payload_bytes =
-      st40_rfc8331_payload_bytes(static_cast<uint16_t>(payload.size()));
-
   rtp->length = htons(payload_bytes);
   st40_rfc8331_rtp_hdr_bswap(rtp);
-  st40_rfc8331_payload_hdr_bswap(ph);
-  out.resize(sizeof(st40_rfc8331_rtp_hdr) + payload_bytes);
+
+  struct st40_meta meta = {};
+  meta.line_number = 1;
+  meta.did = 0x45;
+  meta.sdid = 0x01;
+  meta.udw_size = static_cast<uint16_t>(payload.size());
+  uint32_t written = 0;
+  st40_rfc8331_encode_packet(reinterpret_cast<uint8_t*>(rtp + 1), payload_bytes, &meta,
+                             payload.data(), &written);
 }
 
 static int send_rtp_burst(const st_tests_context* ctx, uint16_t port,

--- a/tests/integration_tests/noctx/testcases/st40i_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st40i_tests.cpp
@@ -119,10 +119,8 @@ static void build_split_rtp_packet(std::vector<uint8_t>& out, uint16_t seq, uint
   uint16_t checksum = st40_calc_checksum(3 + payload.size(), udw_dst);
   st40_set_udw(static_cast<int>(payload.size() + 3), checksum, udw_dst);
 
-  uint32_t total_bits = (3 + payload.size() + 1) * 10;
-  uint32_t total_size = (total_bits + 7) / 8;
-  uint32_t total_size_aligned = (total_size + 3) & ~0x3u;
-  uint32_t payload_bytes = sizeof(st40_rfc8331_payload_hdr) - 4 + total_size_aligned;
+  uint32_t payload_bytes =
+      st40_rfc8331_payload_bytes(static_cast<uint16_t>(payload.size()));
 
   rtp->length = htons(payload_bytes);
   rtp->swapped_first_hdr_chunk = htonl(rtp->swapped_first_hdr_chunk);

--- a/tests/integration_tests/noctx/testcases/st40i_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st40i_tests.cpp
@@ -123,9 +123,8 @@ static void build_split_rtp_packet(std::vector<uint8_t>& out, uint16_t seq, uint
       st40_rfc8331_payload_bytes(static_cast<uint16_t>(payload.size()));
 
   rtp->length = htons(payload_bytes);
-  rtp->swapped_first_hdr_chunk = htonl(rtp->swapped_first_hdr_chunk);
-  ph->swapped_first_hdr_chunk = htonl(ph->swapped_first_hdr_chunk);
-  ph->swapped_second_hdr_chunk = htonl(ph->swapped_second_hdr_chunk);
+  st40_rfc8331_rtp_hdr_bswap(rtp);
+  st40_rfc8331_payload_hdr_bswap(ph);
   out.resize(sizeof(st40_rfc8331_rtp_hdr) + payload_bytes);
 }
 

--- a/tests/integration_tests/st40_test.cpp
+++ b/tests/integration_tests/st40_test.cpp
@@ -51,34 +51,17 @@ static int tx_anc_build_rtp_packet(tests_context* s, struct st40_rfc8331_rtp_hdr
   s->rtp_tmstamp++;
   s->seq_id++;
   if (s->check_sha) {
-    struct st40_rfc8331_payload_hdr* payload_hdr =
-        (struct st40_rfc8331_payload_hdr*)(&rtp[1]);
-    int total_size, payload_len, udw_size = s->frame_size;
-    payload_hdr->first_hdr_chunk.c = 0;
-    payload_hdr->first_hdr_chunk.line_number = 10;
-    payload_hdr->first_hdr_chunk.horizontal_offset = 0;
-    payload_hdr->first_hdr_chunk.s = 0;
-    payload_hdr->first_hdr_chunk.stream_num = 0;
-    payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x43);
-    payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x02);
-    payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
-    st40_rfc8331_payload_hdr_bswap(payload_hdr);
+    int udw_size = s->frame_size;
+    struct st40_meta meta = {};
+    meta.line_number = 10;
+    meta.did = 0x43;
+    meta.sdid = 0x02;
+    meta.udw_size = static_cast<uint16_t>(udw_size);
+    uint32_t payload_len = 0;
+    st40_rfc8331_encode_packet((uint8_t*)&rtp[1], st40_rfc8331_payload_bytes(udw_size),
+                               &meta, s->frame_buf[s->seq_id % TEST_SHA_HIST_NUM],
+                               &payload_len);
     rtp->first_hdr_chunk.anc_count = 1;
-    for (int i = 0; i < udw_size; i++) {
-      st40_set_udw(i + 3,
-                   st40_add_parity_bits(s->frame_buf[s->seq_id % TEST_SHA_HIST_NUM][i]),
-                   (uint8_t*)&payload_hdr->second_hdr_chunk);
-    }
-    uint16_t check_sum =
-        st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk);
-    st40_set_udw(udw_size + 3, check_sum, (uint8_t*)&payload_hdr->second_hdr_chunk);
-    total_size = ((3 + udw_size + 1) * 10) / 8;  // Calculate size of the
-                                                 // 10-bit words: DID, SDID, DATA_COUNT
-                                                 // + size of buffer with data + checksum
-    total_size = (4 - total_size % 4) + total_size;  // Calculate word align to the 32-bit
-                                                     // word of ANC data packet
-    payload_len =
-        sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size;  // Full size of one ANC
     rtp->length = htons(payload_len);
     *pkt_len = payload_len + sizeof(struct st40_rfc8331_rtp_hdr);
   } else {
@@ -128,59 +111,40 @@ static int tx_rtp_done(void* args) {
 }
 
 static void rx_handle_rtp(tests_context* s, struct st40_rfc8331_rtp_hdr* hdr) {
-  struct st40_rfc8331_payload_hdr* payload_hdr =
-      (struct st40_rfc8331_payload_hdr*)(&hdr[1]);
+  uint8_t* payload = (uint8_t*)&hdr[1];
+  uint32_t payload_offset = 0;
+  uint32_t payload_room = ST40_MAX_META * st40_rfc8331_payload_bytes(255);
   int anc_count = hdr->first_hdr_chunk.anc_count;
-  int idx, total_size, payload_len;
 
-  for (idx = 0; idx < anc_count; idx++) {
-    st40_rfc8331_payload_hdr_bswap(payload_hdr);
-    if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.did) ||
-        !st40_check_parity_bits(payload_hdr->second_hdr_chunk.sdid) ||
-        !st40_check_parity_bits(payload_hdr->second_hdr_chunk.data_count)) {
-      err("anc RTP checkParityBits for payload hdr error\n");
-      s->rx_meta_fail_cnt++;
-      return;
-    }
-    int udw_size = payload_hdr->second_hdr_chunk.data_count & 0xff;
-
-    // verify checksum
-    uint16_t checksum = 0;
-    checksum = st40_get_udw(udw_size + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
-    /* Re-swap second chunk to wire order; the 10-bit UDW/checksum reads below assume
-     * network byte layout. */
-    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
-    if (checksum !=
-        st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk)) {
-      s->sha_fail_cnt++;
-      return;
-    }
-    // get payload
-    uint16_t data;
-    uint8_t* udw = (uint8_t*)st_test_zmalloc(udw_size);
+  for (int idx = 0; idx < anc_count; idx++) {
+    struct st40_meta meta;
+    uint8_t* udw = (uint8_t*)st_test_zmalloc(256);
     ASSERT_TRUE(udw != NULL);
-    for (int i = 0; i < udw_size; i++) {
-      data = st40_get_udw(i + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
-      if (!st40_check_parity_bits(data)) {
-        err("anc RTP checkParityBits for udw error\n");
-        s->rx_meta_fail_cnt++;
-      }
-      udw[i] = data & 0xff;
+    uint32_t consumed = 0;
+    enum st40_rfc8331_decode_result rc = st40_rfc8331_decode_packet(
+        payload + payload_offset, payload_room - payload_offset, &meta, udw, 256,
+        &consumed);
+    if (rc == ST40_RFC8331_DECODE_PARITY_FAIL) {
+      err("anc RTP parity error\n");
+      s->rx_meta_fail_cnt++;
+      st_test_free(udw);
+      return;
+    }
+    if (rc == ST40_RFC8331_DECODE_CHECKSUM_FAIL) {
+      s->sha_fail_cnt++;
+      st_test_free(udw);
+      return;
+    }
+    if (rc != ST40_RFC8331_DECODE_OK) {
+      st_test_free(udw);
+      return;
     }
     {
       std::unique_lock<std::mutex> lck(s->mtx);
       s->buf_q.push(udw);
       s->cv.notify_all();
     }
-
-    total_size = ((3 + udw_size + 1) * 10) / 8;  // Calculate size of the
-                                                 // 10-bit words: DID, SDID, DATA_COUNT
-                                                 // + size of buffer with data + checksum
-    total_size = (4 - total_size % 4) + total_size;  // Calculate word align to the 32-bit
-                                                     // word of ANC data packet
-    payload_len =
-        sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size;  // Full size of one ANC
-    payload_hdr = (struct st40_rfc8331_payload_hdr*)((uint8_t*)payload_hdr + payload_len);
+    payload_offset += consumed;
   }
 }
 

--- a/tests/integration_tests/st40_test.cpp
+++ b/tests/integration_tests/st40_test.cpp
@@ -62,8 +62,7 @@ static int tx_anc_build_rtp_packet(tests_context* s, struct st40_rfc8331_rtp_hdr
     payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x43);
     payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x02);
     payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
-    payload_hdr->swapped_first_hdr_chunk = htonl(payload_hdr->swapped_first_hdr_chunk);
-    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
+    st40_rfc8331_payload_hdr_bswap(payload_hdr);
     rtp->first_hdr_chunk.anc_count = 1;
     for (int i = 0; i < udw_size; i++) {
       st40_set_udw(i + 3,
@@ -135,8 +134,7 @@ static void rx_handle_rtp(tests_context* s, struct st40_rfc8331_rtp_hdr* hdr) {
   int idx, total_size, payload_len;
 
   for (idx = 0; idx < anc_count; idx++) {
-    payload_hdr->swapped_first_hdr_chunk = ntohl(payload_hdr->swapped_first_hdr_chunk);
-    payload_hdr->swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
+    st40_rfc8331_payload_hdr_bswap(payload_hdr);
     if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.did) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.sdid) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.data_count)) {
@@ -149,6 +147,8 @@ static void rx_handle_rtp(tests_context* s, struct st40_rfc8331_rtp_hdr* hdr) {
     // verify checksum
     uint16_t checksum = 0;
     checksum = st40_get_udw(udw_size + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
+    /* Re-swap second chunk to wire order; the 10-bit UDW/checksum reads below assume
+     * network byte layout. */
     payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
     if (checksum !=
         st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk)) {

--- a/tests/tools/RxTxApp/src/rx_ancillary_app.c
+++ b/tests/tools/RxTxApp/src/rx_ancillary_app.c
@@ -6,52 +6,40 @@
 
 static void app_rx_anc_handle_rtp(struct st_app_rx_anc_session* s, void* usrptr) {
   struct st40_rfc8331_rtp_hdr* hdr = (struct st40_rfc8331_rtp_hdr*)usrptr;
-  struct st40_rfc8331_payload_hdr* payload_hdr =
-      (struct st40_rfc8331_payload_hdr*)(&hdr[1]);
+  uint8_t* payload = (uint8_t*)&hdr[1];
+  uint32_t payload_offset = 0;
+  /* RTP payload size is not exposed here; cap at maximum possible ANC bytes
+   * (ST40_MAX_META * worst-case per-packet size) so the decoder's bounds
+   * check still fires if a malformed packet claims an impossible size. */
+  uint32_t payload_room = ST40_MAX_META * st40_rfc8331_payload_bytes(255);
 
   int anc_count = hdr->first_hdr_chunk.anc_count;
-  int idx, total_size, payload_len;
   dbg("%s(%d), anc_count %d\n", __func__, s->idx, anc_count);
 
-  for (idx = 0; idx < anc_count; idx++) {
-    st40_rfc8331_payload_hdr_bswap(payload_hdr);
-    if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.did) ||
-        !st40_check_parity_bits(payload_hdr->second_hdr_chunk.sdid) ||
-        !st40_check_parity_bits(payload_hdr->second_hdr_chunk.data_count)) {
-      err("%s(%d), anc RTP checkParityBits error\n", __func__, s->idx);
+  uint8_t udw_buf[256];
+  for (int idx = 0; idx < anc_count; idx++) {
+    struct st40_meta meta;
+    uint32_t consumed = 0;
+    enum st40_rfc8331_decode_result rc = st40_rfc8331_decode_packet(
+        payload + payload_offset, payload_room - payload_offset, &meta, udw_buf,
+        sizeof(udw_buf), &consumed);
+    if (rc == ST40_RFC8331_DECODE_PARITY_FAIL) {
+      err("%s(%d), anc RTP parity error\n", __func__, s->idx);
       return;
     }
-    int udw_size = payload_hdr->second_hdr_chunk.data_count & 0xff;
-
-    // verify checksum
-    uint16_t checksum = 0;
-    checksum = st40_get_udw(udw_size + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
-    /* Re-swap second chunk to wire order; the 10-bit UDW/checksum reads below assume
-     * network byte layout. */
-    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
-    if (checksum !=
-        st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk)) {
+    if (rc == ST40_RFC8331_DECODE_CHECKSUM_FAIL) {
       err("%s(%d), anc frame checksum error\n", __func__, s->idx);
       return;
     }
-    // get payload
-#ifdef DEBUG
-    uint16_t data;
-    for (int i = 0; i < udw_size; i++) {
-      data = st40_get_udw(i + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
-      if (!st40_check_parity_bits(data)) err("anc udw checkParityBits error\n");
-      dbg("%c", data & 0xff);
+    if (rc != ST40_RFC8331_DECODE_OK) {
+      err("%s(%d), anc decode error %d\n", __func__, s->idx, rc);
+      return;
     }
+#ifdef DEBUG
+    for (uint16_t i = 0; i < meta.udw_size; i++) dbg("%c", udw_buf[i]);
     dbg("\n");
 #endif
-    total_size = ((3 + udw_size + 1) * 10) / 8;  // Calculate size of the
-                                                 // 10-bit words: DID, SDID, DATA_COUNT
-                                                 // + size of buffer with data + checksum
-    total_size = (4 - total_size % 4) + total_size;  // Calculate word align to the 32-bit
-                                                     // word of ANC data packet
-    payload_len =
-        sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size;  // Full size of one ANC
-    payload_hdr = (struct st40_rfc8331_payload_hdr*)((uint8_t*)payload_hdr + payload_len);
+    payload_offset += consumed;
   }
 
   s->stat_frame_total_received++;

--- a/tests/tools/RxTxApp/src/rx_ancillary_app.c
+++ b/tests/tools/RxTxApp/src/rx_ancillary_app.c
@@ -14,8 +14,7 @@ static void app_rx_anc_handle_rtp(struct st_app_rx_anc_session* s, void* usrptr)
   dbg("%s(%d), anc_count %d\n", __func__, s->idx, anc_count);
 
   for (idx = 0; idx < anc_count; idx++) {
-    payload_hdr->swapped_first_hdr_chunk = ntohl(payload_hdr->swapped_first_hdr_chunk);
-    payload_hdr->swapped_second_hdr_chunk = ntohl(payload_hdr->swapped_second_hdr_chunk);
+    st40_rfc8331_payload_hdr_bswap(payload_hdr);
     if (!st40_check_parity_bits(payload_hdr->second_hdr_chunk.did) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.sdid) ||
         !st40_check_parity_bits(payload_hdr->second_hdr_chunk.data_count)) {
@@ -27,6 +26,8 @@ static void app_rx_anc_handle_rtp(struct st_app_rx_anc_session* s, void* usrptr)
     // verify checksum
     uint16_t checksum = 0;
     checksum = st40_get_udw(udw_size + 3, (uint8_t*)&payload_hdr->second_hdr_chunk);
+    /* Re-swap second chunk to wire order; the 10-bit UDW/checksum reads below assume
+     * network byte layout. */
     payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
     if (checksum !=
         st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk)) {

--- a/tests/tools/RxTxApp/src/tx_ancillary_app.c
+++ b/tests/tools/RxTxApp/src/tx_ancillary_app.c
@@ -226,8 +226,7 @@ static void app_tx_anc_build_rtp(struct st_app_tx_anc_session* s, void* usrptr,
   payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x43);
   payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x02);
   payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
-  payload_hdr->swapped_first_hdr_chunk = htonl(payload_hdr->swapped_first_hdr_chunk);
-  payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
+  st40_rfc8331_payload_hdr_bswap(payload_hdr);
   for (int i = 0; i < udw_size; i++) {
     st40_set_udw(i + 3, st40_add_parity_bits(s->st40_frame_cursor[i]),
                  (uint8_t*)&payload_hdr->second_hdr_chunk);

--- a/tests/tools/RxTxApp/src/tx_ancillary_app.c
+++ b/tests/tools/RxTxApp/src/tx_ancillary_app.c
@@ -197,12 +197,9 @@ static void app_tx_anc_build_rtp(struct st_app_tx_anc_session* s, void* usrptr,
   /* generate one anc rtp for test purpose */
   struct st40_rfc8331_rtp_hdr* hdr = (struct st40_rfc8331_rtp_hdr*)usrptr;
 
-  struct st40_rfc8331_payload_hdr* payload_hdr =
-      (struct st40_rfc8331_payload_hdr*)(&hdr[1]);
   uint16_t udw_size = s->st40_source_end - s->st40_frame_cursor > 255
                           ? 255
                           : s->st40_source_end - s->st40_frame_cursor;
-  uint16_t check_sum, total_size, payload_len;
   hdr->base.marker = 1;
   hdr->first_hdr_chunk.anc_count = 1;
   hdr->base.payload_type = s->st40_payload_type;
@@ -218,28 +215,20 @@ static void app_tx_anc_build_rtp(struct st_app_tx_anc_session* s, void* usrptr,
   hdr->seq_number_ext = htons((uint16_t)(s->st40_seq_id >> 16));
   s->st40_seq_id++;
   s->st40_rtp_tmstamp++;
-  payload_hdr->first_hdr_chunk.c = 0;
-  payload_hdr->first_hdr_chunk.line_number = 10;
-  payload_hdr->first_hdr_chunk.horizontal_offset = 0;
-  payload_hdr->first_hdr_chunk.s = 0;
-  payload_hdr->first_hdr_chunk.stream_num = 0;
-  payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x43);
-  payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x02);
-  payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
-  st40_rfc8331_payload_hdr_bswap(payload_hdr);
-  for (int i = 0; i < udw_size; i++) {
-    st40_set_udw(i + 3, st40_add_parity_bits(s->st40_frame_cursor[i]),
-                 (uint8_t*)&payload_hdr->second_hdr_chunk);
-  }
-  check_sum = st40_calc_checksum(3 + udw_size, (uint8_t*)&payload_hdr->second_hdr_chunk);
-  st40_set_udw(udw_size + 3, check_sum, (uint8_t*)&payload_hdr->second_hdr_chunk);
-  total_size = ((3 + udw_size + 1) * 10) / 8;  // Calculate size of the
-                                               // 10-bit words: DID, SDID, DATA_COUNT
-                                               // + size of buffer with data + checksum
-  total_size = (4 - total_size % 4) + total_size;  // Calculate word align to the 32-bit
-                                                   // word of ANC data packet
-  payload_len =
-      sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size;  // Full size of one ANC
+
+  struct st40_meta meta = {
+      .c = 0,
+      .line_number = 10,
+      .hori_offset = 0,
+      .s = 0,
+      .stream_num = 0,
+      .did = 0x43,
+      .sdid = 0x02,
+      .udw_size = udw_size,
+  };
+  uint32_t payload_len = 0;
+  st40_rfc8331_encode_packet((uint8_t*)&hdr[1], st40_rfc8331_payload_bytes(udw_size),
+                             &meta, s->st40_frame_cursor, &payload_len);
   *mbuf_len = payload_len + sizeof(struct st40_rfc8331_rtp_hdr);
   hdr->length = htons(payload_len);
 

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -28,6 +28,7 @@ unit_sources = [
   'session/st40/prev_window_test.cpp',
   'session/st40/bitmap_test.cpp',
   'session/st40/err_packets_test.cpp',
+  'session/st40/rfc8331_payload_bytes_test.cpp',
   'session/st30_harness.c',
   'session/st30/redundancy_test.cpp',
   'session/st30/timestamp_test.cpp',

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -29,6 +29,7 @@ unit_sources = [
   'session/st40/bitmap_test.cpp',
   'session/st40/err_packets_test.cpp',
   'session/st40/rfc8331_payload_bytes_test.cpp',
+  'session/st40/rfc8331_codec_test.cpp',
   'session/st30_harness.c',
   'session/st30/redundancy_test.cpp',
   'session/st30/timestamp_test.cpp',

--- a/tests/unit/pipeline/st40p_harness.c
+++ b/tests/unit/pipeline/st40p_harness.c
@@ -228,13 +228,6 @@ static struct rte_mbuf* make_pipeline_mbuf(uint16_t seq, uint32_t ts, int marker
   return m;
 }
 
-static uint32_t ut40p_anc_payload_bytes(uint16_t udw_size) {
-  uint32_t total_bits = (uint32_t)(3 + udw_size + 1) * 10;
-  uint32_t total_size = (total_bits + 7) / 8;
-  total_size = (total_size + 3) & ~0x3U;
-  return sizeof(struct st40_rfc8331_payload_hdr) - 4 + total_size;
-}
-
 static struct rte_mbuf* make_multi_anc_mbuf(uint16_t seq, uint32_t ts, int marker,
                                             uint16_t dpdk_port_id,
                                             const uint16_t* udw_sizes,
@@ -243,7 +236,7 @@ static struct rte_mbuf* make_multi_anc_mbuf(uint16_t seq, uint32_t ts, int marke
 
   size_t payload_len = 0;
   for (uint8_t anc_idx = 0; anc_idx < anc_count; anc_idx++)
-    payload_len += ut40p_anc_payload_bytes(udw_sizes[anc_idx]);
+    payload_len += st40_rfc8331_payload_bytes(udw_sizes[anc_idx]);
 
   size_t rtp_len = sizeof(struct st40_rfc8331_rtp_hdr) + payload_len;
   size_t total = UT40P_L234_HDR_LEN + rtp_len;
@@ -299,7 +292,7 @@ static struct rte_mbuf* make_multi_anc_mbuf(uint16_t seq, uint32_t ts, int marke
     uint16_t checksum = st40_calc_checksum(3 + udw_size, udw_dst);
     st40_set_udw(udw_size + 3, checksum, udw_dst);
 
-    payload += ut40p_anc_payload_bytes(udw_size);
+    payload += st40_rfc8331_payload_bytes(udw_size);
   }
 
   m->data_len = total;

--- a/tests/unit/pipeline/st40p_harness.c
+++ b/tests/unit/pipeline/st40p_harness.c
@@ -281,8 +281,7 @@ static struct rte_mbuf* make_multi_anc_mbuf(uint16_t seq, uint32_t ts, int marke
     payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x01);
     payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
 
-    payload_hdr->swapped_first_hdr_chunk = htonl(payload_hdr->swapped_first_hdr_chunk);
-    payload_hdr->swapped_second_hdr_chunk = htonl(payload_hdr->swapped_second_hdr_chunk);
+    st40_rfc8331_payload_hdr_bswap(payload_hdr);
 
     uint8_t* udw_dst = (uint8_t*)&payload_hdr->second_hdr_chunk;
     for (uint16_t udw_idx = 0; udw_idx < udw_size; udw_idx++) {

--- a/tests/unit/pipeline/st40p_harness.c
+++ b/tests/unit/pipeline/st40p_harness.c
@@ -269,29 +269,20 @@ static struct rte_mbuf* make_multi_anc_mbuf(uint16_t seq, uint32_t ts, int marke
   uint8_t* payload = (uint8_t*)(rtp + 1);
   for (uint8_t anc_idx = 0; anc_idx < anc_count; anc_idx++) {
     uint16_t udw_size = udw_sizes[anc_idx];
-    struct st40_rfc8331_payload_hdr* payload_hdr =
-        (struct st40_rfc8331_payload_hdr*)payload;
+    uint8_t udw_buf[256];
+    for (uint16_t udw_idx = 0; udw_idx < udw_size; udw_idx++)
+      udw_buf[udw_idx] = (uint8_t)(((uint16_t)(anc_idx + 1) * 17 + udw_idx) & 0xff);
 
-    payload_hdr->first_hdr_chunk.c = 0;
-    payload_hdr->first_hdr_chunk.line_number = 10 + anc_idx;
-    payload_hdr->first_hdr_chunk.horizontal_offset = 0;
-    payload_hdr->first_hdr_chunk.s = 0;
-    payload_hdr->first_hdr_chunk.stream_num = 0;
-    payload_hdr->second_hdr_chunk.did = st40_add_parity_bits(0x45);
-    payload_hdr->second_hdr_chunk.sdid = st40_add_parity_bits(0x01);
-    payload_hdr->second_hdr_chunk.data_count = st40_add_parity_bits(udw_size);
-
-    st40_rfc8331_payload_hdr_bswap(payload_hdr);
-
-    uint8_t* udw_dst = (uint8_t*)&payload_hdr->second_hdr_chunk;
-    for (uint16_t udw_idx = 0; udw_idx < udw_size; udw_idx++) {
-      uint8_t v = (uint8_t)(((uint16_t)(anc_idx + 1) * 17 + udw_idx) & 0xff);
-      st40_set_udw(udw_idx + 3, st40_add_parity_bits(v), udw_dst);
-    }
-    uint16_t checksum = st40_calc_checksum(3 + udw_size, udw_dst);
-    st40_set_udw(udw_size + 3, checksum, udw_dst);
-
-    payload += st40_rfc8331_payload_bytes(udw_size);
+    struct st40_meta meta = {
+        .line_number = (uint16_t)(10 + anc_idx),
+        .did = 0x45,
+        .sdid = 0x01,
+        .udw_size = udw_size,
+    };
+    uint32_t written = 0;
+    st40_rfc8331_encode_packet(payload, st40_rfc8331_payload_bytes(udw_size), &meta,
+                               udw_buf, &written);
+    payload += written;
   }
 
   m->data_len = total;

--- a/tests/unit/session/st40/rfc8331_codec_test.cpp
+++ b/tests/unit/session/st40/rfc8331_codec_test.cpp
@@ -1,0 +1,181 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Pin st40_rfc8331_encode_packet / st40_rfc8331_decode_packet against
+ * RFC 8331 wire format. Three groups:
+ *   - round-trip identity over a meta x udw_size matrix
+ *   - one input per decode_result enum value
+ *   - one canonical encoded byte pattern (anchors the spec)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "st40_api.h"
+
+namespace {
+
+constexpr uint32_t kBufRoom = 1024;
+
+std::vector<uint8_t> make_udw(uint16_t n, uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::vector<uint8_t> v(n);
+  for (auto& b : v) b = static_cast<uint8_t>(rng() & 0xFF);
+  return v;
+}
+
+struct st40_meta make_meta(uint16_t udw_size) {
+  struct st40_meta m {};
+  m.c = 1;
+  m.line_number = 0x1AB;
+  m.hori_offset = 0x2CD;
+  m.s = 1;
+  m.stream_num = 7;
+  m.did = 0x61;
+  m.sdid = 0x02;
+  m.udw_size = udw_size;
+  m.udw_offset = 0;
+  return m;
+}
+
+}  // namespace
+
+class St40Rfc8331CodecTest : public ::testing::Test {};
+
+TEST_F(St40Rfc8331CodecTest, RoundTripMatrix) {
+  const uint16_t sizes[] = {0, 1, 8, 9, 100, 255};
+  uint32_t seed = 0xC0FFEEu;
+  for (uint16_t sz : sizes) {
+    auto in = make_meta(sz);
+    auto udw = make_udw(sz, seed++);
+
+    std::vector<uint8_t> buf(kBufRoom, 0);
+    uint32_t written = 0;
+    ASSERT_EQ(st40_rfc8331_encode_packet(buf.data(), kBufRoom, &in, udw.data(), &written),
+              0)
+        << "encode udw_size=" << sz;
+    EXPECT_EQ(written, st40_rfc8331_payload_bytes(sz));
+
+    struct st40_meta out {};
+    std::vector<uint8_t> udw_out(sz ? sz : 1, 0xFF);
+    uint32_t consumed = 0;
+    ASSERT_EQ(
+        st40_rfc8331_decode_packet(buf.data(), written, &out, udw_out.data(),
+                                   static_cast<uint32_t>(udw_out.size()), &consumed),
+        ST40_RFC8331_DECODE_OK)
+        << "decode udw_size=" << sz;
+    EXPECT_EQ(consumed, written);
+    EXPECT_EQ(out.c, in.c);
+    EXPECT_EQ(out.line_number, in.line_number);
+    EXPECT_EQ(out.hori_offset, in.hori_offset);
+    EXPECT_EQ(out.s, in.s);
+    EXPECT_EQ(out.stream_num, in.stream_num);
+    EXPECT_EQ(out.did, in.did);
+    EXPECT_EQ(out.sdid, in.sdid);
+    EXPECT_EQ(out.udw_size, sz);
+    for (uint16_t i = 0; i < sz; i++) {
+      EXPECT_EQ(udw_out[i], udw[i]) << "udw mismatch sz=" << sz << " i=" << i;
+    }
+  }
+}
+
+TEST_F(St40Rfc8331CodecTest, DecodeOkMetaOnly) {
+  auto in = make_meta(4);
+  auto udw = make_udw(4, 1);
+  std::vector<uint8_t> buf(kBufRoom, 0);
+  uint32_t written = 0;
+  ASSERT_EQ(st40_rfc8331_encode_packet(buf.data(), kBufRoom, &in, udw.data(), &written),
+            0);
+
+  struct st40_meta out {};
+  uint32_t consumed = 0;
+  EXPECT_EQ(st40_rfc8331_decode_packet(buf.data(), written, &out, nullptr, 0, &consumed),
+            ST40_RFC8331_DECODE_OK);
+  EXPECT_EQ(out.udw_size, 4);
+  EXPECT_EQ(consumed, written);
+}
+
+TEST_F(St40Rfc8331CodecTest, DecodeShortBufferHeader) {
+  uint8_t tiny[3] = {0};
+  struct st40_meta out {};
+  uint32_t consumed = 0;
+  EXPECT_EQ(st40_rfc8331_decode_packet(tiny, sizeof(tiny), &out, nullptr, 0, &consumed),
+            ST40_RFC8331_DECODE_SHORT_BUFFER);
+}
+
+TEST_F(St40Rfc8331CodecTest, DecodeShortBufferBody) {
+  auto in = make_meta(20);
+  auto udw = make_udw(20, 2);
+  std::vector<uint8_t> buf(kBufRoom, 0);
+  uint32_t written = 0;
+  ASSERT_EQ(st40_rfc8331_encode_packet(buf.data(), kBufRoom, &in, udw.data(), &written),
+            0);
+  struct st40_meta out {};
+  uint32_t consumed = 0;
+  /* feed only the 8-byte header -- body is missing */
+  EXPECT_EQ(st40_rfc8331_decode_packet(buf.data(), 8, &out, nullptr, 0, &consumed),
+            ST40_RFC8331_DECODE_SHORT_BUFFER);
+}
+
+TEST_F(St40Rfc8331CodecTest, DecodeShortBufferUdwOut) {
+  auto in = make_meta(10);
+  auto udw = make_udw(10, 3);
+  std::vector<uint8_t> buf(kBufRoom, 0);
+  uint32_t written = 0;
+  ASSERT_EQ(st40_rfc8331_encode_packet(buf.data(), kBufRoom, &in, udw.data(), &written),
+            0);
+  struct st40_meta out {};
+  std::vector<uint8_t> small_out(5, 0);
+  uint32_t consumed = 0;
+  EXPECT_EQ(st40_rfc8331_decode_packet(buf.data(), written, &out, small_out.data(), 5,
+                                       &consumed),
+            ST40_RFC8331_DECODE_SHORT_BUFFER);
+}
+
+TEST_F(St40Rfc8331CodecTest, DecodeParityFail) {
+  auto in = make_meta(4);
+  auto udw = make_udw(4, 4);
+  std::vector<uint8_t> buf(kBufRoom, 0);
+  uint32_t written = 0;
+  ASSERT_EQ(st40_rfc8331_encode_packet(buf.data(), kBufRoom, &in, udw.data(), &written),
+            0);
+  /* Corrupt DID byte (low 8 bits of second_hdr_chunk on the wire are at
+   * offset 4..7; flip a bit in the parity-bearing nibble). */
+  buf[4] ^= 0x01;
+  struct st40_meta out {};
+  std::vector<uint8_t> udw_out(4, 0);
+  uint32_t consumed = 0;
+  EXPECT_EQ(
+      st40_rfc8331_decode_packet(buf.data(), written, &out, udw_out.data(), 4, &consumed),
+      ST40_RFC8331_DECODE_PARITY_FAIL);
+}
+
+TEST_F(St40Rfc8331CodecTest, DecodeChecksumFail) {
+  auto in = make_meta(4);
+  auto udw = make_udw(4, 5);
+  std::vector<uint8_t> buf(kBufRoom, 0);
+  uint32_t written = 0;
+  ASSERT_EQ(st40_rfc8331_encode_packet(buf.data(), kBufRoom, &in, udw.data(), &written),
+            0);
+  /* Last 4 bytes hold the 10-bit checksum field; toggle a bit in the
+   * second-to-last byte (avoids the all-zero padding tail). */
+  buf[written - 3] ^= 0x40;
+  struct st40_meta out {};
+  std::vector<uint8_t> udw_out(4, 0);
+  uint32_t consumed = 0;
+  EXPECT_EQ(
+      st40_rfc8331_decode_packet(buf.data(), written, &out, udw_out.data(), 4, &consumed),
+      ST40_RFC8331_DECODE_CHECKSUM_FAIL);
+}
+
+TEST_F(St40Rfc8331CodecTest, EncodeNoSpace) {
+  auto in = make_meta(10);
+  auto udw = make_udw(10, 6);
+  uint8_t small[8] = {0};
+  uint32_t written = 0xDEAD;
+  EXPECT_EQ(st40_rfc8331_encode_packet(small, sizeof(small), &in, udw.data(), &written),
+            -ENOSPC);
+}

--- a/tests/unit/session/st40/rfc8331_payload_bytes_test.cpp
+++ b/tests/unit/session/st40/rfc8331_payload_bytes_test.cpp
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Pin the wire-aligned byte size returned by st40_rfc8331_payload_bytes()
+ * against hand-computed RFC 8331 §2.1 values. Any change to the helper's
+ * arithmetic (10-bit packing, ceil-to-byte, 4-byte align, +hdr) breaks
+ * wire compatibility with the TX/RX data path and the noctx test builder.
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St40Rfc8331PayloadBytesTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "st40_api.h"
+
+class St40Rfc8331PayloadBytesTest : public ::testing::Test {};
+
+/* Values computed by hand from (ceil((3+udw+1)*10 / 8) aligned to 4) + 4. */
+TEST_F(St40Rfc8331PayloadBytesTest, MatchesRfc8331Formula) {
+  EXPECT_EQ(st40_rfc8331_payload_bytes(0), 12u);
+  EXPECT_EQ(st40_rfc8331_payload_bytes(1), 12u);
+  EXPECT_EQ(st40_rfc8331_payload_bytes(8), 20u);
+  EXPECT_EQ(st40_rfc8331_payload_bytes(9), 24u);
+  EXPECT_EQ(st40_rfc8331_payload_bytes(100), 136u);
+  EXPECT_EQ(st40_rfc8331_payload_bytes(255), 328u);
+}


### PR DESCRIPTION
Replaces ~30 hand-rolled copies of the SMPTE ST 2110-40 / RFC 8331 wire dance (byte-count math, header byte-swap, per-packet encode/decode) across the library, gstreamer plugins, RxTxApp, and tests with a three-layer helper stack in [st40_api.h](vscode-file://vscode-app/c:/Users/mkasiewi/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

st40_rfc8331_payload_bytes() — sizing math (5 sites)
st40_rfc8331_{rtp,payload}_hdr_bswap() — header byte-swap (~17 sites)
st40_rfc8331_{encode,decode}_packet() — full packet codec with a result enum (8 sites)
Net: ~160 LOC removed, latent RX checksum-ordering bug fixed by consolidation, round-trip unit test pins the wire format. TX session intentionally retains direct primitive use to preserve its per-value parity test hook. Verified: 137/137 *St40* unit tests + 36/36 *St40* KahawaiTest on real E810 VFs.