### PR TITLE
Add: 12-bit and UYVY pix_fmts to mtl_st20p ffmpeg plugin

### DIFF
--- a/.github/actions/validate-host/action.yml
+++ b/.github/actions/validate-host/action.yml
@@ -97,6 +97,10 @@ runs:
 
     - name: 'installation: Auto-align host components (ICE driver & SVT-JPEG-XS)'
       shell: bash
+      env:
+        MTL_INSTALL_PREFIX: ${{ github.workspace }}/.local_install/mtl
+        PKG_CONFIG_PATH: ${{ github.workspace }}/.local_install/dpdk/lib/x86_64-linux-gnu/pkgconfig:${{ github.workspace }}/.local_install/mtl/lib/x86_64-linux-gnu/pkgconfig
+        LD_LIBRARY_PATH: ${{ github.workspace }}/.local_install/dpdk/lib/x86_64-linux-gnu:${{ github.workspace }}/.local_install/mtl/lib/x86_64-linux-gnu
       run: |
         export SETUP_BUILD_AND_INSTALL_ICE_DRIVER=1
         export PLUGIN_BUILD_AND_INSTALL_JPEGXS=1

--- a/ecosystem/ffmpeg_plugin/README.md
+++ b/ecosystem/ffmpeg_plugin/README.md
@@ -115,9 +115,13 @@ formats. The same `-pix_fmt` must be used on TX and RX.
 | `-pix_fmt`    | Wire format                   | ST 2110-20:2022 §6.2 compliant |
 | ------------- | ----------------------------- | ------------------------------ |
 | `yuv422p10le` | YUV 4:2:2 10-bit RFC 4175 PG2BE10 | yes (Table 2)              |
-| `y210le`      | YUV 4:2:2 10-bit RFC 4175 PG2BE10 | yes (Table 2)              |
 | `yuv444p10le` | YUV 4:4:4 10-bit RFC 4175 PG4BE10 | yes (Table 1)              |
-| `gbrp10le`    | RGB 10-bit RFC 4175 PG4BE10       | yes (Table 1)              |
+| `yuv422p12le` | YUV 4:2:2 12-bit RFC 4175 PG2BE12 | yes (Table 2)              |
+| `yuv444p12le` | YUV 4:4:4 12-bit RFC 4175 PG2BE12 | yes (Table 1)              |
+| `y210le`      | YUV 4:2:2 10-bit RFC 4175 PG2BE10 | yes (Table 2)              |
+| `uyvy422`     | YUV 4:2:2 8-bit RFC 4175          | yes (Table 2)              |
+| `gbrp10le`    | RGB 4:4:4 10-bit RFC 4175 PG4BE10 | yes (Table 1)              |
+| `gbrp12le`    | RGB 4:4:4 12-bit RFC 4175 PG2BE12 | yes (Table 1)              |
 | `yuv420p`     | Planar I420 passthrough (`ST_FRAME_FMT_YUV420CUSTOM8`) | **no** — MTL-to-MTL only, not interoperable with third-party receivers |
 
 ## 3. ST22 compressed video run guide

