### PR TITLE
Tests: Removed pcap capture from st22p and st41

### DIFF
--- a/tests/validation/tests/single/st22p/test_codec.py
+++ b/tests/validation/tests/single/st22p/test_codec.py
@@ -30,7 +30,6 @@ def test_st22p_codec(
     test_time,
     codec,
     test_config,
-    pcap_capture,
     media_file,
 ):
     """Test st22p codec types (JPEG-XS and H264_CBR)."""
@@ -67,6 +66,4 @@ def test_st22p_codec(
         codec_threads=2,
         test_time=test_time,
     )
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)

--- a/tests/validation/tests/single/st22p/test_format.py
+++ b/tests/validation/tests/single/st22p/test_format.py
@@ -28,7 +28,6 @@ def test_st22p_format(
     setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
-    pcap_capture,
     media_file,
 ):
     """Test st22p with different media formats/resolutions."""
@@ -57,6 +56,4 @@ def test_st22p_format(
         test_time=test_time,
     )
 
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)

--- a/tests/validation/tests/single/st22p/test_fps.py
+++ b/tests/validation/tests/single/st22p/test_fps.py
@@ -47,7 +47,6 @@ def test_st22p_fps(
     fps,
     codec,
     test_config,
-    pcap_capture,
     media_file,
 ):
     """Test st22p at different frame rates."""
@@ -74,6 +73,4 @@ def test_st22p_fps(
         codec_threads=16,
         test_time=test_time,
     )
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)

--- a/tests/validation/tests/single/st22p/test_interlace.py
+++ b/tests/validation/tests/single/st22p/test_interlace.py
@@ -33,7 +33,6 @@ def test_st22p_interlace(
     setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
-    pcap_capture,
     media_file,
 ):
     """Test st22p interlaced video transmission."""
@@ -62,6 +61,4 @@ def test_st22p_interlace(
         interlaced=True,
         test_time=test_time,
     )
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)

--- a/tests/validation/tests/single/st22p/test_quality.py
+++ b/tests/validation/tests/single/st22p/test_quality.py
@@ -35,7 +35,6 @@ def test_st22p_quality(
     test_time,
     quality,
     test_config,
-    pcap_capture,
     media_file,
 ):
     """Test st22p JPEG-XS encoder quality settings."""
@@ -63,7 +62,5 @@ def test_st22p_quality(
         codec_threads=2,
         test_time=test_time,
     )
-    result = app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    result = app.execute_test(build=mtl_path, test_time=test_time, host=host)
     assert result, "st22p quality test failed validation."

--- a/tests/validation/tests/single/st22p/test_unicast.py
+++ b/tests/validation/tests/single/st22p/test_unicast.py
@@ -28,7 +28,6 @@ def test_st22p_unicast(
     setup_interfaces: InterfaceSetup,
     test_time,
     test_config,
-    pcap_capture,
     media_file,
 ):
     """Test st22p unicast transmission mode."""
@@ -56,6 +55,4 @@ def test_st22p_unicast(
         codec_threads=2,
         test_time=test_time,
     )
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)

--- a/tests/validation/tests/single/st41/test_st41.py
+++ b/tests/validation/tests/single/st41/test_st41.py
@@ -52,7 +52,6 @@ def test_st41_dit(
     dit,
     test_config,
     media_file,
-    pcap_capture,
 ):
     """Test the Data Item Type (DIT) fastmetadata_data_item_type."""
     _, media_file_path = media_file
@@ -78,9 +77,7 @@ def test_st41_dit(
         test_time=test_time,
     )
 
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)
 
 
 @pytest.mark.nightly
@@ -116,7 +113,6 @@ def test_st41_fps(
     fps,
     test_config,
     media_file,
-    pcap_capture,
 ):
     """Test st41 with different frame rates."""
     _, media_file_path = media_file
@@ -143,9 +139,7 @@ def test_st41_fps(
         test_time=test_time,
     )
 
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)
 
 
 @pytest.mark.nightly
@@ -178,7 +172,6 @@ def test_st41_k_bit(
     k_bit,
     test_config,
     media_file,
-    pcap_capture,
 ):
     """Test st41 with different k-bit values."""
     _, media_file_path = media_file
@@ -204,9 +197,7 @@ def test_st41_k_bit(
         test_time=test_time,
     )
 
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)
 
 
 @pytest.mark.nightly
@@ -239,7 +230,6 @@ def test_st41_no_chain(
     type_mode,
     test_config,
     media_file,
-    pcap_capture,
 ):
     """Test st41 with tx_no_chain=True."""
     _, media_file_path = media_file
@@ -267,9 +257,7 @@ def test_st41_no_chain(
         test_time=test_time,
     )
 
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)
 
 
 @pytest.mark.nightly
@@ -304,7 +292,6 @@ def test_st41_payload_type(
     type_mode,
     test_config,
     media_file,
-    pcap_capture,
 ):
     """Test st41 with different payload types."""
     _, media_file_path = media_file
@@ -330,9 +317,7 @@ def test_st41_payload_type(
         test_time=test_time,
     )
 
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)
 
 
 @pytest.mark.nightly
@@ -367,7 +352,6 @@ def test_st41_type_mode(
     type_mode,
     test_config,
     media_file,
-    pcap_capture,
 ):
     """Test st41 with different transmission modes (unicast, multicast)."""
     _, media_file_path = media_file
@@ -394,6 +378,4 @@ def test_st41_type_mode(
         test_time=test_time,
     )
 
-    app.execute_test(
-        build=mtl_path, test_time=test_time, host=host, netsniff=pcap_capture
-    )
+    app.execute_test(build=mtl_path, test_time=test_time, host=host)


### PR DESCRIPTION
Tests: Removed pcap capture from st22p and st41 tests due to not supported by EBU List