### PR TITLE
Ci: Never skip matrix jobs at job level, gate steps instead

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -62,13 +62,16 @@ jobs:
             image_suffix: "-rocky9"
     steps:
       - name: Harden Runner
+        if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: Checkout repository
+        if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
+        if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           buildkitd-flags: "--debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host"
@@ -77,7 +80,7 @@ jobs:
 
       - name: Login to Docker Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        if: ${{ env.DOCKER_REGISTRY_LOGIN == 'true' }}
+        if: ${{ needs.changes.outputs.ubuntu_build == 'true' && env.DOCKER_REGISTRY_LOGIN == 'true' }}
         id: dockerLoginStep
         continue-on-error: true
         with:
@@ -86,6 +89,7 @@ jobs:
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Build image (${{ matrix.name }})
+        if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: "${{ env.DOCKER_REGISTRY_LOGIN == 'true' && steps.dockerLoginStep.outcome == 'SUCCESS' && github.ref == 'refs/heads/main' }}"

--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -69,7 +69,6 @@ jobs:
     needs:
       - gtest-check-for-changes
       - build
-    if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
     strategy:
       matrix:
         nic:
@@ -80,32 +79,32 @@ jobs:
     runs-on: ${{ matrix.nic }}
     steps:
       - name: Harden Runner
-        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - name: Checkout MTL
-        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: OpenVisualCloud/Media-Transport-Library/.github/actions/checkout-clean@main
         with:
           ref: '${{ inputs.branch-to-checkout || github.sha || github.ref }}'
 
       - name: Validate host and download artifacts
-        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: ./.github/actions/validate-host
 
       - name: Check and build ice driver if needed
-        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         run: |
           if ! sudo modinfo ice | grep -Ei '^version:[[:space:]]*Kahawai_'; then ./script/build_ice_driver.sh; fi
 
       - name: 'cleanup: Kill stale processes before test'
-        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: ./.github/actions/cleanup
 
       - name: Run gtest bare metal
-        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         env:
           NIGHTLY: 0
           EXIT_ON_FAILURE: 1

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -52,7 +52,6 @@ jobs:
     needs:
       - smoke-check-for-changes
       - build
-    if: ${{ github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
     concurrency:
       group: smoke-${{ github.workflow }}-${{ github.ref }}-${{ matrix.nic }}
       cancel-in-progress: true
@@ -67,25 +66,25 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: 'preparation: Harden Runner'
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - name: 'preparation: Checkout MTL'
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: OpenVisualCloud/Media-Transport-Library/.github/actions/checkout-clean@main
         with:
           ref: '${{ github.ref }}'
       - name: 'preparation: Validate host and download artifacts'
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: ./.github/actions/validate-host
 
       - name: 'cleanup: Kill stale processes before test'
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         uses: ./.github/actions/cleanup
 
       - name: 'installation: Install pipenv environment'
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         working-directory: tests/validation
         id: pipenv-install
         run: |
@@ -93,12 +92,12 @@ jobs:
           source .venv/bin/activate
           pip install -r requirements.txt
       - name: Create session ID
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         run: |
           runner_name=${{ runner.name }}
           echo "SESSION_ID=${runner_name##*-}" >> "$GITHUB_ENV"
       - name: Set PCI device env variable
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         run: |
           if [ "${{ matrix.nic }}" = "e810" ]; then
             echo "PCI_DEVICE=8086:1592,8086:1592" >> "$GITHUB_ENV"
@@ -110,7 +109,7 @@ jobs:
             echo "PCI_DEVICE=8086:1249,8086:1249" >> "$GITHUB_ENV"
           fi
       - name: Generate test framework config files
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         working-directory: tests/validation/configs
         run: |
           python3 gen_config.py \
@@ -124,17 +123,17 @@ jobs:
             --ebu_user ${{ secrets.RUNNER_EBU_LIST_USER }} \
             --ebu_password ${{ secrets.RUNNER_EBU_LIST_PASSWORD }}
       - name: Export workflow tag for PCAP naming
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         shell: bash
         run: |
           echo "MTL_GITHUB_WORKFLOW=${{ github.workflow }}:${{ matrix.nic }}" >> "$GITHUB_ENV"
       - name: 'execution: Run validation-bare-metal tests in virtual environment'
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         timeout-minutes: 60
         run: |
           tests/validation/.venv/bin/python3 -m pytest --topology_config=tests/validation/configs/topology_config.yaml --test_config=tests/validation/configs/test_config.yaml -m smoke -x --template=html/index.html --report=report.html
       - name: "upload report"
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         id: upload-report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -142,7 +141,7 @@ jobs:
           path: |
             report.html
       - name: "Add report to summary"
-        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' }}
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.repository == 'OpenVisualCloud/Media-Transport-Library' }}
         run: |
           {
             echo "## Smoke Tests Report"


### PR DESCRIPTION
A false job-level if on a matrix job prevents GitHub from expanding the matrix at all, so it posts a single unsuffixed 'Skipped' check instead of one per matrix value. Required checks like 'run-gtest-tests (e810)' then never get created and branch protection waits on them forever.

run-gtest-tests and run-smoke-tests moved the github.repository guard from the job if down into every step's if alongside the existing changed check, so the job (and its full matrix) always runs and reports a status, just skipping the real work in a few seconds when nothing relevant changed.

ubuntu-docker-build had no gating at all and always ran a full image build regardless of path-filter results; its steps now skip the same way when ubuntu_build wasn't triggered.