### PR TITLE
Ci: Add missing st22 avcodec cache

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -60,3 +60,4 @@ runs:
           ./tests/tools/RxTxApp/build/RxTxApp
           ./ecosystem/gstreamer_plugin/builddir/libgstmtl_*.so
           ./tests/tools/gstreamer_tools/builddir/*.so
+          ./script/build/st22_avcodec_plugin/libst_plugin_st22_avcodec.so

--- a/.github/workflows/custom-pytest.yml
+++ b/.github/workflows/custom-pytest.yml
@@ -14,8 +14,12 @@ on:
         description: Marker
         required: false
         type: string
+      test_filter:
+        description: 'Pytest keyword filter (-k), e.g. test_st20p_resolutions'
+        required: false
+        type: string
       dir:
-        description: Directory (subdirectory of tests/validation)
+        description: 'Directory (subdirectory of tests/validation) or a specific test path'
         required: true
         type: string
         default: tests
@@ -106,7 +110,8 @@ jobs:
           ./.venv/bin/python3 -m pytest \
             --test_config=./configs/test_config.yaml \
             --topology_config=./configs/topology_config.yaml \
-            ${{ inputs.marker && format('-m ''{0}''', inputs.marker) || '' }} \
+            ${{ inputs.marker && format('-m "{0}"', inputs.marker) || '' }} \
+            ${{ inputs.test_filter && format('-k "{0}"', inputs.test_filter) || '' }} \
             --template=html/index.html \
             --report=./report.html \
             "./${{ inputs.dir }}"

--- a/script/hash_sources_plugins.env
+++ b/script/hash_sources_plugins.env
@@ -1,0 +1,11 @@
+# Paths that affect the st22 avcodec plugin build artifact.
+# One path per line (glob-free). Relative to repository root.
+
+# CICD dependency
+.github/scripts/setup_environment.sh
+
+# Build driver for the plugin
+script/build_st22_avcodec_plugin.sh
+
+plugins/st22_avcodec/
+VERSION

--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -1421,6 +1421,14 @@ def _register_local_libs(hosts, mtl_path):
     for p in raw_paths:
         for part in p.split(":"):
             lib_dirs.append(os.path.join(mtl_path, part.removeprefix("./")))
+
+    # Also register plugin paths from .local_install/plugins if it exists
+    plugins_base = os.path.join(mtl_path, ".local_install/plugins")
+    if os.path.isdir(plugins_base):
+        for root, dirs, files in os.walk(plugins_base):
+            if any(f.endswith(".so") for f in files):
+                lib_dirs.append(root)
+
     conf = "\\n".join(lib_dirs)
     ffmpeg_bin = os.path.join(mtl_path, FFMPEG_PATH.removeprefix("./"))
     # /usr/local/lib precedes /etc/ld.so.conf.d/* in /etc/ld.so.conf, so any
@@ -1428,7 +1436,9 @@ def _register_local_libs(hosts, mtl_path):
     purge = (
         "mkdir -p /var/backups/mtl_libav_shadow && "
         "mv -f /usr/local/lib/libav*.so* /usr/local/lib/libsw*.so* "
-        "/usr/local/lib/libpostproc*.so* /var/backups/mtl_libav_shadow/ "
+        "/usr/local/lib/libpostproc*.so* /usr/local/lib/x86_64-linux-gnu/libst_plugin_st22_avcodec.so* "
+        "/usr/local/lib64/libst_plugin_st22_avcodec.so* "
+        "/usr/local/lib/libst_plugin_st22_avcodec.so* /var/backups/mtl_libav_shadow/ "
         "2>/dev/null; true"
     )
     for host in hosts.values():

--- a/tests/validation/mtl_engine/application_base.py
+++ b/tests/validation/mtl_engine/application_base.py
@@ -42,6 +42,8 @@ def mtl_plugin_check_cmd(plugin_so: str) -> str:
         f"ldconfig -p 2>/dev/null | grep -q {plugin_so} "
         f"|| test -f /usr/local/lib/x86_64-linux-gnu/{plugin_so} "
         f"|| test -f /usr/local/lib64/{plugin_so} "
+        f"|| ( [ -d .local_install/plugins ] && find .local_install/plugins -name "
+        f"'{plugin_so}' 2>/dev/null | grep -q '{plugin_so}' ) "
         '|| { cfg="${KAHAWAI_CFG_PATH:-kahawai.json}"; ok=1; '
         f"for p in $(grep -F '{plugin_so}' \"$cfg\" 2>/dev/null | grep -oE '/[^\"]+\\.so'); do "
         '[ -f "$p" ] && ok=0 && break; done; [ "$ok" = 0 ]; }'

--- a/tests/validation/mtl_engine/const.py
+++ b/tests/validation/mtl_engine/const.py
@@ -24,8 +24,7 @@ MTL_LIB_PATH = f"{MTL_LIB_PATH}:{PREFIX}/mtl/lib/x86_64-linux-gnu"
 DPDK_LIB_PATH = f"{PREFIX}/dpdk/lib/x86_64-linux-gnu"
 FFMPEG_LIB_PATH = f"{PREFIX}/ffmpeg/lib"
 GSTREAMER_LIB_PATH = f"{PREFIX}/gstreamer/gstreamer-1.0"
+PLUGIN_PATH = f"{PREFIX}/plugins/lib/x86_64-linux-gnu"
 
 
-LD_LIB_PATH_REL = (
-    f"{MTL_LIB_PATH}:{DPDK_LIB_PATH}:{FFMPEG_LIB_PATH}:{GSTREAMER_LIB_PATH}"
-)
+LD_LIB_PATH_REL = f"{MTL_LIB_PATH}:{DPDK_LIB_PATH}:{FFMPEG_LIB_PATH}:{GSTREAMER_LIB_PATH}:{PLUGIN_PATH}"


### PR DESCRIPTION
Enable st22p pytests adding missing libst_plugin_st22_avcodec.so artifact into cache.