### PR TITLE
Fix ST20/ST22 per-port loss over-counting on redundant sessions

### DIFF
--- a/.github/agents/mtl-system-admin.agent.md
+++ b/.github/agents/mtl-system-admin.agent.md
@@ -31,6 +31,7 @@ Without this step, MCP tool calls will fail with "Cannot read properties of unde
 
 - **MCP tools ONLY.** You must NEVER run shell commands via `run_in_terminal`, `execute`, or any terminal tool. All system operations (status checks, hugepages, driver info, devbind, etc.) must go through `mcp_mtl-system-se_*` MCP tools. If no MCP tool exists for an operation, tell the user — do not fall back to shell commands.
 - **Probe before acting.** Always start with `system_status` to understand current state.
+- **Build `debugonly` for tests.** When building MTL to run integration tests, always use `build_mtl(mode="debugonly")`, never `release`. The simulate-loss / redundancy packet-drop test paths are gated by `MTL_SIMULATE_PACKET_DROPS`, which is defined only for non-release builds; a `release` build silently compiles them out so drop tests skip their assertions.
 - **Fix in dependency order.** DPDK → ICE driver → VFs → MTL → MtlManager → tests.
 - **VFs destroyed on ICE reload.** After `ice_driver_rebuild`, always `setup_after_reboot_auto`.
 - **Verify after each step.** Confirm the fix worked before moving on.
@@ -41,8 +42,9 @@ Without this step, MCP tool calls will fail with "Cannot read properties of unde
 1. **Load tools** — `tool_search("mcp mtl system setup reboot manager gtest")` to load all MCP tools
 2. **Probe** — `system_status` for full readiness overview
 3. **Setup** — `setup_after_reboot_auto` handles hugepages + CPU governor + VFs + MtlManager
-4. **Test** — `run_gtest(gtest_filter="St20p*")` for a smoke test
-5. **Report** — end with a status summary showing DPDK, ICE, VFs, MtlManager, and test results
+4. **Build for tests** — `build_mtl(mode="debugonly")` so simulate-loss / redundancy drop paths are compiled in (never `release` when the goal is running tests)
+5. **Test** — `run_gtest(gtest_filter="St20p*")` for a smoke test
+6. **Report** — end with a status summary showing DPDK, ICE, VFs, MtlManager, and test results
 
 For full tool inventory, decision trees (reboot, crash, build failure), and key facts,
 see `.github/instructions/mtl-system-setup.instructions.md`.

--- a/.github/mcp/mtl_mcp_server.py
+++ b/.github/mcp/mtl_mcp_server.py
@@ -855,12 +855,19 @@ def dpdk_build() -> str:
 
 
 @mcp.tool()
-def build_mtl(mode: str = "release") -> str:
+def build_mtl(mode: str = "debugonly") -> str:
     """
     Build the Media Transport Library.
 
+    Use 'debugonly' (the default) when building to run integration tests:
+    the simulate-loss / redundancy packet-drop test paths are guarded by
+    MTL_SIMULATE_PACKET_DROPS, which is only defined for non-release builds.
+    A 'release' build silently compiles those paths out, so tests that rely
+    on them (e.g. *redundant* drop tests) skip their drop assertions.
+
     Args:
-        mode: Build mode — 'release', 'debug' (with ASAN), or 'debugonly' (debug without ASAN).
+        mode: Build mode — 'debugonly' (debug without ASAN, default — required
+            for simulate-loss tests), 'debug' (with ASAN), or 'release'.
     """
     if mode not in ("release", "debug", "debugonly"):
         return f"Error: mode must be 'release', 'debug', or 'debugonly'. Got '{mode}'."
@@ -1362,6 +1369,30 @@ def status_report() -> str:
 # ===================================================================
 
 
