### PR TITLE
Ci: Suspended support of e825 nic in CI tests

### DIFF
--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -75,7 +75,6 @@ jobs:
         nic:
           - e810
           - e830
-          - e825
           - e835
       fail-fast: false
     runs-on: ${{ matrix.nic }}

--- a/.github/workflows/nightly-gtest.yml
+++ b/.github/workflows/nightly-gtest.yml
@@ -31,7 +31,6 @@ jobs:
         nic:
           - e810
           - e830
-          - e825
           - e835
       fail-fast: false
     runs-on: ${{ matrix.nic }}

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -22,7 +22,6 @@ jobs:
         nic:
           - e810
           - e830
-          - e825
           - e835
         dir:
           - cross_app

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -61,7 +61,6 @@ jobs:
         nic:
           - e810
           - e830
-          - e825
           - e835
       fail-fast: false
     runs-on: ${{ matrix.nic }}


### PR DESCRIPTION
Ci: Suspended support of e825 NIC in CI tests due to platform issues to not block Ci workflows untill 825 NIC platform will be working back.