### PR TITLE
 Ci: Enable JPEG-XS plugin cache on test runners

### DIFF
--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -576,9 +576,16 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		# Build and install imtl-plugin (MTL JPEG-XS encoder/decoder bridge)
 		pushd "${JPEGXS_REPO}/imtl-plugin" >/dev/null || exit 1
 		rm -rf build
-		meson setup build
-		meson compile -C build
-		sudo meson install -C build
+		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
+			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
+			meson setup build --prefix="${local_base}/plugins"
+			meson compile -C build
+			meson install -C build
+		else
+			meson setup build
+			meson compile -C build
+			sudo meson install -C build
+		fi
 		popd >/dev/null
 
 		# Rebuild FFmpeg with JPEG-XS support

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,7 @@ jobs:
             echo "ECOSYSTEM_BUILD_AND_INSTALL_GSTREAMER_PLUGIN=${gstreamer_miss}"
             echo "ECOSYSTEM_BUILD_AND_INSTALL_RIST_PLUGIN=${librist_miss}"
             echo "PLUGIN_BUILD_AND_INSTALL_AVCODEC=${plugins_miss}"
+            echo "PLUGIN_BUILD_AND_INSTALL_JPEGXS=${plugins_miss}"
           } >> "$GITHUB_ENV"
 
           any_miss=0


### PR DESCRIPTION
Summary
Fixes OSError ("MTL codec plugin libst_plugin_st22_svt_jpeg_xs.so not found") on nightly/smoke pytest runs. Builds and caches the media transport bridge plugin while using the local host's system-installed base SVT-JPEG-XS library.

Changes
build.yml: Wire cache miss trigger PLUGIN_BUILD_AND_INSTALL_JPEGXS to ${plugins_miss}.
setup_environment.sh: Adjust Meson compile step to honor --prefix pointing to .local_install/plugins rather than calling sudo meson install on the global system layout.
