### PR TITLE
Fix: st41 fastmetadata pytest failures and stale SvtJpegxs CI staleness check

### DIFF
--- a/.github/scripts/setup_environment.sh
+++ b/.github/scripts/setup_environment.sh
@@ -487,6 +487,9 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		if ! ldconfig -p 2>/dev/null | grep -q "libSvtJpegxs.so.0"; then
 			echo "Core SvtJpegxs library not found."
 			need_build=1
+		elif ! pkg-config --atleast-version="${SVT_JPEG_XS_MIN_VER}" SvtJpegxs 2>/dev/null; then
+			echo "Core SvtJpegxs library is outdated (< ${SVT_JPEG_XS_MIN_VER} required by FFmpeg). Rebuilding."
+			need_build=1
 		fi
 
 		export SVT_JPEG_XS_REPO="${setup_script_folder}/SVT-JPEG-XS"

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -399,7 +399,7 @@ static void tx_fastmetadata_session_build_packet(
   struct rte_udp_hdr* udp;
   struct st41_rtp_hdr* rtp;
 
-  if (rte_pktmbuf_data_len(pkt) < sizeof(*hdr)) {
+  if (rte_pktmbuf_tailroom(pkt) < sizeof(*hdr)) {
     err("%s: packet is less than fmd hdr size", __func__);
     return;
   }
@@ -435,7 +435,8 @@ static void tx_fastmetadata_session_build_packet(
   uint16_t data_item_length =
       (data_item_length_bytes + 3) / 4; /* expressed in number of 4-byte words */
 
-  if (rte_pktmbuf_data_len(pkt) < sizeof(*hdr) + data_item_length_bytes) {
+  if (rte_pktmbuf_tailroom(pkt) + rte_pktmbuf_data_len(pkt) <
+      sizeof(*hdr) + data_item_length_bytes) {
     err("%s: packet doesn't contain RTP payload", __func__);
     return;
   }

--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -1409,6 +1409,20 @@ static int st_json_parse_tx_fmd(int idx, json_object* fmd_obj,
     fmd->info.fmd_fps = ST_FPS_P25;
   } else if (strcmp(fmd_fps, "p29") == 0) {
     fmd->info.fmd_fps = ST_FPS_P29_97;
+  } else if (strcmp(fmd_fps, "p119") == 0) {
+    fmd->info.fmd_fps = ST_FPS_P119_88;
+  } else if (strcmp(fmd_fps, "p120") == 0) {
+    fmd->info.fmd_fps = ST_FPS_P120;
+  } else if (strcmp(fmd_fps, "p100") == 0) {
+    fmd->info.fmd_fps = ST_FPS_P100;
+  } else if (strcmp(fmd_fps, "p60") == 0) {
+    fmd->info.fmd_fps = ST_FPS_P60;
+  } else if (strcmp(fmd_fps, "p30") == 0) {
+    fmd->info.fmd_fps = ST_FPS_P30;
+  } else if (strcmp(fmd_fps, "p24") == 0) {
+    fmd->info.fmd_fps = ST_FPS_P24;
+  } else if (strcmp(fmd_fps, "p23") == 0) {
+    fmd->info.fmd_fps = ST_FPS_P23_98;
   } else {
     err("%s, invalid fmd fps %s\n", __func__, fmd_fps);
     return -ST_JSON_NOT_VALID;

--- a/versions.env
+++ b/versions.env
@@ -9,6 +9,7 @@ FFMPEG_VERSION=7.0
 XDP_TOOLS_VER=1.6.3
 EBPF_VER=1.5.0
 SVT_JPEG_XS_VER=8e50180ad909a0bdcdf91b462c64033f0fe3e112
+SVT_JPEG_XS_MIN_VER=0.10.0
 
 DPDK_REPO=https://github.com/dpdk/dpdk/archive/refs/tags/v${DPDK_VER}.tar.gz
 ICE_REPO=https://downloadmirror.intel.com/${ICE_DMID}/ice-${ICE_VER}.tar.gz


### PR DESCRIPTION
Fixes test_st41_no_chain (ST2110-41 fast-metadata, no-RTP-chain mode) end
to end: a missing JSON fps option that made the RxTxApp config rejected, a
tx-side packet-size validation bug that rejected every packet, and a CI
staleness check that let a stale SvtJpegxs install silently break the
FFmpeg plugin build.

Changes:

Fix: parse_json.c — st_json_parse_tx_fmd()
only recognized p25/p29 for the fast-metadata fps JSON field; the
higher/lower frame rates used by test_st41_no_chain (p119, p120,
p100, p60, p30, p24, p23) fell through to the invalid fmd fps
error path. Added the missing mappings to ST_FPS_*.

Fix: st_tx_fastmetadata_session.c —
tx_fastmetadata_session_build_packet() validated packet capacity against
rte_pktmbuf_data_len(pkt), which is 0 right after rte_pktmbuf_alloc()
and still excludes the RTP header at the second check point. Both checks
therefore rejected every packet unconditionally (packet is less than fmd hdr size / invalid pkt_len 0 for every packet, per the failing-run log).
Switched to rte_pktmbuf_tailroom(pkt) [+ rte_pktmbuf_data_len(pkt)], which
reflects actual buffer capacity instead of bytes committed so far.

Fix: setup_environment.sh — the JPEG-XS
need_build staleness check only tested ldconfig SONAME presence, not
version, so a stale SvtJpegxs core lib (surviving git clean as a
system-wide install on a persistent self-hosted runner) was treated as
up-to-date after versions.env required SvtJpegxs >= 0.10.0 for the
FFmpeg plugin build. Added a pkg-config --atleast-version check so an
outdated install now triggers a rebuild instead of being silently skipped.
The minimum version is a new versions.env variable
(SVT_JPEG_XS_MIN_VER), matching the existing convention for pinned
versions rather than a literal in the script.