### PR TITLE
Test: Fixed st20p pytests

### DIFF
--- a/.github/actions/source-checksums/action.yml
+++ b/.github/actions/source-checksums/action.yml
@@ -20,6 +20,9 @@ outputs:
   librist:
     description: 'Hash for librist sources (includes MTL hash)'
     value: ${{ steps.compute.outputs.librist }}
+  plugins:
+    description: 'Hash for st22 avcodec plugin sources (includes MTL hash)'
+    value: ${{ steps.compute.outputs.plugins }}
 
 runs:
   using: composite

--- a/.github/actions/validate-host/action.yml
+++ b/.github/actions/validate-host/action.yml
@@ -69,27 +69,38 @@ runs:
       with:
         key: stash-plugins-${{ steps.local-checksums.outputs.plugins }}
         path: .local_install/plugins
-        fail-on-cache-miss: true
+        # Non-fatal: a missing/failed st22 plugin build only disables the codec
+        # tests (they skip via require_encoder); it must not abort validation.
+        fail-on-cache-miss: false
 
     - name: Make artifacts executable
       shell: bash
       run: |
         find .local_install -type f \( -name '*.so*' -o -path '*/bin/*' \) -exec chmod +x {} + 2>/dev/null || true
 
-    - name: Stage st22 plugins for runtime kahawai.json
+    - name: 'kahawai: Generate CI plugin registry from cache'
       shell: bash
       run: |
-        # The runtime ~/.kahawai.json references plugins under /usr/local/lib.
-        # Publish the cached st22 avcodec plugin there so MTL can dlopen it.
+        # Build a CI-owned kahawai.json that points at the cached st22 avcodec
+        # plugin under .local_install/plugins -- no system install. MTL loads it
+        # via KAHAWAI_CFG_PATH (exported below). The plugin .so itself is built
+        # by the build workflow and restored from the `plugins` cache above.
+        # The template reproduces the runner plugin set: jpegxs/sample stay at
+        # their /usr/local install paths (a missing .so is a non-fatal dlopen
+        # warning), only avcodec is sourced from the cache.
         set -euo pipefail
-        src="$(find .local_install/plugins -name 'libst_plugin_st22_avcodec.so' -print -quit 2>/dev/null || true)"
-        if [ -n "${src}" ]; then
-          sudo install -D -m 0755 "${src}" "/usr/local/lib/x86_64-linux-gnu/libst_plugin_st22_avcodec.so"
-          sudo ldconfig 2>/dev/null || true
-          echo "::notice::Staged $(basename "${src}") to /usr/local/lib/x86_64-linux-gnu"
-        else
-          echo "::warning::st22 avcodec plugin not found in .local_install/plugins"
+        WS="${{ github.workspace }}"
+        template="${WS}/.github/workflows/kahawai_template.json"
+        cfg="${RUNNER_TEMP:-/tmp}/kahawai_ci.json"
+        plugin_dir="$(find "${WS}/.local_install/plugins" -name 'libst_plugin_st22_avcodec.so' -printf '%h\n' -quit 2>/dev/null || true)"
+        if [ -z "${plugin_dir}" ]; then
+          echo "::warning::st22 avcodec plugin not found in .local_install/plugins; H264 st22p tests will skip"
+          plugin_dir="${WS}/.local_install/plugins/lib/x86_64-linux-gnu"
         fi
+        cp -f "${template}" "${cfg}"
+        sed -i "s+REPLACE_BY_CICD_PLUGIN_DIR+${plugin_dir}+g" "${cfg}"
+        echo "KAHAWAI_CFG_PATH=${cfg}" >> "$GITHUB_ENV"
+        echo "::notice::CI kahawai registry ${cfg} (avcodec from ${plugin_dir})"
 
     - name: Validate ice drivers
       shell: bash

--- a/.github/actions/validate-host/action.yml
+++ b/.github/actions/validate-host/action.yml
@@ -64,10 +64,32 @@ runs:
         path: .local_install/librist
         fail-on-cache-miss: true
 
+    - name: 'cache: Restore plugins'
+      uses: actions/cache/restore@v4
+      with:
+        key: stash-plugins-${{ steps.local-checksums.outputs.plugins }}
+        path: .local_install/plugins
+        fail-on-cache-miss: true
+
     - name: Make artifacts executable
       shell: bash
       run: |
         find .local_install -type f \( -name '*.so*' -o -path '*/bin/*' \) -exec chmod +x {} + 2>/dev/null || true
