### PR TITLE
Ci: Never skip the build gate job, only its steps

### DIFF
--- a/.github/workflows/gtest-bare-metal.yml
+++ b/.github/workflows/gtest-bare-metal.yml
@@ -50,17 +50,18 @@ jobs:
 
   build:
     needs: gtest-check-for-changes
-    if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Harden Runner
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Build workflow
+        if: ${{ needs.gtest-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
         uses: ./.github/actions/wait-for-workflow
         with:
           check_name: build

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -34,17 +34,18 @@ jobs:
           filters: .github/path_filters.yml
   build:
     needs: smoke-check-for-changes
-    if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Harden Runner
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Build workflow
+        if: ${{ needs.smoke-check-for-changes.outputs.changed == 'true' && github.event_name != 'workflow_dispatch' }}
         uses: ./.github/actions/wait-for-workflow
         with:
           check_name: build


### PR DESCRIPTION
run-gtest-tests and run-smoke-tests needs: [.., build], and a job that needs a skipped job is itself skipped even with a custom if that doesn't call always() -- so whenever changed was false the build gate job skipped, which skipped the whole matrix again, silently undoing the previous fix.

build's job-level if is dropped; the changed/workflow_dispatch check now only gates its own steps, so the job always completes and the matrix jobs depending on it never get skipped by inheritance.

Fixes: 63fc4046a24ad2ed80744ba14fac6b005cdd06bd