### PR TITLE
ST30 (audio) RX: report frame corruption and assemble by RTP timestamp

### DIFF
--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -100,7 +100,7 @@ All counters are `uint64_t`, monotonic, thread-safe (per-session spinlock).
  │     ST20 / ST22 (transport): intra-frame loss detected                       │
  │                                    ──► stat_frames_incomplete++             │
  │                                                                             │
- │     ST20p / ST40p: frame delivered with intra-frame loss             │
+ │     ST20p / ST30p / ST40p: frame delivered with unrecovered loss     │
  │                                    ──► stat_frames_corrupted++              │
  │                                        (frame still delivered with          │
  │                                         ST_FRAME_STATUS_CORRUPTED)          │
@@ -164,7 +164,7 @@ frames did the app receive / drop / send".
 
 Populated by pipeline session types (`ST20p`, `ST30p`, `ST40p` for both
 RX and TX). For transport-only paths and types with no per-frame
-integrity concept (`stat_frames_corrupted` on `ST30p` audio, `ST41` RX),
+integrity concept (`stat_frames_corrupted` on `ST41` RX),
 the relevant counters stay 0.
 
 > **ST20 / ST22 only:** the transport-layer field `stat_frames_incomplete`
@@ -318,11 +318,14 @@ Cross-frame reorders are not tracked. Watch
 **Audio/Anc/FMD (ST30/40/41).** Loss uses post-redundancy `session_seq_id` →
 `stat_pkts_unrecovered` is **exact**. ST30 adds `stat_pkts_dropped`,
 `stat_pkts_len_mismatch_dropped`, `stat_slot_get_frame_fail`. ST40/41 add
-`stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`. ST20p and
-ST40p RX mark frames whose constituent packets had unrecoverable gaps as
-`ST_FRAME_STATUS_CORRUPTED` and count them in `stat_frames_corrupted`;
-the frame is still delivered to the app (the app should consult
-`frame->status`).
+`stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`. ST20p,
+ST30p and ST40p RX mark frames whose constituent packets had unrecovered
+(post-redundancy) gaps as `ST_FRAME_STATUS_CORRUPTED` and count them in
+`stat_frames_corrupted`; the frame is still delivered to the app (the app
+should consult `frame->status`). For count-based assembly (ST30 audio /
+ST40 anc) a fully-lost frame is absorbed — the delivered frame count drops
+rather than emitting an extra incomplete frame — so under heavy contiguous
+loss `stat_frames_corrupted` is a lower bound on frame-integrity impact.
 
 **TX (any type).** `stat_epoch_drop` = app handed frame too late, slots were
 skipped (counter advanced by the number of skipped slots).

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -83,6 +83,11 @@ typedef struct st_rx_audio_session_handle_impl* st30_rx_handle;
 #define ST30_RX_FLAG_FORCE_NUMA (MTL_BIT32(2))
 /**
  * Flag bit in flags of struct st30_rx_ops.
+ * If enabled, simulate random packet loss, test usage only.
+ */
+#define ST30_RX_FLAG_SIMULATE_PKT_LOSS (MTL_BIT32(3))
+/**
+ * Flag bit in flags of struct st30_rx_ops.
  * Enable the timing analyze in the stat dump
  */
 #define ST30_RX_FLAG_TIMING_PARSER_STAT (MTL_BIT32(16))
@@ -284,6 +289,8 @@ struct st30_rx_frame_meta {
   uint32_t rtp_timestamp;
   /** received data size for current frame */
   size_t frame_recv_size;
+  /** Frame status, complete or corrupted by unrecovered packet loss */
+  enum st_frame_status status;
 };
 
 /**

--- a/include/st30_pipeline_api.h
+++ b/include/st30_pipeline_api.h
@@ -246,6 +246,12 @@ enum st30p_rx_flag {
   /** Force the numa of the created session, both CPU and memory */
   ST30P_RX_FLAG_FORCE_NUMA = (MTL_BIT32(2)),
 