--- a/ecosystem/ffmpeg_plugin/mtl_st20p_rx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st20p_rx.c
@@ -124,6 +124,14 @@ static int mtl_st20p_read_header(AVFormatContext* ctx) {
       ops_rx.transport_fmt = ST20_FMT_YUV_422_10BIT;
       ops_rx.output_fmt = ST_FRAME_FMT_Y210;
       break;
+    case AV_PIX_FMT_YUV422P12LE:
+      ops_rx.transport_fmt = ST20_FMT_YUV_422_12BIT;
+      ops_rx.output_fmt = ST_FRAME_FMT_YUV422PLANAR12LE;
+      break;
+    case AV_PIX_FMT_UYVY422:
+      ops_rx.transport_fmt = ST20_FMT_YUV_422_8BIT;
+      ops_rx.output_fmt = ST_FRAME_FMT_UYVY;
+      break;
     case AV_PIX_FMT_RGB24:
       ops_rx.transport_fmt = ST20_FMT_RGB_8BIT;
       ops_rx.output_fmt = ST_FRAME_FMT_RGB8;
@@ -132,9 +140,17 @@ static int mtl_st20p_read_header(AVFormatContext* ctx) {
       ops_rx.transport_fmt = ST20_FMT_YUV_444_10BIT;
       ops_rx.output_fmt = ST_FRAME_FMT_YUV444PLANAR10LE;
       break;
+    case AV_PIX_FMT_YUV444P12LE:
+      ops_rx.transport_fmt = ST20_FMT_YUV_444_12BIT;
+      ops_rx.output_fmt = ST_FRAME_FMT_YUV444PLANAR12LE;
+      break;
     case AV_PIX_FMT_GBRP10LE:
       ops_rx.transport_fmt = ST20_FMT_RGB_10BIT;
       ops_rx.output_fmt = ST_FRAME_FMT_GBRPLANAR10LE;
+      break;
+    case AV_PIX_FMT_GBRP12LE:
+      ops_rx.transport_fmt = ST20_FMT_RGB_12BIT;
+      ops_rx.output_fmt = ST_FRAME_FMT_GBRPLANAR12LE;
       break;
     case AV_PIX_FMT_YUV420P:
       /* MTL-to-MTL passthrough only: YUV420CUSTOM8 receives the raw

--- a/ecosystem/ffmpeg_plugin/mtl_st20p_tx.c
+++ b/ecosystem/ffmpeg_plugin/mtl_st20p_tx.c
@@ -98,6 +98,14 @@ static int mtl_st20p_write_header(AVFormatContext* ctx) {
       ops_tx.input_fmt = ST_FRAME_FMT_Y210;
       ops_tx.transport_fmt = ST20_FMT_YUV_422_10BIT;
       break;
+    case AV_PIX_FMT_YUV422P12LE:
+      ops_tx.input_fmt = ST_FRAME_FMT_YUV422PLANAR12LE;
+      ops_tx.transport_fmt = ST20_FMT_YUV_422_12BIT;
+      break;
+    case AV_PIX_FMT_UYVY422:
+      ops_tx.input_fmt = ST_FRAME_FMT_UYVY;
+      ops_tx.transport_fmt = ST20_FMT_YUV_422_8BIT;
+      break;
     case AV_PIX_FMT_RGB24:
       ops_tx.input_fmt = ST_FRAME_FMT_RGB8;
       ops_tx.transport_fmt = ST20_FMT_RGB_8BIT;
@@ -106,9 +114,17 @@ static int mtl_st20p_write_header(AVFormatContext* ctx) {
       ops_tx.input_fmt = ST_FRAME_FMT_YUV444PLANAR10LE;
       ops_tx.transport_fmt = ST20_FMT_YUV_444_10BIT;
       break;
+    case AV_PIX_FMT_YUV444P12LE:
+      ops_tx.input_fmt = ST_FRAME_FMT_YUV444PLANAR12LE;
+      ops_tx.transport_fmt = ST20_FMT_YUV_444_12BIT;
+      break;
     case AV_PIX_FMT_GBRP10LE:
       ops_tx.input_fmt = ST_FRAME_FMT_GBRPLANAR10LE;
       ops_tx.transport_fmt = ST20_FMT_RGB_10BIT;
+      break;
+    case AV_PIX_FMT_GBRP12LE:
+      ops_tx.input_fmt = ST_FRAME_FMT_GBRPLANAR12LE;
+      ops_tx.transport_fmt = ST20_FMT_RGB_12BIT;
       break;
     case AV_PIX_FMT_YUV420P:
       /* MTL-to-MTL passthrough only: YUV420CUSTOM8 sends the planar I420

--- a/tests/validation/common/integrity/video_integrity.py
+++ b/tests/validation/common/integrity/video_integrity.py
@@ -58,12 +58,21 @@ def calculate_yuv_frame_size(width: int, height: int, file_format: str) -> int:
             pixel_size = 2.5
         case "YUV422PLANAR10LE" | "yuv422p10le":
             pixel_size = 4
+        case "yuv422p12le":
+            # 4:2:2 12-bit planar: Y full + half U + half V, 2 bytes per sample
+            pixel_size = 4
         case "yuv444p10le" | "gbrp10le":
             # 3 planes (Y/U/V or G/B/R), 10-bit samples padded to 2 bytes each
+            pixel_size = 6
+        case "yuv444p12le" | "gbrp12le":
+            # 3 planes (Y/U/V or G/B/R), 12-bit samples padded to 2 bytes each
             pixel_size = 6
         case "yuv420p":
             # I420: full Y plane + quarter-size U + quarter-size V
             pixel_size = 1.5
+        case "uyvy422":
+            # Packed 4:2:2 8-bit, 2 bytes per pixel
+            pixel_size = 2
         case "y210le":
             # Packed 4:2:2 10-bit, 2 samples per pixel × 2 bytes per sample
             pixel_size = 4

--- a/tests/validation/tests/single/st20p/test_pix_fmt.py
+++ b/tests/validation/tests/single/st20p/test_pix_fmt.py
@@ -18,6 +18,10 @@ PIX_FMTS = [
     "gbrp10le",
     "yuv420p",
     "y210le",
+    "uyvy422",
+    "yuv422p12le",
+    "yuv444p12le",
+    "gbrp12le",
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Extend the st20p ffmpeg muxer/demuxer pixel-format mapping with the remaining transport formats that have a direct AVPixelFormat: yuv422p12le, yuv444p12le, gbrp12le, and uyvy422. Both TX input_fmt and RX output_fmt switch tables are kept symmetric.

Cover the new formats in the st20p pix_fmt loopback test and teach the video integrity frame-size helper their per-pixel byte sizes.