### PR TITLE
test: Mark ptp tests as xfail

### DIFF
--- a/tests/validation/tests/single/ptp/st20_interfaces_mix/test_st20_interfaces_mix_refactored.py
+++ b/tests/validation/tests/single/ptp/st20_interfaces_mix/test_st20_interfaces_mix_refactored.py
@@ -12,7 +12,7 @@ from mtl_engine.media_files import yuv_files_422rfc10
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.ptp
 @pytest.mark.parametrize(
     "interface_profile",


### PR DESCRIPTION
Marking the ptp tests as xfail due to the ptp tests failing due to the architecture not supporting multiple interfaces in the same iommu group.