+  /**
+   * Flag bit in flags of struct st30p_rx_ops.
+   * If enabled, simulate random packet loss, test usage only.
+   */
+  ST30P_RX_FLAG_SIMULATE_PKT_LOSS = (MTL_BIT32(3)),
+
   /** Enable the st30p_rx_get_frame block behavior to wait until a frame becomes
    available or timeout(default: 1s, use st30p_rx_set_block_timeout to customize) */
   ST30P_RX_FLAG_BLOCK_GET = (MTL_BIT32(15)),

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -454,8 +454,8 @@ struct st_rx_user_stats {
    * redundancy. The frame is still handed to the application; the
    * application should consult frame->status to decide what to do.
    * Populated by RX session types that classify per-frame integrity
-   * (ST20p, ST40p). Always 0 for types with no per-frame corruption
-   * concept (audio ST30, ST41).
+   * (ST20p, ST30p, ST40p). Always 0 for types with no per-frame
+   * corruption concept (ST41).
    */
   uint64_t stat_frames_corrupted;
 };

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.c
@@ -95,7 +95,7 @@ static int rx_st30p_frame_ready(void* priv, void* addr, struct st30_rx_frame_met
   frame->timestamp = meta->timestamp;
   frame->receive_timestamp = meta->timestamp_first_pkt;
   frame->rtp_timestamp = meta->rtp_timestamp;
-  frame->status = ST_FRAME_STATUS_COMPLETE;
+  frame->status = meta->status;
   framebuff->stat = ST30P_RX_FRAME_READY;
   /* point to next */
   ctx->framebuff_producer_idx = rx_st30p_next_idx(ctx, framebuff->idx);
@@ -144,6 +144,8 @@ static int rx_st30p_create_transport(struct mtl_main_impl* impl, struct st30p_rx
     ops_rx.socket_id = ops->socket_id;
     ops_rx.flags |= ST30_RX_FLAG_FORCE_NUMA;
   }
+  if (ops->flags & ST30P_RX_FLAG_SIMULATE_PKT_LOSS)
+    ops_rx.flags |= ST30_RX_FLAG_SIMULATE_PKT_LOSS;
 
   transport = st30_rx_create(impl, &ops_rx);
   if (!transport) {
@@ -330,6 +332,8 @@ struct st30_frame* st30p_rx_get_frame(st30p_rx_handle handle) {
   frame = &framebuff->frame;
   ctx->stat_get_frame_succ++;
   __atomic_fetch_add(&ctx->stat_frames_received, 1, __ATOMIC_RELAXED);
+  if (frame->status == ST_FRAME_STATUS_CORRUPTED)
+    __atomic_fetch_add(&ctx->stat_frames_corrupted, 1, __ATOMIC_RELAXED);
   MT_USDT_ST30P_RX_FRAME_GET(idx, framebuff->idx, frame->addr);
   dbg("%s(%d), frame %u(%p) succ\n", __func__, idx, framebuff->idx, frame->addr);
   /* check if dump USDT enabled */
@@ -567,6 +571,8 @@ int st30p_rx_get_session_stats(st30p_rx_handle handle, struct st30_rx_user_stats
       __atomic_load_n(&ctx->stat_frames_received, __ATOMIC_RELAXED);
   stats->common.stat_frames_dropped =
       __atomic_load_n(&ctx->stat_frames_dropped, __ATOMIC_RELAXED);
+  stats->common.stat_frames_corrupted =
+      __atomic_load_n(&ctx->stat_frames_corrupted, __ATOMIC_RELAXED);
   ret = 0;
 out:
   MT_HANDLE_RELEASE(ctx);
@@ -586,6 +592,7 @@ int st30p_rx_reset_session_stats(st30p_rx_handle handle) {
 
   __atomic_store_n(&ctx->stat_frames_received, 0, __ATOMIC_RELAXED);
   __atomic_store_n(&ctx->stat_frames_dropped, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&ctx->stat_frames_corrupted, 0, __ATOMIC_RELAXED);
   ret = st30_rx_reset_session_stats(ctx->transport);
   MT_HANDLE_RELEASE(ctx);
   return ret;

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.h
@@ -63,6 +63,7 @@ struct st30p_rx_ctx {
   /* cumulative user-facing counters; reset only by reset_session_stats */
   uint64_t stat_frames_received;
   uint64_t stat_frames_dropped;
+  uint64_t stat_frames_corrupted;
 };
 
 #endif

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -945,7 +945,6 @@ struct st_rx_audio_session_impl {
   uint32_t pkt_len;       /* data len(byte) for each pkt */
   uint32_t st30_pkt_size; /* size for each pkt which include the header */
   int st30_total_pkts;    /* total pkts in one frame */
-  int st30_pkt_idx;       /* pkt index in current frame */
   int session_seq_id;     /* global session seq id to track continuity across redundant */
   int latest_seq_id[MTL_SESSION_PORT_MAX]; /* latest seq id */
 
@@ -958,7 +957,12 @@ struct st_rx_audio_session_impl {
   uint64_t first_pkt_ptp_ts; /* PTP time stamp for the first pkt */
   int64_t tmstamp;
   size_t frame_recv_size;
-  uint32_t frame_unrecovered_pkts; /* post-redundancy lost pkts in current frame */
+
+  /* positional single-slot frame assembly: packets are placed by their RTP
+   * timestamp offset within the open frame and tracked in frame_bitmap. */
+  uint32_t rtp_ticks_per_frame; /* media-clock ticks spanning one frame buffer */
+  uint32_t samples_per_pkt;     /* sample-clock ticks carried by one packet */
+  uint8_t* frame_bitmap;        /* per-pkt received bitmap for the open frame */
 
   /* simulated packet loss for test usage, ST30_RX_FLAG_SIMULATE_PKT_LOSS */
   uint16_t burst_loss_max;

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -958,6 +958,12 @@ struct st_rx_audio_session_impl {
   uint64_t first_pkt_ptp_ts; /* PTP time stamp for the first pkt */
   int64_t tmstamp;
   size_t frame_recv_size;
+  uint32_t frame_unrecovered_pkts; /* post-redundancy lost pkts in current frame */
+
+  /* simulated packet loss for test usage, ST30_RX_FLAG_SIMULATE_PKT_LOSS */
+  uint16_t burst_loss_max;
+  float sim_loss_rate;
+  uint16_t burst_loss_cnt;
 
   /* st30 rtp info */
   struct rte_ring* st30_rtps_ring;

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -352,6 +352,10 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
         seq_id, s->session_seq_id);
     s->port_user_stats.common.stat_pkts_unrecovered +=
         (uint16_t)(seq_id - s->session_seq_id - 1);
+    /* attribute the whole gap to the frame currently being assembled; audio places
+     * packets by arrival order, so a gap straddling a frame boundary is charged to
+     * this frame rather than split across the boundary */
+    s->frame_unrecovered_pkts += (uint16_t)(seq_id - s->session_seq_id - 1);
   }
 
   /* The package is accepted and goes into the frame */
@@ -418,6 +422,8 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     meta->channel = ops->channel;
     meta->rtp_timestamp = s->first_pkt_rtp_ts;
     meta->frame_recv_size = s->frame_recv_size;
+    meta->status =
+        s->frame_unrecovered_pkts ? ST_FRAME_STATUS_CORRUPTED : ST_FRAME_STATUS_COMPLETE;
 
     MT_USDT_ST30_RX_FRAME_AVAILABLE(s->mgr->idx, s->idx, frame->idx, frame->addr,
                                     s->first_pkt_rtp_ts, meta->frame_recv_size);
@@ -442,6 +448,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
     }
     s->frame_recv_size = 0;
     s->st30_pkt_idx = 0;
+    s->frame_unrecovered_pkts = 0;
     rte_atomic32_inc(&s->stat_frames_received);
     s->st30_cur_frame = NULL;
   }
@@ -568,6 +575,8 @@ static void rx_audio_session_reset(struct st_rx_audio_session_impl* s,
   s->tmstamp = -1;
   s->frame_recv_size = 0;
   s->st30_pkt_idx = 0;
+  s->frame_unrecovered_pkts = 0;
+  s->burst_loss_cnt = 0;
   s->st30_cur_frame = NULL;
   s->first_pkt_rtp_ts = 0;
   s->stat_last_time = init_stat_time_now ? mt_get_monotonic_time() : 0;
@@ -652,6 +661,19 @@ static int ra_dump_pcap(struct st_rx_audio_session_impl* s, struct rte_mbuf** mb
   return 0;
 }
 
+static bool ra_simulate_pkt_loss(struct st_rx_audio_session_impl* s) {
+  if (s->burst_loss_cnt == 0) {
+    if (((float)rand() / (float)RAND_MAX) < s->sim_loss_rate) {
+      s->burst_loss_cnt = rand() % s->burst_loss_max + 1;
+    } else {
+      return false;
+    }
+  }
+  s->burst_loss_cnt--;
+  dbg("%s(%d), simulate pkt loss, burst left %u\n", __func__, s->idx, s->burst_loss_cnt);
+  return true;
+}
+
 static int rx_audio_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf, uint16_t nb) {
   struct st_rx_session_priv* s_priv = priv;
   struct st_rx_audio_session_impl* s = s_priv->session;
@@ -675,11 +697,15 @@ static int rx_audio_session_handle_mbuf(void* priv, struct rte_mbuf** mbuf, uint
 
   if (ST30_TYPE_FRAME_LEVEL == st30_type) {
     for (uint16_t i = 0; i < nb; i++) {
+      if ((s->ops.flags & ST30_RX_FLAG_SIMULATE_PKT_LOSS) && ra_simulate_pkt_loss(s))
+        continue;
       int rc = rx_audio_session_handle_frame_pkt(impl, s, mbuf[i], s_port);
       if (rc < 0 && rc != -EAGAIN) s->port_user_stats.common.port[s_port].err_packets++;
     }
   } else {
     for (uint16_t i = 0; i < nb; i++) {
+      if ((s->ops.flags & ST30_RX_FLAG_SIMULATE_PKT_LOSS) && ra_simulate_pkt_loss(s))
+        continue;
       int rc = rx_audio_session_handle_rtp_pkt(impl, s, mbuf[i], s_port);
       if (rc < 0 && rc != -EAGAIN) s->port_user_stats.common.port[s_port].err_packets++;
     }
@@ -928,6 +954,14 @@ static int rx_audio_session_attach(struct mtl_main_impl* impl,
   }
   s->st30_frame_size = ops->framebuff_size;
   rx_audio_session_reset(s, true);
+
+  if (ops->flags & ST30_RX_FLAG_SIMULATE_PKT_LOSS) {
+    /* st30_rx_ops exposes no loss tuning knobs; use fixed test defaults */
+    s->burst_loss_max = 1;
+    s->sim_loss_rate = 0.1;
+    info("%s(%d), simulated packet loss max burst %u rate %f\n", __func__, idx,
+         s->burst_loss_max, s->sim_loss_rate);
+  }
 
   if (ops->flags & ST30_RX_FLAG_TIMING_PARSER_STAT) {
     info("%s(%d), enable the timing analyze stat\n", __func__, idx);

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -106,6 +106,11 @@ static int rx_audio_session_free_frames(struct st_rx_audio_session_impl* s) {
     s->st30_frames = NULL;
   }
 
+  if (s->frame_bitmap) {
+    mt_rte_free(s->frame_bitmap);
+    s->frame_bitmap = NULL;
+  }
+
   dbg("%s(%d), succ\n", __func__, s->idx);
   return 0;
 }
@@ -142,6 +147,13 @@ static int rx_audio_session_alloc_frames(struct st_rx_audio_session_impl* s) {
     st30_frame->flags = ST_FT_FLAG_RTE_MALLOC;
     st30_frame->addr = frame;
     st30_frame->iova = rte_malloc_virt2iova(frame);
+  }
+
+  s->frame_bitmap = mt_rte_zmalloc_socket(((size_t)s->st30_total_pkts + 7) / 8, soc_id);
+  if (!s->frame_bitmap) {
+    err("%s(%d), frame_bitmap alloc fail\n", __func__, idx);
+    rx_audio_session_free_frames(s);
+    return -ENOMEM;
   }
 
   dbg("%s(%d), succ\n", __func__, idx);
@@ -248,6 +260,95 @@ static int rx_audio_session_usdt_dump_frame(struct st_rx_audio_session_impl* s,
   return 0;
 }
 
+static int rx_audio_session_open_frame(struct st_rx_audio_session_impl* s,
+                                       enum mtl_session_port s_port, uint32_t tmstamp,
+                                       uint64_t ptp_ts) {
+  s->st30_cur_frame = rx_audio_session_get_frame(s);
+  if (!s->st30_cur_frame) {
+    s->port_user_stats.stat_slot_get_frame_fail++;
+    return -EIO;
+  }
+
+  /* Anchor on the grid floor carried by s->tmstamp so a missing leading packet
+   * leaves slot 0 unset; resync to the arriving ts on a jump beyond one frame. */
+  uint32_t spp = s->samples_per_pkt ? s->samples_per_pkt : 1;
+  uint32_t grid_base = (uint32_t)(s->tmstamp + 1);
+  uint32_t base = (((uint32_t)(tmstamp - grid_base) / spp) < (uint32_t)s->st30_total_pkts)
+                      ? grid_base
+                      : tmstamp;
+
+  memset(s->frame_bitmap, 0, ((size_t)s->st30_total_pkts + 7) / 8);
+  s->frame_recv_size = 0;
+  s->first_pkt_rtp_ts = base;
+  s->first_pkt_ptp_ts = ptp_ts;
+  s->tmstamp = (int64_t)(uint32_t)(base - 1);
+  s->port_user_stats.common.port[s_port].frames++;
+  return 0;
+}
+
+/* Close the open frame: COMPLETE when every positional slot was filled,
+ * CORRUPTED otherwise (mirrors st20 rv_frame_notify). The floor watermark is
+ * advanced to the next frame so a late packet for this just-closed frame is
+ * dropped by the redundancy filter. */
+static void rx_audio_session_frame_notify(struct mtl_main_impl* impl,
+                                          struct st_rx_audio_session_impl* s) {
+  struct st30_rx_ops* ops = &s->ops;
+  struct st30_rx_frame_meta* meta = &s->meta;
+  struct st_frame_trans* frame = s->st30_cur_frame;
+  uint64_t tsc_start = 0;
+
+  if (s->enable_timing_parser) {
+    struct st_rx_audio_tp* tp = s->tp;
+    uint64_t now = mt_get_tsc(impl);
+    if ((now - tp->last_parse_time) > (200 * NS_PER_MS)) {
+      for (int sp = 0; sp < ops->num_port; sp++) {
+        struct st_ra_tp_slot* slot = &s->tp->slot[sp];
+        ra_tp_slot_parse_result(s, sp);
+        if (s->enable_timing_parser_meta) {
+          ops->notify_timing_parser_result(ops->priv, sp, &slot->meta);
+        }
+        ra_tp_slot_init(slot);
+      }
+      tp->last_parse_time = now;
+    }
+  }
+
+  meta->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
+  meta->timestamp = s->first_pkt_rtp_ts;
+  meta->timestamp_first_pkt = s->first_pkt_ptp_ts;
+  meta->fmt = ops->fmt;
+  meta->sampling = ops->sampling;
+  meta->channel = ops->channel;
+  meta->rtp_timestamp = s->first_pkt_rtp_ts;
+  meta->frame_recv_size = s->frame_recv_size;
+  meta->status = (s->frame_recv_size >= s->st30_frame_size) ? ST_FRAME_STATUS_COMPLETE
+                                                            : ST_FRAME_STATUS_CORRUPTED;
+
+  MT_USDT_ST30_RX_FRAME_AVAILABLE(s->mgr->idx, s->idx, frame->idx, frame->addr,
+                                  s->first_pkt_rtp_ts, meta->frame_recv_size);
+  if (MT_USDT_ST30_RX_FRAME_DUMP_ENABLED()) {
+    rx_audio_session_usdt_dump_frame(s, frame);
+  } else {
+    rx_audio_session_usdt_dump_close(s);
+  }
+
+  bool time_measure = mt_sessions_time_measure(impl);
+  if (time_measure) tsc_start = mt_get_tsc(impl);
+  int ret = ops->notify_frame_ready(ops->priv, frame->addr, meta);
+  if (time_measure) {
+    uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+    s->stat_max_notify_frame_us = RTE_MAX(s->stat_max_notify_frame_us, delta_us);
+  }
+  if (ret < 0) {
+    warn("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
+    rx_audio_session_put_frame(s, frame);
+  }
+
+  s->tmstamp = (int64_t)(uint32_t)(s->first_pkt_rtp_ts + s->rtp_ticks_per_frame - 1);
+  rte_atomic32_inc(&s->stat_frames_received);
+  s->st30_cur_frame = NULL;
+}
+
 static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
                                              struct st_rx_audio_session_impl* s,
                                              struct rte_mbuf* mbuf,
@@ -292,11 +393,6 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
 
   enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
 
-  if (s->st30_pkt_idx == 0) {
-    s->first_pkt_rtp_ts = tmstamp;
-    s->first_pkt_ptp_ts = mt_mbuf_time_stamp(impl, mbuf, port);
-  }
-
   if (unlikely(s->latest_seq_id[s_port] == -1)) s->latest_seq_id[s_port] = seq_id - 1;
   if (unlikely(s->session_seq_id == -1)) s->session_seq_id = seq_id - 1;
   if (unlikely(s->tmstamp == -1)) s->tmstamp = tmstamp - 1;
@@ -324,7 +420,8 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   s->port_user_stats.common.port[s_port].packets++;
   s->port_user_stats.common.port[s_port].bytes += mbuf->pkt_len;
 
-  /* all packets need to have increasing timestamp */
+  /* drop packets older than the open frame's base (or the next-frame floor
+   * between frames); the bitmap dedups packets inside the open frame */
   if (!mt_seq32_greater(tmstamp, s->tmstamp)) {
     dbg("%s(%d,%d), drop as pkt seq_id %u (%u) or tmstamp %u (%ld) is old\n", __func__,
         s->idx, s_port, seq_id, s->latest_seq_id[s_port], tmstamp, s->tmstamp);
@@ -342,7 +439,6 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
          __func__, s->idx, tmstamp, s->tmstamp);
   }
   s->redundant_error_cnt[s_port] = 0;
-  s->tmstamp = tmstamp;
 
   /* hole in seq id packets going into the session check if the seq_id of the session is
    * consistent */
@@ -352,10 +448,6 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
         seq_id, s->session_seq_id);
     s->port_user_stats.common.stat_pkts_unrecovered +=
         (uint16_t)(seq_id - s->session_seq_id - 1);
-    /* attribute the whole gap to the frame currently being assembled; audio places
-     * packets by arrival order, so a gap straddling a frame boundary is charged to
-     * this frame rather than split across the boundary */
-    s->frame_unrecovered_pkts += (uint16_t)(seq_id - s->session_seq_id - 1);
   }
 
   /* The package is accepted and goes into the frame */
@@ -364,93 +456,49 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   if (mt_seq16_greater(seq_id, s->session_seq_id)) s->session_seq_id = seq_id;
 
   if (!s->st30_cur_frame) {
-    s->st30_cur_frame = rx_audio_session_get_frame(s);
-    if (!s->st30_cur_frame) {
+    if (rx_audio_session_open_frame(s, s_port, tmstamp,
+                                    mt_mbuf_time_stamp(impl, mbuf, port)) < 0) {
       dbg("%s(%d,%d), seq %d drop as frame run out\n", __func__, s->idx, s_port, seq_id);
-      s->port_user_stats.stat_slot_get_frame_fail++;
       MT_USDT_ST30_RX_NO_FRAMEBUFFER(s->mgr->idx, s->idx, tmstamp);
       return -EIO;
     }
-
-    s->port_user_stats.common.port[s_port].frames++;
   }
 
-  uint32_t offset = s->st30_pkt_idx * s->pkt_len;
-  if ((offset + s->pkt_len) > s->st30_frame_size) {
-    dbg("%s(%d,%d): invalid offset %u frame size %" PRIu64 "\n", __func__, s->idx, s_port,
-        offset, s->st30_frame_size);
-    s->port_user_stats.stat_pkts_dropped++;
-    return -EIO;
+  uint32_t spp = s->samples_per_pkt ? s->samples_per_pkt : 1;
+  uint32_t idx = (tmstamp - s->first_pkt_rtp_ts) / spp;
+
+  if (idx >= (uint32_t)s->st30_total_pkts) {
+    /* forward jump: close the open frame (CORRUPTED if partial), emit nothing
+     * for any wholly-missing frames in between, then open a fresh frame at this
+     * timestamp. A late packet for the just-closed frame is dropped — the
+     * single slot keeps no history of it. */
+    rx_audio_session_frame_notify(impl, s);
+    if (rx_audio_session_open_frame(s, s_port, tmstamp,
+                                    mt_mbuf_time_stamp(impl, mbuf, port)) < 0) {
+      dbg("%s(%d,%d), seq %d drop as frame run out\n", __func__, s->idx, s_port, seq_id);
+      MT_USDT_ST30_RX_NO_FRAMEBUFFER(s->mgr->idx, s->idx, tmstamp);
+      return -EIO;
+    }
+    idx = (tmstamp - s->first_pkt_rtp_ts) / spp;
   }
-  rte_memcpy(s->st30_cur_frame->addr + offset, payload, s->pkt_len);
+
+  if (mt_bitmap_test_and_set(s->frame_bitmap, (int)idx)) {
+    dbg("%s(%d,%d), seq %d idx %u already received\n", __func__, s->idx, s_port, seq_id,
+        idx);
+    s->port_user_stats.common.stat_pkts_redundant++;
+    return 0;
+  }
+
+  rte_memcpy(s->st30_cur_frame->addr + (size_t)idx * s->pkt_len, payload, s->pkt_len);
   s->frame_recv_size += s->pkt_len;
   s->port_user_stats.common.stat_pkts_received++;
-  s->st30_pkt_idx++;
 
   if (s->enable_timing_parser) {
     ra_tp_on_packet(s, s_port, tmstamp, mt_mbuf_time_stamp(impl, mbuf, port));
   }
 
-  // notify frame done
   if (s->frame_recv_size >= s->st30_frame_size) {
-    struct st30_rx_frame_meta* meta = &s->meta;
-    uint64_t tsc_start = 0;
-    struct st_frame_trans* frame = s->st30_cur_frame;
-
-    if (s->enable_timing_parser) {
-      /* parse timing result every 200ms */
-      struct st_rx_audio_tp* tp = s->tp;
-      uint64_t now = mt_get_tsc(impl);
-      if ((now - tp->last_parse_time) > (200 * NS_PER_MS)) {
-        for (int sp = 0; sp < ops->num_port; sp++) {
-          struct st_ra_tp_slot* slot = &s->tp->slot[sp];
-          ra_tp_slot_parse_result(s, sp);
-          if (s->enable_timing_parser_meta) {
-            ops->notify_timing_parser_result(ops->priv, sp, &slot->meta);
-          }
-          ra_tp_slot_init(slot);
-        }
-        tp->last_parse_time = now;
-      }
-    }
-
-    meta->tfmt = ST10_TIMESTAMP_FMT_MEDIA_CLK;
-    meta->timestamp = s->first_pkt_rtp_ts;
-    meta->timestamp_first_pkt = s->first_pkt_ptp_ts;
-    meta->fmt = ops->fmt;
-    meta->sampling = ops->sampling;
-    meta->channel = ops->channel;
-    meta->rtp_timestamp = s->first_pkt_rtp_ts;
-    meta->frame_recv_size = s->frame_recv_size;
-    meta->status =
-        s->frame_unrecovered_pkts ? ST_FRAME_STATUS_CORRUPTED : ST_FRAME_STATUS_COMPLETE;
-
-    MT_USDT_ST30_RX_FRAME_AVAILABLE(s->mgr->idx, s->idx, frame->idx, frame->addr,
-                                    s->first_pkt_rtp_ts, meta->frame_recv_size);
-    /* check if dump USDT enabled */
-    if (MT_USDT_ST30_RX_FRAME_DUMP_ENABLED()) {
-      rx_audio_session_usdt_dump_frame(s, frame);
-    } else {
-      rx_audio_session_usdt_dump_close(s);
-    }
-
-    /* get a full frame */
-    bool time_measure = mt_sessions_time_measure(impl);
-    if (time_measure) tsc_start = mt_get_tsc(impl);
-    int ret = ops->notify_frame_ready(ops->priv, frame->addr, meta);
-    if (time_measure) {
-      uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
-      s->stat_max_notify_frame_us = RTE_MAX(s->stat_max_notify_frame_us, delta_us);
-    }
-    if (ret < 0) {
-      err("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
-      rx_audio_session_put_frame(s, frame);
-    }
-    s->frame_recv_size = 0;
-    s->st30_pkt_idx = 0;
-    s->frame_unrecovered_pkts = 0;
-    rte_atomic32_inc(&s->stat_frames_received);
-    s->st30_cur_frame = NULL;
+    rx_audio_session_frame_notify(impl, s);
   }
 
   return 0;
@@ -574,8 +622,6 @@ static void rx_audio_session_reset(struct st_rx_audio_session_impl* s,
   s->latest_seq_id[MTL_SESSION_PORT_R] = -1;
   s->tmstamp = -1;
   s->frame_recv_size = 0;
-  s->st30_pkt_idx = 0;
-  s->frame_unrecovered_pkts = 0;
   s->burst_loss_cnt = 0;
   s->st30_cur_frame = NULL;
   s->first_pkt_rtp_ts = 0;
@@ -953,6 +999,10 @@ static int rx_audio_session_attach(struct mtl_main_impl* impl,
     return -EIO;
   }
   s->st30_frame_size = ops->framebuff_size;
+  uint32_t per_frame_div = (uint32_t)st30_get_sample_size(ops->fmt) * ops->channel;
+  s->rtp_ticks_per_frame =
+      per_frame_div ? (uint32_t)(s->st30_frame_size / per_frame_div) : 0;
+  s->samples_per_pkt = per_frame_div ? (s->pkt_len / per_frame_div) : 0;
   rx_audio_session_reset(s, true);
 
   if (ops->flags & ST30_RX_FLAG_SIMULATE_PKT_LOSS) {

--- a/tests/integration_tests/st30p_test.cpp
+++ b/tests/integration_tests/st30p_test.cpp
@@ -206,11 +206,11 @@ static void test_st30p_rx_frame_thread(void* args) {
     if (frame->channel != s->audio_channel) s->incomplete_frame_cnt++;
     if (frame->ptime != s->audio_ptime) s->incomplete_frame_cnt++;
     if (frame->sampling != s->audio_sampling) s->incomplete_frame_cnt++;
+    if (!st_is_frame_complete(frame->status)) s->incomplete_frame_cnt++;
 
     dbg("%s(%d), timestamp %" PRIu64 "\n", __func__, s->idx, frame->timestamp);
     if (frame->timestamp == timestamp) s->incomplete_frame_cnt++;
     timestamp = frame->timestamp;
-
     /* check user timestamp if it has */
     if (s->user_timestamp && !s->user_pacing) {
       if (s->pre_timestamp) {
@@ -882,8 +882,134 @@ TEST(St30p, redundant_stats) {
 
   /* verify RX received frames */
   EXPECT_GT(test_ctx_rx->fb_rec, 0) << "Must have received frames";
+  EXPECT_EQ(rx_stats.common.stat_frames_corrupted, (uint64_t)0)
+      << "clean redundant session must not report corrupted frames";
   info("%s, TX sent %d, RX received %d frames\n", __func__, test_ctx_tx->fb_send,
        test_ctx_rx->fb_rec);
+
+  ret = st30p_tx_free(tx_handle);
+  EXPECT_GE(ret, 0);
+  ret = st30p_rx_free(rx_handle);
+  EXPECT_GE(ret, 0);
+
+  delete test_ctx_tx;
+  delete test_ctx_rx;
+}
+
+/*
+ * Verify ST30p RX reports per-frame corruption when post-redundancy packet
+ * loss occurs. ST30P_RX_FLAG_SIMULATE_PKT_LOSS drops packets on the RX side
+ * so frames close short of full coverage; those frames must be delivered to
+ * the app with status ST_FRAME_STATUS_CORRUPTED and counted in
+ * common.stat_frames_corrupted.
+ */
+TEST(St30p, rx_simulate_pkt_loss) {
+  auto ctx = (struct st_tests_context*)st_test_ctx();
+  auto st = ctx->handle;
+  int ret;
+  struct st30p_tx_ops ops_tx;
+  struct st30p_rx_ops ops_rx;
+  int udp_port = ST30P_TEST_UDP_PORT + 200;
+
+  auto test_ctx_tx = new tests_context();
+  ASSERT_TRUE(test_ctx_tx != NULL);
+  test_ctx_tx->idx = 0;
+  test_ctx_tx->ctx = ctx;
+  test_ctx_tx->fb_cnt = 3;
+
+  memset(&ops_tx, 0, sizeof(ops_tx));
+  ops_tx.name = "st30p_sim_loss_tx";
+  ops_tx.priv = test_ctx_tx;
+  ops_tx.port.num_port = 1;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_R],
+         MTL_IP_ADDR_LEN);
+  snprintf(ops_tx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
+           ctx->para.port[MTL_PORT_P]);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = udp_port;
+  ops_tx.port.payload_type = ST30P_TEST_PAYLOAD_TYPE;
+  ops_tx.fmt = ST30_FMT_PCM24;
+  ops_tx.channel = 2;
+  ops_tx.sampling = ST30_SAMPLING_48K;
+  ops_tx.ptime = ST30_PTIME_1MS;
+  ops_tx.framebuff_size = st30_calculate_framebuff_size(
+      ops_tx.fmt, ops_tx.ptime, ops_tx.sampling, ops_tx.channel, 10 * NS_PER_MS, NULL);
+  ops_tx.framebuff_cnt = test_ctx_tx->fb_cnt;
+  ops_tx.flags |= ST30P_TX_FLAG_BLOCK_GET;
+
+  test_ctx_tx->frame_size = ops_tx.framebuff_size;
+  test_ctx_tx->audio_fmt = ops_tx.fmt;
+  test_ctx_tx->audio_channel = ops_tx.channel;
+  test_ctx_tx->audio_sampling = ops_tx.sampling;
+  test_ctx_tx->audio_ptime = ops_tx.ptime;
+
+  auto tx_handle = st30p_tx_create(st, &ops_tx);
+  ASSERT_TRUE(tx_handle != NULL);
+  test_ctx_tx->handle = tx_handle;
+  test_ctx_tx->stop = false;
+  auto tx_thread = std::thread(test_st30p_tx_frame_thread, test_ctx_tx);
+
+  auto test_ctx_rx = new tests_context();
+  ASSERT_TRUE(test_ctx_rx != NULL);
+  test_ctx_rx->idx = 0;
+  test_ctx_rx->ctx = ctx;
+  test_ctx_rx->fb_cnt = 3;
+
+  memset(&ops_rx, 0, sizeof(ops_rx));
+  ops_rx.name = "st30p_sim_loss_rx";
+  ops_rx.priv = test_ctx_rx;
+  ops_rx.port.num_port = 1;
+  memcpy(ops_rx.port.ip_addr[MTL_SESSION_PORT_P], ctx->para.sip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  snprintf(ops_rx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
+           ctx->para.port[MTL_PORT_R]);
+  ops_rx.port.udp_port[MTL_SESSION_PORT_P] = udp_port;
+  ops_rx.port.payload_type = ST30P_TEST_PAYLOAD_TYPE;
+  ops_rx.fmt = ST30_FMT_PCM24;
+  ops_rx.channel = 2;
+  ops_rx.sampling = ST30_SAMPLING_48K;
+  ops_rx.ptime = ST30_PTIME_1MS;
+  ops_rx.framebuff_size = st30_calculate_framebuff_size(
+      ops_rx.fmt, ops_rx.ptime, ops_rx.sampling, ops_rx.channel, 10 * NS_PER_MS, NULL);
+  ops_rx.framebuff_cnt = test_ctx_rx->fb_cnt;
+  ops_rx.flags |= ST30P_RX_FLAG_BLOCK_GET | ST30P_RX_FLAG_SIMULATE_PKT_LOSS;
+
+  test_ctx_rx->frame_size = ops_rx.framebuff_size;
+  test_ctx_rx->audio_fmt = ops_rx.fmt;
+  test_ctx_rx->audio_channel = ops_rx.channel;
+  test_ctx_rx->audio_sampling = ops_rx.sampling;
+  test_ctx_rx->audio_ptime = ops_rx.ptime;
+
+  auto rx_handle = st30p_rx_create(st, &ops_rx);
+  ASSERT_TRUE(rx_handle != NULL);
+  ret = st30p_rx_set_block_timeout(rx_handle, NS_PER_S);
+  EXPECT_EQ(ret, 0);
+  test_ctx_rx->handle = rx_handle;
+  test_ctx_rx->stop = false;
+  auto rx_thread = std::thread(test_st30p_rx_frame_thread, test_ctx_rx);
+
+  ret = mtl_start(st);
+  EXPECT_GE(ret, 0);
+  sleep(10);
+
+  test_ctx_tx->stop = true;
+  st30p_tx_wake_block(tx_handle);
+  test_ctx_tx->cv.notify_all();
+  tx_thread.join();
+
+  test_ctx_rx->stop = true;
+  st30p_rx_wake_block(rx_handle);
+  test_ctx_rx->cv.notify_all();
+  rx_thread.join();
+
+  struct st30_rx_user_stats rx_stats;
+  ret = st30p_rx_get_session_stats(rx_handle, &rx_stats);
+  EXPECT_GE(ret, 0);
+
+  EXPECT_GT(test_ctx_rx->fb_rec, 0) << "Must have received frames";
+  EXPECT_GT(rx_stats.common.stat_frames_corrupted, (uint64_t)0)
+      << "simulated packet loss must produce corrupted frames";
+  info("%s, RX received %d frames, %" PRIu64 " corrupted\n", __func__,
+       test_ctx_rx->fb_rec, rx_stats.common.stat_frames_corrupted);
 
   ret = st30p_tx_free(tx_handle);
   EXPECT_GE(ret, 0);

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -35,6 +35,7 @@ unit_sources = [
   'session/st30/stats_test.cpp',
   'session/st30/reorder_test.cpp',
   'session/st30/err_packets_test.cpp',
+  'session/st30/corruption_test.cpp',
   'session/st20_harness.c',
   'session/st20/slot_test.cpp',
   'session/st20/redundancy_test.cpp',
@@ -47,6 +48,8 @@ unit_sources = [
   'pipeline/st40p_test.cpp',
   'pipeline/st20p_harness.c',
   'pipeline/st20p_test.cpp',
+  'pipeline/st30p_harness.c',
+  'pipeline/st30p_test.cpp',
   'main.cpp',
 ]
 

--- a/tests/unit/pipeline/st30p_harness.c
+++ b/tests/unit/pipeline/st30p_harness.c
@@ -95,12 +95,13 @@ void ut30p_ctx_destroy(ut30p_ctx* ctx) {
   free(ctx);
 }
 
-int ut30p_inject_frame(ut30p_ctx* ctx, uint32_t timestamp) {
+int ut30p_inject_frame(ut30p_ctx* ctx, enum st_frame_status status, uint32_t timestamp) {
   struct st30_rx_frame_meta meta;
   memset(&meta, 0, sizeof(meta));
   meta.timestamp = timestamp;
   meta.rtp_timestamp = timestamp;
   meta.frame_recv_size = 1;
+  meta.status = status;
 
   static uint8_t dummy_frame_storage;
   return rx_st30p_frame_ready(&ctx->pipeline, &dummy_frame_storage, &meta);
@@ -120,6 +121,10 @@ uint64_t ut30p_stat_frames_received(const ut30p_ctx* ctx) {
 
 uint64_t ut30p_stat_frames_dropped(const ut30p_ctx* ctx) {
   return ctx->pipeline.stat_frames_dropped;
+}
+
+uint64_t ut30p_stat_frames_corrupted(const ut30p_ctx* ctx) {
+  return ctx->pipeline.stat_frames_corrupted;
 }
 
 uint32_t ut30p_stat_busy(const ut30p_ctx* ctx) {

--- a/tests/unit/pipeline/st30p_harness.h
+++ b/tests/unit/pipeline/st30p_harness.h
@@ -35,15 +35,17 @@ ut30p_ctx* ut30p_ctx_create(int framebuff_cnt);
 void ut30p_ctx_destroy(ut30p_ctx* ctx);
 
 /** Inject one synthetic audio frame as if the transport just completed it.
+ *  status is ST_FRAME_STATUS_COMPLETE or _CORRUPTED.
  *  Returns 0 on accept, -EBUSY when no free framebuf (drives the
  *  stat_frames_dropped path). */
-int ut30p_inject_frame(ut30p_ctx* ctx, uint32_t timestamp);
+int ut30p_inject_frame(ut30p_ctx* ctx, enum st_frame_status status, uint32_t timestamp);
 
 struct st30_frame* ut30p_get_frame(ut30p_ctx* ctx);
 int ut30p_put_frame(ut30p_ctx* ctx, struct st30_frame* frame);
 
 uint64_t ut30p_stat_frames_received(const ut30p_ctx* ctx);
 uint64_t ut30p_stat_frames_dropped(const ut30p_ctx* ctx);
+uint64_t ut30p_stat_frames_corrupted(const ut30p_ctx* ctx);
 uint32_t ut30p_stat_busy(const ut30p_ctx* ctx);
 
 int ut30p_get_session_stats(ut30p_ctx* ctx, struct st30_rx_user_stats* stats);

--- a/tests/unit/pipeline/st30p_test.cpp
+++ b/tests/unit/pipeline/st30p_test.cpp
@@ -6,10 +6,9 @@
  *   stat_frames_received → bumped in st30p_rx_get_frame() (app consumes).
  *   stat_frames_dropped  → bumped in rx_st30p_frame_ready() when no free
  *                          framebuf is available (back-pressure).
+ *   stat_frames_corrupted → bumped in st30p_rx_get_frame() iff the frame's
+ *                          status is ST_FRAME_STATUS_CORRUPTED.
  *   stat_busy            → bumps 1:1 with stat_frames_dropped.
- *
- * ST30p has no per-frame corrupted concept; frames_corrupted is not
- * tracked by this layer and not asserted on.
  */
 
 #include <gtest/gtest.h>
@@ -32,7 +31,10 @@ class St30PipelineRxTest : public ::testing::Test {
   }
 
   int inject(uint32_t ts) {
-    return ut30p_inject_frame(ctx_, ts);
+    return ut30p_inject_frame(ctx_, ST_FRAME_STATUS_COMPLETE, ts);
+  }
+  int inject_corrupted(uint32_t ts) {
+    return ut30p_inject_frame(ctx_, ST_FRAME_STATUS_CORRUPTED, ts);
   }
   struct st30_frame* get_frame() {
     return ut30p_get_frame(ctx_);
@@ -45,6 +47,9 @@ class St30PipelineRxTest : public ::testing::Test {
   }
   uint64_t frames_dropped() {
     return ut30p_stat_frames_dropped(ctx_);
+  }
+  uint64_t frames_corrupted() {
+    return ut30p_stat_frames_corrupted(ctx_);
   }
   uint32_t stat_busy() {
     return ut30p_stat_busy(ctx_);
@@ -134,4 +139,27 @@ TEST_F(St30PipelineRxTest, GetSessionStatsOverlay) {
 
   EXPECT_EQ(api.common.stat_frames_received, frames_received());
   EXPECT_EQ(api.common.stat_frames_dropped, frames_dropped());
+}
+
+/* CORRUPTED frames are still delivered to the application.  They bump
+ * BOTH stat_frames_received and stat_frames_corrupted; COMPLETE frames
+ * bump only the former. */
+TEST_F(St30PipelineRxTest, CorruptedDeliveredAndCounted) {
+  ASSERT_EQ(inject(1000), 0);
+  ASSERT_EQ(inject_corrupted(2000), 0);
+  ASSERT_EQ(inject(3000), 0);
+
+  for (int i = 0; i < 3; i++) {
+    struct st30_frame* f = get_frame();
+    ASSERT_NE(f, nullptr) << "frame " << i;
+    EXPECT_EQ(put_frame(f), 0);
+  }
+
+  EXPECT_EQ(frames_received(), 3u);
+  EXPECT_EQ(frames_corrupted(), 1u)
+      << "only the CORRUPTED frame must bump stat_frames_corrupted";
+
+  struct st30_rx_user_stats api {};
+  ASSERT_EQ(ut30p_get_session_stats(ctx_, &api), 0);
+  EXPECT_EQ(api.common.stat_frames_corrupted, 1u);
 }

--- a/tests/unit/pipeline/st30p_test.cpp
+++ b/tests/unit/pipeline/st30p_test.cpp
@@ -163,3 +163,20 @@ TEST_F(St30PipelineRxTest, CorruptedDeliveredAndCounted) {
   ASSERT_EQ(ut30p_get_session_stats(ctx_, &api), 0);
   EXPECT_EQ(api.common.stat_frames_corrupted, 1u);
 }
+
+/* CORRUPTED transport frames must each be delivered via get_frame and counted
+ * in stat_frames_corrupted (the count rises by exactly the corrupted count). */
+TEST_F(St30PipelineRxTest, CorruptedFramesCountedInStats) {
+  ASSERT_EQ(inject(1000), 0);           /* real frame */
+  ASSERT_EQ(inject_corrupted(2000), 0); /* corrupted frame */
+  ASSERT_EQ(inject_corrupted(3000), 0); /* corrupted frame */
+
+  for (int i = 0; i < 3; i++) {
+    struct st30_frame* f = get_frame();
+    ASSERT_NE(f, nullptr) << "frame " << i;
+    EXPECT_EQ(put_frame(f), 0);
+  }
+
+  EXPECT_EQ(frames_received(), 3u);
+  EXPECT_EQ(frames_corrupted(), 2u) << "both corrupted frames counted";
+}

--- a/tests/unit/session/st30/corruption_test.cpp
+++ b/tests/unit/session/st30/corruption_test.cpp
@@ -38,10 +38,12 @@ class St30RxCorruptionTest : public St30RxBaseTest {
 TEST_F(St30RxCorruptionTest, CleanStreamNoFalseCorruption) {
   use_single_port();
   int n = ppf();
+  uint32_t s = spp();
   uint16_t seq = 0;
-  uint32_t ts = 1000;
+  uint32_t base = 1000;
   for (int f = 0; f < 3; f++) {
-    for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+    for (int i = 0; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
+    base += (uint32_t)n * s;
   }
 
   EXPECT_EQ(complete(), 3u);
@@ -49,161 +51,304 @@ TEST_F(St30RxCorruptionTest, CleanStreamNoFalseCorruption) {
   EXPECT_EQ(last_status(), ST_FRAME_STATUS_COMPLETE);
 }
 
-/* (b) Single mid-frame gap: the frame absorbing the gap closes CORRUPTED. */
+/* Intra-frame reorder: packets arriving out of timestamp order are placed
+ * positionally and the frame still closes COMPLETE. */
+TEST_F(St30RxCorruptionTest, IntraFrameReorderCompletes) {
+  use_single_port();
+  int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
+  uint16_t seq = 0;
+
+  /* slot 0 establishes the frame base, then later slots arrive pair-swapped */
+  feed(seq++, base + 0u * s, MTL_SESSION_PORT_P);
+  for (int i = 1; i < n; i += 2) {
+    int hi = (i + 1 < n) ? i + 1 : i;
+    feed(seq++, base + (uint32_t)hi * s, MTL_SESSION_PORT_P);
+    if (hi != i) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
+  }
+
+  EXPECT_EQ(complete(), 1u);
+  EXPECT_EQ(corrupted(), 0u);
+  EXPECT_EQ(last_status(), ST_FRAME_STATUS_COMPLETE);
+}
+
+/* (b) Single mid-frame gap: the partial frame closes CORRUPTED when the next
+ * frame's first packet forward-jumps the timestamp. */
 TEST_F(St30RxCorruptionTest, MidFrameGapCorruptsFrame) {
   use_single_port();
   int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
   uint16_t seq = 0;
-  uint32_t ts = 1000;
-  int fed = 0;
-  /* feed n accepted packets but skip seq 5 mid-frame */
-  while (fed < n) {
-    if (seq == 5) {
-      seq++; /* drop seq 5 */
-      continue;
-    }
-    feed(seq++, ts++, MTL_SESSION_PORT_P);
-    fed++;
+
+  for (int i = 0; i < n; i++) {
+    if (i == 5) continue; /* drop slot 5 */
+    feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
   }
+  /* forward jump closes the partial frame CORRUPTED */
+  feed(seq++, base + (uint32_t)n * s, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(corrupted(), 1u);
   EXPECT_EQ(complete(), 0u);
   EXPECT_EQ(last_status(), ST_FRAME_STATUS_CORRUPTED);
 }
 
-/* (c) Boundary straddle: the gap surfaces on the packet that opens the next
- * frame, so the NEW frame is CORRUPTED while the PRIOR frame stays COMPLETE. */
+/* (c) The prior frame stays COMPLETE while a later partial frame closes
+ * CORRUPTED on the forward jump that opens the frame after it. */
 TEST_F(St30RxCorruptionTest, BoundaryStraddleCorruptsNewFrameOnly) {
   use_single_port();
   int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
   uint16_t seq = 0;
-  uint32_t ts = 1000;
 
   /* frame 1: clean */
-  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+  for (int i = 0; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
   EXPECT_EQ(complete(), 1u);
   EXPECT_EQ(corrupted(), 0u);
 
-  /* frame 2: first packet skips one seq, revealing the gap */
-  seq++; /* drop the seq that would open frame 2 contiguously */
-  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+  /* frame 2: missing slot 5 */
+  uint32_t base2 = base + (uint32_t)n * s;
+  for (int i = 0; i < n; i++) {
+    if (i == 5) continue;
+    feed(seq++, base2 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+  }
+  /* frame 3 first packet forward-jumps, closing frame 2 CORRUPTED */
+  feed(seq++, base2 + (uint32_t)n * s, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(complete(), 1u) << "prior frame must stay COMPLETE";
-  EXPECT_EQ(corrupted(), 1u) << "new frame must be CORRUPTED";
+  EXPECT_EQ(corrupted(), 1u) << "partial frame must be CORRUPTED";
 }
 
-/* (d) Full-frame loss: a whole frame's worth of contiguous seq is dropped.
- * The lost frame is absorbed (never emitted COMPLETE); exactly one CORRUPTED
- * frame carries the gap. */
-TEST_F(St30RxCorruptionTest, FullFrameLossEmitsOneCorrupted) {
-  use_single_port();
-  int n = ppf();
-  uint16_t seq = 0;
-  uint32_t ts = 1000;
-
-  /* frame 1: clean */
-  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
-
-  /* drop a whole frame's worth of contiguous seq */
-  seq += n;
-
-  /* next accepted frame carries the entire gap */
-  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
-
-  EXPECT_EQ(complete(), 1u) << "no frame falsely COMPLETE";
-  EXPECT_EQ(corrupted(), 1u) << "exactly one CORRUPTED frame";
-}
-
-/* (e) Reorder / same-seq duplicate that never advances session_seq_id must
- * not raise a false gap, nor double-count corruption. */
+/* (e) Reorder / duplicate that lands on a filled slot must not corrupt the
+ * frame nor double-count. */
 TEST_F(St30RxCorruptionTest, ReorderDoesNotFalselyCorrupt) {
   use_single_port();
   int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
   uint16_t seq = 0;
-  uint32_t ts = 1000;
-  int fed;
 
-  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 0 */
-  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 1 */
-  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 2 */
-  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 3 */
-  feed(1, ts++, MTL_SESSION_PORT_P);     /* backward seq, fresh ts */
-  fed = 5;
-  while (fed < n) {
-    feed(seq++, ts++, MTL_SESSION_PORT_P);
-    fed++;
-  }
+  feed(seq++, base + 0u * s, MTL_SESSION_PORT_P);
+  feed(seq++, base + 1u * s, MTL_SESSION_PORT_P);
+  feed(seq++, base + 2u * s, MTL_SESSION_PORT_P);
+  feed(seq++, base + 3u * s, MTL_SESSION_PORT_P);
+  feed(seq++, base + 1u * s, MTL_SESSION_PORT_P); /* duplicate slot 1 */
+  for (int i = 4; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(complete(), 1u);
   EXPECT_EQ(corrupted(), 0u);
 }
 
-/* (f) First packet of the session seeds session_seq_id, so a non-zero start
- * seq must not register a false opening gap. */
+/* (f) First packet of the session seeds the base, so a non-zero start seq must
+ * not register a false gap. */
 TEST_F(St30RxCorruptionTest, FirstPacketSeedingNoFalseGap) {
   use_single_port();
   int n = ppf();
+  uint32_t s = spp();
   uint16_t seq = 1000;
-  uint32_t ts = 1000;
-  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+  uint32_t base = 1000;
+  for (int i = 0; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(complete(), 1u);
   EXPECT_EQ(corrupted(), 0u);
 }
 
-/* (f) Session reset clears the loss accumulator: a gap charged before reset
- * must not leak corruption into a clean frame fed afterwards. */
+/* (f) Session reset discards the open partial frame: a gap before reset must
+ * not leak corruption into a clean frame fed afterwards. */
 TEST_F(St30RxCorruptionTest, ResetClearsAccumulator) {
   use_single_port();
-  uint32_t ts = 1000;
+  uint32_t s = spp();
+  uint32_t base = 1000;
 
   /* partial frame with a gap, never closed */
-  feed(0, ts++, MTL_SESSION_PORT_P);
-  feed(5, ts++, MTL_SESSION_PORT_P); /* gap, accumulator > 0 */
+  feed(0, base + 0u * s, MTL_SESSION_PORT_P);
+  feed(1, base + 5u * s, MTL_SESSION_PORT_P);
 
   ut30_reset(ctx_);
 
   /* clean full frame after reset */
   int n = ppf();
   uint16_t seq = 0;
-  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+  uint32_t base2 = 9000;
+  for (int i = 0; i < n; i++) feed(seq++, base2 + (uint32_t)i * s, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(complete(), 1u);
   EXPECT_EQ(corrupted(), 0u);
 }
 
-/* (g) Redundancy: a per-port loss covered by the other port leaves no session
- * gap, so the frame stays COMPLETE. */
+/* (g) Redundancy: a per-port loss covered by the other port fills every slot,
+ * so the frame stays COMPLETE. */
 TEST_F(St30RxCorruptionTest, RedundancyCoveredLossComplete) {
   int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
   uint16_t seq = 0;
-  uint32_t ts = 1000;
   for (int i = 0; i < n; i++) {
-    /* seq 5 arrives only on R, every other seq only on P */
-    enum mtl_session_port port = (seq == 5) ? MTL_SESSION_PORT_R : MTL_SESSION_PORT_P;
-    feed(seq++, ts++, port);
+    /* slot 5 arrives only on R, every other slot only on P */
+    enum mtl_session_port port = (i == 5) ? MTL_SESSION_PORT_R : MTL_SESSION_PORT_P;
+    feed(seq++, base + (uint32_t)i * s, port);
   }
 
   EXPECT_EQ(complete(), 1u);
   EXPECT_EQ(corrupted(), 0u);
 }
 
-/* (g) Redundancy: loss on both ports leaves a session gap, so the frame
- * closes CORRUPTED. */
+/* (g) Redundancy: loss on both ports leaves a missing slot, so the frame
+ * closes CORRUPTED on the forward jump. */
 TEST_F(St30RxCorruptionTest, RedundancyBothPortsLostCorrupted) {
   int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
   uint16_t seq = 0;
-  uint32_t ts = 1000;
-  int fed = 0;
-  while (fed < n) {
-    if (seq == 5) { /* dropped on both ports */
-      seq++;
-      continue;
-    }
-    feed(seq++, ts++, MTL_SESSION_PORT_P);
-    fed++;
+  for (int i = 0; i < n; i++) {
+    if (i == 5) continue; /* dropped on both ports */
+    feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
   }
+  feed(seq++, base + (uint32_t)n * s, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(corrupted(), 1u);
   EXPECT_EQ(complete(), 0u);
+}
+
+/* ── positional single-slot tests ───────────────────────────────────────
+ *
+ * Whole-frame loss is skipped (nothing emitted); a partially filled frame is
+ * closed CORRUPTED only when a forward jump in RTP timestamp opens the next
+ * frame. Intra-frame reorder is healed by positional placement.
+ */
+
+/* Whole-frame loss emits nothing: the missing frame is skipped, the frames
+ * either side close COMPLETE. */
+TEST_F(St30RxCorruptionTest, WholeFrameLossSkips) {
+  use_single_port();
+  int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
+  uint16_t seq = 0;
+
+  for (int i = 0; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
+  /* skip the whole middle frame: emit nothing for it */
+  uint32_t base3 = base + 2u * (uint32_t)n * s;
+  for (int i = 0; i < n; i++) feed(seq++, base3 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(complete(), 2u);
+  EXPECT_EQ(corrupted(), 0u);
+}
+
+/* A straggler for an already-closed frame arrives after the boundary and is
+ * dropped by the redundancy filter; it does not resurrect the closed frame. */
+TEST_F(St30RxCorruptionTest, LateAcrossBoundaryDropped) {
+  use_single_port();
+  int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
+  uint16_t seq = 0;
+
+  /* frame 1 missing slot 5 */
+  for (int i = 0; i < n; i++) {
+    if (i == 5) continue;
+    feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
+  }
+  /* forward jump opens frame 2, closing frame 1 CORRUPTED */
+  uint32_t base2 = base + (uint32_t)n * s;
+  feed(seq++, base2, MTL_SESSION_PORT_P);
+  ASSERT_EQ(corrupted(), 1u);
+
+  uint64_t redundant_before = redundant();
+  /* late straggler for frame 1's slot 5 */
+  feed(seq++, base + 5u * s, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(redundant(), redundant_before + 1u) << "late straggler dropped";
+  EXPECT_EQ(corrupted(), 1u) << "closed frame not resurrected";
+  EXPECT_EQ(complete(), 0u);
+}
+
+/* A duplicate of an already-placed slot is deduped by the bitmap and counted
+ * redundant; the frame still completes. */
+TEST_F(St30RxCorruptionTest, DuplicateSlotDedupedStillComplete) {
+  use_single_port();
+  int n = ppf();
+  uint32_t s = spp();
+  uint32_t base = 1000;
+  uint16_t seq = 0;
+
+  feed(seq++, base + 0u * s, MTL_SESSION_PORT_P);
+  feed(seq++, base + 1u * s, MTL_SESSION_PORT_P);
+  uint64_t redundant_before = redundant();
+  feed(seq++, base + 1u * s, MTL_SESSION_PORT_P); /* duplicate slot 1 */
+  EXPECT_EQ(redundant(), redundant_before + 1u);
+  for (int i = 2; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(complete(), 1u);
+  EXPECT_EQ(corrupted(), 0u);
+}
+
+/* Leading-packet loss must not re-anchor the media-clock grid. A frame whose
+ * slot 0 is dropped is opened on the GRID base (carried by the next-frame
+ * floor), so its slot 0 stays unset, the frame never reaches full size and
+ * closes CORRUPTED — it must not absorb the following frame's slot 0 nor shift
+ * the grid. Later clean frames stay COMPLETE on their original timestamps. */
+TEST_F(St30RxCorruptionTest, LeadingPacketLossCorrupts) {
+  use_single_port();
+  int n = ppf();
+  uint32_t s = spp();
+  uint16_t seq = 0;
+
+  uint32_t base = 1000;
+  for (int i = 0; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  uint32_t base2 = base + (uint32_t)n * s;
+  for (int i = 1; i < n; i++) feed(seq++, base2 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  uint32_t base3 = base2 + (uint32_t)n * s;
+  for (int i = 0; i < n; i++) feed(seq++, base3 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  uint32_t base4 = base3 + (uint32_t)n * s;
+  for (int i = 0; i < n; i++) feed(seq++, base4 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(corrupted(), 1u) << "leading-loss frame must not absorb the next slot 0";
+  EXPECT_EQ(complete(), 3u) << "frames 1,3,4 COMPLETE; grid did not drift";
+
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 4);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 0), base);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 0), ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 1), base2);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 1), ST_FRAME_STATUS_CORRUPTED);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 2), base3);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 2), ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 3), base4);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 3), ST_FRAME_STATUS_COMPLETE);
+}
+
+/* Leading-loss followed by a whole-frame skip: the partial frame closes
+ * CORRUPTED, the wholly-missing frame emits nothing, and the large forward
+ * jump resyncs onto the arriving (still grid-aligned) timestamp. */
+TEST_F(St30RxCorruptionTest, LeadingLossThenWholeFrameSkip) {
+  use_single_port();
+  int n = ppf();
+  uint32_t s = spp();
+  uint16_t seq = 0;
+
+  uint32_t base = 1000;
+  for (int i = 0; i < n; i++) feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  uint32_t base2 = base + (uint32_t)n * s;
+  for (int i = 1; i < n; i++) feed(seq++, base2 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  /* skip frame 3 entirely, resume at frame 4 */
+  uint32_t base4 = base2 + 2u * (uint32_t)n * s;
+  for (int i = 0; i < n; i++) feed(seq++, base4 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(corrupted(), 1u);
+  EXPECT_EQ(complete(), 2u);
+
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 3);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 0), base);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 0), ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 1), base2);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 1), ST_FRAME_STATUS_CORRUPTED);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 2), base4);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 2), ST_FRAME_STATUS_COMPLETE);
 }

--- a/tests/unit/session/st30/corruption_test.cpp
+++ b/tests/unit/session/st30/corruption_test.cpp
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Per-frame corruption status: a post-redundancy session_seq_id gap charged
+ * to the frame under assembly must close that frame as
+ * ST_FRAME_STATUS_CORRUPTED, while clean / reordered / redundancy-recovered
+ * streams must stay ST_FRAME_STATUS_COMPLETE (no false positive).
+ *
+ * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
+ * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St30RxCorruptionTest.*'
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st30/st30_rx_test_base.h"
+#include "st_api.h"
+
+class St30RxCorruptionTest : public St30RxBaseTest {
+ protected:
+  void use_single_port() {
+    ut30_ctx_destroy(ctx_);
+    ctx_ = ut30_ctx_create(1);
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  uint64_t complete() {
+    return ut30_frames_complete(ctx_);
+  }
+  uint64_t corrupted() {
+    return ut30_frames_corrupted(ctx_);
+  }
+  int last_status() {
+    return ut30_last_frame_status(ctx_);
+  }
+};
+
+/* (a) Clean contiguous stream: every frame closes COMPLETE, none corrupted. */
+TEST_F(St30RxCorruptionTest, CleanStreamNoFalseCorruption) {
+  use_single_port();
+  int n = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  for (int f = 0; f < 3; f++) {
+    for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+  }
+
+  EXPECT_EQ(complete(), 3u);
+  EXPECT_EQ(corrupted(), 0u);
+  EXPECT_EQ(last_status(), ST_FRAME_STATUS_COMPLETE);
+}
+
+/* (b) Single mid-frame gap: the frame absorbing the gap closes CORRUPTED. */
+TEST_F(St30RxCorruptionTest, MidFrameGapCorruptsFrame) {
+  use_single_port();
+  int n = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  int fed = 0;
+  /* feed n accepted packets but skip seq 5 mid-frame */
+  while (fed < n) {
+    if (seq == 5) {
+      seq++; /* drop seq 5 */
+      continue;
+    }
+    feed(seq++, ts++, MTL_SESSION_PORT_P);
+    fed++;
+  }
+
+  EXPECT_EQ(corrupted(), 1u);
+  EXPECT_EQ(complete(), 0u);
+  EXPECT_EQ(last_status(), ST_FRAME_STATUS_CORRUPTED);
+}
+
+/* (c) Boundary straddle: the gap surfaces on the packet that opens the next
+ * frame, so the NEW frame is CORRUPTED while the PRIOR frame stays COMPLETE. */
+TEST_F(St30RxCorruptionTest, BoundaryStraddleCorruptsNewFrameOnly) {
+  use_single_port();
+  int n = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+
+  /* frame 1: clean */
+  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+  EXPECT_EQ(complete(), 1u);
+  EXPECT_EQ(corrupted(), 0u);
+
+  /* frame 2: first packet skips one seq, revealing the gap */
+  seq++; /* drop the seq that would open frame 2 contiguously */
+  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(complete(), 1u) << "prior frame must stay COMPLETE";
+  EXPECT_EQ(corrupted(), 1u) << "new frame must be CORRUPTED";
+}
+
+/* (d) Full-frame loss: a whole frame's worth of contiguous seq is dropped.
+ * The lost frame is absorbed (never emitted COMPLETE); exactly one CORRUPTED
+ * frame carries the gap. */
+TEST_F(St30RxCorruptionTest, FullFrameLossEmitsOneCorrupted) {
+  use_single_port();
+  int n = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+
+  /* frame 1: clean */
+  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+
+  /* drop a whole frame's worth of contiguous seq */
+  seq += n;
+
+  /* next accepted frame carries the entire gap */
+  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(complete(), 1u) << "no frame falsely COMPLETE";
+  EXPECT_EQ(corrupted(), 1u) << "exactly one CORRUPTED frame";
+}
+
+/* (e) Reorder / same-seq duplicate that never advances session_seq_id must
+ * not raise a false gap, nor double-count corruption. */
+TEST_F(St30RxCorruptionTest, ReorderDoesNotFalselyCorrupt) {
+  use_single_port();
+  int n = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  int fed;
+
+  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 0 */
+  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 1 */
+  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 2 */
+  feed(seq++, ts++, MTL_SESSION_PORT_P); /* 3 */
+  feed(1, ts++, MTL_SESSION_PORT_P);     /* backward seq, fresh ts */
+  fed = 5;
+  while (fed < n) {
+    feed(seq++, ts++, MTL_SESSION_PORT_P);
+    fed++;
+  }
+
+  EXPECT_EQ(complete(), 1u);
+  EXPECT_EQ(corrupted(), 0u);
+}
+
+/* (f) First packet of the session seeds session_seq_id, so a non-zero start
+ * seq must not register a false opening gap. */
+TEST_F(St30RxCorruptionTest, FirstPacketSeedingNoFalseGap) {
+  use_single_port();
+  int n = ppf();
+  uint16_t seq = 1000;
+  uint32_t ts = 1000;
+  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(complete(), 1u);
+  EXPECT_EQ(corrupted(), 0u);
+}
+
+/* (f) Session reset clears the loss accumulator: a gap charged before reset
+ * must not leak corruption into a clean frame fed afterwards. */
+TEST_F(St30RxCorruptionTest, ResetClearsAccumulator) {
+  use_single_port();
+  uint32_t ts = 1000;
+
+  /* partial frame with a gap, never closed */
+  feed(0, ts++, MTL_SESSION_PORT_P);
+  feed(5, ts++, MTL_SESSION_PORT_P); /* gap, accumulator > 0 */
+
+  ut30_reset(ctx_);
+
+  /* clean full frame after reset */
+  int n = ppf();
+  uint16_t seq = 0;
+  for (int i = 0; i < n; i++) feed(seq++, ts++, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(complete(), 1u);
+  EXPECT_EQ(corrupted(), 0u);
+}
+
+/* (g) Redundancy: a per-port loss covered by the other port leaves no session
+ * gap, so the frame stays COMPLETE. */
+TEST_F(St30RxCorruptionTest, RedundancyCoveredLossComplete) {
+  int n = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  for (int i = 0; i < n; i++) {
+    /* seq 5 arrives only on R, every other seq only on P */
+    enum mtl_session_port port = (seq == 5) ? MTL_SESSION_PORT_R : MTL_SESSION_PORT_P;
+    feed(seq++, ts++, port);
+  }
+
+  EXPECT_EQ(complete(), 1u);
+  EXPECT_EQ(corrupted(), 0u);
+}
+
+/* (g) Redundancy: loss on both ports leaves a session gap, so the frame
+ * closes CORRUPTED. */
+TEST_F(St30RxCorruptionTest, RedundancyBothPortsLostCorrupted) {
+  int n = ppf();
+  uint16_t seq = 0;
+  uint32_t ts = 1000;
+  int fed = 0;
+  while (fed < n) {
+    if (seq == 5) { /* dropped on both ports */
+      seq++;
+      continue;
+    }
+    feed(seq++, ts++, MTL_SESSION_PORT_P);
+    fed++;
+  }
+
+  EXPECT_EQ(corrupted(), 1u);
+  EXPECT_EQ(complete(), 0u);
+}

--- a/tests/unit/session/st30/err_packets_test.cpp
+++ b/tests/unit/session/st30/err_packets_test.cpp
@@ -108,12 +108,13 @@ TEST_F(St30RxErrPacketsTest, MixedBurstOnlyBadCounted) {
 
 /* Redundancy-filtered packets must not inflate err_packets. */
 TEST_F(St30RxErrPacketsTest, RedundancyFilterDoesNotBumpErrCounter) {
+  uint32_t s = ut30_samples_per_pkt(ctx_);
   /* P delivers the frame first */
-  feed_good(0, 1000, MTL_SESSION_PORT_P);
-  feed_good(1, 1001, MTL_SESSION_PORT_P);
+  feed_good(0, 1000 + 0u * s, MTL_SESSION_PORT_P);
+  feed_good(1, 1000 + 1u * s, MTL_SESSION_PORT_P);
   /* R sends the same packets a beat later -- legitimate redundancy. */
-  feed_good(0, 1000, MTL_SESSION_PORT_R);
-  feed_good(1, 1001, MTL_SESSION_PORT_R);
+  feed_good(0, 1000 + 0u * s, MTL_SESSION_PORT_R);
+  feed_good(1, 1000 + 1u * s, MTL_SESSION_PORT_R);
 
   /* Sanity: the redundancy filter classified them. */
   EXPECT_EQ(ut30_stat_redundant(ctx_), 2u);

--- a/tests/unit/session/st30/redundancy_test.cpp
+++ b/tests/unit/session/st30/redundancy_test.cpp
@@ -30,17 +30,16 @@ TEST_F(St30RxRedundancyTest, NormalRedundancy) {
   EXPECT_EQ(received(), 8u);
 }
 
-/* Timestamp-only filter: R's packets are filtered even with higher seq_ids,
- * because their timestamps are not strictly greater than P's latest.
- * This is the key ST30 difference from ST40 (which checks both ts and seq). */
+/* Redundancy via positional dedup: R's packets land on slots already filled by
+ * P (same frame base), so each is counted redundant and returns accepted (0).
+ * The timestamps are not strictly greater, but positional placement dedups. */
 TEST_F(St30RxRedundancyTest, TimestampOnlyFilter) {
   feed_burst(0, 4, 1000, MTL_SESSION_PORT_P);
 
-  /* port 1 has HIGHER seq_ids but same/old timestamps → filtered */
+  uint32_t s = spp();
   for (int i = 0; i < 4; i++) {
-    int rc = feed(4 + i, 1000 + i, MTL_SESSION_PORT_R);
-    EXPECT_LT(rc, 0) << "seq " << (4 + i)
-                     << " should be filtered (ts not greater, ST30 ignores seq)";
+    int rc = feed(4 + i, 1000 + (uint32_t)i * s, MTL_SESSION_PORT_R);
+    EXPECT_EQ(rc, 0) << "seq " << (4 + i) << " deduped on a filled slot";
   }
 
   EXPECT_EQ(redundant(), 4u);
@@ -63,14 +62,13 @@ TEST_F(St30RxRedundancyTest, NewTimestampAlwaysAccepted) {
       << "Source switch with new timestamp should not produce phantom unrecovered";
 }
 
-/* Same timestamp, different seq on second port. Even though R has a
- * higher seq_id, it is filtered because the timestamp is not strictly
- * greater. */
+/* Same timestamp, different seq on second port: R lands on the slot P already
+ * filled, so it is deduped and counted redundant. */
 TEST_F(St30RxRedundancyTest, SameTimestampDiffSeqFiltered) {
   feed(5, 1000, MTL_SESSION_PORT_P);
 
   int rc = feed(6, 1000, MTL_SESSION_PORT_R);
-  EXPECT_LT(rc, 0) << "Same timestamp should be filtered even with newer seq";
+  EXPECT_EQ(rc, 0) << "same slot deduped";
   EXPECT_EQ(redundant(), 1u);
 }
 
@@ -95,15 +93,15 @@ TEST_F(St30RxRedundancyTest, BurstSwitchoverAudio) {
 }
 
 /* Multiple packets with the same timestamp on the same port. Only the
- * first packet per timestamp is accepted; subsequent ones are filtered. */
+ * first fills the slot; subsequent ones are deduped as redundant. */
 TEST_F(St30RxRedundancyTest, SameTimestampFiltered) {
   feed(0, 1000, MTL_SESSION_PORT_P);
-  /* same ts again — filtered */
+  /* same ts again — deduped */
   int rc = feed(1, 1000, MTL_SESSION_PORT_P);
-  EXPECT_LT(rc, 0) << "Same timestamp should be filtered";
+  EXPECT_EQ(rc, 0) << "same slot deduped";
   /* a third one too */
   rc = feed(5, 1000, MTL_SESSION_PORT_P);
-  EXPECT_LT(rc, 0) << "Same timestamp should be filtered";
+  EXPECT_EQ(rc, 0) << "same slot deduped";
   EXPECT_EQ(redundant(), 2u);
   EXPECT_EQ(received(), 1u);
 }
@@ -130,15 +128,16 @@ TEST_F(St30RxRedundancyTest, ThresholdBypass) {
       << "After exceeding threshold on both ports, packets should be accepted";
 }
 
-/* Interleaved ports with increasing timestamps. P and R alternate, each
- * packet with a strictly newer timestamp. All packets accepted. */
+/* Interleaved ports with strictly newer timestamps spaced by one slot each.
+ * Every packet lands on its own positional slot — all accepted. */
 TEST_F(St30RxRedundancyTest, InterleavedPortsIncreasingTs) {
-  feed(0, 1000, MTL_SESSION_PORT_P);
-  feed(1, 1001, MTL_SESSION_PORT_R);
-  feed(2, 1002, MTL_SESSION_PORT_P);
-  feed(3, 1003, MTL_SESSION_PORT_R);
-  feed(4, 1004, MTL_SESSION_PORT_P);
-  feed(5, 1005, MTL_SESSION_PORT_R);
+  uint32_t s = spp();
+  feed(0, 1000 + 0u * s, MTL_SESSION_PORT_P);
+  feed(1, 1000 + 1u * s, MTL_SESSION_PORT_R);
+  feed(2, 1000 + 2u * s, MTL_SESSION_PORT_P);
+  feed(3, 1000 + 3u * s, MTL_SESSION_PORT_R);
+  feed(4, 1000 + 4u * s, MTL_SESSION_PORT_P);
+  feed(5, 1000 + 5u * s, MTL_SESSION_PORT_R);
 
   EXPECT_EQ(unrecovered(), 0u);
   EXPECT_EQ(redundant(), 0u);
@@ -161,9 +160,10 @@ TEST_F(St30RxRedundancyTest, InterleavedPortsIncreasingTs) {
 
 /* P delivers all frames; R is silent. P is credited once per frame. */
 TEST_F(St30RxRedundancyTest, PerPortFramesPrimaryOnly) {
+  uint32_t t = (uint32_t)ppf() * spp();
   feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_P);
-  feed_burst(ppf(), ppf(), 2000, MTL_SESSION_PORT_P);
-  feed_burst(2 * ppf(), ppf(), 3000, MTL_SESSION_PORT_P);
+  feed_burst(ppf(), ppf(), 1000 + t, MTL_SESSION_PORT_P);
+  feed_burst(2 * ppf(), ppf(), 1000 + 2 * t, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(frames_done(), 3);
   EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 3u);
@@ -172,8 +172,9 @@ TEST_F(St30RxRedundancyTest, PerPortFramesPrimaryOnly) {
 
 /* All frames originate on R; P is silent. R is credited once per frame. */
 TEST_F(St30RxRedundancyTest, PerPortFramesSecondaryOnly) {
+  uint32_t t = (uint32_t)ppf() * spp();
   feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_R);
-  feed_burst(ppf(), ppf(), 2000, MTL_SESSION_PORT_R);
+  feed_burst(ppf(), ppf(), 1000 + t, MTL_SESSION_PORT_R);
 
   EXPECT_EQ(frames_done(), 2);
   EXPECT_EQ(port_frames(MTL_SESSION_PORT_P), 0u);
@@ -198,13 +199,15 @@ TEST_F(St30RxRedundancyTest, PerPortFramesPrimaryFirstSecondaryFiltered) {
  * (with a strictly newer ts). R wins the credit for frame N+1; P keeps the
  * credit for frame N. */
 TEST_F(St30RxRedundancyTest, PerPortFramesAlternatingWinner) {
+  uint32_t t = (uint32_t)ppf() * spp();
+  uint32_t s = spp();
   /* frame 1: P starts and finishes */
   feed_burst(0, ppf(), 1000, MTL_SESSION_PORT_P);
   /* frame 2: R sends the first pkt (new ts) — wins the credit */
-  feed(ppf(), 2000, MTL_SESSION_PORT_R);
-  /* finish frame 2 from R (or P, same outcome — credit already assigned) */
+  feed(ppf(), 1000 + t, MTL_SESSION_PORT_R);
+  /* finish frame 2 from R */
   for (int i = 1; i < ppf(); i++) {
-    feed(ppf() + i, 2000 + i, MTL_SESSION_PORT_R);
+    feed(ppf() + i, 1000 + t + (uint32_t)i * s, MTL_SESSION_PORT_R);
   }
 
   EXPECT_EQ(frames_done(), 2);
@@ -220,10 +223,11 @@ TEST_F(St30RxRedundancyTest, PerPortFramesAlternatingWinner) {
  * fresh timestamps. The handover must be seamless — every unique packet
  * accepted exactly once, no phantom unrecovered. */
 TEST_F(St30RxRedundancyTest, PortGoesSilentMidStreamPeerContinues) {
-  for (int i = 0; i < 4; i++) feed(i, 1000 + i, MTL_SESSION_PORT_P);
-  for (int i = 0; i < 4; i++) feed(i, 1000 + i, MTL_SESSION_PORT_R);
+  uint32_t s = spp();
+  for (int i = 0; i < 4; i++) feed(i, 1000 + (uint32_t)i * s, MTL_SESSION_PORT_P);
+  for (int i = 0; i < 4; i++) feed(i, 1000 + (uint32_t)i * s, MTL_SESSION_PORT_R);
   /* P dies. R takes over with strictly newer timestamps. */
-  for (int i = 4; i < 8; i++) feed(i, 1000 + i, MTL_SESSION_PORT_R);
+  for (int i = 4; i < 8; i++) feed(i, 1000 + (uint32_t)i * s, MTL_SESSION_PORT_R);
 
   EXPECT_EQ(received(), 8u);
   EXPECT_EQ(redundant(), 4u) << "R's first 4 pkts duplicated P's";
@@ -235,13 +239,14 @@ TEST_F(St30RxRedundancyTest, PortGoesSilentMidStreamPeerContinues) {
  * recurring source switches do not leak phantom unrecovered, do not
  * accumulate redundant, and do not corrupt session_seq tracking. */
 TEST_F(St30RxRedundancyTest, SustainedAlternatingBurstSwitchover) {
+  uint32_t s = spp();
   uint32_t ts = 1000;
   uint16_t seq = 0;
   for (int g = 0; g < 8; g++) {
     enum mtl_session_port p = (g % 2 == 0) ? MTL_SESSION_PORT_P : MTL_SESSION_PORT_R;
-    for (int i = 0; i < 4; i++) feed(seq + i, ts + i, p);
+    for (int i = 0; i < 4; i++) feed(seq + i, ts + (uint32_t)i * s, p);
     seq += 4;
-    ts += 4;
+    ts += 4u * s;
   }
 
   EXPECT_EQ(received(), 32u);

--- a/tests/unit/session/st30/st30_rx_test_base.h
+++ b/tests/unit/session/st30/st30_rx_test_base.h
@@ -64,6 +64,9 @@ class St30RxBaseTest : public ::testing::Test {
   int ppf() {
     return ut30_pkts_per_frame(ctx_);
   }
+  uint32_t spp() {
+    return ut30_samples_per_pkt(ctx_);
+  }
 
   uint64_t port_pkts(enum mtl_session_port p) {
     return ut30_stat_port_pkts(ctx_, p);

--- a/tests/unit/session/st30/stats_test.cpp
+++ b/tests/unit/session/st30/stats_test.cpp
@@ -49,12 +49,14 @@ TEST_F(St30RxStatsTest, MultipleFrames) {
   ASSERT_NE(ctx_, nullptr);
 
   int total = ppf();
+  uint32_t s = spp();
   uint16_t seq = 0;
-  uint32_t ts = 1000;
+  uint32_t base = 1000;
   for (int f = 0; f < 3; f++) {
     for (int i = 0; i < total; i++) {
-      feed(seq++, ts++, MTL_SESSION_PORT_P);
+      feed(seq++, base + (uint32_t)i * s, MTL_SESSION_PORT_P);
     }
+    base += (uint32_t)total * s;
   }
 
   EXPECT_EQ(frames_done(), 3);
@@ -141,12 +143,13 @@ TEST_F(St30RxStatsTest, PortLostNotInflatedAtSeqWrap) {
  * has its own monotonic timestamp. Reconstruction must succeed — every
  * packet accepted exactly once, no unrecovered, no redundant. */
 TEST_F(St30RxStatsTest, DisjointPortLossesUnionRecovers) {
-  feed(0, 1000, MTL_SESSION_PORT_R);
-  feed(1, 1001, MTL_SESSION_PORT_R);
-  feed(2, 1002, MTL_SESSION_PORT_R);
-  feed(3, 1003, MTL_SESSION_PORT_P);
-  feed(4, 1004, MTL_SESSION_PORT_P);
-  feed(5, 1005, MTL_SESSION_PORT_P);
+  uint32_t s = spp();
+  feed(0, 1000 + 0u * s, MTL_SESSION_PORT_R);
+  feed(1, 1000 + 1u * s, MTL_SESSION_PORT_R);
+  feed(2, 1000 + 2u * s, MTL_SESSION_PORT_R);
+  feed(3, 1000 + 3u * s, MTL_SESSION_PORT_P);
+  feed(4, 1000 + 4u * s, MTL_SESSION_PORT_P);
+  feed(5, 1000 + 5u * s, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(received(), 6u);
   EXPECT_EQ(redundant(), 0u);
@@ -211,13 +214,13 @@ class St30RxFramePoolTest : public ::testing::Test {
     int pkts = ut30_pkts_per_frame(ctx_);
     ut30_feed_full_frame(ctx_, next_seq_, next_ts_, MTL_SESSION_PORT_P);
     next_seq_ = (uint16_t)(next_seq_ + pkts);
-    next_ts_ += (uint32_t)pkts;
+    next_ts_ += (uint32_t)pkts * ut30_samples_per_pkt(ctx_);
   }
 
   void feed_first_pkt() {
     ut30_feed_pkt(ctx_, next_seq_, next_ts_, MTL_SESSION_PORT_P);
     next_seq_ = (uint16_t)(next_seq_ + 1);
-    next_ts_ += 1;
+    next_ts_ += (uint32_t)ut30_pkts_per_frame(ctx_) * ut30_samples_per_pkt(ctx_);
   }
 
   uint64_t slot_fail() {

--- a/tests/unit/session/st30/timestamp_test.cpp
+++ b/tests/unit/session/st30/timestamp_test.cpp
@@ -25,9 +25,10 @@ TEST_F(St30RxTimestampTest, AudioFrameBoundary) {
   int total_pkts = ppf();
   ASSERT_GT(total_pkts, 0);
 
-  /* each packet needs a unique (increasing) timestamp */
+  /* each packet lands in its own positional slot */
+  uint32_t s = spp();
   for (int i = 0; i < total_pkts; i++) {
-    feed(i, 1000 + i, MTL_SESSION_PORT_P);
+    feed(i, 1000 + (uint32_t)i * s, MTL_SESSION_PORT_P);
   }
 
   EXPECT_EQ(received(), (uint64_t)total_pkts);
@@ -35,15 +36,14 @@ TEST_F(St30RxTimestampTest, AudioFrameBoundary) {
   EXPECT_EQ(unrecovered(), 0u);
 }
 
-/* 32-bit timestamp wraparound from near UINT32_MAX to near zero.
- * The wrapped timestamps should be accepted as strictly greater. */
+/* 32-bit timestamp wraparound from near UINT32_MAX past zero. Positional
+ * slots span the wrap boundary and every packet is accepted. */
 TEST_F(St30RxTimestampTest, TimestampWrapAround) {
   ut30_ctx_destroy(ctx_);
   ctx_ = ut30_ctx_create(1);
   ASSERT_NE(ctx_, nullptr);
 
-  feed_burst(0, 4, 0xFFFFFFF0, MTL_SESSION_PORT_P);
-  feed_burst(4, 4, 0x00000010, MTL_SESSION_PORT_P);
+  feed_burst(0, 8, 0xFFFFFFF0, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(unrecovered(), 0u);
   EXPECT_EQ(received(), 8u);
@@ -82,7 +82,7 @@ TEST_F(St30RxTimestampTest, BackToBackMonotonic) {
   ASSERT_NE(ctx_, nullptr);
 
   for (int i = 0; i < 40; i++) {
-    feed(i, 1000 + i, MTL_SESSION_PORT_P);
+    feed(i, 1000 + (uint32_t)i * spp(), MTL_SESSION_PORT_P);
   }
 
   EXPECT_EQ(unrecovered(), 0u);

--- a/tests/unit/session/st30_harness.c
+++ b/tests/unit/session/st30_harness.c
@@ -15,6 +15,7 @@
 /* ── tuning constants ─────────────────────────────────────────────────── */
 
 #define UT30_FRAME_COUNT 2
+#define UT30_FRAME_STORAGE 8
 #define UT30_FRAME_CAPACITY 8192
 
 /*
@@ -31,14 +32,20 @@ struct ut30_test_ctx {
   struct st_rx_audio_sessions_mgr mgr;
   struct st_rx_audio_session_impl session;
 
-  struct st_frame_trans frames[UT30_FRAME_COUNT];
-  uint8_t frame_storage[UT30_FRAME_COUNT][UT30_FRAME_CAPACITY];
+  struct st_frame_trans frames[UT30_FRAME_STORAGE];
+  uint8_t frame_storage[UT30_FRAME_STORAGE][UT30_FRAME_CAPACITY];
+  uint8_t* bitmap_storage;
 
   bool hold_frames;
 
   uint64_t frames_complete;
   uint64_t frames_corrupted;
   enum st_frame_status last_status;
+
+  /* ordered log of delivered frames for timeline assertions */
+  uint64_t rec_ts[64];
+  int rec_status[64];
+  int rec_n;
 };
 
 #include "session/st30_harness.h"
@@ -64,6 +71,11 @@ static int ut30_notify_frame_ready(void* priv, void* frame,
       ctx->frames_corrupted++;
     else
       ctx->frames_complete++;
+    if (ctx->rec_n < (int)(sizeof(ctx->rec_ts) / sizeof(ctx->rec_ts[0]))) {
+      ctx->rec_ts[ctx->rec_n] = meta->timestamp;
+      ctx->rec_status[ctx->rec_n] = meta->status;
+      ctx->rec_n++;
+    }
   }
 
   if (ctx->hold_frames) return 0;
@@ -103,7 +115,7 @@ ut30_test_ctx* ut30_ctx_create(int num_port) {
   ctx->mgr.parent = &ctx->impl;
   ctx->mgr.idx = 0;
 
-  for (int i = 0; i < UT30_FRAME_COUNT; i++) {
+  for (int i = 0; i < UT30_FRAME_STORAGE; i++) {
     memset(&ctx->frames[i], 0, sizeof(ctx->frames[i]));
     ctx->frames[i].idx = i;
     ctx->frames[i].addr = ctx->frame_storage[i];
@@ -140,6 +152,16 @@ ut30_test_ctx* ut30_ctx_create(int num_port) {
   s->st30_frame_size = pkt_multiple * UT30_PKT_PAYLOAD;
   s->ops.framebuff_size = (uint32_t)s->st30_frame_size;
   s->st30_pkt_size = UT30_PKT_PAYLOAD + sizeof(struct st_rfc3550_audio_hdr);
+  s->rtp_ticks_per_frame =
+      (uint32_t)(s->st30_frame_size / (st30_get_sample_size(s->ops.fmt) * UT30_CHANNELS));
+  s->samples_per_pkt =
+      (uint32_t)(s->pkt_len / (st30_get_sample_size(s->ops.fmt) * UT30_CHANNELS));
+  ctx->bitmap_storage = calloc(1, ((size_t)s->st30_total_pkts + 7) / 8);
+  if (!ctx->bitmap_storage) {
+    free(ctx);
+    return NULL;
+  }
+  s->frame_bitmap = ctx->bitmap_storage;
 
   s->port_maps[MTL_SESSION_PORT_P] = MTL_PORT_P;
   s->port_maps[MTL_SESSION_PORT_R] = MTL_PORT_R;
@@ -155,6 +177,8 @@ ut30_test_ctx* ut30_ctx_create(int num_port) {
 }
 
 void ut30_ctx_destroy(ut30_test_ctx* ctx) {
+  if (!ctx) return;
+  free(ctx->bitmap_storage);
   free(ctx);
 }
 
@@ -207,8 +231,9 @@ int ut30_feed_pkt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
 
 void ut30_feed_burst(ut30_test_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
                      enum mtl_session_port port) {
+  uint32_t spp = ctx->session.samples_per_pkt;
   for (int i = 0; i < count; i++) {
-    ut30_feed_pkt(ctx, seq_start + i, ts + i, port);
+    ut30_feed_pkt(ctx, seq_start + i, ts + (uint32_t)i * spp, port);
   }
 }
 
@@ -306,6 +331,24 @@ int ut30_pkts_per_frame(const ut30_test_ctx* ctx) {
   return ctx->session.st30_total_pkts;
 }
 
+uint32_t ut30_samples_per_pkt(const ut30_test_ctx* ctx) {
+  return ctx->session.samples_per_pkt;
+}
+
+int ut30_frame_log_count(const ut30_test_ctx* ctx) {
+  return ctx->rec_n;
+}
+
+uint64_t ut30_frame_log_ts(const ut30_test_ctx* ctx, int i) {
+  if (i < 0 || i >= ctx->rec_n) return 0;
+  return ctx->rec_ts[i];
+}
+
+int ut30_frame_log_status(const ut30_test_ctx* ctx, int i) {
+  if (i < 0 || i >= ctx->rec_n) return -1;
+  return ctx->rec_status[i];
+}
+
 uint64_t ut30_stat_port_pkts(const ut30_test_ctx* ctx, enum mtl_session_port port) {
   return ctx->session.port_user_stats.common.port[port].packets;
 }
@@ -378,8 +421,9 @@ void ut30_bump_slot_get_frame_fail(ut30_test_ctx* ctx, uint64_t n) {
 void ut30_feed_full_frame(ut30_test_ctx* ctx, uint16_t seq_start, uint32_t ts_start,
                           enum mtl_session_port port) {
   int pkts = ctx->session.st30_total_pkts;
+  uint32_t spp = ctx->session.samples_per_pkt;
   for (int i = 0; i < pkts; i++) {
-    ut30_feed_pkt(ctx, (uint16_t)(seq_start + i), ts_start + (uint32_t)i, port);
+    ut30_feed_pkt(ctx, (uint16_t)(seq_start + i), ts_start + (uint32_t)i * spp, port);
   }
 }
 

--- a/tests/unit/session/st30_harness.c
+++ b/tests/unit/session/st30_harness.c
@@ -35,6 +35,10 @@ struct ut30_test_ctx {
   uint8_t frame_storage[UT30_FRAME_COUNT][UT30_FRAME_CAPACITY];
 
   bool hold_frames;
+
+  uint64_t frames_complete;
+  uint64_t frames_corrupted;
+  enum st_frame_status last_status;
 };
 
 #include "session/st30_harness.h"
@@ -51,9 +55,17 @@ static uint64_t ut30_ptp_time(struct mtl_main_impl* impl, enum mtl_port port) {
 
 static int ut30_notify_frame_ready(void* priv, void* frame,
                                    struct st30_rx_frame_meta* meta) {
-  (void)meta;
   ut30_test_ctx* ctx = priv;
   if (!ctx || !frame) return 0;
+
+  if (meta) {
+    ctx->last_status = meta->status;
+    if (meta->status == ST_FRAME_STATUS_CORRUPTED)
+      ctx->frames_corrupted++;
+    else
+      ctx->frames_complete++;
+  }
+
   if (ctx->hold_frames) return 0;
 
   struct st_rx_audio_session_impl* s = &ctx->session;
@@ -272,6 +284,22 @@ int ut30_session_seq_id(const ut30_test_ctx* ctx) {
 
 int ut30_frames_received(const ut30_test_ctx* ctx) {
   return rte_atomic32_read(&ctx->session.stat_frames_received);
+}
+
+uint64_t ut30_frames_complete(const ut30_test_ctx* ctx) {
+  return ctx->frames_complete;
+}
+
+uint64_t ut30_frames_corrupted(const ut30_test_ctx* ctx) {
+  return ctx->frames_corrupted;
+}
+
+int ut30_last_frame_status(const ut30_test_ctx* ctx) {
+  return ctx->last_status;
+}
+
+void ut30_reset(ut30_test_ctx* ctx) {
+  rx_audio_session_reset(&ctx->session, false);
 }
 
 int ut30_pkts_per_frame(const ut30_test_ctx* ctx) {

--- a/tests/unit/session/st30_harness.h
+++ b/tests/unit/session/st30_harness.h
@@ -48,7 +48,8 @@ int ut30_feed_pkt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
                   enum mtl_session_port port);
 
 /* Convenience: feed `count` consecutive packets starting at `seq_start`,
- * all with the same `ts`. */
+ * with RTP timestamps starting at `ts` and striding by samples_per_pkt so
+ * each lands in its own positional slot. */
 void ut30_feed_burst(ut30_test_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
                      enum mtl_session_port port);
 
@@ -126,6 +127,15 @@ void ut30_reset(ut30_test_ctx* ctx);
  * synthetic configuration. Tests use it to derive expected counts. */
 int ut30_pkts_per_frame(const ut30_test_ctx* ctx);
 
+/* Sample-clock ticks carried by one packet (RTP timestamp advance per packet). */
+uint32_t ut30_samples_per_pkt(const ut30_test_ctx* ctx);
+
+/* Ordered log of delivered frames, captured by the frame-ready stub. `count` is
+ * the number logged; `ts`/`status` index into it. */
+int ut30_frame_log_count(const ut30_test_ctx* ctx);
+uint64_t ut30_frame_log_ts(const ut30_test_ctx* ctx, int i);
+int ut30_frame_log_status(const ut30_test_ctx* ctx, int i);
+
 /* Per-reason drop counters. */
 uint64_t ut30_stat_wrong_pt(const ut30_test_ctx* ctx);
 uint64_t ut30_stat_wrong_ssrc(const ut30_test_ctx* ctx);
@@ -138,8 +148,8 @@ uint64_t ut30_stat_slot_get_frame_fail(const ut30_test_ctx* ctx);
 void ut30_set_hold_frames(ut30_test_ctx* ctx, bool hold);
 
 /* Feed every packet of a single frame on the same wire. Per-packet RTP
- * timestamps start at `ts_start` and increment by 1 (audio handler
- * requires strictly increasing tmstamp). */
+ * timestamps start at `ts_start` and stride by samples_per_pkt so each lands
+ * in its own positional slot. */
 void ut30_feed_full_frame(ut30_test_ctx* ctx, uint16_t seq_start, uint32_t ts_start,
                           enum mtl_session_port port);
 

--- a/tests/unit/session/st30_harness.h
+++ b/tests/unit/session/st30_harness.h
@@ -109,6 +109,19 @@ int ut30_session_seq_id(const ut30_test_ctx* ctx);
  * stat counter). */
 int ut30_frames_received(const ut30_test_ctx* ctx);
 
+/* Per-frame status tally captured by the harness frame-ready stub from
+ * st30_rx_frame_meta::status. `complete` counts frames delivered with
+ * ST_FRAME_STATUS_COMPLETE, `corrupted` counts ST_FRAME_STATUS_CORRUPTED;
+ * `last` returns the status of the most recently delivered frame (or
+ * ST_FRAME_STATUS_COMPLETE before any frame is delivered). */
+uint64_t ut30_frames_complete(const ut30_test_ctx* ctx);
+uint64_t ut30_frames_corrupted(const ut30_test_ctx* ctx);
+int ut30_last_frame_status(const ut30_test_ctx* ctx);
+
+/* Drive the production session reset, clearing the per-frame loss accumulator
+ * and sequence watermarks. Test-side frame-status tallies are preserved. */
+void ut30_reset(ut30_test_ctx* ctx);
+
 /* Number of audio packets that constitute one frame in this harness's
  * synthetic configuration. Tests use it to derive expected counts. */
 int ut30_pkts_per_frame(const ut30_test_ctx* ctx);


### PR DESCRIPTION
## Summary

Two commits fixing ST2110-30 audio RX frame assembly and loss reporting.

## Commits

1. **Report CORRUPTED status on ST30p RX packet loss**
   Audio RX previously reported every delivered frame as `COMPLETE`. Now a frame
   that loses packets is delivered with `ST_FRAME_STATUS_CORRUPTED` and counted in
   `stat_frames_corrupted`, surfaced through the `st30p` API (matches st20 behavior).

2. **Place ST30 RX packets by RTP timestamp**
   Replaces arrival-order assembly with positional placement: each packet lands at
   `idx = (rtp_ts - base) / samples_per_pkt`, deduped via a `frame_bitmap` (shared
   `mt_bitmap_*` helpers, like st20). Frames anchor to the media-clock grid, so
   leading-packet loss yields `CORRUPTED` without drifting the timeline; a
   wholly-lost frame is skipped; reordered packets heal. Removes the interim
   placeholder-frame mechanism and `frame_unrecovered_pkts`.

## Testing

- New unit tests under `tests/unit/session/st30/`.
- New integration test `St30p.rx_simulate_pkt_loss`.