+
+    - name: Stage st22 plugins for runtime kahawai.json
+      shell: bash
+      run: |
+        # The runtime ~/.kahawai.json references plugins under /usr/local/lib.
+        # Publish the cached st22 avcodec plugin there so MTL can dlopen it.
+        set -euo pipefail
+        src="$(find .local_install/plugins -name 'libst_plugin_st22_avcodec.so' -print -quit 2>/dev/null || true)"
+        if [ -n "${src}" ]; then
+          sudo install -D -m 0755 "${src}" "/usr/local/lib/x86_64-linux-gnu/libst_plugin_st22_avcodec.so"
+          sudo ldconfig 2>/dev/null || true
+          echo "::notice::Staged $(basename "${src}") to /usr/local/lib/x86_64-linux-gnu"
+        else
+          echo "::warning::st22 avcodec plugin not found in .local_install/plugins"
+        fi
 
     - name: Validate ice drivers
       shell: bash
@@ -100,7 +122,7 @@ runs:
         # Refresh linker cache (best-effort)
         sudo ldconfig 2>/dev/null || true
 
-        echo "::notice::Host environment configured for .local_install/{dpdk,mtl,ffmpeg,gstreamer}"
+        echo "::notice::Host environment configured for .local_install/{dpdk,mtl,ffmpeg,gstreamer,librist,plugins}"
 
     - name: Read shadow host credentials
       id: shadow-creds

--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -37,7 +37,7 @@ export MTL_INSTALL_PREFIX
 : "${ECOSYSTEM_BUILD_AND_INSTALL_OBS_PLUGIN:=0}"
 
 : "${PLUGIN_BUILD_AND_INSTALL_SAMPLE:=0}"
-: "${PLUGIN_BUILD_AND_INSTALL_PLUGIN_AVCODEC:=0}"
+: "${PLUGIN_BUILD_AND_INSTALL_AVCODEC:=0}"
 : "${PLUGIN_BUILD_AND_INSTALL_JPEGXS:=0}"
 
 : "${HOOK_PYTHON:=0}"
@@ -510,14 +510,18 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 	fi
 
 	if [ "${PLUGIN_BUILD_AND_INSTALL_AVCODEC}" == "1" ]; then
-		echo "$STEP Plugin sample build and install"
-		bash "${root_folder}/script/build_st22_avcodec_plugin.sh"
-		STEP=$((STEP + 1))
-	fi
-
-	if [ "${PLUGIN_BUILD_AND_INSTALL_AVCODEC}" == "1" ]; then
-		echo "$STEP Plugin sample build and install"
-		"${root_folder}/script/build_st22_avcodec_plugin.sh"
+		echo "$STEP Plugin AVCODEC build and install"
+		# st22 avcodec plugin installs to a sibling directory for independent caching.
+		# It links libavcodec/libavutil, provided by the .local_install/ffmpeg build.
+		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
+			MTL_PLUGIN_PREFIX="${local_base}/plugins" \
+				PKG_CONFIG_PATH="${local_base}/ffmpeg/lib/pkgconfig:${local_base}/ffmpeg/lib/x86_64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}" \
+				LD_LIBRARY_PATH="${local_base}/ffmpeg/lib:${local_base}/ffmpeg/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}" \
+				bash "${root_folder}/script/build_st22_avcodec_plugin.sh"
+		else
+			bash "${root_folder}/script/build_st22_avcodec_plugin.sh"
+		fi
 		STEP=$((STEP + 1))
 	fi
 
@@ -679,7 +683,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		"ECOSYSTEM_BUILD_AND_INSTALL_RIST_PLUGIN:RIST plugin" \
 		"ECOSYSTEM_BUILD_AND_INSTALL_OBS_PLUGIN:OBS plugin" \
 		"PLUGIN_BUILD_AND_INSTALL_SAMPLE:Sample plugin" \
-		"PLUGIN_BUILD_AND_INSTALL_PLUGIN_AVCODEC:AVCodec plugin" \
+		"PLUGIN_BUILD_AND_INSTALL_AVCODEC:AVCodec plugin" \
 		"PLUGIN_BUILD_AND_INSTALL_JPEGXS:JPEG-XS plugin" \
 		"HOOK_PYTHON:Python hook" \
 		"HOOK_RUST:Rust hook" \

--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -331,8 +331,43 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
 		echo "Building e810 driver version: $ICE_VER form mirror $ICE_DMID"
 
