### PR TITLE
build: fix compilation on non-x86 (aarch64) hosts

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -73,7 +73,9 @@ if is_windows
 endif
 
 # simd build option, enable sse4.2 default, todo: do we need AVX2/AVX512 for app ?
-app_c_args += ['-msse4.2']
+if cc.has_argument('-msse4.2')
+  app_c_args += ['-msse4.2']
+endif
 
 if is_windows
   ws2_32_dep = cc.find_library('ws2_32', required: true)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -98,7 +98,9 @@ mtl_c_args += ['-Wall']
 mtl_c_args += ['-Wunused-parameter']
 
 #simd build option, enable sse4.2 default
-mtl_c_args += ['-msse4.2']
+if cc.has_argument('-msse4.2')
+  mtl_c_args += ['-msse4.2']
+endif
 
 # default no asan dep
 asan_dep = []

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -1282,10 +1282,12 @@ int mtl_port_ip_info(mtl_handle mt, enum mtl_port port, uint8_t ip[MTL_IP_ADDR_L
 }
 
 enum mtl_simd_level mtl_get_simd_level(void) {
+#ifdef RTE_ARCH_X86
   if (rte_cpu_get_flag_enabled(RTE_CPUFLAG_AVX512VBMI2))
     return MTL_SIMD_LEVEL_AVX512_VBMI2;
   if (rte_cpu_get_flag_enabled(RTE_CPUFLAG_AVX512VL)) return MTL_SIMD_LEVEL_AVX512;
   if (rte_cpu_get_flag_enabled(RTE_CPUFLAG_AVX2)) return MTL_SIMD_LEVEL_AVX2;
+#endif
   /* no simd */
   return MTL_SIMD_LEVEL_NONE;
 }

--- a/lib/src/st2110/st_convert.c
+++ b/lib/src/st2110/st_convert.c
@@ -1001,6 +1001,7 @@ int st20_yuv422p10le_to_rfc4175_422be10_simd(uint16_t* y, uint16_t* b, uint16_t*
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -1024,6 +1025,11 @@ int st20_yuv422p10le_to_rfc4175_422be10_simd_dma(
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(udma);
+  MTL_MAY_UNUSED(y_iova);
+  MTL_MAY_UNUSED(b_iova);
+  MTL_MAY_UNUSED(r_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -1170,6 +1176,9 @@ int st20_rfc4175_422be10_to_yuv422p10le_simd_dma(mtl_udma_handle udma,
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(udma);
+  MTL_MAY_UNUSED(pg_be_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1282,6 +1291,7 @@ int st20_rfc4175_422be10_to_422le10_simd(struct st20_rfc4175_422_10_pg2_be* pg_b
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1328,6 +1338,8 @@ int st20_rfc4175_422be10_to_422le10_simd_dma(mtl_udma_handle udma,
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
   MTL_MAY_UNUSED(dma);
+  MTL_MAY_UNUSED(pg_be_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1390,6 +1402,7 @@ int st20_rfc4175_422le10_to_422be10_simd(struct st20_rfc4175_422_10_pg2_le* pg_l
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1436,6 +1449,8 @@ int st20_rfc4175_422le10_to_422be10_simd_dma(mtl_udma_handle udma,
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
   MTL_MAY_UNUSED(dma);
+  MTL_MAY_UNUSED(pg_le_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1485,6 +1500,7 @@ int st20_rfc4175_422be10_to_422le8_simd(struct st20_rfc4175_422_10_pg2_be* pg_10
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1522,6 +1538,8 @@ int st20_rfc4175_422be10_to_422le8_simd_dma(mtl_udma_handle udma,
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
   MTL_MAY_UNUSED(dma);
+  MTL_MAY_UNUSED(pg_10_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1679,6 +1697,7 @@ int st20_rfc4175_422le10_to_v210_simd(uint8_t* pg_le, uint8_t* pg_v210, uint32_t
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1787,6 +1806,7 @@ int st20_rfc4175_422be10_to_v210_simd(struct st20_rfc4175_422_10_pg2_be* pg_be,
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1903,6 +1923,8 @@ int st20_rfc4175_422be10_to_v210_simd_dma(mtl_udma_handle udma,
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
   MTL_MAY_UNUSED(dma);
+  MTL_MAY_UNUSED(pg_be_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -1973,6 +1995,7 @@ int st20_v210_to_rfc4175_422be10_simd(uint8_t* pg_v210,
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -2007,6 +2030,9 @@ int st20_v210_to_rfc4175_422be10_simd_dma(mtl_udma_handle udma, uint8_t* pg_v210
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(udma);
+  MTL_MAY_UNUSED(pg_v210_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -2057,6 +2083,7 @@ int st20_rfc4175_422be10_to_y210_simd(struct st20_rfc4175_422_10_pg2_be* pg_be,
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -2083,6 +2110,8 @@ int st20_rfc4175_422be10_to_y210_simd_dma(mtl_udma_handle udma,
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
   MTL_MAY_UNUSED(dma);
+  MTL_MAY_UNUSED(pg_be_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -2127,6 +2156,7 @@ int st20_y210_to_rfc4175_422be10_simd(uint16_t* pg_y210,
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -2151,6 +2181,9 @@ int st20_y210_to_rfc4175_422be10_simd_dma(mtl_udma_handle udma, uint16_t* pg_y21
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(udma);
+  MTL_MAY_UNUSED(pg_y210_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -2233,6 +2266,7 @@ int st20_rfc4175_422be12_to_yuv422p12le_simd(struct st20_rfc4175_422_12_pg2_be* 
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512_VBMI2
   if ((level >= MTL_SIMD_LEVEL_AVX512_VBMI2) &&
@@ -2269,6 +2303,8 @@ int st20_rfc4175_422be12_to_yuv422p12le_simd_dma(mtl_udma_handle udma,
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
   MTL_MAY_UNUSED(dma);
+  MTL_MAY_UNUSED(pg_be_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -2370,6 +2406,7 @@ int st20_rfc4175_422be12_to_422le12_simd(struct st20_rfc4175_422_12_pg2_be* pg_b
 
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {
@@ -2397,6 +2434,8 @@ int st20_rfc4175_422be12_to_422le12_simd_dma(mtl_udma_handle udma,
   MTL_MAY_UNUSED(cpu_level);
   MTL_MAY_UNUSED(ret);
   MTL_MAY_UNUSED(dma);
+  MTL_MAY_UNUSED(pg_be_iova);
+  MTL_MAY_UNUSED(level);
 
 #ifdef MTL_HAS_AVX512
   if ((level >= MTL_SIMD_LEVEL_AVX512) && (cpu_level >= MTL_SIMD_LEVEL_AVX512)) {

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -30,7 +30,9 @@ plugins_c_args += ['-Wall']
 plugins_c_args += ['-Wunused-parameter']
 
 #simd build option, enable sse4.2 default, todo: do we need AVX2/AVX512 for app ?
-plugins_c_args += ['-msse4.2']
+if cc.has_argument('-msse4.2')
+  plugins_c_args += ['-msse4.2']
+endif
 
 if is_windows
   ws2_32_dep = cc.find_library('ws2_32', required: true)

--- a/tests/tools/RxTxApp/meson.build
+++ b/tests/tools/RxTxApp/meson.build
@@ -72,7 +72,9 @@ if is_windows
 endif
 
 # simd build option, enable sse4.2 default, todo: do we need AVX2/AVX512 for app ?
-app_c_args += ['-msse4.2']
+if cc.has_argument('-msse4.2')
+  app_c_args += ['-msse4.2']
+endif
 
 # Keep column tracking enabled on large translation units to avoid misleading-indentation noise.
 app_c_args += ['-flarge-source-files']


### PR DESCRIPTION
## What

Stock MTL does not compile on non-x86 hosts (e.g. aarch64). Two small fixes, each using an idiom the codebase already has:

1. **build: pass -msse4.2 only when the compiler supports it** — the lib, app, plugins and RxTxApp meson files add `-msse4.2` unconditionally; non-x86 compilers reject the flag, so the build fails before any source compiles. Gate it behind `cc.has_argument('-msse4.2')` — the same pattern the AVX2/AVX512 flags already use. No change on x86, where the compiler accepts the flag.

2. **lib: fix non-x86 build of mt_main.c and st_convert.c** — `mtl_get_simd_level()` queries `RTE_CPUFLAG_AVX2/AVX512VL/AVX512VBMI2`, which DPDK declares only on x86; guard the probes with `RTE_ARCH_X86` and fall through to `MTL_SIMD_LEVEL_NONE`, matching the scalar fallbacks used everywhere else. With `MTL_HAS_AVX512*` undefined, the SIMD dispatch wrappers in `st_convert.c` leave their `level`/`udma`/iova parameters unused, which `-Werror -Wunused-parameter` rejects; add the `MTL_MAY_UNUSED()` markers the file already uses for exactly this in its other dispatch functions.

## Validation

- `main` + these two commits compiles cleanly on aarch64 (Ubuntu 24.04, gcc 13.3, DPDK v25.11 built with `-Dplatform=generic`): `meson setup` + `ninja` build `libmtl.so` with `-Werror` and no warnings.
- Full end-to-end validated at v26.01 + the same patches on the same host: lib, apps, plugins, RxTxApp and MtlManager all build; `pkg-config --modversion mtl` reports `26.01.0.REL`; RxTxApp loads and `mtl_init` correctly rejects an empty config.
- x86 behavior is unchanged by construction: `cc.has_argument('-msse4.2')` passes there, `RTE_ARCH_X86` is defined, and `MTL_MAY_UNUSED` is `(void)(x)`.

Both commits carry DCO `Signed-off-by`.