### PR TITLE
Fix: automate SVT-JPEG-XS alignment and prevent ABI mismatch crash

### DIFF
--- a/.github/actions/validate-host/action.yml
+++ b/.github/actions/validate-host/action.yml
@@ -102,9 +102,12 @@ runs:
         echo "KAHAWAI_CFG_PATH=${cfg}" >> "$GITHUB_ENV"
         echo "::notice::CI kahawai registry ${cfg} (avcodec from ${plugin_dir})"
 
-    - name: Validate ice drivers
+    - name: 'installation: Auto-align host components (ICE driver & SVT-JPEG-XS)'
       shell: bash
-      run: ${{ github.workspace }}/script/build_ice_driver.sh
+      run: |
+        export SETUP_BUILD_AND_INSTALL_ICE_DRIVER=1
+        export PLUGIN_BUILD_AND_INSTALL_JPEGXS=1
+        bash ${{ github.workspace }}/.github/scripts/setup_environment.sh
 
     - name: Configure LD_LIBRARY_PATH, PATH, GST_PLUGIN_PATH
       shell: bash

--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -61,6 +61,12 @@ nproc=$(nproc 2>/dev/null || echo 50)
 # shellcheck disable=SC1091
 . "${root_folder}/script/common.sh"
 
+versions_file="${root_folder}/versions.env"
+if [ -f "${versions_file}" ]; then
+	# shellcheck disable=SC1090
+	. "${versions_file}"
+fi
+
 # Before MTL build install
 function setup_ubuntu_install_dependencies() {
 	echo "1.1. Install the build dependency from OS software store"
@@ -463,6 +469,57 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		STEP=$((STEP + 1))
 	fi
 
+	if [ "${PLUGIN_BUILD_AND_INSTALL_JPEGXS}" == "1" ]; then
+		echo "$STEP Plugin JPEG-XS build and install"
+
+		lib_so="libst_plugin_st22_svt_jpeg_xs.so"
+		need_build=0
+
+		# Check plugin .so
+		if ! ldconfig -p 2>/dev/null | grep -q "${lib_so}" &&
+			! test -f /usr/local/lib/x86_64-linux-gnu/${lib_so} &&
+			! test -f /usr/local/lib64/${lib_so}; then
+			echo "MTL JPEG-XS plugin not found."
+			need_build=1
+		fi
+
+		# Check core SvtJpegxs version/presence
+		if ! ldconfig -p 2>/dev/null | grep -q "libSvtJpegxs.so.0"; then
+			echo "Core SvtJpegxs library not found."
+			need_build=1
+		fi
+
+		export SVT_JPEG_XS_REPO="${setup_script_folder}/SVT-JPEG-XS"
+
+		if [ ! -d "${SVT_JPEG_XS_REPO}" ]; then
+			echo "Downloading SVT-JPEG-XS (${SVT_JPEG_XS_VER}) using wget..."
+			wget -q "https://github.com/OpenVisualCloud/SVT-JPEG-XS/archive/refs/tags/${SVT_JPEG_XS_VER}.tar.gz" -O "${setup_script_folder}/SVT-JPEG-XS.tar.gz"
+			mkdir -p "${SVT_JPEG_XS_REPO}"
+			tar -xzf "${setup_script_folder}/SVT-JPEG-XS.tar.gz" -C "${SVT_JPEG_XS_REPO}" --strip-components=1
+			rm -f "${setup_script_folder}/SVT-JPEG-XS.tar.gz"
+		fi
+
+		if [ "${need_build}" -eq 0 ]; then
+			echo "=== SVT-JPEG-XS and MTL bridge plugin are already up-to-date. Alignment skipped ==="
+		else
+			# Build and install SVT-JPEG-XS library
+			pushd "${SVT_JPEG_XS_REPO}/Build/linux" >/dev/null || exit 1
+			./build.sh install
+			popd >/dev/null
+
+			# Build and install imtl-plugin (MTL JPEG-XS encoder/decoder bridge)
+			pushd "${SVT_JPEG_XS_REPO}/imtl-plugin" >/dev/null || exit 1
+			rm -rf build
+			meson setup build
+			meson compile -C build
+			sudo meson install -C build
+			popd >/dev/null
+
+			sudo ldconfig
+		fi
+		STEP=$((STEP + 1))
+	fi
+
 	# After MTL build
 	if [ "${ECOSYSTEM_BUILD_AND_INSTALL_FFMPEG_PLUGIN}" == "1" ]; then
 		echo "$STEP Ecosystem FFMPEG plugin build and install"
@@ -471,14 +528,22 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 			enable_gpu="-g"
 		else
 			echo "Building FFMPEG plugin without GPU Direct support"
+			enable_gpu=""
+		fi
+
+		if [ "${PLUGIN_BUILD_AND_INSTALL_JPEGXS}" == "1" ]; then
+			export FFMPEG_ENABLE_SVT_JPEG_XS="1"
+			enable_jpegxs="-j"
+		else
+			enable_jpegxs=""
 		fi
 
 		# FFmpeg installs to a sibling directory for independent caching
 		if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
 			local_base="$(dirname "${MTL_INSTALL_PREFIX}")"
-			MTL_INSTALL_PREFIX="${local_base}/ffmpeg" bash "${root_folder}/ecosystem/ffmpeg_plugin/build.sh" "${enable_gpu}"
+			MTL_INSTALL_PREFIX="${local_base}/ffmpeg" bash "${root_folder}/ecosystem/ffmpeg_plugin/build.sh" ${enable_gpu} ${enable_jpegxs}
 		else
-			bash "${root_folder}/ecosystem/ffmpeg_plugin/build.sh" "${enable_gpu}"
+			bash "${root_folder}/ecosystem/ffmpeg_plugin/build.sh" ${enable_gpu} ${enable_jpegxs}
 		fi
 		STEP=$((STEP + 1))
 	fi
@@ -557,51 +622,6 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		else
 			bash "${root_folder}/script/build_st22_avcodec_plugin.sh"
 		fi
-		STEP=$((STEP + 1))
-	fi
-
-	if [ "${PLUGIN_BUILD_AND_INSTALL_JPEGXS}" == "1" ]; then
-		echo "$STEP Plugin JPEG-XS build and install"
-
-		JPEGXS_REPO="${setup_script_folder}/SVT-JPEG-XS"
-		if [ ! -d "${JPEGXS_REPO}" ]; then
-			git clone --depth 1 https://github.com/OpenVisualCloud/SVT-JPEG-XS.git "${JPEGXS_REPO}"
-		fi
-
-		# Build and install SVT-JPEG-XS library
-		pushd "${JPEGXS_REPO}/Build/linux" >/dev/null || exit 1
-		./build.sh install
-		popd >/dev/null
-
-		# Build and install imtl-plugin (MTL JPEG-XS encoder/decoder bridge)
-		pushd "${JPEGXS_REPO}/imtl-plugin" >/dev/null || exit 1
-		rm -rf build
-		meson setup build
-		meson compile -C build
-		sudo meson install -C build
-		popd >/dev/null
-
-		# Rebuild FFmpeg with JPEG-XS support
-		FFMPEG_VERSION="${FFMPEG_VERSION:-7.0}"
-		FFMPEG_JPEGXS_DIR="${setup_script_folder}/ffmpeg-jpegxs"
-		if [ -d "${FFMPEG_JPEGXS_DIR}" ]; then
-			rm -rf "${FFMPEG_JPEGXS_DIR}"
-		fi
-
-		wget -q "https://github.com/FFmpeg/FFmpeg/archive/refs/heads/release/${FFMPEG_VERSION}.zip" -O "${setup_script_folder}/ffmpeg-${FFMPEG_VERSION}.zip"
-		unzip -q "${setup_script_folder}/ffmpeg-${FFMPEG_VERSION}.zip" -d "${setup_script_folder}" && rm -f "${setup_script_folder}/ffmpeg-${FFMPEG_VERSION}.zip"
-		mv "${setup_script_folder}/FFmpeg-release-${FFMPEG_VERSION}" "${FFMPEG_JPEGXS_DIR}"
-
-		pushd "${FFMPEG_JPEGXS_DIR}" >/dev/null || exit 1
-		cp -f "${JPEGXS_REPO}/ffmpeg-plugin/libsvtjpegxs"* libavcodec/
-		git init && git add -A && git commit -m "init" --quiet
-		git am --whitespace=fix "${JPEGXS_REPO}/ffmpeg-plugin/${FFMPEG_VERSION}"/*.patch
-		./configure --enable-shared --disable-static --enable-pic --enable-libsvtjpegxs
-		make -j"${nproc}"
-		sudo make install
-		popd >/dev/null
-
-		sudo ldconfig
 		STEP=$((STEP + 1))
 	fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,7 @@ jobs:
           PKG_CONFIG_PATH: ${{ github.workspace }}/.local_install/dpdk/lib/x86_64-linux-gnu/pkgconfig:${{ github.workspace }}/.local_install/mtl/lib/x86_64-linux-gnu/pkgconfig
           LD_LIBRARY_PATH: ${{ github.workspace }}/.local_install/dpdk/lib/x86_64-linux-gnu:${{ github.workspace }}/.local_install/mtl/lib/x86_64-linux-gnu
           TOOLS_BUILD_AND_INSTALL_SET_TAI_OFFSET: '1'
+          PLUGIN_BUILD_AND_INSTALL_JPEGXS: '1'
           # Capture PHC is disciplined to TAI at runtime via phc2sys -O
           # <live_offset>, so the kernel TAI offset is left untouched.
           TOOLS_RUN_SET_TAI_OFFSET: '0'

--- a/.github/workflows/validation-tests.yml
+++ b/.github/workflows/validation-tests.yml
@@ -181,6 +181,10 @@ jobs:
           ./build.sh
           sudo ldconfig
 
+      - name: 'installation: Auto-align SVT-JPEG-XS core and plugin'
+        run: |
+          export PLUGIN_BUILD_AND_INSTALL_JPEGXS=1
+          bash .github/scripts/setup_environment.sh
       - name: 'installation: Install pipenv environment'
         working-directory: tests/validation
         id: pipenv-install

--- a/ecosystem/ffmpeg_plugin/build.sh
+++ b/ecosystem/ffmpeg_plugin/build.sh
@@ -6,6 +6,7 @@
 set -e
 
 enable_gpu=false
+enable_jpegxs=false
 script_path="$(dirname "$(readlink -f "$0")")"
 VERSIONS_ENV_PATH="$(dirname "$(readlink -qe "${BASH_SOURCE[0]}")")/../../versions.env"
 
@@ -23,17 +24,21 @@ usage() {
 	echo "Options:"
 	echo "  -v <version>    Specify the FFmpeg version to build (default is $FFMPEG_VERSION)"
 	echo "  -g              Enable GPU direct mode during compilation"
+	echo "  -j              Enable SVT-JPEG-XS support during compilation"
 	echo "  -h              Display this help and exit"
 }
 
 # Parse command-line options
-while getopts ":v:hg" opt; do
+while getopts ":v:hgj" opt; do
 	case "${opt}" in
 	v)
 		FFMPEG_VERSION=${OPTARG}
 		;;
 	g)
 		enable_gpu=true
+		;;
+	j)
+		enable_jpegxs=true
 		;;
 	h)
 		usage
@@ -100,22 +105,42 @@ build_ffmpeg() {
 		fi
 	done
 
+	# Use bash array to pass extra configuration flags to avoid shellcheck SC2086 word-splitting warnings.
+	extra_config_flags=()
+
 	if [ "$enable_gpu" = true ]; then
 		echo "Building with MTL_GPU_DIRECT_ENABLED"
-		extra_config_flags="--extra-cflags=-DMTL_GPU_DIRECT_ENABLED"
-	else
-		extra_config_flags=""
+		extra_config_flags+=("--extra-cflags=-DMTL_GPU_DIRECT_ENABLED")
+	fi
+
+	local jpegxs_repo="${SVT_JPEG_XS_REPO:-}"
+	if [ -z "$jpegxs_repo" ]; then
+		if [ -d "${script_path}/../../.github/scripts/SVT-JPEG-XS" ]; then
+			jpegxs_repo="${script_path}/../../.github/scripts/SVT-JPEG-XS"
+		fi
+	fi
+
+	if { [ "${FFMPEG_ENABLE_SVT_JPEG_XS:-0}" == "1" ] || [ "$enable_jpegxs" = true ]; } && [ -d "${jpegxs_repo}" ]; then
+		echo "Integrating SVT-JPEG-XS support into FFmpeg..."
+		cp -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxs"* libavcodec/
+		for patch_file in "${jpegxs_repo}/ffmpeg-plugin/${FFMPEG_VERSION}"/*.patch; do
+			if [ -f "$patch_file" ]; then
+				echo "Applying SVT-JPEG-XS patch: $(basename "$patch_file")"
+				patch -p1 <"$patch_file"
+			fi
+		done
+		extra_config_flags+=("--enable-libsvtjpegxs")
 	fi
 
 	if [ -n "${MTL_INSTALL_PREFIX:-}" ]; then
 		# Ensure FFmpeg can find libraries installed in its own prefix (e.g. openh264)
 		export PKG_CONFIG_PATH="${MTL_INSTALL_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 		export LD_LIBRARY_PATH="${MTL_INSTALL_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
-		./configure --prefix="${MTL_INSTALL_PREFIX}" --enable-shared --disable-static --enable-pic --enable-libopenh264 --enable-encoder=libopenh264 --enable-mtl --extra-ldflags="-Wl,-rpath,${MTL_INSTALL_PREFIX}/lib" $extra_config_flags
+		./configure --prefix="${MTL_INSTALL_PREFIX}" --enable-shared --disable-static --enable-pic --enable-libopenh264 --enable-encoder=libopenh264 --enable-mtl --extra-ldflags="-Wl,-rpath,${MTL_INSTALL_PREFIX}/lib" "${extra_config_flags[@]}"
 		make -j "$(nproc)"
 		make install
 	else
-		./configure --enable-shared --disable-static --enable-pic --enable-libopenh264 --enable-encoder=libopenh264 --enable-mtl $extra_config_flags
+		./configure --enable-shared --disable-static --enable-pic --enable-libopenh264 --enable-encoder=libopenh264 --enable-mtl "${extra_config_flags[@]}"
 		make -j "$(nproc)"
 		sudo make install
 		sudo ldconfig

--- a/versions.env
+++ b/versions.env
@@ -8,6 +8,7 @@ RUST_HOOK_CARGO_VER=0.5.5
 FFMPEG_VERSION=7.0
 XDP_TOOLS_VER=1.6.3
 EBPF_VER=1.5.0
+SVT_JPEG_XS_VER=v0.9.0
 
 DPDK_REPO=https://github.com/dpdk/dpdk/archive/refs/tags/v${DPDK_VER}.tar.gz
 ICE_REPO=https://downloadmirror.intel.com/${ICE_DMID}/ice-${ICE_VER}.tar.gz


### PR DESCRIPTION
- Enhance mtl_plugin_check_cmd to detect outdated libSvtJpegxs core library
- Add central align_jpegxs_plugin.sh helper script to abstract compile/install steps
- Call central alignment helper from validation-tests workflow and validate-host action