-		wget "https://downloadmirror.intel.com/${ICE_DMID}/ice-${ICE_VER}.tar.gz"
-		tar xvzf "ice-${ICE_VER}.tar.gz"
+		archive_name="ice-${ICE_VER}.tar.gz"
+		IS_GITHUB_ARCHIVE=0
+		if [ -f "$archive_name" ] && gzip -t "$archive_name" >/dev/null 2>&1; then
+			echo "Found valid local archive $archive_name, skipping download."
+			if tar -tzf "$archive_name" | grep -q "^ethernet-linux-ice"; then
+				IS_GITHUB_ARCHIVE=1
+			fi
+		else
+			rm -f "$archive_name"
+			echo "Downloading ICE driver of version ${ICE_VER}..."
+			wget "https://downloadmirror.intel.com/${ICE_DMID}/${archive_name}" -O "$archive_name" || true
+			if [ ! -f "$archive_name" ] || ! gzip -t "$archive_name" >/dev/null 2>&1; then
+				echo "Intel mirror download failed or was blocked by AWS WAF. Trying GitHub fallback..."
+				rm -f "$archive_name"
+				wget "https://github.com/intel/ethernet-linux-ice/archive/refs/tags/v${ICE_VER}.tar.gz" -O "$archive_name" || true
+				if [ -f "$archive_name" ] && gzip -t "$archive_name" >/dev/null 2>&1; then
+					echo "Successfully downloaded driver from GitHub fallback."
+					IS_GITHUB_ARCHIVE=1
+				else
+					echo "Error: Failed to download a valid $archive_name from both Intel mirror and GitHub."
+					echo "This is likely caused by corporate proxy blockage or firewall settings."
+					rm -f "$archive_name"
+					exit 1
+				fi
+			fi
+		fi
+		if [ -d "ice-${ICE_VER}" ]; then
+			echo "ice-${ICE_VER} directory already exists, please remove it first"
+			exit 1
+		fi
+		tar xvzf "$archive_name"
+		if [ "${IS_GITHUB_ARCHIVE}" -eq 1 ]; then
+			if [ -d "ethernet-linux-ice-${ICE_VER}" ]; then
+				mv "ethernet-linux-ice-${ICE_VER}" "ice-${ICE_VER}"
+			fi
+		fi
+		rm -f "$archive_name"
 		pushd "ice-${ICE_VER}" >/dev/null || exit 1
 
 		for patch_file in "${root_folder}"/patches/ice_drv/"${ICE_VER}"/*.patch; do
@@ -343,7 +378,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		make -j"${nproc}"
 		popd >/dev/null
 		popd >/dev/null
-		rm -rf "ice-${ICE_VER}" "ice-${ICE_VER}.tar.gz"
+		rm -rf "ice-${ICE_VER}"
 		popd >/dev/null
 		STEP=$((STEP + 1))
 	fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ on:
       librist_hash:
         description: 'librist source checksum'
         value: ${{ jobs.checksums.outputs.librist }}
+      plugins_hash:
+        description: 'st22 avcodec plugin source checksum'
+        value: ${{ jobs.checksums.outputs.plugins }}
 
 permissions:
   contents: read
@@ -67,6 +70,7 @@ jobs:
       ffmpeg: ${{ steps.sums.outputs.ffmpeg }}
       gstreamer: ${{ steps.sums.outputs.gstreamer }}
       librist: ${{ steps.sums.outputs.librist }}
+      plugins: ${{ steps.sums.outputs.plugins }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -128,6 +132,13 @@ jobs:
           key: stash-librist-${{ needs.checksums.outputs.librist }}
           path: .local_install/librist
 
+      - name: 'stash: Restore plugins cache'
+        id: plugins-cache
+        uses: actions/cache@v4
+        with:
+          key: stash-plugins-${{ needs.checksums.outputs.plugins }}
+          path: .local_install/plugins
+
       - name: Evaluate cache results
         id: needs-build
         shell: bash
@@ -137,6 +148,7 @@ jobs:
           ffmpeg_miss=${{ steps.ffmpeg-cache.outputs.cache-hit != 'true' && '1' || '0' }}
           gstreamer_miss=${{ steps.gstreamer-cache.outputs.cache-hit != 'true' && '1' || '0' }}
           librist_miss=${{ steps.librist-cache.outputs.cache-hit != 'true' && '1' || '0' }}
+          plugins_miss=${{ steps.plugins-cache.outputs.cache-hit != 'true' && '1' || '0' }}
 
           {
             echo "SETUP_BUILD_AND_INSTALL_DPDK=${dpdk_miss}"
@@ -144,13 +156,14 @@ jobs:
             echo "ECOSYSTEM_BUILD_AND_INSTALL_FFMPEG_PLUGIN=${ffmpeg_miss}"
             echo "ECOSYSTEM_BUILD_AND_INSTALL_GSTREAMER_PLUGIN=${gstreamer_miss}"
             echo "ECOSYSTEM_BUILD_AND_INSTALL_RIST_PLUGIN=${librist_miss}"
+            echo "PLUGIN_BUILD_AND_INSTALL_AVCODEC=${plugins_miss}"
           } >> "$GITHUB_ENV"
 
           any_miss=0
-          [[ "$dpdk_miss" == "1" || "$mtl_miss" == "1" || "$ffmpeg_miss" == "1" || "$gstreamer_miss" == "1" || "$librist_miss" == "1" ]] && any_miss=1
+          [[ "$dpdk_miss" == "1" || "$mtl_miss" == "1" || "$ffmpeg_miss" == "1" || "$gstreamer_miss" == "1" || "$librist_miss" == "1" || "$plugins_miss" == "1" ]] && any_miss=1
           echo "any_miss=${any_miss}" >> "$GITHUB_OUTPUT"
 
-          echo "::notice::DPDK=$( [ "$dpdk_miss" = 1 ] && echo MISS || echo HIT )  MTL=$( [ "$mtl_miss" = 1 ] && echo MISS || echo HIT )  FFmpeg=$( [ "$ffmpeg_miss" = 1 ] && echo MISS || echo HIT )  GStreamer=$( [ "$gstreamer_miss" = 1 ] && echo MISS || echo HIT )  librist=$( [ "$librist_miss" = 1 ] && echo MISS || echo HIT )"
+          echo "::notice::DPDK=$( [ "$dpdk_miss" = 1 ] && echo MISS || echo HIT )  MTL=$( [ "$mtl_miss" = 1 ] && echo MISS || echo HIT )  FFmpeg=$( [ "$ffmpeg_miss" = 1 ] && echo MISS || echo HIT )  GStreamer=$( [ "$gstreamer_miss" = 1 ] && echo MISS || echo HIT )  librist=$( [ "$librist_miss" = 1 ] && echo MISS || echo HIT )  plugins=$( [ "$plugins_miss" = 1 ] && echo MISS || echo HIT )"
 
       # Build what is missing
       - name: Setup environment and build

--- a/.github/workflows/kahawai_template.json
+++ b/.github/workflows/kahawai_template.json
@@ -1,0 +1,29 @@
+{
+    "plugins": [
+        {
+            "enabled": 1,
+            "name": "st22_svt_jpegxs",
+            "path": "/usr/local/lib/x86_64-linux-gnu/libst_plugin_st22_svt_jpeg_xs.so"
+        },
+        {
+            "enabled": 1,
+            "name": "st22_svt_jpegxs",
+            "path": "/usr/local/lib64/libst_plugin_st22_svt_jpeg_xs.so"
+        },
+        {
+            "enabled": 1,
+            "name": "st22_sample",
+            "path": "/usr/local/lib/x86_64-linux-gnu/libst_plugin_st22_sample.so"
+        },
+        {
+            "enabled": 1,
+            "name": "st22_sample",
+            "path": "/usr/local/lib64/libst_plugin_st22_sample.so"
+        },
+        {
+            "enabled": 1,
+            "name": "st22_avcodec",
+            "path": "REPLACE_BY_CICD_PLUGIN_DIR/libst_plugin_st22_avcodec.so"
+        }
+    ]
+}

--- a/script/build_ice_driver.sh
+++ b/script/build_ice_driver.sh
@@ -43,11 +43,32 @@ if [ "$sourced" -eq 0 ]; then
 	archive_name="ice-${ICE_VER}.tar.gz"
 	echo "Building e810 driver version: $ICE_VER form mirror $ICE_DMID"
 
-	rm -f "$archive_name"
-	wget "https://downloadmirror.intel.com/${ICE_DMID}/${archive_name}" -O "$archive_name"
-	if [ ! -f "$archive_name" ]; then
-		echo "Failed to download $archive_name"
-		exit 1
+	IS_GITHUB_ARCHIVE=0
+	# Check if local archive already exists and is a valid compressed file
+	if [ -f "$archive_name" ] && gzip -t "$archive_name" >/dev/null 2>&1; then
+		echo "Found valid local archive $archive_name, skipping download."
+		# Check if the existing local file is actually a GitHub download
+		if tar -tzf "$archive_name" | grep -q "^ethernet-linux-ice"; then
+			IS_GITHUB_ARCHIVE=1
+		fi
+	else
+		rm -f "$archive_name"
+		echo "Downloading ICE driver of version ${ICE_VER}..."
+		wget "https://downloadmirror.intel.com/${ICE_DMID}/${archive_name}" -O "$archive_name" || true
+		if [ ! -f "$archive_name" ] || ! gzip -t "$archive_name" >/dev/null 2>&1; then
+			echo "Intel mirror download failed or was blocked by AWS WAF. Trying GitHub fallback..."
+			rm -f "$archive_name"
+			wget "https://github.com/intel/ethernet-linux-ice/archive/refs/tags/v${ICE_VER}.tar.gz" -O "$archive_name" || true
+			if [ -f "$archive_name" ] && gzip -t "$archive_name" >/dev/null 2>&1; then
+				echo "Successfully downloaded driver from GitHub fallback."
+				IS_GITHUB_ARCHIVE=1
+			else
+				echo "Error: Failed to download a valid $archive_name from both Intel mirror and GitHub."
+				echo "This is likely caused by corporate proxy blockage or firewall settings."
+				rm -f "$archive_name"
+				exit 1
+			fi
+		fi
 	fi
 
 	if [ -d "ice-${ICE_VER}" ]; then
@@ -58,6 +79,12 @@ if [ "$sourced" -eq 0 ]; then
 	tar xvzf "$archive_name"
 
 	rm -f "$archive_name"
+
+	if [ "${IS_GITHUB_ARCHIVE}" -eq 1 ]; then
+		if [ -d "ethernet-linux-ice-${ICE_VER}" ]; then
+			mv "ethernet-linux-ice-${ICE_VER}" "ice-${ICE_VER}"
+		fi
+	fi
 
 	if [ ! -d "ice-${ICE_VER}" ]; then
 		echo "Failed to extract $archive_name"

--- a/script/build_st22_avcodec_plugin.sh
+++ b/script/build_st22_avcodec_plugin.sh
@@ -36,10 +36,21 @@ WORKSPACE=$PWD
 ST22_AVCODEC_PLUGIN_BUILD_DIR=${WORKSPACE}/build/st22_avcodec_plugin
 
 # build st22 avcodec plugin
+# When MTL_PLUGIN_PREFIX is set, install into that prefix (no sudo, used for the
+# CI .local_install cache). Otherwise fall back to a system-wide install.
+meson_prefix_args=()
+if [ -n "${MTL_PLUGIN_PREFIX:-}" ]; then
+	meson_prefix_args+=(--prefix "${MTL_PLUGIN_PREFIX}")
+fi
+
 pushd "${script_folder}/../plugins/st22_avcodec/"
-meson "${ST22_AVCODEC_PLUGIN_BUILD_DIR}" -Dbuildtype="$buildtype"
+meson "${ST22_AVCODEC_PLUGIN_BUILD_DIR}" -Dbuildtype="$buildtype" "${meson_prefix_args[@]}"
 popd
 pushd "${ST22_AVCODEC_PLUGIN_BUILD_DIR}"
 ninja
-sudo ninja install
+if [ -n "${MTL_PLUGIN_PREFIX:-}" ]; then
+	ninja install
+else
+	sudo ninja install
+fi
 popd

--- a/script/hash_sources.sh
+++ b/script/hash_sources.sh
@@ -10,6 +10,7 @@
 #   ffmpeg    = hash(ffmpeg_paths + mtl_checksum)
 #   gstreamer = hash(gstreamer_paths + mtl_checksum)
 #   librist   = hash(librist_paths + mtl_checksum)
+#   plugins   = hash(plugins_paths + mtl_checksum)
 
 set -euo pipefail
 
@@ -97,6 +98,10 @@ gstreamer="$(hash_string "${mtl} ${gstreamer_paths_hash}")"
 librist_paths_hash="$(hash_paths $(read_env "${script_folder}/hash_sources_librist.env"))"
 librist="$(hash_string "${mtl} ${librist_paths_hash}")"
 
+# shellcheck disable=SC2046
+plugins_paths_hash="$(hash_paths $(read_env "${script_folder}/hash_sources_plugins.env"))"
+plugins="$(hash_string "${mtl} ${plugins_paths_hash}")"
+
 # ─── Output ─────────────────────────────────────────────────────────────────
 
 if [ -n "$OUTPUT_ENV" ]; then
@@ -106,6 +111,7 @@ if [ -n "$OUTPUT_ENV" ]; then
 		echo "ffmpeg=${ffmpeg}"
 		echo "gstreamer=${gstreamer}"
 		echo "librist=${librist}"
+		echo "plugins=${plugins}"
 	} >>"$OUTPUT_ENV"
 fi
 
@@ -114,4 +120,5 @@ printf '  %-20s %s\n' \
 	"mtl:" "${mtl}" \
 	"ffmpeg:" "${ffmpeg}" \
 	"gstreamer:" "${gstreamer}" \
-	"librist:" "${librist}"
+	"librist:" "${librist}" \
+	"plugins:" "${plugins}"

--- a/tests/validation/mtl_engine/application_base.py
+++ b/tests/validation/mtl_engine/application_base.py
@@ -22,6 +22,32 @@ logger = logging.getLogger(__name__)
 MTL_PTP_INTERNAL_TIMEOUT = 180
 
 
+# Encoder name -> MTL st22 plugin shared object, for require_encoder()
+# pre-flight checks shared across framework adapters.
+MTL_ENCODER_PLUGIN_MAP = {
+    "libsvt_jpegxs": "libst_plugin_st22_svt_jpeg_xs.so",
+    "libopenh264": "libst_plugin_st22_avcodec.so",
+}
+
+
+def mtl_plugin_check_cmd(plugin_so: str) -> str:
+    """Return a shell test that succeeds when *plugin_so* is loadable on the host.
+
+    Probes, in order: the dynamic-linker cache, the system plugin directories,
+    and the plugin path recorded in the active ``KAHAWAI_CFG_PATH`` registry --
+    which in CI points into the cached ``.local_install/plugins`` tree, so a
+    locally built (non system-installed) plugin is detected too.
+    """
+    return (
+        f"ldconfig -p 2>/dev/null | grep -q {plugin_so} "
+        f"|| test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} "
+        f"|| test -f /usr/local/lib64/{plugin_so} "
+        '|| { cfg="${KAHAWAI_CFG_PATH:-kahawai.json}"; ok=1; '
+        f"for p in $(grep -F '{plugin_so}' \"$cfg\" 2>/dev/null | grep -oE '/[^\"]+\\.so'); do "
+        '[ -f "$p" ] && ok=0 && break; done; [ "$ok" = 0 ]; }'
+    )
+
+
 @dataclass
 class ProcSpec:
     """Specification for one process inside a :meth:`Application._run_proc_group` call.

--- a/tests/validation/mtl_engine/application_base.py
+++ b/tests/validation/mtl_engine/application_base.py
@@ -99,7 +99,7 @@ class Application(ABC):
         """Return the executable name for this framework."""
         pass
 
-    def require_encoder(self, host, encoder: str) -> None:
+    def require_encoder(self, host, encoder: str, use_mtl_plugin: bool = False) -> None:
         """Check that *encoder* is available. No-op by default; override in subclasses."""
         pass
 

--- a/tests/validation/mtl_engine/ffmpeg.py
+++ b/tests/validation/mtl_engine/ffmpeg.py
@@ -21,7 +21,12 @@ from __future__ import annotations
 import logging
 
 from mtl_engine import ffmpeg_app, ip_pools
-from mtl_engine.application_base import Application, ProcSpec
+from mtl_engine.application_base import (
+    MTL_ENCODER_PLUGIN_MAP,
+    Application,
+    ProcSpec,
+    mtl_plugin_check_cmd,
+)
 from mtl_engine.config.mappings import APP_NAME_MAP
 from mtl_engine.const import FFMPEG_EXE, RXTXAPP_EXE
 
@@ -87,19 +92,12 @@ class FFmpeg(Application):
         """
         if use_mtl_plugin:
             # Codecs delivered via MTL plugin (FFmpeg uses -f mtl_st22p)
-            _MTL_PLUGIN_MAP = {
-                "libsvt_jpegxs": "libst_plugin_st22_svt_jpeg_xs.so",
-                "libopenh264": "libst_plugin_st22_avcodec.so",
-            }
-            plugin_so = _MTL_PLUGIN_MAP.get(encoder)
+            plugin_so = MTL_ENCODER_PLUGIN_MAP.get(encoder)
             if plugin_so:
-                check_cmd = (
-                    f"ldconfig -p 2>/dev/null | grep -q {plugin_so} || "
-                    f"test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} || "
-                    f"test -f /usr/local/lib64/{plugin_so}"
-                )
                 res = host.connection.execute_command(
-                    check_cmd, expected_return_codes=None
+                    mtl_plugin_check_cmd(plugin_so),
+                    shell=True,
+                    expected_return_codes=None,
                 )
                 if res.return_code != 0:
                     raise EnvironmentError(

--- a/tests/validation/mtl_engine/ffmpeg.py
+++ b/tests/validation/mtl_engine/ffmpeg.py
@@ -76,29 +76,36 @@ class FFmpeg(Application):
     def get_executable_name(self) -> str:
         return APP_NAME_MAP["ffmpeg"]
 
-    def require_encoder(self, host, encoder: str) -> None:
+    def require_encoder(self, host, encoder: str, use_mtl_plugin: bool = False) -> None:
         """Raise EnvironmentError if *encoder* is not available on *host*.
 
-        For codecs handled by the MTL st22p device (e.g. libsvt_jpegxs), check
-        the MTL plugin .so instead of FFmpeg's built-in encoder list.
+        When *use_mtl_plugin* is True the codec is delivered by the MTL st22p
+        device (FFmpeg uses ``-f mtl_st22p``), so the matching MTL plugin .so is
+        checked instead of FFmpeg's built-in encoder list. Otherwise FFmpeg's
+        own encoder (e.g. ``-c:v libopenh264`` for an st20p YUV->H264 pipe) is
+        verified against ``ffmpeg -encoders``.
         """
-        # Codecs delivered via MTL plugin (FFmpeg uses -f mtl_st22p, not its own encoder)
-        _MTL_PLUGIN_MAP = {
-            "libsvt_jpegxs": "libst_plugin_st22_svt_jpeg_xs.so",
-            "libopenh264": "libst_plugin_st22_avcodec.so",
-        }
-        plugin_so = _MTL_PLUGIN_MAP.get(encoder)
-        if plugin_so:
-            check_cmd = (
-                f"test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} || "
-                f"test -f /usr/local/lib64/{plugin_so}"
-            )
-            res = host.connection.execute_command(check_cmd, expected_return_codes=None)
-            if res.return_code != 0:
-                raise EnvironmentError(
-                    f"MTL codec plugin {plugin_so} (for {encoder}) not found; "
-                    f"install the codec library and rebuild MTL plugins"
+        if use_mtl_plugin:
+            # Codecs delivered via MTL plugin (FFmpeg uses -f mtl_st22p)
+            _MTL_PLUGIN_MAP = {
+                "libsvt_jpegxs": "libst_plugin_st22_svt_jpeg_xs.so",
+                "libopenh264": "libst_plugin_st22_avcodec.so",
+            }
+            plugin_so = _MTL_PLUGIN_MAP.get(encoder)
+            if plugin_so:
+                check_cmd = (
+                    f"ldconfig -p 2>/dev/null | grep -q {plugin_so} || "
+                    f"test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} || "
+                    f"test -f /usr/local/lib64/{plugin_so}"
                 )
+                res = host.connection.execute_command(
+                    check_cmd, expected_return_codes=None
+                )
+                if res.return_code != 0:
+                    raise EnvironmentError(
+                        f"MTL codec plugin {plugin_so} (for {encoder}) not found; "
+                        f"install the codec library and rebuild MTL plugins"
+                    )
             return
 
         res = host.connection.execute_command(

--- a/tests/validation/mtl_engine/rxtxapp.py
+++ b/tests/validation/mtl_engine/rxtxapp.py
@@ -11,7 +11,7 @@ import re
 from mfd_connect import SSHConnection
 
 from . import ip_pools
-from .application_base import Application
+from .application_base import MTL_ENCODER_PLUGIN_MAP, Application, mtl_plugin_check_cmd
 from .config.mappings import APP_NAME_MAP, RXTXAPP_CMDLINE_PARAM_MAP
 from .config.universal_params import UNIVERSAL_PARAMS
 from .execute import log_fail
@@ -503,23 +503,14 @@ class RxTxApp(Application):
     def get_executable_name(self) -> str:
         return APP_NAME_MAP["rxtxapp"]
 
-    # Encoder → MTL plugin .so mapping for pre-flight checks.
-    _ENCODER_PLUGIN_MAP = {
-        "libsvt_jpegxs": "libst_plugin_st22_svt_jpeg_xs.so",
-        "libopenh264": "libst_plugin_st22_avcodec.so",
-    }
-
     def require_encoder(self, host, encoder: str, use_mtl_plugin: bool = False) -> None:
         """Raise EnvironmentError if the MTL codec plugin for *encoder* is not installed."""
-        plugin_so = self._ENCODER_PLUGIN_MAP.get(encoder)
+        plugin_so = MTL_ENCODER_PLUGIN_MAP.get(encoder)
         if not plugin_so:
             return  # Unknown encoder — skip check, let runtime fail if needed
-        # Check standard install paths
-        check_cmd = (
-            f"test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} || "
-            f"test -f /usr/local/lib64/{plugin_so}"
+        res = host.connection.execute_command(
+            mtl_plugin_check_cmd(plugin_so), shell=True, expected_return_codes=None
         )
-        res = host.connection.execute_command(check_cmd, expected_return_codes=None)
         if res.return_code != 0:
             raise EnvironmentError(
                 f"MTL codec plugin {plugin_so} (for {encoder}) not found; "

--- a/tests/validation/mtl_engine/rxtxapp.py
+++ b/tests/validation/mtl_engine/rxtxapp.py
@@ -509,7 +509,7 @@ class RxTxApp(Application):
         "libopenh264": "libst_plugin_st22_avcodec.so",
     }
 
-    def require_encoder(self, host, encoder: str) -> None:
+    def require_encoder(self, host, encoder: str, use_mtl_plugin: bool = False) -> None:
         """Raise EnvironmentError if the MTL codec plugin for *encoder* is not installed."""
         plugin_so = self._ENCODER_PLUGIN_MAP.get(encoder)
         if not plugin_so:

--- a/tests/validation/tests/single/st22p/test_codec.py
+++ b/tests/validation/tests/single/st22p/test_codec.py
@@ -44,7 +44,7 @@ def test_st22p_codec(
     encoder = codec_encoder_map.get(codec)
     app = app_factory(application)
     if encoder:
-        app.require_encoder(host, encoder)
+        app.require_encoder(host, encoder, use_mtl_plugin=True)
 
     interfaces_list = setup_interfaces.get_interfaces_list_single(
         test_config.get("interface_type", "VF")

--- a/tests/validation/tests/single/st22p/test_format.py
+++ b/tests/validation/tests/single/st22p/test_format.py
@@ -40,7 +40,7 @@ def test_st22p_format(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
-    app.require_encoder(host, "libsvt_jpegxs")
+    app.require_encoder(host, "libsvt_jpegxs", use_mtl_plugin=True)
     app.create_command(
         session_type="st22p",
         test_mode="multicast",

--- a/tests/validation/tests/single/st22p/test_fps.py
+++ b/tests/validation/tests/single/st22p/test_fps.py
@@ -59,6 +59,13 @@ def test_st22p_fps(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
+    codec_encoder_map = {
+        "H264_CBR": "libopenh264",
+        "JPEG-XS": "libsvt_jpegxs",
+    }
+    encoder = codec_encoder_map.get(codec)
+    if encoder:
+        app.require_encoder(host, encoder, use_mtl_plugin=True)
     app.create_command(
         session_type="st22p",
         test_mode="multicast",

--- a/tests/validation/tests/single/st22p/test_interlace.py
+++ b/tests/validation/tests/single/st22p/test_interlace.py
@@ -45,7 +45,7 @@ def test_st22p_interlace(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
-    app.require_encoder(host, "libsvt_jpegxs")
+    app.require_encoder(host, "libsvt_jpegxs", use_mtl_plugin=True)
     app.create_command(
         session_type="st22p",
         test_mode="multicast",

--- a/tests/validation/tests/single/st22p/test_quality.py
+++ b/tests/validation/tests/single/st22p/test_quality.py
@@ -47,7 +47,7 @@ def test_st22p_quality(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
-    app.require_encoder(host, "libsvt_jpegxs")
+    app.require_encoder(host, "libsvt_jpegxs", use_mtl_plugin=True)
     app.create_command(
         session_type="st22p",
         test_mode="multicast",

--- a/tests/validation/tests/single/st22p/test_unicast.py
+++ b/tests/validation/tests/single/st22p/test_unicast.py
@@ -40,7 +40,7 @@ def test_st22p_unicast(
     test_time = max(test_time, 90)
 
     app = app_factory(application)
-    app.require_encoder(host, "libsvt_jpegxs")
+    app.require_encoder(host, "libsvt_jpegxs", use_mtl_plugin=True)
     app.create_command(
         session_type="st22p",
         test_mode="unicast",


### PR DESCRIPTION
Test: Root problem - require_encoder("libopenh264") unconditionally redirected to the MTL st22 plugin check, breaking st20p (which uses ffmpeg's native encoder).

Fix — added a use_mtl_plugin flag