### PR TITLE
Test: Removed single node performance tests from nightly pytest scope.

### DIFF
--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -27,7 +27,6 @@ jobs:
           - st40p
           - gstreamer
           - kernel_socket
-          - performance
           - ptp
           - rss_mode
           - rx_timing

--- a/tests/validation/tests/single/performance/test_1tx_1nic_1port.py
+++ b/tests/validation/tests/single/performance/test_1tx_1nic_1port.py
@@ -12,8 +12,6 @@ from mtl_engine.media_files import yuv_files
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.nightly
-
 
 @pytest.mark.parametrize(
     "video_format",

--- a/tests/validation/tests/single/performance/test_1tx_1rx_2nics_2ports.py
+++ b/tests/validation/tests/single/performance/test_1tx_1rx_2nics_2ports.py
@@ -12,8 +12,6 @@ from mtl_engine.media_files import yuv_files
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.nightly
-
 
 @pytest.mark.parametrize(
     "video_format",

--- a/tests/validation/tests/single/performance/test_2tx_2nics_2ports.py
+++ b/tests/validation/tests/single/performance/test_2tx_2nics_2ports.py
@@ -12,8 +12,6 @@ from mtl_engine.media_files import yuv_files
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.nightly
-
 
 @pytest.mark.parametrize(
     "video_format",

--- a/tests/validation/tests/single/performance/test_2tx_2rx_4nics_4ports.py
+++ b/tests/validation/tests/single/performance/test_2tx_2rx_4nics_4ports.py
@@ -12,8 +12,6 @@ from mtl_engine.media_files import yuv_files
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.nightly
-
 
 @pytest.mark.parametrize(
     "video_format",

--- a/tests/validation/tests/single/performance/test_4tx_4nics_4ports.py
+++ b/tests/validation/tests/single/performance/test_4tx_4nics_4ports.py
@@ -12,8 +12,6 @@ from mtl_engine.media_files import yuv_files
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.nightly
-
 
 @pytest.mark.parametrize(
     "video_format",

--- a/tests/validation/tests/single/performance/test_4tx_4rx_4nics_8ports.py
+++ b/tests/validation/tests/single/performance/test_4tx_4rx_4nics_8ports.py
@@ -12,8 +12,6 @@ from mtl_engine.media_files import yuv_files
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.nightly
-
 
 @pytest.mark.parametrize(
     "video_format",


### PR DESCRIPTION
Test: Removed single node performance tests from nightly pytest scope.

Depreceated tests doesn't reflect reas status of the MTL performance capacity.