### PR TITLE
Test: Skipped unsupported 10bit h264 tests

### DIFF
--- a/tests/validation/tests/single/st22p/test_codec.py
+++ b/tests/validation/tests/single/st22p/test_codec.py
@@ -36,6 +36,9 @@ def test_st22p_codec(
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
 
+    if codec == "H264_CBR" and "10" in media_file_info["file_format"]:
+        pytest.skip("H264_CBR codec plugin does not support 10-bit formats")
+
     # Check codec encoder availability
     codec_encoder_map = {
         "H264_CBR": "libopenh264",

--- a/tests/validation/tests/single/st22p/test_fps.py
+++ b/tests/validation/tests/single/st22p/test_fps.py
@@ -52,6 +52,10 @@ def test_st22p_fps(
     """Test st22p at different frame rates."""
     media_file_info, media_file_path = media_file
     host = list(hosts.values())[0]
+
+    if codec == "H264_CBR" and "10" in media_file_info["file_format"]:
+        pytest.skip("H264_CBR codec plugin does not support 10-bit formats")
+
     interfaces_list = setup_interfaces.get_interfaces_list_single(
         test_config.get("interface_type", "VF")
     )


### PR DESCRIPTION
Test: Skipped unsupported 10bit h264 tests

Test is skipped due to lack of support for 10 bit pixel format in the avcodec plugin. Current implementation support only 8bit pixel format.