+def _build_has_simulate_drops() -> bool:
+    """True if build/ was compiled with MTL_SIMULATE_PACKET_DROPS.
+
+    The macro is defined only for non-release builds (see meson.build). It
+    gates the simulate-loss / redundancy packet-drop test paths, so a release
+    build makes those tests silently skip their drop assertions. Detected by
+    inspecting the compile database emitted by meson.
+    """
+    ccmds = REPO_ROOT / "build/compile_commands.json"
+    try:
+        return "MTL_SIMULATE_PACKET_DROPS" in ccmds.read_text()
+    except OSError:
+        return False
+
+
+_SIM_DROPS_HINT = (
+    "\n\n> **Warning:** `build/` was compiled in **release** mode "
+    "(no `MTL_SIMULATE_PACKET_DROPS`). Simulate-loss / redundancy "
+    "packet-drop test paths are compiled out, so their drop assertions "
+    'silently skip. Rebuild with `build_mtl(mode="debugonly")` before '
+    "running these tests."
+)
+
+
 @mcp.tool()
 def run_gtest(
     p_port: str = "",
@@ -1388,6 +1419,8 @@ def run_gtest(
     binary = REPO_ROOT / "build/tests/KahawaiTest"
     if not binary.is_file():
         return "Error: KahawaiTest not built. Run `build_mtl` first."
+
+    sim_hint = "" if _build_has_simulate_drops() else _SIM_DROPS_HINT
 
     # Auto-discover ports from VFIO-bound VFs
     if not p_port or not r_port:
@@ -1465,6 +1498,7 @@ def run_gtest(
     # Save full log
     log_path = _save_test_log("gtest", out)
     summary += f"\n- Full log: `{log_path}`"
+    summary += sim_hint
 
     # Include last 40 lines for context
     tail = "\n".join(out.splitlines()[-40:])
@@ -1536,6 +1570,8 @@ def run_noctx_tests(
     binary = REPO_ROOT / "build/tests/KahawaiTest"
     if not binary.is_file():
         return "Error: KahawaiTest not built. Run `build_mtl` first."
+
+    sim_hint = "" if _build_has_simulate_drops() else _SIM_DROPS_HINT
 
     port_list = f"{port_1},{port_2},{port_3},{port_4}"
 
@@ -1625,6 +1661,7 @@ def run_noctx_tests(
         f"- Full log: `{log_path}`\n"
         f"\n### Per-test results\n{per_test}\n"
         f"{last_failure}"
+        f"{sim_hint}"
     )
 
 

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -39,6 +39,7 @@ All counters are `uint64_t`, monotonic, thread-safe (per-session spinlock).
  │                      stat_lost_packets    += gap_size                       │
  │     backward seq ──► port[i].reordered_packets++                            │
  │     same seq     ──► port[i].duplicates_same_port++  (audio/anc/fmd only)   │
+ │     (video charges port[i].lost_packets at frame recycle — see step 8)      │
  └──────┬───────────────────────────────────────────────────────────────────────┘
         │
         ▼
@@ -96,6 +97,11 @@ All counters are `uint64_t`, monotonic, thread-safe (per-session spinlock).
  │                                          .frames_partial[P]++               │
  │       (same for port R)                                                     │
  │       gap → estimated missing pkts ──► stat_pkts_unrecovered += est         │
+ │       per-port deficit (deferred)  ──► port[i].lost_packets += deficit      │
+ │         deficit = max(0, span − recv_on_port[i])                            │
+ │         span = pkts_received + this-frame all-port holes                    │
+ │         charged at frame recycle, not at completion, so late                │
+ │         redundant twins are counted first (stats appear one frame later)    │
  │                                                                             │
  │     ST20 / ST22 (transport): intra-frame loss detected                       │
  │                                    ──► stat_frames_incomplete++             │
@@ -125,7 +131,7 @@ actually got.
 
 | Counter | Meaning |
 |---|---|
-| `port[i].lost_packets` | Packets missing on **this** port (pre-redundancy) |
+| `port[i].lost_packets` | Packets missing on **this** port (pre-redundancy). Video: per-frame deficit `max(0, span − recv_on_port[i])` charged to each participating port at frame recycle (appears one frame after the loss). Audio/anc/fmd: per-port forward sequence gap. |
 | `port[i].reordered_packets` | Backward arrival on the same port |
 | `port[i].duplicates_same_port` | Same seq twice on the same port (audio/anc/fmd; always 0 for video) |
 | `stat_pkts_redundant` | Cross-port duplicate filtered — **expected** on 2-port sessions |
@@ -138,6 +144,10 @@ save_rate (%)         == 100 * lost / (lost + unrecovered)
 ```
 
 `save_rate` answers: **"is redundancy covering the gaps?"** 100% = yes.
+
+> **Note.** A same-port duplicate or retransmit inflates that port's received
+> count, so a genuine `port[i].lost_packets` deficit can be masked (read as 0).
+> Aggregate cross-port recovery accounting is unaffected.
 
 ### Reading table
 

--- a/lib/src/st2110/st_header.h
+++ b/lib/src/st2110/st_header.h
@@ -441,6 +441,9 @@ struct st_rx_video_slot_impl {
   uint64_t timestamp_first_pkt;
   /* Per-port high-water mark of pkt_idx within the current frame (init -1). */
   int last_pkt_idx[MTL_SESSION_PORT_MAX];
+  /* complete frame delivered; per-port loss accounting deferred to recycle so
+   * late redundant twins are counted first */
+  bool loss_pending;
 };
 
 enum st20_detect_status {

--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -809,6 +809,39 @@ static int rv_st22_usdt_dump_frame(struct mtl_main_impl* impl,
   return 0;
 }
 
+/* Charge each port the frame's reception deficit at finalisation.
+ * expected = pkts_received + all-port holes; stat_lost_packets stays the
+ * sum of the per-port deficits. A port whose link is down receives nothing
+ * and is a dead wire (counted via frames_partial), not charged phantom
+ * per-packet loss. A link-up port that fell short missed those packets and
+ * is charged the full deficit. */
+static void rv_slot_account_per_port_loss(struct st_rx_video_session_impl* s,
+                                          struct st_rx_video_slot_impl* slot,
+                                          uint32_t expected) {
+  struct mtl_main_impl* impl = s->impl;
+  for (int s_port = 0; s_port < s->ops.num_port; s_port++) {
+    uint32_t recv = slot->pkts_recv_per_port[s_port];
+    enum mtl_port port = mt_port_logic2phy(s->port_maps, s_port);
+    if (mt_if_port_is_down(impl, port)) continue;
+    if (expected <= recv) continue;
+    uint32_t deficit = expected - recv;
+    s->port_user_stats.common.port[s_port].lost_packets += deficit;
+    s->port_user_stats.common.stat_lost_packets += deficit;
+  }
+}
+
+/* Charge every slot still holding a deferred deficit at end-of-stream (detach),
+ * so frames completed-but-port-short are not dropped by the recycle-triggered
+ * accounting model. Clears loss_pending so a re-attach cannot re-charge. */
+static void rv_flush_pending_loss(struct st_rx_video_session_impl* s) {
+  for (int i = 0; i < s->slot_max; i++) {
+    struct st_rx_video_slot_impl* slot = &s->slots[i];
+    if (!slot->loss_pending) continue;
+    rv_slot_account_per_port_loss(s, slot, slot->pkts_received);
+    slot->loss_pending = false;
+  }
+}
+
 static void rv_frame_notify(struct st_rx_video_session_impl* s,
                             struct st_rx_video_slot_impl* slot) {
   struct st20_rx_ops* ops = &s->ops;
@@ -880,6 +913,7 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
 
   if (meta->frame_recv_size >= s->st20_frame_size) {
     meta->status = ST_FRAME_STATUS_COMPLETE;
+    slot->loss_pending = true;
     if (ops->num_port > 1) {
       if ((slot->pkts_recv_per_port[MTL_SESSION_PORT_P] < slot->pkts_received) &&
           (slot->pkts_recv_per_port[MTL_SESSION_PORT_R] < slot->pkts_received))
@@ -924,6 +958,8 @@ static void rv_frame_notify(struct st_rx_video_session_impl* s,
     float pd_sz_per_pkt = (float)meta->frame_recv_size / slot->pkts_received;
     int miss_pkts = (s->st20_frame_size - meta->frame_recv_size) / pd_sz_per_pkt;
     if (miss_pkts > 0) s->port_user_stats.common.stat_pkts_unrecovered += miss_pkts;
+    rv_slot_account_per_port_loss(
+        s, slot, slot->pkts_received + (miss_pkts > 0 ? (uint32_t)miss_pkts : 0));
     dbg("%s(%d), miss pkts %d for current frame\n", __func__, s->idx, miss_pkts);
 
 #if 0 /* for miss pkt detail */
@@ -988,6 +1024,7 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
   int ret = -EIO;
 
   if (st_is_frame_complete(status)) {
+    slot->loss_pending = true;
     /* Per-port completeness accounting (mirrors ST20). With redundancy,
      * the frame may be complete overall while one port was missing pkts;
      * surface that asymmetry via frames_partial. */
@@ -1021,6 +1058,7 @@ static void rv_st22_frame_notify(struct st_rx_video_session_impl* s,
     if (miss_pkts < 0) miss_pkts = 0;
     dbg("%s(%d), miss pkts %d for current frame\n", __func__, s->idx, miss_pkts);
     if (miss_pkts > 0) s->port_user_stats.common.stat_pkts_unrecovered += miss_pkts;
+    rv_slot_account_per_port_loss(s, slot, slot->pkts_received + (uint32_t)miss_pkts);
 #if 0 /* for miss pkt detail */
     int total_pkts = s->st22_expect_size_per_frame / pd_sz_per_pkt;
     dbg("%s(%d), total_pkts %d\n", __func__, s->idx, total_pkts);
@@ -1180,6 +1218,13 @@ static struct st_rx_video_slot_impl* rv_slot_by_tmstamp(
       rv_frame_notify(s, slot);
     slot->frame = NULL;
   }
+  /* Charge any deferred (complete-frame) per-port loss now that late redundant
+   * twins have had their chance to land. Incomplete frames already accounted
+   * inline and leave loss_pending clear, so this never double-charges. */
+  if (slot->loss_pending) {
+    rv_slot_account_per_port_loss(s, slot, slot->pkts_received);
+    slot->loss_pending = false;
+  }
 
   rv_slot_init_frame_size(slot);
   slot->tmstamp = tmstamp;
@@ -1287,23 +1332,18 @@ static struct st_rx_video_slot_impl* rv_rtp_slot_by_tmstamp(
 
 static void rv_slot_full_frame(struct st_rx_video_session_impl* s,
                                struct st_rx_video_slot_impl* slot) {
-  /* end of frame */
+  /* end of frame; retain pkts_received/pkts_recv_per_port so deferred per-port
+   * loss accounting at recycle sees late redundant twins */
   rv_frame_notify(s, slot);
   rv_slot_init_frame_size(slot);
-  slot->pkts_received = 0;
-  slot->pkts_recv_per_port[MTL_SESSION_PORT_P] = 0;
-  slot->pkts_recv_per_port[MTL_SESSION_PORT_R] = 0;
   slot->frame = NULL; /* frame pass to app */
 }
 
 static void rv_st22_slot_full_frame(struct st_rx_video_session_impl* s,
                                     struct st_rx_video_slot_impl* slot) {
-  /* end of frame */
+  /* end of frame; retain counters for deferred per-port loss accounting */
   rv_st22_frame_notify(s, slot, ST_FRAME_STATUS_COMPLETE);
   rv_slot_init_frame_size(slot);
-  slot->pkts_received = 0;
-  slot->pkts_recv_per_port[MTL_SESSION_PORT_P] = 0;
-  slot->pkts_recv_per_port[MTL_SESSION_PORT_R] = 0;
   slot->frame = NULL; /* frame pass to app */
 }
 
@@ -1674,11 +1714,7 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
         rv_tp_pkt_handle(s, mbuf, s_port, slot, tmstamp, pkt_idx);
       return 0;
     }
-    if (pkt_idx > (slot->last_pkt_idx[s_port] + 1) && slot->last_pkt_idx[s_port] >= 0) {
-      int gap = pkt_idx - slot->last_pkt_idx[s_port] - 1;
-      s->port_user_stats.common.stat_lost_packets += gap;
-      s->port_user_stats.common.port[s_port].lost_packets += gap;
-    } else if (pkt_idx < slot->last_pkt_idx[s_port]) {
+    if (pkt_idx < slot->last_pkt_idx[s_port]) {
       /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
        * behind the highest accepted index for THIS port in the current frame */
       s->port_user_stats.common.port[s_port].reordered_packets++;
@@ -1708,9 +1744,9 @@ static int rv_handle_frame_pkt(struct st_rx_video_session_impl* s, struct rte_mb
       return -EIO;
     }
   }
-  /* only advance, never regress: a reorder must not move the high-water
-   * mark backward, otherwise the next forward jump re-counts already-lost
-   * packets as new losses */
+  /* high-water mark per port, used only for intra-frame reorder detection
+   * (a later pkt_idx below this mark is a backward arrival). Advance, never
+   * regress, so a reorder does not lower the mark. */
   if (pkt_idx > slot->last_pkt_idx[s_port]) slot->last_pkt_idx[s_port] = pkt_idx;
 
   /* if enable_timing_parser */
@@ -2072,11 +2108,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
-    if (pkt_idx > (slot->last_pkt_idx[s_port] + 1) && slot->last_pkt_idx[s_port] >= 0) {
-      int gap = pkt_idx - slot->last_pkt_idx[s_port] - 1;
-      s->port_user_stats.common.stat_lost_packets += gap;
-      s->port_user_stats.common.port[s_port].lost_packets += gap;
-    } else if (pkt_idx < slot->last_pkt_idx[s_port]) {
+    if (pkt_idx < slot->last_pkt_idx[s_port]) {
       /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
        * behind the highest accepted index for THIS port in the current frame */
       s->port_user_stats.common.port[s_port].reordered_packets++;
@@ -2243,11 +2275,7 @@ static int rv_handle_hdr_split_pkt(struct st_rx_video_session_impl* s,
       slot->pkts_recv_per_port[s_port]++;
       return 0;
     }
-    if (pkt_idx > (slot->last_pkt_idx[s_port] + 1) && slot->last_pkt_idx[s_port] >= 0) {
-      int gap = pkt_idx - slot->last_pkt_idx[s_port] - 1;
-      s->port_user_stats.common.stat_lost_packets += gap;
-      s->port_user_stats.common.port[s_port].lost_packets += gap;
-    } else if (pkt_idx < slot->last_pkt_idx[s_port]) {
+    if (pkt_idx < slot->last_pkt_idx[s_port]) {
       /* intra-frame reorder on this port: a not-yet-seen pkt_idx arrived
        * behind the highest accepted index for THIS port in the current frame */
       s->port_user_stats.common.port[s_port].reordered_packets++;
@@ -3154,6 +3182,7 @@ static void rv_reset_slot(struct st_rx_video_session_impl* s,
   slot->seq_id_got = false;
   slot->pkts_received = 0;
   for (int i = 0; i < MTL_SESSION_PORT_MAX; i++) slot->pkts_recv_per_port[i] = 0;
+  slot->loss_pending = false;
   slot->timestamp_first_pkt = 0;
   slot->second_field = false;
   slot->st22_payload_length = 0;
@@ -3830,6 +3859,7 @@ static int rv_detach(struct mtl_main_impl* impl, struct st_rx_video_sessions_mgr
                      struct st_rx_video_session_impl* s) {
   if (!mgr || !s) return -EINVAL;
   s->attached = false;
+  rv_flush_pending_loss(s);
   rv_stat(mgr, s);
   rv_uinit(impl, s);
   return 0;

--- a/tests/integration_tests/noctx/testcases/st20p_redundant_tests.cpp
+++ b/tests/integration_tests/noctx/testcases/st20p_redundant_tests.cpp
@@ -18,11 +18,18 @@ TEST_F(NoCtxTest, st20p_redundant_latency_drops_even_odd) {
   }
 
 /**
- * This test requires MTL_SIMULATE_PACKET_DROPS to be enabled in the build.
- * so DEBUG mode is necessary for proper functionality.
- * The packet skip feature affects the critical path performance,
+ * This test requires MTL_SIMULATE_PACKET_DROPS to be enabled in the build
+ * (debug/debugonly), so the TX side actually drops the configured packets.
+ * The packet skip feature affects the critical path performance and is
+ * compiled out of release builds. Without it no packets are dropped, so the
+ * test would pass vacuously and mask regressions — skip instead of giving a
+ * misleading green result.
  */
-#ifdef MTL_SIMULATE_PACKET_DROPS
+#ifndef MTL_SIMULATE_PACKET_DROPS
+  GTEST_SKIP() << "requires MTL_SIMULATE_PACKET_DROPS (build with debugonly/debug); "
+                  "without it no packets are dropped and the test cannot validate "
+                  "per-port loss";
+#else
   ctx->para.flags |= MTL_FLAG_REDUNDANT_SIMULATE_PACKET_LOSS;
   ctx->para.port_packet_loss[TX_SESSION_PORT_0].tx_stream_loss_id =
       0; /* drop even packets */
@@ -100,16 +107,14 @@ TEST_F(NoCtxTest, st20p_redundant_latency_drops_even_odd) {
   ASSERT_TRUE(waitForSession(latencyBundle.handler->session));
   sleepUntilFailure(testDurationS);
 
+  /* Grab stats before stopping — captures steady-state counters before
+   * session teardown introduces incomplete-frame artifacts. */
+  st20_rx_user_stats stats;
+  st20p_rx_get_session_stats(rxBundle.handler->sessionsHandleRx, &stats);
+
   latencyBundle.handler->session.stop();
   primaryBundle.handler->session.stop();
   rxBundle.handler->session.stop();
-
-  st20_rx_user_stats stats;
-  st20p_rx_get_session_stats(rxBundle.handler->sessionsHandleRx, &stats);
-  st20_tx_user_stats statsTxPrimary;
-  st20p_tx_get_session_stats(primaryBundle.handler->sessionsHandleTx, &statsTxPrimary);
-  st20_tx_user_stats statsTxRedundant;
-  st20p_tx_get_session_stats(latencyBundle.handler->sessionsHandleTx, &statsTxRedundant);
 
   uint64_t framesSend = primaryStrategy->idx_tx;
   uint64_t framesRecieved = rxStrategy->idx_rx;
@@ -117,15 +122,35 @@ TEST_F(NoCtxTest, st20p_redundant_latency_drops_even_odd) {
   ASSERT_NEAR(framesSend, framesRecieved, framesSend / 100)
       << "Comparison against primary stream";
 
-  /* packets will not match exactly if we use redundant simulate packet loss */
-  if (!(ctx->para.flags & MTL_FLAG_REDUNDANT_SIMULATE_PACKET_LOSS)) {
-    uint64_t packetsSend = statsTxPrimary.common.port[MTL_SESSION_PORT_P].packets +
-                           statsTxRedundant.common.port[MTL_SESSION_PORT_P].packets;
-    uint64_t packetsRecieved = stats.common.port[MTL_SESSION_PORT_P].packets +
-                               stats.common.port[MTL_SESSION_PORT_R].packets;
+  /* The test is skipped above unless MTL_SIMULATE_PACKET_DROPS is compiled in,
+   * so by here the even/odd drops are active and per-port loss must be
+   * reported. With 50% simulated drops (divider=2) each port misses half the
+   * packets, and the other port recovers them. */
+  uint64_t lost_p = stats.common.port[MTL_SESSION_PORT_P].lost_packets;
+  uint64_t lost_r = stats.common.port[MTL_SESSION_PORT_R].lost_packets;
+  uint64_t pkts_p = stats.common.port[MTL_SESSION_PORT_P].packets;
+  uint64_t pkts_r = stats.common.port[MTL_SESSION_PORT_R].packets;
 
-    ASSERT_NEAR(packetsSend, packetsRecieved, packetsSend / 10)
-        << "Comparison against primary stream";
-    ASSERT_LE(stats.common.stat_lost_packets, packetsRecieved / 1000) << "Lost packets";
+  EXPECT_GT(lost_p, 0u) << "P must report per-port loss with 50% drops";
+  EXPECT_GT(lost_r, 0u) << "R must report per-port loss with 50% drops";
+  EXPECT_EQ(stats.common.stat_lost_packets, lost_p + lost_r)
+      << "session lost == sum of per-port lost";
+
+  /* Each port should lose ~50% of the merged stream's packets */
+  if (pkts_p + lost_p > 0) {
+    double pct_p = 100.0 * lost_p / (pkts_p + lost_p);
+    EXPECT_NEAR(pct_p, 50.0, 5.0) << "P loss percentage should be ~50%";
   }
+  if (pkts_r + lost_r > 0) {
+    double pct_r = 100.0 * lost_r / (pkts_r + lost_r);
+    EXPECT_NEAR(pct_r, 50.0, 5.0) << "R loss percentage should be ~50%";
+  }
+
+  /* With the TX-first stop and drain delay, there should be no
+   * incomplete frames from teardown. All per-port losses should have
+   * been recovered by the other port. */
+  EXPECT_EQ(stats.stat_frames_incomplete, 0u)
+      << "no incomplete frames expected after TX-first stop with drain";
+  EXPECT_EQ(stats.common.stat_pkts_unrecovered, 0u)
+      << "no post-redundancy loss expected with complementary 50/50 drops";
 }

--- a/tests/unit/session/st20/bitmap_test.cpp
+++ b/tests/unit/session/st20/bitmap_test.cpp
@@ -42,10 +42,16 @@ TEST_F(St20RxBitmapTest, SeqIdWrapAround32WithGap) {
    * 0xFFFFFFFE) + 1 = 2. Use line 1 so the offset stays inside the frame. */
   ut20_feed_pkt(ctx_, 0x00000000, 1000, 1, 0, 40, MTL_SESSION_PORT_P);
 
-  /* Both packets accepted; the missing seq=0xFFFFFFFF (pkt_idx 1) counted lost. */
+  /* Both lines fill the frame by bytes (2 x 40B = 80B) even though pkt_idx
+   * jumps 0 -> 2 (the wrapped seq 0xFFFFFFFF / idx 1 never arrived). A
+   * byte-complete frame charges ZERO per-port loss before and after recycle;
+   * the old inline-gap model charged 1 on that 0->2 jump. */
   EXPECT_EQ(received(), 2u);
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
   EXPECT_EQ(idx_oo_bitmap(), 0u);
+
+  flush();
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
 }
 
 /* Reorder across the wrap: pkt_idx 1 (seq 0) arrives before pkt_idx 0

--- a/tests/unit/session/st20/redundancy_test.cpp
+++ b/tests/unit/session/st20/redundancy_test.cpp
@@ -456,12 +456,13 @@ TEST_F(St20RxRedundancyWideTest, OtherPortDiesAfterOnePacketReconstructs) {
   EXPECT_EQ(pkts_unrecovered(), 0u);
 }
 
-/* Sustained single-port operation: R is silent for many consecutive frames
- * while P delivers each one alone. Counters must scale linearly with no
- * pollution from the missing wire — no phantom losses, no phantom
- * duplicates, and per-port frame credit attributed entirely to P. */
+/* Sustained single-port operation: the R wire is link-down (cable pulled)
+ * for many consecutive frames while P delivers each one alone. A dead wire
+ * receives nothing by definition, so it must not be charged per-port loss —
+ * counters scale linearly with P, R only accrues frames_partial. */
 TEST_F(St20RxRedundancyTest, SustainedSinglePortAcrossManyFrames) {
   constexpr int N = 16;
+  set_port_down(MTL_SESSION_PORT_R, true);
   for (int i = 0; i < N; i++) feed_full(1000u + 1000u * i, MTL_SESSION_PORT_P);
 
   EXPECT_EQ(frames_received(), N);
@@ -470,7 +471,28 @@ TEST_F(St20RxRedundancyTest, SustainedSinglePortAcrossManyFrames) {
       << "R never contributed a packet to any frame";
   EXPECT_EQ(redundant(), 0u);
   EXPECT_EQ(pkts_unrecovered(), 0u);
+
+  /* Recycle every pending slot so the deferred per-port accounting runs. */
+  flush();
   EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
   EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u)
-      << "a silent wire must not be charged with phantom losses";
+      << "a link-down wire must not be charged with phantom losses";
+}
+
+/* Companion to the dead-wire case: the R link is UP but silent. An up port
+ * is expected to carry data, so every packet it failed to deliver is genuine
+ * loss and must be charged to its per-port deficit at frame finalisation. */
+TEST_F(St20RxRedundancyTest, SilentLinkUpPortChargedLoss) {
+  set_port_down(MTL_SESSION_PORT_R, false);
+  feed_full(1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(frames_partial(MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u) << "deficit deferred until recycle";
+
+  /* Recycle the slot so the deferred per-port accounting runs. */
+  flush();
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+  EXPECT_GT(port_lost(MTL_SESSION_PORT_R), 0u)
+      << "an up wire that delivered nothing missed every packet of the frame";
 }

--- a/tests/unit/session/st20/reorder_test.cpp
+++ b/tests/unit/session/st20/reorder_test.cpp
@@ -38,79 +38,72 @@ TEST_F(St20RxReorderTest, ReorderThenDuplicateNotDoubleCounted) {
   EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
 }
 
-/* Regression: after a reorder, slot->last_pkt_idx must NOT regress, otherwise
- * the next forward jump re-counts already-lost packets as new losses.
- *
- * Sequence on a single port (line_num=0 for all so the frame offset check
- * does not interfere; pkt_idx is derived purely from RTP seq):
- *   seq 1000 → pkt_idx 0, base established
- *   seq 1005 → pkt_idx 5, forward jump → gap = 4 lost (pkts 1..4)
- *   seq 1003 → pkt_idx 3, reorder (recovers one of the "lost" pkts)
- *   seq 1006 → pkt_idx 6, only pkt 4 is a NEW loss between the prior
- *              high-water mark (5) and 6
- *
- * Expected port_lost == 4 (the four lost in the first forward jump; the
- * implementation does not decrement on reorder recovery, but it must NOT
- * inflate by another 2 just because last_pkt_idx regressed to 3). */
+/* Regression: after a reorder, slot->last_pkt_idx must NOT regress, else the
+ * next forward jump re-counts already-seen packets. Single port, line_num=0
+ * so pkt_idx comes purely from RTP seq:
+ *   seq 1000→idx 0, 1005→idx 5, 1003→idx 3 (reorder), 1006→idx 6.
+ * Four distinct packets (0,3,5,6) of the eight-packet frame arrive. */
 TEST_F(St20RxReorderTest, ReorderDoesNotRegressLastPktIdx) {
-  /* Payload 10 bytes/pkt so 4 pkts (40B) fit in the 80B harness frame
-   * without auto-closing the slot at frame_recv_size >= frame_size. */
+  /* 10 bytes/pkt so the slot does not auto-close before all four arrive. */
   ut20_feed_pkt(ctx_, 1000, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
   ut20_feed_pkt(ctx_, 1005, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
   ut20_feed_pkt(ctx_, 1003, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
   ut20_feed_pkt(ctx_, 1006, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
 
+  /* Before recycle: reorder counted once, loss is deferred (still 0). */
   EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 1u);
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 4u)
-      << "If last_pkt_idx regresses on reorder, pkt 6 over-counts lost as "
-         "6-3-1=2 instead of 0, inflating port_lost from 4 to 6";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u) << "loss is deferred, not inline";
+
+  /* After recycle: deficit = span(8) - recv_on_P(4) = 4, charged once. */
+  flush();
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 4u);
 }
 
-/* Cross-port: each port's `last_pkt_idx` is tracked separately, so a
- * packet arriving on one port can never poison the gap or reorder
- * arithmetic for the next packet on the OTHER port. Every port's
- * loss/reorder counter reflects only events on its own stream.
- *
- *   1. P sends pkt 0 (P_last = 0)
- *   2. R sends pkt 5 (first pkt on R; no gap counted, R_last = 5)
- *   3. P sends pkt 3 (P_last = 0 → forward jump on P: gap = 2 lost on P)
- *   4. R sends pkt 6 (R_last = 5 → in-order on R: no gap, no reorder)
- *
- * P's forward jump must NOT register as reorder (it's a gap on P), and R's
- * counters must be untouched by anything happening on P. */
+/* Cross-port: each port tracks its own last_pkt_idx, so an arrival on one
+ * wire never poisons gap/reorder math on the other.
+ *   P→idx 0, R→idx 5, P→idx 3, R→idx 6.
+ * P's forward jump is a gap (not reorder); R stays in order. */
 TEST_F(St20RxReorderTest, ReorderOnOnePortDoesNotPoisonOtherPort) {
   ut20_feed_pkt(ctx_, 1000, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
   ut20_feed_pkt(ctx_, 1005, 1000, 0, 0, 10, MTL_SESSION_PORT_R);
   ut20_feed_pkt(ctx_, 1003, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
   ut20_feed_pkt(ctx_, 1006, 1000, 0, 0, 10, MTL_SESSION_PORT_R);
 
-  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u)
-      << "P sent pkts 0 then 3: forward gap on P, not reorder";
-  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u);
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u)
-      << "P's forward jump from pkt 0 to pkt 3 implies 2 missing on P's stream";
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u)
-      << "R sent pkt 5 then pkt 6: first-pkt establishes R_last, then in-order";
+  /* Before recycle: no reorder on either wire, no inline loss. */
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 0u) << "P gap, not reorder";
+  EXPECT_EQ(port_reordered(MTL_SESSION_PORT_R), 0u) << "R untouched by P";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u);
+
+  /* After recycle: both wires delivered the same count of a symmetric pattern,
+   * so each carries an identical, non-zero deficit. Asserting symmetry (not a
+   * literal value tied to the harness geometry/estimator) is what proves the
+   * non-poisoning property: neither wire's pattern skews the other's loss. */
+  flush();
+  EXPECT_GT(port_lost(MTL_SESSION_PORT_P), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), port_lost(MTL_SESSION_PORT_R));
 }
 
-/* Multi-step reorder: large initial gap, then several reorders fill it in
- * out of order, then resume forward. Ensures the high-water-mark fix holds
- * across a sequence of regressions, and that lost is counted exactly once
- * per missing slot (not re-added on each subsequent forward step). */
+/* Multi-step reorder: large initial gap, several reorders fill it out of
+ * order, then resume forward. Confirms the high-water mark holds and loss is
+ * counted once per missing slot, not re-added on each forward step. */
 TEST_F(St20RxReorderTest, MultipleReordersDoNotInflateLost) {
-  /* 8 pkts of 10 bytes each fit the 80B harness frame. */
-  ut20_feed_pkt(ctx_, 100, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* pkt 0 */
-  ut20_feed_pkt(ctx_, 106, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* pkt 6, gap=5 */
-  ut20_feed_pkt(ctx_, 102, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* reorder */
-  ut20_feed_pkt(ctx_, 104, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* reorder */
-  ut20_feed_pkt(ctx_, 101, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* reorder */
-  ut20_feed_pkt(ctx_, 107, 1000, 0, 0, 10, MTL_SESSION_PORT_P); /* in-order, gap=0 */
+  /* idx 0,6,2,4,1,7 → six distinct packets of the 8-packet frame. */
+  ut20_feed_pkt(ctx_, 100, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 106, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 102, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 104, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 101, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
+  ut20_feed_pkt(ctx_, 107, 1000, 0, 0, 10, MTL_SESSION_PORT_P);
 
+  /* Before recycle: three reorders, loss deferred (still 0). */
   EXPECT_EQ(port_reordered(MTL_SESSION_PORT_P), 3u);
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 5u)
-      << "Lost must be counted exactly once when pkt 6 arrived; the three "
-         "subsequent reorders must not inflate it, and pkt 7 must compute "
-         "gap from the high-water mark (6), not the last reordered idx";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u);
+
+  /* After recycle: deficit = span(8) - recv_on_P(6) = 2, counted once
+   * despite the repeated reorders. */
+  flush();
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u);
 }
 
 /* Sustained cross-wire interleaving across many frames: every frame is

--- a/tests/unit/session/st20/st20_rx_test_base.h
+++ b/tests/unit/session/st20/st20_rx_test_base.h
@@ -105,4 +105,20 @@ class St20RxBaseTest : public ::testing::Test {
   void feed_full(uint32_t ts, enum mtl_session_port port) {
     ut20_feed_full_frame(ctx_, ts, port);
   }
+
+  void set_port_down(enum mtl_session_port p, bool down) {
+    ut20_set_port_down(ctx_, p, down);
+  }
+
+  /* Finalise the frame(s) under test by rotating the slot window through the
+   * real rv_slot_by_tmstamp recycle path: with redundancy slot_max==2, two
+   * fresh fully-redundant (zero-deficit) frames evict the slots under test and
+   * charge any deferred per-port loss. Read per-port loss AFTER calling this. */
+  void flush() {
+    for (int f = 0; f < 2; f++) {
+      uint32_t ts = 90000 + static_cast<uint32_t>(f) * 1000u;
+      feed_full(ts, MTL_SESSION_PORT_P);
+      feed_full(ts, MTL_SESSION_PORT_R);
+    }
+  }
 };

--- a/tests/unit/session/st20/stats_test.cpp
+++ b/tests/unit/session/st20/stats_test.cpp
@@ -58,22 +58,29 @@ TEST_F(St20RxStatsTest, ReceivedPlusRedundantInvariant) {
 }
 
 /* lost_packets invariant: stat_lost_packets equals the sum of per-port
- * lost counters. Inducing real loss on each wire (a one-packet gap on
- * the primary and a one-packet gap on the secondary, each filled by the
- * other wire) makes the invariant non-trivial. Uses a 4-pkt frame so
- * intra-frame gaps are expressible. */
+ * lost counters. P delivers {0,2}, R delivers {1,3}; the frame fully
+ * reconstructs (4 unique pkts) but each port carries a per-frame deficit
+ * of 2 charged at finalisation. */
 TEST_F(St20RxStatsTest, LostPacketsInvariant) {
   ut20_test_ctx* wide = ut20_ctx_create_geom(2, 4);
   ASSERT_NE(wide, nullptr);
 
   ut20_feed_frame_pkt(wide, 0, 1000, MTL_SESSION_PORT_P);
-  ut20_feed_frame_pkt(wide, 1, 1000, MTL_SESSION_PORT_R); /* R first; R_last=1 */
-  ut20_feed_frame_pkt(wide, 3, 1000, MTL_SESSION_PORT_R); /* R skipped pkt 2 */
-  ut20_feed_frame_pkt(wide, 2, 1000, MTL_SESSION_PORT_P); /* P jumped 0->2 */
+  ut20_feed_frame_pkt(wide, 1, 1000, MTL_SESSION_PORT_R);
+  ut20_feed_frame_pkt(wide, 3, 1000, MTL_SESSION_PORT_R);
+  ut20_feed_frame_pkt(wide, 2, 1000, MTL_SESSION_PORT_P);
+  /* Recycle the slot (slot_max==2) so the completed frame's deferred per-port
+   * loss is accounted; flush frames are fully redundant (zero deficit). */
+  for (uint32_t ts = 90000; ts <= 91000; ts += 1000) {
+    for (int i = 0; i < 4; i++) {
+      ut20_feed_frame_pkt(wide, i, ts, MTL_SESSION_PORT_P);
+      ut20_feed_frame_pkt(wide, i, ts, MTL_SESSION_PORT_R);
+    }
+  }
 
-  EXPECT_EQ(ut20_frames_received(wide), 1);
-  EXPECT_EQ(ut20_stat_port_lost(wide, MTL_SESSION_PORT_P), 1u);
-  EXPECT_EQ(ut20_stat_port_lost(wide, MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(ut20_frames_received(wide), 3);
+  EXPECT_EQ(ut20_stat_port_lost(wide, MTL_SESSION_PORT_P), 2u);
+  EXPECT_EQ(ut20_stat_port_lost(wide, MTL_SESSION_PORT_R), 2u);
   EXPECT_EQ(ut20_stat_lost_pkts(wide), ut20_stat_port_lost(wide, MTL_SESSION_PORT_P) +
                                            ut20_stat_port_lost(wide, MTL_SESSION_PORT_R))
       << "stat_lost_packets must equal the sum of per-port lost_packets";
@@ -120,35 +127,47 @@ class St20RxStatsWideTest : public ::testing::Test {
   uint64_t port_lost(enum mtl_session_port p) {
     return ut20_stat_port_lost(ctx_, p);
   }
+  /* Completed-frame per-port loss is charged when the slot is recycled; with
+   * redundancy slot_max==2, so two fresh fully-redundant (zero-deficit) frames
+   * rotate the slot window and finalise the frame under test. */
+  void flush() {
+    for (int f = 0; f < 2; f++) {
+      uint32_t ts = 90000 + (uint32_t)f * 1000u;
+      for (int i = 0; i < kPktsPerFrame; i++) {
+        feed(i, ts, MTL_SESSION_PORT_P);
+        feed(i, ts, MTL_SESSION_PORT_R);
+      }
+    }
+  }
 };
 
-/* P jumps from pkt 0 to pkt 3 in its own sequence, leaving a 2-pkt hole;
- * R fills the hole in order. The loss attributed to P equals the size of
- * P's own gap; R records no loss. */
+/* P delivers {0,3}, R delivers {1,2}; the frame reconstructs from the
+ * union of both wires. Each port carries a per-frame deficit equal to the
+ * two packets the OTHER port supplied. */
 TEST_F(St20RxStatsWideTest, PortLossCountsOwnGapsOnly) {
   feed(0, 1000, MTL_SESSION_PORT_P);
   feed(1, 1000, MTL_SESSION_PORT_R);
   feed(2, 1000, MTL_SESSION_PORT_R);
-  feed(3, 1000, MTL_SESSION_PORT_P); /* P jumped 0 -> 3 on its wire */
+  feed(3, 1000, MTL_SESSION_PORT_P);
+  flush();
 
-  EXPECT_EQ(frames_received(), 1);
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u)
-      << "P's wire skipped pkts 1 and 2 between its own observations";
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u) << "R sent pkts 1 and 2 in order";
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u) << "P missed pkts 1 and 2";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 2u) << "R missed pkts 0 and 3";
 }
 
-/* Both wires misbehave concurrently: R reorders its own packets while P
- * skips two indices. The two per-port counters must not contaminate each
- * other and reordering on one wire must not be classified as loss on
- * either wire. */
+/* P delivers {0,3}, R delivers {2,1} (reordered on its own wire). Reorder
+ * does not affect the loss count — only the per-frame delivery count at
+ * finalisation matters, so each port carries a deficit of 2. */
 TEST_F(St20RxStatsWideTest, PerPortLossIsIndependent) {
-  feed(0, 1000, MTL_SESSION_PORT_P); /* P_last = 0 */
-  feed(2, 1000, MTL_SESSION_PORT_R); /* R first; R_last = 2 */
-  feed(1, 1000, MTL_SESSION_PORT_R); /* R reorder of its own packet */
-  feed(3, 1000, MTL_SESSION_PORT_P); /* P jumps 0 -> 3 */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1000, MTL_SESSION_PORT_R);
+  feed(1, 1000, MTL_SESSION_PORT_R); /* reorder on R */
+  feed(3, 1000, MTL_SESSION_PORT_P);
+  flush();
 
-  EXPECT_EQ(frames_received(), 1);
-  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u);
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 2u);
   EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u);
 }
 
@@ -162,8 +181,9 @@ TEST_F(St20RxStatsWideTest, UnrecoveredZeroWhenReconstructionSucceeds) {
   feed(1, 1000, MTL_SESSION_PORT_R); /* recovers P's gap */
   feed(2, 1000, MTL_SESSION_PORT_R);
   feed(3, 1000, MTL_SESSION_PORT_P);
+  flush();
 
-  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(frames_received(), 3);
   EXPECT_GE(lost_session(), 1u) << "P's wire really skipped packets";
   EXPECT_EQ(pkts_unrecovered(), 0u)
       << "every gap on one wire was filled by the other wire";
@@ -334,4 +354,249 @@ TEST_F(St20RxStatsWideTest, UnrecoveredWhenBothPortsMissSamePacket) {
   EXPECT_GE(pkts_unrecovered(), 1u) << "the missing pkt is post-redundancy loss";
   EXPECT_LE(pkts_unrecovered(), lost_session())
       << "documented invariant: unrecovered <= lost";
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Per-port loss contract.
+ *
+ * Contract pinned by these cases:
+ *   port[i].lost_packets += max(0, expected_this_frame - unique_arrivals_on_i)
+ *                          charged at frame finalisation.
+ *   expected_this_frame   = pkts_received + this frame's all-port holes.
+ *   stat_lost_packets      = sum over ports of port[i].lost_packets.
+ *
+ * A per-packet forward-gap-on-each-port's-own-sequence model is blind to
+ * frame-edge losses and double-counts packets dropped on BOTH ports. The
+ * tests below isolate those two failure modes.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+class St20RxStatsSinglePortTest : public ::testing::Test {
+ protected:
+  static constexpr int kPktsPerFrame = 4;
+  ut20_test_ctx* ctx_ = nullptr;
+  void SetUp() override {
+    ASSERT_EQ(ut20_init(), 0);
+    ctx_ = ut20_ctx_create_geom(1, kPktsPerFrame);
+    ASSERT_NE(ctx_, nullptr);
+  }
+  void TearDown() override {
+    if (ctx_) ut20_ctx_destroy(ctx_);
+  }
+  void feed(int pkt_idx, uint32_t ts) {
+    ut20_feed_frame_pkt(ctx_, pkt_idx, ts, MTL_SESSION_PORT_P);
+  }
+  uint64_t port_lost_p() {
+    return ut20_stat_port_lost(ctx_, MTL_SESSION_PORT_P);
+  }
+  uint64_t lost_session() {
+    return ut20_stat_lost_pkts(ctx_);
+  }
+  uint64_t pkts_unrecovered() {
+    return ut20_stat_pkts_unrecovered(ctx_);
+  }
+  int frames_received() {
+    return ut20_frames_received(ctx_);
+  }
+};
+
+/* Single-port session: a packet dropped at the LEADING edge of the frame
+ * has no prior packet on this port to compare against, so the per-packet
+ * forward-gap detector cannot see it. The new contract recognises it as
+ * a per-frame deficit at finalisation. */
+TEST_F(St20RxStatsSinglePortTest, GapBeforeFirstSeenPktCountedAsPerPortLoss) {
+  /* Frame ts=1000: pkt 0 dropped on wire; deliver pkts 1,2,3. */
+  feed(1, 1000);
+  feed(2, 1000);
+  feed(3, 1000);
+  /* Drive a clean second frame so the partial slot is reclaimed/finalised. */
+  for (int i = 0; i < kPktsPerFrame; i++) feed(i, 2000);
+
+  EXPECT_EQ(port_lost_p(), 1u)
+      << "leading-edge loss on single-port session must charge port[P]";
+  EXPECT_EQ(lost_session(), pkts_unrecovered())
+      << "single-port: stat_lost_packets == stat_pkts_unrecovered";
+}
+
+/* P delivers contiguous prefix (pkts 0..2); R delivers only the trailing
+ * pkt (3). The frame fully reconstructs but each port carries a deficit
+ * equal to what the OTHER port covered, even though neither port observed
+ * a per-packet forward gap in its own sequence stream. */
+TEST_F(St20RxStatsWideTest, LastPacketDroppedOnPortCountsAsPerPortDeficit) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1000, MTL_SESSION_PORT_P);
+  feed(3, 1000, MTL_SESSION_PORT_R); /* R's only contribution */
+  flush();
+
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(pkts_unrecovered(), 0u) << "frame recovered through redundancy";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 1u) << "P missed pkt 3";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 3u) << "R missed pkts 0,1,2";
+  EXPECT_EQ(lost_session(), port_lost(MTL_SESSION_PORT_P) + port_lost(MTL_SESSION_PORT_R))
+      << "stat_lost_packets equals the sum of per-port deficits";
+}
+
+/* Both ports drop the same packet index: hole is unrecoverable. The new
+ * contract charges the hole to EACH port's per-frame deficit, so
+ * stat_lost_packets (= sum of per-port deficits) counts it once per port,
+ * while stat_pkts_unrecovered counts the all-port hole exactly once. */
+TEST_F(St20RxStatsWideTest, BothPortsMissSamePacketNoDoubleCount) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_R);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_P);
+  feed(3, 1000, MTL_SESSION_PORT_R);
+  /* Drive two complete subsequent frames so the partial slot is reclaimed. */
+  for (int i = 0; i < kPktsPerFrame; i++) {
+    feed(i, 2000, MTL_SESSION_PORT_P);
+    feed(i, 2000, MTL_SESSION_PORT_R);
+  }
+  for (int i = 0; i < kPktsPerFrame; i++) {
+    feed(i, 3000, MTL_SESSION_PORT_P);
+    feed(i, 3000, MTL_SESSION_PORT_R);
+  }
+
+  EXPECT_EQ(pkts_unrecovered(), 1u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 1u);
+  EXPECT_EQ(lost_session(), port_lost(MTL_SESSION_PORT_P) + port_lost(MTL_SESSION_PORT_R))
+      << "stat_lost_packets equals the sum of per-port deficits";
+}
+
+/* The very first frame can be corrupted — there is no prior complete
+ * frame from which to latch "expected pkts per frame". Accounting must
+ * derive `expected` from the in-flight frame's own geometry, otherwise
+ * startup losses are silently dropped. */
+TEST_F(St20RxStatsWideTest, FirstFrameCorruptedCountsLossCorrectly) {
+  /* First frame: only pkts 0,1 delivered (both ports); pkts 2,3 dropped. */
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(0, 1000, MTL_SESSION_PORT_R);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  /* Drive two complete subsequent frames so the slot is reclaimed. */
+  for (int i = 0; i < kPktsPerFrame; i++) {
+    feed(i, 2000, MTL_SESSION_PORT_P);
+    feed(i, 2000, MTL_SESSION_PORT_R);
+  }
+  for (int i = 0; i < kPktsPerFrame; i++) {
+    feed(i, 3000, MTL_SESSION_PORT_P);
+    feed(i, 3000, MTL_SESSION_PORT_R);
+  }
+
+  EXPECT_GE(frames_incomplete(), 1u);
+  EXPECT_EQ(pkts_unrecovered(), 2u) << "pkts 2 and 3 unrecoverable on first frame";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 2u);
+  EXPECT_EQ(lost_session(), port_lost(MTL_SESSION_PORT_P) + port_lost(MTL_SESSION_PORT_R))
+      << "stat_lost_packets equals the sum of per-port deficits";
+}
+
+/* Opposite-edge drops: P provides contiguous prefix, R provides contiguous
+ * suffix. Frame fully reconstructs but each port carries the deficit the
+ * other port covered. */
+TEST_F(St20RxStatsWideTest, ContiguousPrefixSuffixPerPortDeficit) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_P);
+  feed(2, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_R);
+  flush();
+
+  EXPECT_EQ(frames_received(), 3);
+  EXPECT_EQ(pkts_unrecovered(), 0u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 2u);
+  EXPECT_EQ(lost_session(), port_lost(MTL_SESSION_PORT_P) + port_lost(MTL_SESSION_PORT_R))
+      << "stat_lost_packets equals the sum of per-port deficits";
+}
+
+/* A completed-but-port-short frame whose slot is never recycled: P delivers
+ * {0,3}, R delivers {1,2}; the frame finalises (loss_pending set) but no later
+ * frame rotates its slot, so the deferred per-port deficit stays pending until
+ * the detach flush runs, mirroring the production teardown path. */
+TEST_F(St20RxStatsWideTest, FinalSlotDeficitChargedAtDetach) {
+  feed(0, 1000, MTL_SESSION_PORT_P);
+  feed(1, 1000, MTL_SESSION_PORT_R);
+  feed(2, 1000, MTL_SESSION_PORT_R);
+  feed(3, 1000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(frames_received(), 1);
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 0u)
+      << "deficit deferred: the slot has not been recycled";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 0u);
+
+  ut20_session_detach(ctx_);
+
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_P), 2u) << "detach flush charges P's deficit";
+  EXPECT_EQ(port_lost(MTL_SESSION_PORT_R), 2u) << "detach flush charges R's deficit";
+  EXPECT_EQ(lost_session(),
+            port_lost(MTL_SESSION_PORT_P) + port_lost(MTL_SESSION_PORT_R));
+}
+
+/* Known, tolerated limitation: a same-wire duplicate/retransmit of an
+ * already-received packet inflates pkts_recv_per_port, so the expected <= recv
+ * guard in rv_slot_account_per_port_loss zeroes the genuine per-port deficit.
+ * This is accepted to keep the redundant common-path twin credit correct
+ * (unconditional ++ on the bitmap-set branch) and the per-packet handler cheap;
+ * the precise fix would need per-port per-index delivery tracking. This test
+ * PINS the masked behaviour so a future change to it is a conscious decision. */
+TEST(St20Stats, same_port_dup_masks_deficit_known_limitation) {
+  ASSERT_EQ(ut20_init(), 0);
+  ut20_test_ctx* ctx = ut20_ctx_create_geom(1, 4);
+  ASSERT_NE(ctx, nullptr);
+
+  ut20_feed_frame_pkt(ctx, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt(ctx, 1, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt(ctx, 3, 1000, MTL_SESSION_PORT_P); /* pkt 2 lost on wire */
+  ut20_feed_frame_pkt(ctx, 0, 1000, MTL_SESSION_PORT_P); /* same-port duplicate */
+
+  /* Recycle the incomplete slot so its deferred deficit is finalised. */
+  for (int i = 0; i < 4; i++) ut20_feed_frame_pkt(ctx, i, 2000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(ut20_stat_port_lost(ctx, MTL_SESSION_PORT_P), 0u)
+      << "same-port dup inflates recv; deficit guard masks the per-port hole";
+  EXPECT_EQ(ut20_stat_lost_pkts(ctx), 0u);
+
+  ut20_ctx_destroy(ctx);
+}
+
+/* Control for the regression above: the identical 0,1,3 gap WITHOUT the masking
+ * duplicate must charge the loss. If this also reads 0, incomplete-frame
+ * charging is broken more broadly than the duplicate-masking case. */
+TEST(St20Stats, single_port_gap_charges_deficit_control) {
+  ASSERT_EQ(ut20_init(), 0);
+  ut20_test_ctx* ctx = ut20_ctx_create_geom(1, 4);
+  ASSERT_NE(ctx, nullptr);
+
+  ut20_feed_frame_pkt(ctx, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt(ctx, 1, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_frame_pkt(ctx, 3, 1000, MTL_SESSION_PORT_P); /* pkt 2 lost on wire */
+
+  for (int i = 0; i < 4; i++) ut20_feed_frame_pkt(ctx, i, 2000, MTL_SESSION_PORT_P);
+
+  EXPECT_EQ(ut20_stat_port_lost(ctx, MTL_SESSION_PORT_P), 1u);
+  EXPECT_EQ(ut20_stat_lost_pkts(ctx), 1u);
+
+  ut20_ctx_destroy(ctx);
+}
+
+/* RTP-passthrough mode (ST20_TYPE_RTP_LEVEL) has no frame-completion event to
+ * defer per-port loss to, so rv_handle_rtp_pkt INTENTIONALLY keeps the inline
+ * forward-gap charge that frame mode dropped. This pins that a sequence gap is
+ * still counted in RTP mode. Feed seq 0,1,3 (gap at 2); the loss must surface
+ * inline in stat_lost_packets without any frame finalisation. */
+TEST(St20Stats, rtp_mode_loss_accounting_regression) {
+  ASSERT_EQ(ut20_init(), 0);
+  ut20_test_ctx* ctx = ut20_ctx_create_geom(1, 4);
+  ASSERT_NE(ctx, nullptr);
+  ut20_ctx_enable_rtp(ctx);
+
+  ut20_feed_rtp_pkt(ctx, 0, 0, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_rtp_pkt(ctx, 1, 1, 1000, MTL_SESSION_PORT_P);
+  ut20_feed_rtp_pkt(ctx, 3, 3, 1000, MTL_SESSION_PORT_P); /* seq 2 lost on wire */
+
+  EXPECT_GE(ut20_stat_lost_pkts(ctx), 1u)
+      << "RTP-mode sequence gap at seq 2 must charge at least one lost packet";
+
+  ut20_ctx_destroy(ctx);
 }

--- a/tests/unit/session/st20_harness.c
+++ b/tests/unit/session/st20_harness.c
@@ -194,6 +194,14 @@ void ut20_ctx_destroy(ut20_test_ctx* ctx) {
   for (int i = 0; i < UT20_FRAME_COUNT; i++) {
     rte_atomic32_set(&ctx->frames[i].refcnt, 0);
   }
+  if (ctx->session.rtps_ring) {
+    void* deq = NULL;
+    while (rte_ring_sc_dequeue(ctx->session.rtps_ring, &deq) == 0) {
+      rte_pktmbuf_free((struct rte_mbuf*)deq);
+    }
+    rte_ring_free(ctx->session.rtps_ring);
+    ctx->session.rtps_ring = NULL;
+  }
   free(ctx);
 }
 
@@ -284,6 +292,38 @@ void ut20_feed_full_frame(ut20_test_ctx* ctx, uint32_t ts, enum mtl_session_port
   }
 }
 
+static int ut20_notify_rtp_ready(void* priv) {
+  (void)priv;
+  return 0;
+}
+
+void ut20_ctx_enable_rtp(ut20_test_ctx* ctx) {
+  struct st_rx_video_session_impl* s = &ctx->session;
+  char ring_name[32];
+  snprintf(ring_name, sizeof(ring_name), "ut20_rtp_%p", (void*)ctx);
+  s->rtps_ring =
+      rte_ring_create(ring_name, 128, s->socket_id, RING_F_SP_ENQ | RING_F_SC_DEQ);
+  s->ops.type = ST20_TYPE_RTP_LEVEL;
+  s->ops.notify_rtp_ready = ut20_notify_rtp_ready;
+  s->pkt_handler = rv_handle_rtp_pkt;
+}
+
+int ut20_feed_rtp_pkt(ut20_test_ctx* ctx, int pkt_idx, uint32_t seq, uint32_t ts,
+                      enum mtl_session_port port) {
+  uint16_t ln, lo, ll;
+  pkt_idx_to_line(pkt_idx, &ln, &lo, &ll);
+  struct rte_mbuf* m = make_video_mbuf(seq, ts, ln, lo, ll);
+  if (!m) return -1;
+  int rc = rv_handle_rtp_pkt(&ctx->session, m, port, true);
+  /* drain whatever the handler enqueued so the ring never fills */
+  void* deq = NULL;
+  while (rte_ring_sc_dequeue(ctx->session.rtps_ring, &deq) == 0) {
+    rte_pktmbuf_free((struct rte_mbuf*)deq);
+  }
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
 int ut20_feed_pkt_pt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
                      uint16_t line_offset, uint16_t line_length,
                      enum mtl_session_port port, uint8_t pt) {
@@ -336,6 +376,14 @@ void ut20_ctx_set_pt(ut20_test_ctx* ctx, uint8_t pt) {
 
 void ut20_ctx_set_ssrc(ut20_test_ctx* ctx, uint32_t ssrc) {
   ctx->session.ops.ssrc = ssrc;
+}
+
+void ut20_set_port_down(ut20_test_ctx* ctx, enum mtl_session_port port, bool down) {
+  enum mtl_port phy = mt_port_logic2phy(ctx->session.port_maps, port);
+  if (down)
+    ctx->impl.inf[phy].status |= MT_IF_STAT_PORT_DOWN;
+  else
+    ctx->impl.inf[phy].status &= ~MT_IF_STAT_PORT_DOWN;
 }
 
 /* ── stat accessors ───────────────────────────────────────────────────── */
@@ -408,6 +456,10 @@ int ut20_total_frame_pkts(void) {
 
 int ut20_pkts_per_frame(const ut20_test_ctx* ctx) {
   return (int)ctx->session.ops.height;
+}
+
+void ut20_session_detach(ut20_test_ctx* ctx) {
+  rv_flush_pending_loss(&ctx->session);
 }
 
 uint64_t ut20_stat_wrong_pt(const ut20_test_ctx* ctx) {

--- a/tests/unit/session/st20_harness.h
+++ b/tests/unit/session/st20_harness.h
@@ -77,6 +77,17 @@ int ut20_feed_frame_pkt_seq(ut20_test_ctx* ctx, int pkt_idx, uint32_t seq, uint3
 /* Feed every packet of one full frame on `port`, in pkt_idx order. */
 void ut20_feed_full_frame(ut20_test_ctx* ctx, uint32_t ts, enum mtl_session_port port);
 
+/* Switch the session into RTP-passthrough mode (ST20_TYPE_RTP_LEVEL): allocate
+ * the rtps_ring, install a no-op notify_rtp_ready, and route packets through
+ * rv_handle_rtp_pkt. Call once after ut20_ctx_create*() and before feeding. */
+void ut20_ctx_enable_rtp(ut20_test_ctx* ctx);
+
+/* Feed packet `pkt_idx` of an RTP-mode frame at timestamp `ts` with explicit
+ * sequence `seq`, driving rv_handle_rtp_pkt directly. Requires a prior
+ * ut20_ctx_enable_rtp(). */
+int ut20_feed_rtp_pkt(ut20_test_ctx* ctx, int pkt_idx, uint32_t seq, uint32_t ts,
+                      enum mtl_session_port port);
+
 /* Feed one packet with an overridden RTP payload type (`pt`) — for negative
  * tests that assert PT validation. All other fields as ut20_feed_pkt(). */
 int ut20_feed_pkt_pt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
@@ -92,6 +103,11 @@ int ut20_feed_pkt_ssrc(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t l
  * ut20_ctx_create() and before feeding any packet. */
 void ut20_ctx_set_pt(ut20_test_ctx* ctx, uint8_t pt);
 void ut20_ctx_set_ssrc(ut20_test_ctx* ctx, uint32_t ssrc);
+
+/* Force a session port's physical link up/down. A link-down port is a dead
+ * wire: it never receives data and is not charged per-port loss at frame
+ * finalisation (see rv_slot_account_per_port_loss). */
+void ut20_set_port_down(ut20_test_ctx* ctx, enum mtl_session_port port, bool down);
 
 /* Wrapper feeders — drive the production `_handle_mbuf` wrapper instead
  * of the per-packet handler. Use these (not the direct feeders above)
@@ -178,6 +194,11 @@ int ut20_total_frame_pkts(void);
 /* Live geometry: number of packets per frame for THIS context. Returns
  * the value passed to ut20_ctx_create_geom() (or 2 for ut20_ctx_create()). */
 int ut20_pkts_per_frame(const ut20_test_ctx* ctx);
+
+/* Drive the production detach-time flush of any slot still holding a deferred
+ * per-port deficit (test-only). Exercises `rv_flush_pending_loss`, the path the
+ * production `rv_detach` runs before its final stat dump. */
+void ut20_session_detach(ut20_test_ctx* ctx);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- On a healthy 2-port (redundant) session, `port[i].lost_packets` was charged
  inline the moment a forward sequence gap appeared on a port — before the
  matching packet had a chance to arrive on the *other* port.
- The redundant twin recovered the data, but the first port was still booked as
  having lost it, inflating `stat_lost_packets` and pushing `save_rate` below
  100% on a link that was actually losing nothing.
- Per-port loss is now computed **once per frame, at frame recycle**, as each
  port's reception *deficit* (`max(0, span − received_on_port)`), after both
  ports have delivered everything they were going to.
- RTP passthrough has no frame finalization, so it keeps the inline gap charge.
- Adds unit coverage that drives the **real** recycle path, documents the model
  and one known limitation, makes the release-build redundant drop tests skip
  instead of passing vacuously, and defaults the MCP build to `debugonly` so the
  simulate-drop test paths are actually compiled in.