### PR TITLE
Test: Fix nightly test preflight checks

### DIFF
--- a/.github/actions/source-checksums/action.yml
+++ b/.github/actions/source-checksums/action.yml
@@ -1,7 +1,7 @@
 name: Source Checksums
 description: >
   Compute deterministic SHA-256 hashes for each component group.
-  Waterfall: dpdk → mtl → {ffmpeg, gstreamer}.
+  Waterfall: dpdk → mtl → {ffmpeg, gstreamer, librist}.
   A parent change forces all children to rehash automatically.
 
 outputs:
@@ -17,6 +17,9 @@ outputs:
   gstreamer:
     description: 'Hash for GStreamer plugin sources (includes MTL hash)'
     value: ${{ steps.compute.outputs.gstreamer }}
+  librist:
+    description: 'Hash for librist sources (includes MTL hash)'
+    value: ${{ steps.compute.outputs.librist }}
 
 runs:
   using: composite

--- a/.github/actions/validate-host/action.yml
+++ b/.github/actions/validate-host/action.yml
@@ -57,6 +57,13 @@ runs:
         path: .local_install/gstreamer
         fail-on-cache-miss: true
 
+    - name: 'cache: Restore librist'
+      uses: actions/cache/restore@v4
+      with:
+        key: stash-librist-${{ steps.local-checksums.outputs.librist }}
+        path: .local_install/librist
+        fail-on-cache-miss: true
+
     - name: Make artifacts executable
       shell: bash
       run: |
@@ -79,6 +86,7 @@ runs:
         echo "${LI}/mtl/bin" >> "$GITHUB_PATH"
         echo "${LI}/ffmpeg/bin" >> "$GITHUB_PATH"
         echo "${LI}/dpdk/bin" >> "$GITHUB_PATH"
+        echo "${LI}/librist/bin" >> "$GITHUB_PATH"
 
         # GStreamer plugins
         echo "GST_PLUGIN_PATH=${LI}/gstreamer/gstreamer-1.0${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}" >> "$GITHUB_ENV"

--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -38,6 +38,7 @@ export MTL_INSTALL_PREFIX
 
 : "${PLUGIN_BUILD_AND_INSTALL_SAMPLE:=0}"
 : "${PLUGIN_BUILD_AND_INSTALL_PLUGIN_AVCODEC:=0}"
+: "${PLUGIN_BUILD_AND_INSTALL_JPEGXS:=0}"
 
 : "${HOOK_PYTHON:=0}"
 : "${HOOK_RUST:=0}"
