### PR TITLE
Ci: skip copying missing jpeg-xs helper files on v0.9.0

### DIFF
--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -493,7 +493,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
 		if [ ! -d "${SVT_JPEG_XS_REPO}" ]; then
 			echo "Downloading SVT-JPEG-XS (${SVT_JPEG_XS_VER}) using wget..."
-			wget -q "https://github.com/OpenVisualCloud/SVT-JPEG-XS/archive/refs/tags/${SVT_JPEG_XS_VER}.tar.gz" -O "${setup_script_folder}/SVT-JPEG-XS.tar.gz"
+			if ! wget -q "https://github.com/OpenVisualCloud/SVT-JPEG-XS/archive/refs/tags/${SVT_JPEG_XS_VER}.tar.gz" -O "${setup_script_folder}/SVT-JPEG-XS.tar.gz"; then
+				wget -q "https://github.com/OpenVisualCloud/SVT-JPEG-XS/archive/${SVT_JPEG_XS_VER}.tar.gz" -O "${setup_script_folder}/SVT-JPEG-XS.tar.gz"
+			fi
 			mkdir -p "${SVT_JPEG_XS_REPO}"
 			tar -xzf "${setup_script_folder}/SVT-JPEG-XS.tar.gz" -C "${SVT_JPEG_XS_REPO}" --strip-components=1
 			rm -f "${setup_script_folder}/SVT-JPEG-XS.tar.gz"

--- a/ecosystem/ffmpeg_plugin/build.sh
+++ b/ecosystem/ffmpeg_plugin/build.sh
@@ -122,7 +122,10 @@ build_ffmpeg() {
 
 	if { [ "${FFMPEG_ENABLE_SVT_JPEG_XS:-0}" == "1" ] || [ "$enable_jpegxs" = true ]; } && [ -d "${jpegxs_repo}" ]; then
 		echo "Integrating SVT-JPEG-XS support into FFmpeg..."
-		cp -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxs"* libavcodec/
+		# copy wrapper files if they exist (not all SVT-JPEG-XS versions package them outside patches, e.g. v0.9.0 handles them fully inside the patches)
+		if [ -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxsenc.c" ] || [ -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxsdec.c" ]; then
+			cp -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxs"* libavcodec/
+		fi
 		for patch_file in "${jpegxs_repo}/ffmpeg-plugin/${FFMPEG_VERSION}"/*.patch; do
 			if [ -f "$patch_file" ]; then
 				echo "Applying SVT-JPEG-XS patch: $(basename "$patch_file")"

--- a/ecosystem/ffmpeg_plugin/build.sh
+++ b/ecosystem/ffmpeg_plugin/build.sh
@@ -126,7 +126,13 @@ build_ffmpeg() {
 		if [ -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxsenc.c" ] || [ -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxsdec.c" ]; then
 			cp -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxs"* libavcodec/
 		fi
-		for patch_file in "${jpegxs_repo}/ffmpeg-plugin/${FFMPEG_VERSION}"/*.patch; do
+
+		local patch_dir="${jpegxs_repo}/ffmpeg-plugin/${FFMPEG_VERSION}"
+		if [ ! -d "$patch_dir" ]; then
+			patch_dir="${jpegxs_repo}/ffmpeg-plugin"
+		fi
+
+		for patch_file in "${patch_dir}"/*.patch; do
 			if [ -f "$patch_file" ]; then
 				echo "Applying SVT-JPEG-XS patch: $(basename "$patch_file")"
 				patch -p1 <"$patch_file"

--- a/ecosystem/ffmpeg_plugin/build.sh
+++ b/ecosystem/ffmpeg_plugin/build.sh
@@ -120,9 +120,16 @@ build_ffmpeg() {
 		fi
 	fi
 
-	if { [ "${FFMPEG_ENABLE_SVT_JPEG_XS:-0}" == "1" ] || [ "$enable_jpegxs" = true ]; } && [ -d "${jpegxs_repo}" ]; then
+	if { [ "${FFMPEG_ENABLE_SVT_JPEG_XS:-0}" == "1" ] || [ "$enable_jpegxs" = true ]; }; then
 		echo "Integrating SVT-JPEG-XS support into FFmpeg..."
-		# copy wrapper files if they exist (not all SVT-JPEG-XS versions package them outside patches, e.g. v0.9.0 handles them fully inside the patches)
+		if [ ! -d "${jpegxs_repo}" ] && ! wget -q "https://github.com/OpenVisualCloud/SVT-JPEG-XS/archive/refs/tags/${SVT_JPEG_XS_VER}.tar.gz" -O "${script_path}/SVT-JPEG-XS.tar.gz"; then
+			wget -q "https://github.com/OpenVisualCloud/SVT-JPEG-XS/archive/${SVT_JPEG_XS_VER}.tar.gz" -O "${script_path}/SVT-JPEG-XS.tar.gz"
+
+			mkdir -p "${jpegxs_repo}"
+			tar -xzf "${script_path}/SVT-JPEG-XS.tar.gz" -C "${jpegxs_repo}" --strip-components=1
+			rm -f "${script_path}/SVT-JPEG-XS.tar.gz"
+		fi
+
 		if [ -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxsenc.c" ] || [ -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxsdec.c" ]; then
 			cp -f "${jpegxs_repo}/ffmpeg-plugin/libsvtjpegxs"* libavcodec/
 		fi

--- a/versions.env
+++ b/versions.env
@@ -8,7 +8,7 @@ RUST_HOOK_CARGO_VER=0.5.5
 FFMPEG_VERSION=7.0
 XDP_TOOLS_VER=1.6.3
 EBPF_VER=1.5.0
-SVT_JPEG_XS_VER=v0.9.0
+SVT_JPEG_XS_VER=8e50180ad909a0bdcdf91b462c64033f0fe3e112
 
 DPDK_REPO=https://github.com/dpdk/dpdk/archive/refs/tags/v${DPDK_VER}.tar.gz
 ICE_REPO=https://downloadmirror.intel.com/${ICE_DMID}/ice-${ICE_VER}.tar.gz


### PR DESCRIPTION
Ci: skip copying missing jpeg-xs helper files on v0.9.0