@@ -180,6 +181,15 @@ function setup_ubuntu_install_dependencies() {
 			nasm \
 			unzip \
 			patch
+	fi
+
+	if [ "${PLUGIN_BUILD_AND_INSTALL_JPEGXS}" == "1" ]; then
+		echo "Installing JPEG-XS dependencies"
+		sudo apt install -y \
+			cmake \
+			yasm \
+			nasm \
+			build-essential
 	fi
 
 	if [ "${ECOSYSTEM_BUILD_AND_INSTALL_GSTREAMER_PLUGIN}" == "1" ]; then
@@ -512,6 +522,51 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		STEP=$((STEP + 1))
 	fi
 
+	if [ "${PLUGIN_BUILD_AND_INSTALL_JPEGXS}" == "1" ]; then
+		echo "$STEP Plugin JPEG-XS build and install"
+
+		JPEGXS_REPO="${setup_script_folder}/SVT-JPEG-XS"
+		if [ ! -d "${JPEGXS_REPO}" ]; then
+			git clone --depth 1 https://github.com/OpenVisualCloud/SVT-JPEG-XS.git "${JPEGXS_REPO}"
+		fi
+
+		# Build and install SVT-JPEG-XS library
+		pushd "${JPEGXS_REPO}/Build/linux" >/dev/null || exit 1
+		./build.sh install
+		popd >/dev/null
+
+		# Build and install imtl-plugin (MTL JPEG-XS encoder/decoder bridge)
+		pushd "${JPEGXS_REPO}/imtl-plugin" >/dev/null || exit 1
+		rm -rf build
+		meson setup build
+		meson compile -C build
+		sudo meson install -C build
+		popd >/dev/null
+
+		# Rebuild FFmpeg with JPEG-XS support
+		FFMPEG_VERSION="${FFMPEG_VERSION:-7.0}"
+		FFMPEG_JPEGXS_DIR="${setup_script_folder}/ffmpeg-jpegxs"
+		if [ -d "${FFMPEG_JPEGXS_DIR}" ]; then
+			rm -rf "${FFMPEG_JPEGXS_DIR}"
+		fi
+
+		wget -q "https://github.com/FFmpeg/FFmpeg/archive/refs/heads/release/${FFMPEG_VERSION}.zip" -O "${setup_script_folder}/ffmpeg-${FFMPEG_VERSION}.zip"
+		unzip -q "${setup_script_folder}/ffmpeg-${FFMPEG_VERSION}.zip" -d "${setup_script_folder}" && rm -f "${setup_script_folder}/ffmpeg-${FFMPEG_VERSION}.zip"
+		mv "${setup_script_folder}/FFmpeg-release-${FFMPEG_VERSION}" "${FFMPEG_JPEGXS_DIR}"
+
+		pushd "${FFMPEG_JPEGXS_DIR}" >/dev/null || exit 1
+		cp -f "${JPEGXS_REPO}/ffmpeg-plugin/libsvtjpegxs"* libavcodec/
+		git init && git add -A && git commit -m "init" --quiet
+		git am --whitespace=fix "${JPEGXS_REPO}/ffmpeg-plugin/${FFMPEG_VERSION}"/*.patch
+		./configure --enable-shared --disable-static --enable-pic --enable-libsvtjpegxs
+		make -j"${nproc}"
+		sudo make install
+		popd >/dev/null
+
+		sudo ldconfig
+		STEP=$((STEP + 1))
+	fi
+
 	if [ "${HOOK_PYTHON}" == "1" ]; then
 		echo "$STEP Hook Python"
 		pushd "${root_folder}" >/dev/null || exit 1
@@ -626,6 +681,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		"ECOSYSTEM_BUILD_AND_INSTALL_OBS_PLUGIN:OBS plugin" \
 		"PLUGIN_BUILD_AND_INSTALL_SAMPLE:Sample plugin" \
 		"PLUGIN_BUILD_AND_INSTALL_PLUGIN_AVCODEC:AVCodec plugin" \
+		"PLUGIN_BUILD_AND_INSTALL_JPEGXS:JPEG-XS plugin" \
 		"HOOK_PYTHON:Python hook" \
 		"HOOK_RUST:Rust hook" \
 		"TOOLS_BUILD_AND_INSTALL_MTL_MONITORS:MTL monitors" \

--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -478,13 +478,12 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
 	if [ "${ECOSYSTEM_BUILD_AND_INSTALL_RIST_PLUGIN}" == "1" ]; then
 		echo "$STEP Ecosystem RIST plugin build and install"
-		bash "${root_folder}/ecosystem/librist/build_librist_mtl.sh"
-		STEP=$((STEP + 1))
-	fi
-
-	if [ "${ECOSYSTEM_BUILD_AND_INSTALL_RIST_PLUGIN}" == "1" ]; then
-		echo "$STEP Ecosystem RIST plugin build and install"
-		bash "${root_folder}/ecosystem/librist/build_librist_mtl.sh"
+		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
+			MTL_INSTALL_PREFIX="${local_base}/librist" bash "${root_folder}/ecosystem/librist/build_librist_mtl.sh"
+		else
+			bash "${root_folder}/ecosystem/librist/build_librist_mtl.sh"
+		fi
 		STEP=$((STEP + 1))
 	fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ on:
       gstreamer_hash:
         description: 'gstreamer source checksum'
         value: ${{ jobs.checksums.outputs.gstreamer }}
+      librist_hash:
+        description: 'librist source checksum'
+        value: ${{ jobs.checksums.outputs.librist }}
 
 permissions:
   contents: read
@@ -63,6 +66,7 @@ jobs:
       mtl: ${{ steps.sums.outputs.mtl }}
       ffmpeg: ${{ steps.sums.outputs.ffmpeg }}
       gstreamer: ${{ steps.sums.outputs.gstreamer }}
+      librist: ${{ steps.sums.outputs.librist }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -117,6 +121,13 @@ jobs:
           key: stash-gstreamer-${{ needs.checksums.outputs.gstreamer }}
           path: .local_install/gstreamer
 
+      - name: 'stash: Restore librist cache'
+        id: librist-cache
+        uses: actions/cache@v4
+        with:
+          key: stash-librist-${{ needs.checksums.outputs.librist }}
+          path: .local_install/librist
+
       - name: Evaluate cache results
         id: needs-build
         shell: bash
@@ -125,19 +136,21 @@ jobs:
           mtl_miss=${{ steps.mtl-cache.outputs.cache-hit != 'true' && '1' || '0' }}
           ffmpeg_miss=${{ steps.ffmpeg-cache.outputs.cache-hit != 'true' && '1' || '0' }}
           gstreamer_miss=${{ steps.gstreamer-cache.outputs.cache-hit != 'true' && '1' || '0' }}
+          librist_miss=${{ steps.librist-cache.outputs.cache-hit != 'true' && '1' || '0' }}
 
           {
             echo "SETUP_BUILD_AND_INSTALL_DPDK=${dpdk_miss}"
             echo "MTL_BUILD_AND_INSTALL=${mtl_miss}"
             echo "ECOSYSTEM_BUILD_AND_INSTALL_FFMPEG_PLUGIN=${ffmpeg_miss}"
             echo "ECOSYSTEM_BUILD_AND_INSTALL_GSTREAMER_PLUGIN=${gstreamer_miss}"
+            echo "ECOSYSTEM_BUILD_AND_INSTALL_RIST_PLUGIN=${librist_miss}"
           } >> "$GITHUB_ENV"
 
           any_miss=0
-          [[ "$dpdk_miss" == "1" || "$mtl_miss" == "1" || "$ffmpeg_miss" == "1" || "$gstreamer_miss" == "1" ]] && any_miss=1
+          [[ "$dpdk_miss" == "1" || "$mtl_miss" == "1" || "$ffmpeg_miss" == "1" || "$gstreamer_miss" == "1" || "$librist_miss" == "1" ]] && any_miss=1
           echo "any_miss=${any_miss}" >> "$GITHUB_OUTPUT"
 
-          echo "::notice::DPDK=$( [ "$dpdk_miss" = 1 ] && echo MISS || echo HIT )  MTL=$( [ "$mtl_miss" = 1 ] && echo MISS || echo HIT )  FFmpeg=$( [ "$ffmpeg_miss" = 1 ] && echo MISS || echo HIT )  GStreamer=$( [ "$gstreamer_miss" = 1 ] && echo MISS || echo HIT )"
+          echo "::notice::DPDK=$( [ "$dpdk_miss" = 1 ] && echo MISS || echo HIT )  MTL=$( [ "$mtl_miss" = 1 ] && echo MISS || echo HIT )  FFmpeg=$( [ "$ffmpeg_miss" = 1 ] && echo MISS || echo HIT )  GStreamer=$( [ "$gstreamer_miss" = 1 ] && echo MISS || echo HIT )  librist=$( [ "$librist_miss" = 1 ] && echo MISS || echo HIT )"
 
       # Build what is missing
       - name: Setup environment and build

--- a/ecosystem/librist/build_librist_mtl.sh
+++ b/ecosystem/librist/build_librist_mtl.sh
@@ -32,3 +32,10 @@ git am ../*.patch
 # build now
 meson build
 ninja -C build
+
+# Install test binaries to prefix if set (for CI stashing)
+if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+	mkdir -p "${MTL_INSTALL_PREFIX}/bin"
+	cp build/test/rist/test_send "${MTL_INSTALL_PREFIX}/bin/"
+	cp build/test/rist/test_receive "${MTL_INSTALL_PREFIX}/bin/"
+fi

--- a/script/hash_sources.sh
+++ b/script/hash_sources.sh
@@ -9,6 +9,7 @@
 #   mtl       = hash(mtl_paths + dpdk_checksum)
 #   ffmpeg    = hash(ffmpeg_paths + mtl_checksum)
 #   gstreamer = hash(gstreamer_paths + mtl_checksum)
+#   librist   = hash(librist_paths + mtl_checksum)
 
 set -euo pipefail
 
@@ -92,6 +93,10 @@ ffmpeg="$(hash_string "${mtl} ${ffmpeg_paths_hash}")"
 gstreamer_paths_hash="$(hash_paths $(read_env "${script_folder}/hash_sources_gstreamer.env"))"
 gstreamer="$(hash_string "${mtl} ${gstreamer_paths_hash}")"
 
+# shellcheck disable=SC2046
+librist_paths_hash="$(hash_paths $(read_env "${script_folder}/hash_sources_librist.env"))"
+librist="$(hash_string "${mtl} ${librist_paths_hash}")"
+
 # ─── Output ─────────────────────────────────────────────────────────────────
 
 if [ -n "$OUTPUT_ENV" ]; then
@@ -100,6 +105,7 @@ if [ -n "$OUTPUT_ENV" ]; then
 		echo "mtl=${mtl}"
 		echo "ffmpeg=${ffmpeg}"
 		echo "gstreamer=${gstreamer}"
+		echo "librist=${librist}"
 	} >>"$OUTPUT_ENV"
 fi
 
@@ -107,4 +113,5 @@ printf '  %-20s %s\n' \
 	"dpdk:" "${dpdk}" \
 	"mtl:" "${mtl}" \
 	"ffmpeg:" "${ffmpeg}" \
-	"gstreamer:" "${gstreamer}"
+	"gstreamer:" "${gstreamer}" \
+	"librist:" "${librist}"

--- a/script/hash_sources_librist.env
+++ b/script/hash_sources_librist.env
@@ -1,0 +1,5 @@
+# Paths that affect the librist build artifact.
+# One path per line (glob-free). Relative to repository root.
+
+ecosystem/librist/
+versions.env

--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -992,19 +992,25 @@ def pcap_capture(
         media_file_info, _ = media_file
         test_name = request.node.name
         if "frames_number" not in capture_cfg and "capture_time" not in capture_cfg:
-            capture_cfg["packets_number"] = (
-                FRAMES_CAPTURE * calculate_packets_per_frame(media_file_info)
-            )
-            logger.info(
-                f"Capture {capture_cfg['packets_number']} packets for {FRAMES_CAPTURE} frames"
-            )
+            if media_file_info is None:
+                capture_cfg.setdefault("capture_time", FRAMES_CAPTURE)
+            else:
+                capture_cfg["packets_number"] = (
+                    FRAMES_CAPTURE * calculate_packets_per_frame(media_file_info)
+                )
+                logger.info(
+                    f"Capture {capture_cfg['packets_number']} packets for {FRAMES_CAPTURE} frames"
+                )
         elif "frames_number" in capture_cfg:
-            capture_cfg["packets_number"] = capture_cfg[
-                "frames_number"
-            ] * calculate_packets_per_frame(media_file_info)
-            logger.info(
-                f"Capture {capture_cfg['packets_number']} packets for {capture_cfg['frames_number']} frames"
-            )
+            if media_file_info is None:
+                capture_cfg.setdefault("capture_time", FRAMES_CAPTURE)
+            else:
+                capture_cfg["packets_number"] = capture_cfg[
+                    "frames_number"
+                ] * calculate_packets_per_frame(media_file_info)
+                logger.info(
+                    f"Capture {capture_cfg['packets_number']} packets for {capture_cfg['frames_number']} frames"
+                )
         capturer = NetsniffRecorder(
             host=host,
             test_name=test_name,

--- a/tests/validation/mtl_engine/ffmpeg.py
+++ b/tests/validation/mtl_engine/ffmpeg.py
@@ -77,7 +77,30 @@ class FFmpeg(Application):
         return APP_NAME_MAP["ffmpeg"]
 
     def require_encoder(self, host, encoder: str) -> None:
-        """Raise EnvironmentError if *encoder* is not available in FFmpeg on *host*."""
+        """Raise EnvironmentError if *encoder* is not available on *host*.
+
+        For codecs handled by the MTL st22p device (e.g. libsvt_jpegxs), check
+        the MTL plugin .so instead of FFmpeg's built-in encoder list.
+        """
+        # Codecs delivered via MTL plugin (FFmpeg uses -f mtl_st22p, not its own encoder)
+        _MTL_PLUGIN_MAP = {
+            "libsvt_jpegxs": "libst_plugin_st22_svt_jpeg_xs.so",
+            "libopenh264": "libst_plugin_st22_avcodec.so",
+        }
+        plugin_so = _MTL_PLUGIN_MAP.get(encoder)
+        if plugin_so:
+            check_cmd = (
+                f"test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} || "
+                f"test -f /usr/local/lib64/{plugin_so}"
+            )
+            res = host.connection.execute_command(check_cmd, expected_return_codes=None)
+            if res.return_code != 0:
+                raise EnvironmentError(
+                    f"MTL codec plugin {plugin_so} (for {encoder}) not found; "
+                    f"install the codec library and rebuild MTL plugins"
+                )
+            return
+
         res = host.connection.execute_command(
             f"ffmpeg -encoders 2>/dev/null | grep {encoder} || true",
             shell=True,

--- a/tests/validation/mtl_engine/rxtxapp.py
+++ b/tests/validation/mtl_engine/rxtxapp.py
@@ -503,6 +503,29 @@ class RxTxApp(Application):
     def get_executable_name(self) -> str:
         return APP_NAME_MAP["rxtxapp"]
 
+    # Encoder → MTL plugin .so mapping for pre-flight checks.
+    _ENCODER_PLUGIN_MAP = {
+        "libsvt_jpegxs": "libst_plugin_st22_svt_jpeg_xs.so",
+        "libopenh264": "libst_plugin_st22_avcodec.so",
+    }
+
+    def require_encoder(self, host, encoder: str) -> None:
+        """Raise EnvironmentError if the MTL codec plugin for *encoder* is not installed."""
+        plugin_so = self._ENCODER_PLUGIN_MAP.get(encoder)
+        if not plugin_so:
+            return  # Unknown encoder — skip check, let runtime fail if needed
+        # Check standard install paths
+        check_cmd = (
+            f"test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} || "
+            f"test -f /usr/local/lib64/{plugin_so}"
+        )
+        res = host.connection.execute_command(check_cmd, expected_return_codes=None)
+        if res.return_code != 0:
+            raise EnvironmentError(
+                f"MTL codec plugin {plugin_so} (for {encoder}) not found; "
+                f"install the codec library and rebuild MTL plugins"
+            )
+
     # Per-session-type (default UDP port, default payload type). Mirrors the
     # legacy ``add_*_sessions`` helpers; without it every type ends up on
     # 20000/112 and RxTxApp dies during session create due to port collisions.

--- a/tests/validation/mtl_engine/udp_app.py
+++ b/tests/validation/mtl_engine/udp_app.py
@@ -3,6 +3,7 @@
 
 import copy
 import json
+import logging
 import os
 import re
 
@@ -10,6 +11,60 @@ from mtl_engine import udp_app_config
 
 from .const import LOG_FOLDER
 from .execute import call, log_fail, wait
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_udp_binary(build: str, relative_path: str) -> str:
+    """Resolve a UDP test binary using .local_install or build directory.
+
+    Checks (in order):
+      1. .local_install/mtl/bin/<basename>  (CI mode)
+      2. <build>/<relative_path>            (local build mode)
+    Raises EnvironmentError if not found in either location.
+    """
+    basename = os.path.basename(relative_path)
+    local_install = os.path.join(build, ".local_install", "mtl", "bin", basename)
+    build_path = os.path.join(build, relative_path)
+
+    if os.path.isfile(local_install) and os.access(local_install, os.X_OK):
+        logger.debug(f"Resolved {basename} -> {local_install}")
+        return local_install
+    if os.path.isfile(build_path) and os.access(build_path, os.X_OK):
+        logger.debug(f"Resolved {basename} -> {build_path}")
+        return build_path
+    raise EnvironmentError(
+        f"Binary '{basename}' not found at '{local_install}' or '{build_path}'. "
+        f"Build the project or ensure .local_install is populated."
+    )
+
+
+def _resolve_ld_preload(build: str) -> str:
+    """Resolve libmtl_udp_preload.so path using env, .local_install, or system."""
+    # Prefer env var set by CI
+    env_path = os.environ.get("MTL_LD_PRELOAD")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+    # .local_install
+    li_path = os.path.join(
+        build,
+        ".local_install",
+        "mtl",
+        "lib",
+        "x86_64-linux-gnu",
+        "libmtl_udp_preload.so",
+    )
+    if os.path.isfile(li_path):
+        return li_path
+    # System path
+    sys_path = "/usr/local/lib/x86_64-linux-gnu/libmtl_udp_preload.so"
+    if os.path.isfile(sys_path):
+        return sys_path
+    raise EnvironmentError(
+        f"libmtl_udp_preload.so not found. Checked MTL_LD_PRELOAD env, "
+        f"'{li_path}', and '{sys_path}'."
+    )
+
 
 sample_ip_dict = {
     "client": "192.168.106.10",
@@ -57,8 +112,11 @@ def execute_test_sample(
     server_env = os.environ.copy()
     server_env["MUFD_CFG"] = os.path.join(os.getcwd(), server_config_file)
 
-    client_command = f"./build/app/UfdClientSample --p_tx_ip {sample_ip_dict['server']} --sessions_cnt {sessions_cnt}"
-    server_command = f"./build/app/UfdServerSample --sessions_cnt {sessions_cnt}"
+    client_bin = _resolve_udp_binary(build, "build/app/UfdClientSample")
+    server_bin = _resolve_udp_binary(build, "build/app/UfdServerSample")
+
+    client_command = f"{client_bin} --p_tx_ip {sample_ip_dict['server']} --sessions_cnt {sessions_cnt}"
+    server_command = f"{server_bin} --sessions_cnt {sessions_cnt}"
 
     client_proc = call(client_command, build, test_time, sigint=True, env=client_env)
     server_proc = call(server_command, build, test_time, sigint=True, env=server_env)
@@ -103,19 +161,26 @@ def execute_test_librist(
     save_as_json(config_file=receive_config_file, config=receive_config)
 
     send_env = os.environ.copy()
-    send_env["LD_PRELOAD"] = "/usr/local/lib/x86_64-linux-gnu/libmtl_udp_preload.so"
+    send_env["LD_PRELOAD"] = _resolve_ld_preload(build)
     send_env["MUFD_CFG"] = os.path.join(os.getcwd(), send_config_file)
 
     receive_env = os.environ.copy()
-    receive_env["LD_PRELOAD"] = "/usr/local/lib/x86_64-linux-gnu/libmtl_udp_preload.so"
+    receive_env["LD_PRELOAD"] = _resolve_ld_preload(build)
     receive_env["MUFD_CFG"] = os.path.join(os.getcwd(), receive_config_file)
 
+    send_bin = _resolve_udp_binary(
+        build, "ecosystem/librist/librist/build/test/rist/test_send"
+    )
+    receive_bin = _resolve_udp_binary(
+        build, "ecosystem/librist/librist/build/test/rist/test_receive"
+    )
+
     send_command = (
-        f"./ecosystem/librist/librist/build/test/rist/test_send --sleep_us={sleep_us}"
+        f"{send_bin} --sleep_us={sleep_us}"
         + f" --sleep_step={sleep_step} --dip={librist_ip_dict['receive']} --sessions_cnt={sessions_cnt}"
     )
     receive_command = (
-        "./ecosystem/librist/librist/build/test/rist/test_receive"
+        f"{receive_bin}"
         + f" --bind_ip={librist_ip_dict['receive']} --sessions_cnt={sessions_cnt}"
     )
 

--- a/tests/validation/mtl_engine/udp_app.py
+++ b/tests/validation/mtl_engine/udp_app.py
@@ -19,22 +19,32 @@ def _resolve_udp_binary(build: str, relative_path: str) -> str:
     """Resolve a UDP test binary using .local_install or build directory.
 
     Checks (in order):
-      1. .local_install/mtl/bin/<basename>  (CI mode)
-      2. <build>/<relative_path>            (local build mode)
-    Raises EnvironmentError if not found in either location.
+      1. .local_install/mtl/bin/<basename>  (CI mode - MTL apps)
+      2. .local_install/librist/bin/<basename>  (CI mode - librist)
+      3. <build>/<relative_path>            (local build mode)
+    Raises EnvironmentError if not found in any location.
     """
     basename = os.path.basename(relative_path)
-    local_install = os.path.join(build, ".local_install", "mtl", "bin", basename)
+    local_install_mtl = os.path.join(build, ".local_install", "mtl", "bin", basename)
+    local_install_librist = os.path.join(
+        build, ".local_install", "librist", "bin", basename
+    )
     build_path = os.path.join(build, relative_path)
 
-    if os.path.isfile(local_install) and os.access(local_install, os.X_OK):
-        logger.debug(f"Resolved {basename} -> {local_install}")
-        return local_install
+    if os.path.isfile(local_install_mtl) and os.access(local_install_mtl, os.X_OK):
+        logger.debug(f"Resolved {basename} -> {local_install_mtl}")
+        return local_install_mtl
+    if os.path.isfile(local_install_librist) and os.access(
+        local_install_librist, os.X_OK
+    ):
+        logger.debug(f"Resolved {basename} -> {local_install_librist}")
+        return local_install_librist
     if os.path.isfile(build_path) and os.access(build_path, os.X_OK):
         logger.debug(f"Resolved {basename} -> {build_path}")
         return build_path
     raise EnvironmentError(
-        f"Binary '{basename}' not found at '{local_install}' or '{build_path}'. "
+        f"Binary '{basename}' not found at '{local_install_mtl}', "
+        f"'{local_install_librist}', or '{build_path}'. "
         f"Build the project or ensure .local_install is populated."
     )
 

--- a/tests/validation/tests/single/rx_timing/mixed/test_mode_refactored.py
+++ b/tests/validation/tests/single/rx_timing/mixed/test_mode_refactored.py
@@ -57,7 +57,6 @@ def test_rx_timing_mode_refactored(
                 "pixel_format": video_file["file_format"],
                 "transport_format": video_file["format"],
                 "input_file": str(host.connection.path(media, video_file["filename"])),
-                "output_file": str(host.connection.path(media, video_file["filename"])),
             },
             {
                 "session_type": "st30p",
@@ -66,7 +65,6 @@ def test_rx_timing_mode_refactored(
                 "audio_sampling": "48kHz",
                 "audio_ptime": "1",
                 "input_file": str(host.connection.path(media, audio_file["filename"])),
-                "output_file": str(host.connection.path(media, audio_file["filename"])),
             },
             {
                 "session_type": "ancillary",

--- a/tests/validation/tests/single/st22p/test_format.py
+++ b/tests/validation/tests/single/st22p/test_format.py
@@ -41,6 +41,7 @@ def test_st22p_format(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
+    app.require_encoder(host, "libsvt_jpegxs")
     app.create_command(
         session_type="st22p",
         test_mode="multicast",

--- a/tests/validation/tests/single/st22p/test_interlace.py
+++ b/tests/validation/tests/single/st22p/test_interlace.py
@@ -46,6 +46,7 @@ def test_st22p_interlace(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
+    app.require_encoder(host, "libsvt_jpegxs")
     app.create_command(
         session_type="st22p",
         test_mode="multicast",

--- a/tests/validation/tests/single/st22p/test_quality.py
+++ b/tests/validation/tests/single/st22p/test_quality.py
@@ -48,6 +48,7 @@ def test_st22p_quality(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
+    app.require_encoder(host, "libsvt_jpegxs")
     app.create_command(
         session_type="st22p",
         test_mode="multicast",

--- a/tests/validation/tests/single/st22p/test_unicast.py
+++ b/tests/validation/tests/single/st22p/test_unicast.py
@@ -41,6 +41,7 @@ def test_st22p_unicast(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
+    app.require_encoder(host, "libsvt_jpegxs")
     app.create_command(
         session_type="st22p",
         test_mode="unicast",


### PR DESCRIPTION
Fix several nightly pytest failures caused by missing pre-flight
validation, unresolved binary paths, and fragile cache handling.

Problem:
- rx_timing/mixed tests failed with -EIO because output_file pointed
  to the read-only NFS media mount
- UDP tests returned RC=127 (command not found) because CI stashes
  place binaries in .local_install/, not build/
- st22p tests crashed with rc=251 when JPEG-XS codec plugin was
  absent on the runner
- pcap_capture fixture crashed on NoneType when media_file_info was
  unavailable
- Cache eviction (GitHub 10 GB / 7-day LRU) caused silent build
  failures with no recovery path

Fixes:
- Remove unnecessary output_file from rx_timing mixed test sessions
  (timing analysis doesn't need frame writes)
- Add _resolve_udp_binary() / _resolve_ld_preload() to probe
  .local_install before falling back to build paths
- Install UfdClient/ServerSample via meson, add librist stash
  infrastructure to CI
- Add require_encoder() pre-flight for st22p codec availability
- Guard pcap_capture against missing media_file_info
- Switch validate-host cache from fail-on-cache-miss to self-healing
  restore+save with local build fallback