### PR TITLE
Fix: locking issue when using frame manual release

### DIFF
--- a/.github/instructions/mtl-gtest.instructions.md
+++ b/.github/instructions/mtl-gtest.instructions.md
@@ -41,6 +41,14 @@ applyTo: "tests/integration_tests/**,.github/scripts/gtest.sh"
 | `Dma*` | DMA engine tests (need --dma_dev) | ~1 min |
 | `Cvt*` | Color conversion tests | ~30s |
 
+## Pipeline TX Flag Semantics
+
+- `*_TX_FLAG_DROP_WHEN_LATE` requires `*_TX_FLAG_USER_PACING`; use a TAI frame timestamp for deterministic late-frame checks.
+- A dropped frame triggers `notify_frame_done` with `ST_FRAME_STATUS_DROPPED` and also triggers `notify_frame_late`; the callbacks are not mutually exclusive.
+- Buffer reclamation does not prove callback completion; synchronize callback observations independently.
+- `*_TX_FLAG_BLOCK_GET` timeouts apply to each `get_frame` wait and must exceed any deliberately scheduled future timestamp.
+- Every frame returned by `get_frame` remains application-owned until it is submitted or released with the matching `put_frame_abort` API.
+
 ## Quick Run (MCP tool preferred)
 
 ```bash

--- a/.github/instructions/mtl-validation-authoring.instructions.md
+++ b/.github/instructions/mtl-validation-authoring.instructions.md
@@ -1,0 +1,61 @@
+---
+description: "Use when authoring or refactoring pytest cases under tests/validation/tests/** or the shared engine under tests/validation/mtl_engine/**. Defines the functionality-first paradigm: tests verify a behavior (not a framework), parametrize by application, push shared/library-level logic into the Application base class, and keep app-specific translation in each adapter via universal params."
+name: "MTL Validation — Test Authoring Paradigm"
+applyTo: "tests/validation/tests/**,tests/validation/mtl_engine/**"
+---
+
+# Authoring MTL validation tests: test the functionality, not the framework
+
+A validation test verifies an MTL **behavior** (a frame rate is honored, a
+pixel format round-trips intact, latency stays bounded). It must not be written
+against one framework's mechanics. Follow this paradigm — [test_fps.py](../../tests/validation/tests/single/st20p/test_fps.py)
+is the reference.
+
+## 1. Parametrize by `application`
+
+```python
+@pytest.mark.parametrize("application", ["rxtxapp", "ffmpeg"])
+def test_st20p_xxx(application, app_factory, ...):
+    app = app_factory(application)
+    app.create_command(**config_params)   # universal params only
+    app.execute_test(build=mtl_path, host=host, ...)
+```
+
+List **only** the applications that actually support the behavior under test.
+If an adapter exposes no control for it, leave that application out and add it
+later when support lands. Do not fork the test per framework.
+
+## 2. Drive everything through universal params
+
+Tests pass framework-neutral `config_params`; each adapter translates them.
+When a feature needs a new knob:
+
+- add it to `UNIVERSAL_PARAMS` in
+  [config/universal_params.py](../../tests/validation/mtl_engine/config/universal_params.py)
+  (else `set_params` raises `Unknown parameter`);
+- wire the translation in each adapter's config/command builder
+  (`rxtxapp.py`, `ffmpeg.py`, `GstreamerApp.py`) — only in the ones that
+  support it.
+
+Never hardcode a framework's config shape (JSON keys, CLI flags) in the test.
+
+## 3. Push shared logic into the `Application` base class
+
+Anything not specific to one adapter lives in
+[application_base.py](../../tests/validation/mtl_engine/application_base.py),
+so every framework reuses it. In particular, **output emitted by libmtl itself
+is framework-agnostic** — the library prints the same session statistics no
+matter which application drives it, so parse it in the base class, not in a
+test or a single adapter. The test then calls a named helper and asserts on the
+returned value.
+
+Rule of thumb: if two adapters would copy the same helper, it belongs in the
+base class. If a test greps `self.last_output` (a `str`; split on `"\n"`),
+that grep almost certainly belongs in the base class or the adapter.
+
+## 4. Keep the test body about the behavior
+
+Build config → `create_command` → `execute_test` → assert via base-class /
+engine helpers. Use `fail_on_error=False` when the behavior under test
+deliberately breaks the default RX/TX result gate, and assert on the specific
+metric instead.

--- a/.github/mcp/run_server.sh
+++ b/.github/mcp/run_server.sh
@@ -18,9 +18,14 @@ if [[ ! -x "$VENV_DIR/bin/python3" ]]; then
 	python3 -m venv "$VENV_DIR"
 fi
 
+# Repair venv if pip is missing (e.g. venv created before ensurepip was available)
+if ! "$VENV_DIR/bin/python3" -m pip --version >/dev/null 2>&1; then
+	"$VENV_DIR/bin/python3" -m ensurepip --upgrade
+fi
+
 # Install deps if mcp module is missing
 if ! "$VENV_DIR/bin/python3" -c "import mcp" 2>/dev/null; then
-	"$VENV_DIR/bin/pip" install --quiet -r "$REQUIREMENTS"
+	"$VENV_DIR/bin/python3" -m pip install --quiet -r "$REQUIREMENTS"
 fi
 
 exec "$VENV_DIR/bin/python3" "$SERVER"

--- a/.github/mcp/run_validation_server.sh
+++ b/.github/mcp/run_validation_server.sh
@@ -18,9 +18,14 @@ if [[ ! -x "$VENV_DIR/bin/python3" ]]; then
 	python3 -m venv "$VENV_DIR"
 fi
 
+# Repair venv if pip is missing (e.g. venv created before ensurepip was available)
+if ! "$VENV_DIR/bin/python3" -m pip --version >/dev/null 2>&1; then
+	"$VENV_DIR/bin/python3" -m ensurepip --upgrade
+fi
+
 # Install deps if mcp module is missing
 if ! "$VENV_DIR/bin/python3" -c "import mcp" 2>/dev/null; then
-	"$VENV_DIR/bin/pip" install --quiet -r "$REQUIREMENTS"
+	"$VENV_DIR/bin/python3" -m pip install --quiet -r "$REQUIREMENTS"
 fi
 
 exec "$VENV_DIR/bin/python3" "$SERVER"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * st40: add RX timestamp to st40_frame_info
 * st30: add RX timestamp to st30_frame
 * st20/st30/st40: add TX_FLAG_EXACT_USER_PACING for precise user-controlled pacing
-* st20p: add ST20P_TX_FLAG_DROP_OLD_FRAME to fix buffer overflow in case of epoch drops
+* st20p: add ST20P_TX_FLAG_DROP_WHEN_LATE to fix buffer overflow in case of epoch drops
 * st20: Change ST2022-7 stream class from D to A; update packet detection and slot allocation
 * GStreamer: add ST40 RX plugin, DMA offload, zero-copy for ST20, PTP/redundant support
 * FFmpeg: add redundant mode support

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -1825,6 +1825,8 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
  * IN_USER state so the application can safely unmap / release external buffers.
  * Call this function once cleanup is complete to release the slot back to FREE.
  * When ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE is not set this is a silent no-op.
+ * When an internal converter is used, notify_frame_done fires before the slot
+ * is ever parked in IN_USER, so this is also always a silent no-op.
  *
  * @param handle
  *   The handle to the tx st2110-20 pipeline session.

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -902,10 +902,14 @@ struct st20p_tx_ops {
    */
   int (*notify_frame_available)(void* priv);
   /**
-   * Optional. Callback when frame done in the lib. If TX_FLAG_DROP_WHEN_LATE is enabled
-   * this will be called only when the notify_frame_late is not triggered.
+   * Optional. Callback when frame done in the lib.
    * And only non-block method can be used within this callback as it run from lcore
    * tasklet routine.
+   *
+   * Special case: if both ST20P_TX_FLAG_DROP_WHEN_LATE and ST20P_TX_FLAG_USER_PACING
+   * are enabled, it is also called for a frame dropped for being late, with
+   * frame->status set to ST_FRAME_STATUS_DROPPED. notify_frame_late fires for that
+   * same frame, the two callbacks are not mutually exclusive.
    */
   int (*notify_frame_done)(void* priv, struct st_frame* frame);
 
@@ -1083,10 +1087,14 @@ struct st22p_tx_ops {
    */
   int (*notify_frame_available)(void* priv);
   /**
-   * Optional. Callback when frame done in the lib. If TX_FLAG_DROP_WHEN_LATE is enabled
-   * this will be called only when the notify_frame_late is not triggered.
+   * Optional. Callback when frame done in the lib.
    * And only non-block method can be used within this callback as it run from lcore
    * tasklet routine.
+   *
+   * Special case: if both ST22P_TX_FLAG_DROP_WHEN_LATE and ST22P_TX_FLAG_USER_PACING
+   * are enabled, it is also called for a frame dropped for being late, with
+   * frame->status set to ST_FRAME_STATUS_DROPPED. notify_frame_late fires for that
+   * same frame, the two callbacks are not mutually exclusive.
    */
   int (*notify_frame_done)(void* priv, struct st_frame* frame);
 

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -156,9 +156,11 @@ static bool tx_st20p_if_frame_late(struct st20p_tx_ctx* ctx,
       cur_tai, frame_tai);
 
   if (ctx->ops.notify_frame_done && !framebuff->frame_done_cb_called) {
+    /* Set before the callback: it may release this slot to FREE, letting a
+     * concurrent get_frame() reset this same flag for the next cycle. */
+    framebuff->frame_done_cb_called = true;
     frame->status = ST_FRAME_STATUS_DROPPED;
     ctx->ops.notify_frame_done(ctx->ops.priv, frame);
-    framebuff->frame_done_cb_called = true;
   }
 
   if (ctx->ops.notify_frame_late) ctx->ops.notify_frame_late(ctx->ops.priv, 0);
@@ -278,9 +280,11 @@ static int tx_st20p_frame_done(void* priv, uint16_t frame_idx,
 
   if (ctx->ops.notify_frame_done &&
       !framebuff->frame_done_cb_called) { /* notify app which frame done */
+    /* Set before the callback: see the matching comment in
+     * tx_st20p_if_frame_late(). */
+    framebuff->frame_done_cb_called = true;
     frame->status = ST_FRAME_STATUS_COMPLETE;
     ctx->ops.notify_frame_done(ctx->ops.priv, frame);
-    framebuff->frame_done_cb_called = true;
   }
   if (ret == 0)
     atomic_fetch_add_explicit(&ctx->stat_frames_sent, 1, memory_order_relaxed);
@@ -375,8 +379,10 @@ static int tx_st20p_convert_put_frame(void* priv, struct st20_convert_frame_meta
   }
 
   if (ctx->ops.notify_frame_done && !framebuff->frame_done_cb_called) {
-    ctx->ops.notify_frame_done(ctx->ops.priv, &framebuff->src);
+    /* Set before the callback: see the matching comment in
+     * tx_st20p_if_frame_late(). */
     framebuff->frame_done_cb_called = true;
+    ctx->ops.notify_frame_done(ctx->ops.priv, &framebuff->src);
   }
 
   ret = 0;
@@ -973,8 +979,10 @@ int st20p_tx_put_ext_frame(st20p_tx_handle handle, struct st_frame* frame,
       atomic_store_explicit(&framebuff->stat, ST20P_TX_FRAME_CONVERTED,
                             memory_order_release);
       if (ctx->ops.notify_frame_done && !framebuff->frame_done_cb_called) {
-        ctx->ops.notify_frame_done(ctx->ops.priv, &framebuff->src);
+        /* Set before the callback: see the matching comment in
+         * tx_st20p_if_frame_late(). */
         framebuff->frame_done_cb_called = true;
+        ctx->ops.notify_frame_done(ctx->ops.priv, &framebuff->src);
       }
     } else {
       atomic_store_explicit(&framebuff->stat, ST20P_TX_FRAME_READY, memory_order_release);

--- a/lib/src/st2110/pipeline/st20_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st20_pipeline_tx.c
@@ -1025,15 +1025,19 @@ int st20p_tx_notify_ext_frame_free(st20p_tx_handle handle, struct st_frame* fram
     goto out;
   }
 
+  if (ctx->internal_converter) {
+    /* Internal converter releases the ext buffer synchronously in
+     * put_ext_frame; the frame never parks in IN_USER. Always a no-op. */
+    dbg("%s(%d), frame %u internal converter no-op\n", __func__, idx, framebuff->idx);
+    ret = 0;
+    goto out;
+  }
+
   if (ST20P_TX_FRAME_IN_USER !=
       atomic_load_explicit(&framebuff->stat, memory_order_acquire)) {
-    /* Frame is not in IN_USER, this happens when the converter already released
-     * the ext buffer during put_ext_frame and the frame went CONVERTED -> FREE
-     * without the IN_USER step.  Silently succeed so callers can always call
-     * this unconditionally from notify_frame_done. */
-    dbg("%s(%d), frame %u not in_user (stat %d), skip\n", __func__, idx, framebuff->idx,
+    err("%s(%d), frame %u not in_user (stat %d)\n", __func__, idx, framebuff->idx,
         (int)atomic_load_explicit(&framebuff->stat, memory_order_relaxed));
-    ret = 0;
+    ret = -EIO;
     goto out;
   }
   atomic_store_explicit(&framebuff->stat, ST20P_TX_FRAME_FREE, memory_order_release);

--- a/lib/src/st2110/st_tx_audio_session.c
+++ b/lib/src/st2110/st_tx_audio_session.c
@@ -721,7 +721,8 @@ static int tx_audio_session_tasklet_frame(struct mtl_main_impl* impl,
         if (frame_end_time > pacing->tsc_time_cursor) {
           s->port_user_stats.common.stat_exceed_frame_time++;
           dbg("%s(%d), frame %d build time out %" PRIu64 " us\n", __func__, idx,
-              s->st30_frame_idx, (frame_end_time - pacing->tsc_time_cursor) / NS_PER_US);
+              s->st30_frame_idx,
+              (uint64_t)((frame_end_time - pacing->tsc_time_cursor) / NS_PER_US));
         }
         s->check_frame_done_time = false;
       }

--- a/lib/src/st2110/st_tx_fastmetadata_session.c
+++ b/lib/src/st2110/st_tx_fastmetadata_session.c
@@ -703,7 +703,8 @@ static int tx_fastmetadata_session_tasklet_frame(
       if (frame_end_time > pacing->tsc_time_cursor) {
         s->port_user_stats.common.stat_exceed_frame_time++;
         dbg("%s(%d), frame %" PRIu16 " build time out %f us\n", __func__, idx,
-            s->st41_frame_idx, (frame_end_time - pacing->tsc_time_cursor) / NS_PER_US);
+            s->st41_frame_idx,
+            (double)((frame_end_time - pacing->tsc_time_cursor) / NS_PER_US));
       }
       s->check_frame_done_time = false;
     }

--- a/tests/integration_tests/st20p_test.cpp
+++ b/tests/integration_tests/st20p_test.cpp
@@ -2,6 +2,7 @@
  * Copyright(c) 2025 Intel Corporation
  */
 
+#include <set>
 #include <thread>
 
 #include "log.h"
@@ -233,6 +234,25 @@ static int test_st20p_tx_frame_done(void* priv, struct st_frame* frame) {
 
   err("%s(%d), unknown frame_addr %p\n", __func__, s->idx, frame->addr[0]);
   st20p_tx_notify_ext_frame_free((st20p_tx_handle)s->handle, frame);
+  return 0;
+}
+
+/* holds the first slot done past notify_frame_done, releasing every other
+ * slot immediately, to prove the two-phase MANUAL_RELEASE contract.
+ * held_frame is written on the pipeline scheduler thread and read from the
+ * test's main thread, so it must be atomic. */
+struct tx_ext_release_ctx {
+  st20p_tx_handle handle;
+  std::atomic<struct st_frame*> held_frame;
+};
+
+static int test_tx_ext_release_frame_done(void* priv, struct st_frame* frame) {
+  auto* s = (tx_ext_release_ctx*)priv;
+
+  struct st_frame* expected = nullptr;
+  if (s->held_frame.compare_exchange_strong(expected, frame)) return 0;
+
+  st20p_tx_notify_ext_frame_free(s->handle, frame);
   return 0;
 }
 
@@ -1651,6 +1671,134 @@ TEST(St20p, transport_yuv422p10le) {
   para.packing = ST20_PACKING_BPM;
 
   st20p_rx_digest_test(fps, width, height, tx_fmt, t_fmt, rx_fmt, &para);
+}
+
+/*
+ * Regression test for ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE's two-phase
+ * release contract: a slot held past notify_frame_done must stay IN_USER
+ * (unreclaimable by st20p_tx_get_frame) until the app explicitly calls
+ * st20p_tx_notify_ext_frame_free() on it.
+ */
+TEST(St20p, tx_ext_frame_manual_release_two_phase) {
+  auto ctx = (struct st_tests_context*)st_test_ctx();
+  auto st = ctx->handle;
+  int ret;
+
+  if (ctx->iova == MTL_IOVA_MODE_PA) {
+    info("%s, skip ext_buf test as it's PA iova mode\n", __func__);
+    return;
+  }
+
+  const int fb_cnt = 3;
+  const int width = 1920, height = 1080;
+  /* single-plane format equal to the transport format so ctx->derive is true:
+   * frames complete via tx_st20p_frame_done (not the internal-converter early
+   * release in put_ext_frame), which is the path that actually parks IN_USER. */
+  const enum st_frame_fmt fmt = ST_FRAME_FMT_YUV422RFC4175PG2BE10;
+
+  tx_ext_release_ctx tctx;
+  tctx.handle = nullptr;
+  tctx.held_frame = nullptr;
+
+  struct st20p_tx_ops ops_tx;
+  memset(&ops_tx, 0, sizeof(ops_tx));
+  ops_tx.name = "st20p_tx_ext_release_test";
+  ops_tx.priv = &tctx;
+  ops_tx.port.num_port = 1;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  snprintf(ops_tx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
+           ctx->para.port[MTL_PORT_P]);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ST20P_TEST_UDP_PORT;
+  ops_tx.port.payload_type = ST20P_TEST_PAYLOAD_TYPE;
+  ops_tx.width = width;
+  ops_tx.height = height;
+  ops_tx.fps = ST_FPS_P59_94;
+  ops_tx.input_fmt = fmt;
+  ops_tx.transport_fmt = ST20_FMT_YUV_422_10BIT;
+  ops_tx.device = ST_PLUGIN_DEVICE_TEST_INTERNAL;
+  ops_tx.framebuff_cnt = fb_cnt;
+  ops_tx.flags = ST20P_TX_FLAG_EXT_FRAME | ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE |
+                 ST20P_TX_FLAG_BLOCK_GET;
+  ops_tx.notify_frame_done = test_tx_ext_release_frame_done;
+
+  auto tx_handle = st20p_tx_create(st, &ops_tx);
+  ASSERT_TRUE(tx_handle != NULL);
+  tctx.handle = tx_handle;
+
+  ret = st20p_tx_set_block_timeout(tx_handle, NS_PER_S / 5); /* 200ms */
+  EXPECT_EQ(ret, 0);
+
+  size_t frame_size = st_frame_size(fmt, width, height, false);
+  size_t pg_sz = mtl_page_size(st);
+  size_t fb_size = frame_size * fb_cnt;
+  size_t ext_fb_iova_map_sz = mtl_size_page_align(fb_size, pg_sz);
+  size_t fb_size_malloc = ext_fb_iova_map_sz + pg_sz;
+  void* ext_fb_malloc = st_test_zmalloc(fb_size_malloc);
+  ASSERT_TRUE(ext_fb_malloc != NULL);
+  uint8_t* ext_fb = (uint8_t*)MTL_ALIGN((uint64_t)ext_fb_malloc, pg_sz);
+  mtl_iova_t ext_fb_iova = mtl_dma_map(st, ext_fb, ext_fb_iova_map_sz);
+  ASSERT_TRUE(ext_fb_iova != MTL_BAD_IOVA);
+
+  struct st_ext_frame ext_frames[fb_cnt];
+  memset(ext_frames, 0, sizeof(ext_frames));
+  for (int i = 0; i < fb_cnt; i++) {
+    ext_frames[i].addr[0] = ext_fb + i * frame_size;
+    ext_frames[i].iova[0] = ext_fb_iova + i * frame_size;
+    ext_frames[i].linesize[0] = st_frame_least_linesize(fmt, width, 0);
+    ext_frames[i].size = frame_size;
+  }
+
+  ret = mtl_start(st);
+  EXPECT_GE(ret, 0);
+
+  /* prime all fb_cnt slots so each has been claimed exactly once */
+  std::set<struct st_frame*> primed_frames;
+  int ext_idx = 0;
+  struct st_frame* frame;
+  for (int i = 0; i < fb_cnt; i++) {
+    frame = st20p_tx_get_frame(tx_handle);
+    ASSERT_TRUE(frame != NULL);
+    primed_frames.insert(frame);
+    ret = st20p_tx_put_ext_frame(tx_handle, frame, &ext_frames[ext_idx++ % fb_cnt]);
+    EXPECT_GE(ret, 0);
+  }
+  ASSERT_EQ((int)primed_frames.size(), fb_cnt);
+
+  /* steady state: one primed slot gets held forever by notify_frame_done,
+   * so get_frame must never reclaim more than fb_cnt - 1 distinct slots */
+  std::set<struct st_frame*> steady_frames;
+  const int steady_cycles = 30;
+  for (int i = 0; i < steady_cycles; i++) {
+    frame = st20p_tx_get_frame(tx_handle);
+    if (!frame) continue; /* timed out waiting on the held slot, expected */
+    steady_frames.insert(frame);
+    ret = st20p_tx_put_ext_frame(tx_handle, frame, &ext_frames[ext_idx++ % fb_cnt]);
+    EXPECT_GE(ret, 0);
+  }
+
+  ASSERT_TRUE(tctx.held_frame.load() != NULL);
+  EXPECT_EQ((int)steady_frames.size(), fb_cnt - 1);
+  EXPECT_EQ(steady_frames.count(tctx.held_frame.load()), 0u);
+
+  /* explicit release: only now can the held slot be reclaimed */
+  ret = st20p_tx_notify_ext_frame_free(tx_handle, tctx.held_frame.load());
+  EXPECT_GE(ret, 0);
+
+  bool held_reclaimed = false;
+  for (int i = 0; i < steady_cycles && !held_reclaimed; i++) {
+    frame = st20p_tx_get_frame(tx_handle);
+    if (!frame) continue;
+    if (frame == tctx.held_frame.load()) held_reclaimed = true;
+    ret = st20p_tx_put_ext_frame(tx_handle, frame, &ext_frames[ext_idx++ % fb_cnt]);
+    EXPECT_GE(ret, 0);
+  }
+  EXPECT_TRUE(held_reclaimed);
+
+  ret = st20p_tx_free(tx_handle);
+  EXPECT_GE(ret, 0);
+  mtl_dma_unmap(st, ext_fb, ext_fb_iova, ext_fb_iova_map_sz);
+  st_test_free(ext_fb_malloc);
 }
 
 TEST(St20p, tx_put_frame_abort) {

--- a/tests/integration_tests/st22p_test.cpp
+++ b/tests/integration_tests/st22p_test.cpp
@@ -2,6 +2,8 @@
  * Copyright(c) 2022 Intel Corporation
  */
 
+#include <atomic>
+#include <chrono>
 #include <thread>
 
 #include "log.h"
@@ -1554,4 +1556,148 @@ TEST(St22p, rx_put_frame_abort) {
 
   delete test_ctx_tx;
   delete test_ctx_rx;
+}
+
+/* written on the pipeline scheduler thread, read from the test's main thread,
+ * so they must be atomic. */
+struct st22p_tx_drop_late_ctx {
+  std::atomic<int> dropped_done_calls{0};
+  std::atomic<int> complete_done_calls{0};
+  std::atomic<int> late_calls{0};
+  /* total frames that have left the pipeline (transmitted or dropped) */
+  int done_total() const {
+    return dropped_done_calls.load() + complete_done_calls.load();
+  }
+};
+
+static int test_st22p_tx_drop_late_frame_done(void* priv, struct st_frame* frame) {
+  auto* s = (st22p_tx_drop_late_ctx*)priv;
+  if (frame->status == ST_FRAME_STATUS_DROPPED)
+    s->dropped_done_calls++;
+  else if (frame->status == ST_FRAME_STATUS_COMPLETE)
+    s->complete_done_calls++;
+  return 0;
+}
+
+static int test_st22p_tx_drop_late_frame_late(void* priv, uint64_t epoch_skipped) {
+  auto* s = (st22p_tx_drop_late_ctx*)priv;
+  (void)epoch_skipped;
+  s->late_calls++;
+  return 0;
+}
+
+/*
+ * Regression test for ST22P_TX_FLAG_DROP_WHEN_LATE end-to-end: a stale TAI
+ * timestamp forces tx_st22p_if_frame_late() to drop the frame (notify_frame_done
+ * DROPPED + notify_frame_late) and free its slot, while on-time frames transmit
+ * normally with no late notification.
+ */
+TEST(St22p, tx_drop_when_late) {
+  auto ctx = (struct st_tests_context*)st_test_ctx();
+  auto st = ctx->handle;
+  int ret;
+
+  const int fb_cnt = 4;
+  const int width = 1920, height = 1080;
+  const enum st_frame_fmt fmt = ST_FRAME_FMT_YUV422PLANAR10LE;
+  const enum st_fps fps = ST_FPS_P25;
+
+  st22p_tx_drop_late_ctx dctx;
+
+  struct st22p_tx_ops ops_tx;
+  memset(&ops_tx, 0, sizeof(ops_tx));
+  ops_tx.name = "st22p_tx_drop_when_late_test";
+  ops_tx.priv = &dctx;
+  ops_tx.port.num_port = 1;
+  memcpy(ops_tx.port.dip_addr[MTL_SESSION_PORT_P], ctx->mcast_ip_addr[MTL_PORT_P],
+         MTL_IP_ADDR_LEN);
+  snprintf(ops_tx.port.port[MTL_SESSION_PORT_P], MTL_PORT_MAX_LEN, "%s",
+           ctx->para.port[MTL_PORT_P]);
+  ops_tx.port.udp_port[MTL_SESSION_PORT_P] = ST22P_TEST_UDP_PORT;
+  ops_tx.port.payload_type = ST22P_TEST_PAYLOAD_TYPE;
+  ops_tx.width = width;
+  ops_tx.height = height;
+  ops_tx.fps = fps;
+  ops_tx.input_fmt = fmt;
+  ops_tx.pack_type = ST22_PACK_CODESTREAM;
+  ops_tx.codec = ST22_CODEC_JPEGXS;
+  ops_tx.device = ST_PLUGIN_DEVICE_TEST;
+  ops_tx.quality = ST22_QUALITY_MODE_QUALITY;
+  ops_tx.framebuff_cnt = fb_cnt;
+  ops_tx.codestream_size = st_frame_size(fmt, width, height, false) / 8;
+  ops_tx.flags =
+      ST22P_TX_FLAG_BLOCK_GET | ST22P_TX_FLAG_USER_PACING | ST22P_TX_FLAG_DROP_WHEN_LATE;
+  ops_tx.notify_frame_done = test_st22p_tx_drop_late_frame_done;
+  ops_tx.notify_frame_late = test_st22p_tx_drop_late_frame_late;
+
+  auto tx_handle = st22p_tx_create(st, &ops_tx);
+  ASSERT_TRUE(tx_handle != NULL);
+
+  ret = st22p_tx_set_block_timeout(tx_handle, (uint64_t)NS_PER_S * 3);
+  EXPECT_EQ(ret, 0);
+
+  ret = mtl_start(st);
+  EXPECT_GE(ret, 0);
+
+  uint64_t frame_period_ns = (uint64_t)((double)NS_PER_S / st_frame_rate(fps));
+
+  /* Produce exactly one frame and block until it leaves the pipeline (either
+   * transmitted or dropped). Keeping a single frame in flight is essential:
+   * tx_st22p_next_frame() always services the NEWEST ENCODED frame, so with
+   * several queued at once the older on-time frames would miss their own TX
+   * window and be dropped too, making the drop count non-deterministic. */
+  auto put_one_and_drain = [&](uint64_t timestamp) -> bool {
+    int done_before = dctx.done_total();
+    struct st_frame* frame = st22p_tx_get_frame(tx_handle);
+    if (!frame) return false;
+    frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+    frame->timestamp = timestamp;
+    if (st22p_tx_put_frame(tx_handle, frame) < 0) return false;
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (dctx.done_total() > done_before) return true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+  };
+
+  /* Warm-up: the first frames race session negotiation / link-up. Pump on-time
+   * frames one at a time until one actually transmits, proving the datapath is
+   * live, then snapshot the counters so link-up jitter cannot taint the asserts.
+   * The half-second margin keeps a warm-up frame from being ruled late while the
+   * link is still coming up. */
+  bool link_up = false;
+  auto warm_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+  while (std::chrono::steady_clock::now() < warm_deadline) {
+    put_one_and_drain(mtl_ptp_read_time(st) + NS_PER_S / 2);
+    if (dctx.complete_done_calls.load() > 0) {
+      link_up = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(link_up) << "datapath never came up (no frame transmitted)";
+
+  int base_dropped = dctx.dropped_done_calls.load();
+  int base_complete = dctx.complete_done_calls.load();
+  int base_late = dctx.late_calls.load();
+
+  /* Measured phase, datapath already live. On-time frames sit a few periods in
+   * the future so pipeline latency cannot make them late; each must transmit. */
+  const int on_time_cnt = 3;
+  for (int i = 0; i < on_time_cnt; i++) {
+    EXPECT_TRUE(put_one_and_drain(mtl_ptp_read_time(st) + frame_period_ns * 4))
+        << "on-time frame " << i << " never completed";
+  }
+
+  /* One clearly-stale frame: tx_st22p_if_frame_late() must drop it
+   * (notify_frame_done DROPPED + notify_frame_late) and free its slot. */
+  EXPECT_TRUE(put_one_and_drain(mtl_ptp_read_time(st) - NS_PER_S))
+      << "stale frame never left the pipeline";
+
+  EXPECT_EQ(dctx.dropped_done_calls.load() - base_dropped, 1);
+  EXPECT_EQ(dctx.complete_done_calls.load() - base_complete, on_time_cnt);
+  EXPECT_EQ(dctx.late_calls.load() - base_late, 1);
+
+  ret = st22p_tx_free(tx_handle);
+  EXPECT_GE(ret, 0);
 }

--- a/tests/tools/RxTxApp/src/app_base.h
+++ b/tests/tools/RxTxApp/src/app_base.h
@@ -103,7 +103,8 @@ struct st_display {
 struct st_user_time {
   uint64_t base_tai_time;
   pthread_mutex_t base_tai_time_mutex;
-  uint64_t user_time_offset;
+  /* signed: a negative offset starts the pacing clock in the past */
+  int64_t user_time_offset;
 };
 
 struct st_app_frameinfo {

--- a/tests/tools/RxTxApp/src/args.c
+++ b/tests/tools/RxTxApp/src/args.c
@@ -949,7 +949,7 @@ int st_app_parse_args(struct st_app_context* ctx, struct mtl_init_params* p, int
         p->flags |= MTL_FLAG_NO_MULTICAST;
         break;
       case ST_ARG_TX_USER_CLOCK_OFFSET:
-        ctx->user_time.user_time_offset = atoi(optarg);
+        ctx->user_time.user_time_offset = atoll(optarg);
         break;
       case ST_ARG_AUTO_STOP:
         ctx->auto_stop = true;

--- a/tests/tools/RxTxApp/src/parse_json.c
+++ b/tests/tools/RxTxApp/src/parse_json.c
@@ -2907,7 +2907,7 @@ int st_app_parse_json(st_json_context_t* ctx, const char* filename) {
       /* parse global clock offset options*/
       json_object* pacing_obj = st_json_object_object_get(tx_group, "user_time_offset");
       if (pacing_obj) {
-        ctx->user_time_offset = json_object_get_int(pacing_obj);
+        ctx->user_time_offset = json_object_get_int64(pacing_obj);
       } else {
         ctx->user_time_offset = ST_APP_USER_CLOCK_DEFAULT_OFFSET;
       }

--- a/tests/tools/RxTxApp/src/parse_json.h
+++ b/tests/tools/RxTxApp/src/parse_json.h
@@ -316,7 +316,7 @@ typedef struct st_json_context {
   bool shared_rx_queues;
   bool tx_no_chain;
   char* log_file;
-  uint64_t user_time_offset;
+  int64_t user_time_offset;
 
   st_json_video_session_t* tx_video_sessions;
   int tx_video_session_cnt;

--- a/tests/tools/RxTxApp/src/rxtx_app.c
+++ b/tests/tools/RxTxApp/src/rxtx_app.c
@@ -672,7 +672,8 @@ int main(int argc, char** argv) {
  */
 uint64_t st_app_user_time(void* ctx, struct st_user_time* user_time, uint64_t frame_num,
                           double frame_time, bool restart_base_time) {
-  uint64_t tai_time, offset;
+  uint64_t tai_time;
+  int64_t offset;
 
   if (!user_time) return 0;
 
@@ -693,7 +694,10 @@ uint64_t st_app_user_time(void* ctx, struct st_user_time* user_time, uint64_t fr
     pthread_mutex_unlock(&user_time->base_tai_time_mutex);
   }
   offset = user_time->user_time_offset;
-  tai_time = user_time->base_tai_time + offset + (uint64_t)(frame_time * frame_num);
+  /* offset may be negative to start the pacing clock in the past, presenting
+   * frames late (used by the drop-when-late tests) */
+  tai_time = user_time->base_tai_time + (uint64_t)(frame_time * frame_num);
+  tai_time = (uint64_t)((int64_t)tai_time + offset);
 
   return tai_time;
 }

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -82,6 +82,7 @@ unit_sources = [
   'pipeline/st40p_concurrency_test.cpp',
   'pipeline/st22p_harness.c',
   'pipeline/st22p_tx_harness.c',
+  'pipeline/st22p_tx_drop_when_late_test.cpp',
   'pipeline/st22p_concurrency_test.cpp',
   'pipeline/st22p_concurrency_stress_test.cpp',
   'ptp/ptp_harness.c',

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -69,6 +69,7 @@ unit_sources = [
   'pipeline/st20p_tx_harness.c',
   'pipeline/st20p_tx_concurrency_test.cpp',
   'pipeline/st20p_tx_blocking_test.cpp',
+  'pipeline/st20p_tx_ext_frame_release_test.cpp',
   'pipeline/st20p_concurrency_test.cpp',
   'pipeline/st20p_concurrency_stress_test.cpp',
   'pipeline/st30p_harness.c',

--- a/tests/unit/pipeline/st20p_tx_ext_frame_release_test.cpp
+++ b/tests/unit/pipeline/st20p_tx_ext_frame_release_test.cpp
@@ -51,6 +51,19 @@ int OnFrameDone(void* priv, struct st_frame* frame) {
   return 0;
 }
 
+int OnFrameDoneReleaseOnly(void* priv, struct st_frame* frame) {
+  auto* cb = static_cast<CallbackCtx*>(priv);
+  cb->call_count++;
+  ut20p_tx_notify_ext_frame_free(cb->tx_ctx, ut20p_tx_frame_idx(frame));
+  return 0;
+}
+
+int OnFrameDoneCountOnly(void* priv, struct st_frame* frame) {
+  auto* cb = static_cast<CallbackCtx*>(priv);
+  cb->call_count++;
+  return 0;
+}
+
 }  // namespace
 
 TEST(St20PipelineTxExtFrameRelease, DoneNotSkippedAcrossReusedSlot) {
@@ -77,6 +90,10 @@ TEST(St20PipelineTxExtFrameRelease, DoneNotSkippedAcrossReusedSlot) {
   ASSERT_NE(cb_ctx.next_cycle_frame, nullptr)
       << "cycle 2 should have claimed the slot cycle 1's callback just freed";
 
+  int idx0 = ut20p_tx_frame_idx(frame1);
+  ASSERT_EQ(ut20p_tx_frame_stat(ctx, idx0),
+            5 /* IN_USER: reclaimed by cycle 2's get_frame */);
+
   /* cycle 2: put -> next -> done, using the frame claimed from inside cycle
    * 1's callback. This is a genuinely new, fully-transmitted frame and must
    * get its own notify_frame_done call. */
@@ -89,6 +106,86 @@ TEST(St20PipelineTxExtFrameRelease, DoneNotSkippedAcrossReusedSlot) {
       << "cycle 2 completed transmission but notify_frame_done was silently "
          "skipped: frame_done_cb_called was clobbered back to true by cycle "
          "1's post-callback write racing cycle 2's get_frame() reset";
+  EXPECT_EQ(ut20p_tx_frame_stat(ctx, idx0),
+            0 /* FREE: cycle 2 released, nothing reclaims it */);
+
+  ut20p_tx_ctx_destroy(ctx);
+}
+
+TEST(St20PipelineTxExtFrameRelease, NotifyFreeOnNonInUserFrameReturnsError) {
+  ASSERT_EQ(ut20p_tx_init(), 0) << "EAL init failed";
+
+  ut20p_tx_ctx* ctx = ut20p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut20p_tx_ctx_set_manual_release(ctx);
+
+  /* freshly created framebuffer starts FREE, not IN_USER. */
+  EXPECT_LT(ut20p_tx_notify_ext_frame_free(ctx, 0), 0);
+
+  ut20p_tx_ctx_destroy(ctx);
+}
+
+TEST(St20PipelineTxExtFrameRelease, NCycleReuseNoDrift) {
+  ASSERT_EQ(ut20p_tx_init(), 0) << "EAL init failed";
+
+  ut20p_tx_ctx* ctx = ut20p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut20p_tx_ctx_set_manual_release(ctx);
+
+  CallbackCtx cb_ctx;
+  cb_ctx.tx_ctx = ctx;
+  ut20p_tx_set_notify_frame_done(ctx, OnFrameDoneReleaseOnly, &cb_ctx);
+
+  constexpr int kCycles = 5;
+  for (int c = 0; c < kCycles; c++) {
+    struct st_frame* frame = ut20p_tx_get_frame(ctx);
+    ASSERT_NE(frame, nullptr) << "cycle " << c;
+    int idx0 = ut20p_tx_frame_idx(frame);
+
+    ASSERT_EQ(ut20p_tx_put_frame(ctx, frame), 0) << "cycle " << c;
+    uint16_t idx;
+    ASSERT_EQ(ut20p_tx_next_frame(ctx, &idx), 0) << "cycle " << c;
+    ASSERT_EQ(ut20p_tx_frame_done(ctx, idx), 0) << "cycle " << c;
+
+    EXPECT_EQ(cb_ctx.call_count, c + 1) << "cycle " << c;
+    EXPECT_EQ(ut20p_tx_frame_stat(ctx, idx0), 0 /* FREE */) << "cycle " << c;
+  }
+
+  ut20p_tx_ctx_destroy(ctx);
+}
+
+TEST(St20PipelineTxExtFrameRelease, InternalConverterNotifyFreeIsNoOp) {
+  ASSERT_EQ(ut20p_tx_init(), 0) << "EAL init failed";
+
+  ut20p_tx_ctx* ctx = ut20p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut20p_tx_ctx_set_internal_converter(ctx);
+  ut20p_tx_ctx_set_manual_release(ctx);
+
+  CallbackCtx cb_ctx;
+  cb_ctx.tx_ctx = ctx;
+  ut20p_tx_set_notify_frame_done(ctx, OnFrameDoneCountOnly, &cb_ctx);
+
+  struct st_frame* frame = ut20p_tx_get_frame(ctx);
+  ASSERT_NE(frame, nullptr);
+  int idx0 = ut20p_tx_frame_idx(frame);
+
+  uint8_t buf[256];
+  struct st_ext_frame ext_frame = {};
+  ext_frame.addr[0] = buf;
+  ext_frame.linesize[0] = 128; /* UYVY, 64px * 2 bytes/px */
+  ext_frame.size = sizeof(buf);
+
+  ASSERT_EQ(ut20p_tx_put_ext_frame(ctx, frame, &ext_frame), 0);
+
+  ASSERT_EQ(cb_ctx.call_count, 1)
+      << "internal converter must fire notify_frame_done synchronously inside "
+         "put_ext_frame";
+  ASSERT_EQ(ut20p_tx_frame_stat(ctx, idx0), 3 /* CONVERTED, never parked IN_USER */);
+
+  EXPECT_EQ(ut20p_tx_notify_ext_frame_free(ctx, idx0), 0)
+      << "internal-converter path must be a silent no-op regardless of frame state, "
+         "not -EIO for not being IN_USER";
 
   ut20p_tx_ctx_destroy(ctx);
 }

--- a/tests/unit/pipeline/st20p_tx_ext_frame_release_test.cpp
+++ b/tests/unit/pipeline/st20p_tx_ext_frame_release_test.cpp
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * ST20p (video) TX EXT_FRAME_MANUAL_RELEASE notify_frame_done regression test.
+ *
+ * tx_st20p_frame_done() transitions a completed frame IN_TRANSMITTING->IN_USER
+ * *before* invoking ctx->ops.notify_frame_done(), specifically so the app can
+ * call st20p_tx_notify_ext_frame_free() (IN_USER->FREE) from inside that
+ * callback. Only after the callback returns does it write
+ * framebuff->frame_done_cb_called = true -- a plain, non-atomic bool, unlike
+ * every other cross-thread-shared field on the framebuff, which uses C11
+ * atomics.
+ *
+ * A natural producer immediately pulls the next frame once its slot is freed
+ * (e.g. woken by the release, or -- as here -- from directly inside the same
+ * notify_frame_done call). get_frame() claims the just-freed slot and resets
+ * frame_done_cb_called to false for the new cycle. That reset lands *before*
+ * the still-executing outer frame_done() writes frame_done_cb_called = true
+ * for the *previous* cycle, clobbering the new cycle's flag back to true.
+ * When the new cycle's own frame_done() runs later, its guard
+ * (!frame_done_cb_called) is now false, so notify_frame_done is silently
+ * skipped for a frame that genuinely completed transmission -- the app is
+ * never told to release its external buffer.
+ */
+
+#include <gtest/gtest.h>
+
+#include "pipeline/st20p_tx_harness.h"
+
+namespace {
+
+struct CallbackCtx {
+  ut20p_tx_ctx* tx_ctx;
+  int call_count = 0;
+  struct st_frame* next_cycle_frame = nullptr;
+};
+
+int OnFrameDone(void* priv, struct st_frame* frame) {
+  auto* cb = static_cast<CallbackCtx*>(priv);
+  cb->call_count++;
+
+  /* release the ext buffer, exactly as EXT_FRAME_MANUAL_RELEASE intends. */
+  ut20p_tx_notify_ext_frame_free(cb->tx_ctx, ut20p_tx_frame_idx(frame));
+
+  if (cb->call_count == 1) {
+    /* pull the next frame immediately, as a tight producer loop would once
+     * woken by the release above. */
+    cb->next_cycle_frame = ut20p_tx_get_frame(cb->tx_ctx);
+  }
+
+  return 0;
+}
+
+}  // namespace
+
+TEST(St20PipelineTxExtFrameRelease, DoneNotSkippedAcrossReusedSlot) {
+  ASSERT_EQ(ut20p_tx_init(), 0) << "EAL init failed";
+
+  ut20p_tx_ctx* ctx = ut20p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut20p_tx_ctx_set_manual_release(ctx);
+
+  CallbackCtx cb_ctx;
+  cb_ctx.tx_ctx = ctx;
+  ut20p_tx_set_notify_frame_done(ctx, OnFrameDone, &cb_ctx);
+
+  /* cycle 1: get -> put -> next -> done. done's callback releases the slot
+   * and immediately claims it again for cycle 2. */
+  struct st_frame* frame1 = ut20p_tx_get_frame(ctx);
+  ASSERT_NE(frame1, nullptr);
+  ASSERT_EQ(ut20p_tx_put_frame(ctx, frame1), 0);
+  uint16_t idx;
+  ASSERT_EQ(ut20p_tx_next_frame(ctx, &idx), 0);
+  ASSERT_EQ(ut20p_tx_frame_done(ctx, idx), 0);
+
+  ASSERT_EQ(cb_ctx.call_count, 1) << "cycle 1 must notify exactly once";
+  ASSERT_NE(cb_ctx.next_cycle_frame, nullptr)
+      << "cycle 2 should have claimed the slot cycle 1's callback just freed";
+
+  /* cycle 2: put -> next -> done, using the frame claimed from inside cycle
+   * 1's callback. This is a genuinely new, fully-transmitted frame and must
+   * get its own notify_frame_done call. */
+  struct st_frame* frame2 = cb_ctx.next_cycle_frame;
+  ASSERT_EQ(ut20p_tx_put_frame(ctx, frame2), 0);
+  ASSERT_EQ(ut20p_tx_next_frame(ctx, &idx), 0);
+  ASSERT_EQ(ut20p_tx_frame_done(ctx, idx), 0);
+
+  EXPECT_EQ(cb_ctx.call_count, 2)
+      << "cycle 2 completed transmission but notify_frame_done was silently "
+         "skipped: frame_done_cb_called was clobbered back to true by cycle "
+         "1's post-callback write racing cycle 2's get_frame() reset";
+
+  ut20p_tx_ctx_destroy(ctx);
+}

--- a/tests/unit/pipeline/st20p_tx_harness.c
+++ b/tests/unit/pipeline/st20p_tx_harness.c
@@ -139,6 +139,13 @@ int ut20p_tx_notify_ext_frame_free(ut20p_tx_ctx* ctx, uint16_t idx) {
   return st20p_tx_notify_ext_frame_free(&ctx->pipeline, frame);
 }
 
+void ut20p_tx_set_notify_frame_done(ut20p_tx_ctx* ctx,
+                                    int (*cb)(void* priv, struct st_frame* frame),
+                                    void* priv) {
+  ctx->pipeline.ops.notify_frame_done = cb;
+  ctx->pipeline.ops.priv = priv;
+}
+
 void ut20p_tx_set_frame_ready(ut20p_tx_ctx* ctx, int idx) {
   __atomic_store_n(&ctx->framebuffs[idx].stat, ST20P_TX_FRAME_READY, __ATOMIC_RELEASE);
 }

--- a/tests/unit/pipeline/st20p_tx_harness.c
+++ b/tests/unit/pipeline/st20p_tx_harness.c
@@ -133,9 +133,42 @@ void ut20p_tx_ctx_set_manual_release(ut20p_tx_ctx* ctx) {
   ctx->pipeline.ops.flags |= ST20P_TX_FLAG_EXT_FRAME_MANUAL_RELEASE;
 }
 
+static int ut20p_tx_stub_convert(struct st_frame* src, struct st_frame* dst) {
+  MTL_MAY_UNUSED(src);
+  MTL_MAY_UNUSED(dst);
+  return 0;
+}
+
+static struct st_frame_converter ut20p_tx_stub_converter = {
+    .convert_func = ut20p_tx_stub_convert,
+};
+
+void ut20p_tx_ctx_set_internal_converter(ut20p_tx_ctx* ctx) {
+  struct st20p_tx_ctx* p = &ctx->pipeline;
+  const enum st_frame_fmt fmt = ST_FRAME_FMT_UYVY;
+  const uint32_t width = 64, height = 2;
+
+  p->derive = false;
+  p->internal_converter = &ut20p_tx_stub_converter;
+  p->ops.flags |= ST20P_TX_FLAG_EXT_FRAME;
+
+  for (int i = 0; i < ctx->framebuff_cnt; i++) {
+    struct st20p_tx_frame* fb = &ctx->framebuffs[i];
+    fb->src.priv = fb;
+    fb->src.fmt = fmt;
+    fb->src.width = width;
+    fb->src.height = height;
+    fb->src.interlaced = false;
+  }
+}
+
+int ut20p_tx_put_ext_frame(ut20p_tx_ctx* ctx, struct st_frame* frame,
+                           struct st_ext_frame* ext_frame) {
+  return st20p_tx_put_ext_frame(&ctx->pipeline, frame, ext_frame);
+}
+
 int ut20p_tx_notify_ext_frame_free(ut20p_tx_ctx* ctx, uint16_t idx) {
-  /* derive path: the user-facing frame is &dst (dst.priv -> framebuff). */
-  struct st_frame* frame = &ctx->framebuffs[idx].dst;
+  struct st_frame* frame = tx_st20p_user_frame(&ctx->pipeline, &ctx->framebuffs[idx]);
   return st20p_tx_notify_ext_frame_free(&ctx->pipeline, frame);
 }
 

--- a/tests/unit/pipeline/st20p_tx_harness.h
+++ b/tests/unit/pipeline/st20p_tx_harness.h
@@ -68,6 +68,18 @@ int ut20p_tx_frame_done(ut20p_tx_ctx* ctx, uint16_t idx);
  */
 void ut20p_tx_ctx_set_manual_release(ut20p_tx_ctx* ctx);
 
+/**
+ * Switch the ctx to the internal-converter path (ctx->derive = false, a stub
+ * converter installed): put_ext_frame then converts synchronously and fires
+ * notify_frame_done early with the frame left CONVERTED, never IN_USER. Also
+ * sets ST20P_TX_FLAG_EXT_FRAME. Call before ut20p_tx_get_frame().
+ */
+void ut20p_tx_ctx_set_internal_converter(ut20p_tx_ctx* ctx);
+
+/** Wraps st20p_tx_put_ext_frame(). */
+int ut20p_tx_put_ext_frame(ut20p_tx_ctx* ctx, struct st_frame* frame,
+                           struct st_ext_frame* ext_frame);
+
 /** Wraps st20p_tx_notify_ext_frame_free(): IN_USER -> FREE. */
 int ut20p_tx_notify_ext_frame_free(ut20p_tx_ctx* ctx, uint16_t idx);
 

--- a/tests/unit/pipeline/st20p_tx_harness.h
+++ b/tests/unit/pipeline/st20p_tx_harness.h
@@ -71,6 +71,11 @@ void ut20p_tx_ctx_set_manual_release(ut20p_tx_ctx* ctx);
 /** Wraps st20p_tx_notify_ext_frame_free(): IN_USER -> FREE. */
 int ut20p_tx_notify_ext_frame_free(ut20p_tx_ctx* ctx, uint16_t idx);
 
+/** Register ops.notify_frame_done, so frame_done()/if_frame_late() invoke it. */
+void ut20p_tx_set_notify_frame_done(ut20p_tx_ctx* ctx,
+                                    int (*cb)(void* priv, struct st_frame* frame),
+                                    void* priv);
+
 /**
  * Set framebuffer i to READY state (not yet converted), so that
  * tx_st20p_convert_get_frame finds it in the concurrent-converter tests.

--- a/tests/unit/pipeline/st22p_tx_drop_when_late_test.cpp
+++ b/tests/unit/pipeline/st22p_tx_drop_when_late_test.cpp
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * ST22p (compressed video) TX ST22P_TX_FLAG_DROP_WHEN_LATE regression test.
+ *
+ * tx_st22p_if_frame_late() only fires when both ST22P_TX_FLAG_DROP_WHEN_LATE
+ * and ST22P_TX_FLAG_USER_PACING are set and the newest ENCODED frame carries a
+ * TAI timestamp already past its one-frame-period TX window. On a hit it
+ * drives ENCODED -> DROPPED -> FREE, firing notify_frame_done(DROPPED) once
+ * and then notify_frame_late(), before tx_st22p_next_frame() reports -EBUSY.
+ */
+
+#include <gtest/gtest.h>
+
+#include "pipeline/st22p_tx_harness.h"
+
+namespace {
+
+constexpr uint64_t kBaseTaiNs = 1000000000ULL;        /* 1s */
+constexpr uint64_t kFramePeriodNs25Fps = 40000000ULL; /* NS_PER_S / 25 */
+
+struct CallbackCtx {
+  int done_calls = 0;
+  enum st_frame_status last_done_status = ST_FRAME_STATUS_MAX;
+  int late_calls = 0;
+};
+
+int OnFrameDone(void* priv, struct st_frame* frame) {
+  auto* cb = static_cast<CallbackCtx*>(priv);
+  cb->done_calls++;
+  cb->last_done_status = frame->status;
+  return 0;
+}
+
+int OnFrameLate(void* priv, uint64_t epoch_skipped) {
+  auto* cb = static_cast<CallbackCtx*>(priv);
+  (void)epoch_skipped;
+  cb->late_calls++;
+  return 0;
+}
+
+}  // namespace
+
+TEST(St22PipelineTxDropWhenLate, LateFrameIsDroppedAndFreed) {
+  ASSERT_EQ(ut22p_tx_init(), 0) << "EAL init failed";
+
+  ut22p_tx_ctx* ctx = ut22p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut22p_tx_set_flags(ctx, ST22P_TX_FLAG_DROP_WHEN_LATE | ST22P_TX_FLAG_USER_PACING);
+  ut22p_tx_set_fps(ctx, ST_FPS_P25);
+
+  CallbackCtx cb_ctx;
+  ut22p_tx_set_notify_frame_done(ctx, OnFrameDone, &cb_ctx);
+  ut22p_tx_set_notify_frame_late(ctx, OnFrameLate, &cb_ctx);
+
+  struct st_frame* frame = ut22p_tx_get_frame(ctx);
+  ASSERT_NE(frame, nullptr);
+  frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+  frame->timestamp = kBaseTaiNs;
+  ASSERT_EQ(ut22p_tx_put_frame(ctx, frame), 0);
+  int idx0 = ut22p_tx_frame_idx(frame);
+
+  /* mock wall clock already past the one-period TX window. */
+  ut22p_tx_set_ptp_ns(ctx, kBaseTaiNs + kFramePeriodNs25Fps);
+
+  uint16_t idx;
+  EXPECT_EQ(ut22p_tx_next_frame(ctx, &idx), -EBUSY)
+      << "dropped frame leaves nothing to transmit";
+  EXPECT_EQ(ut22p_tx_frame_stat(ctx, idx0), 0 /* FREE */);
+  EXPECT_EQ(cb_ctx.done_calls, 1);
+  EXPECT_EQ(cb_ctx.last_done_status, ST_FRAME_STATUS_DROPPED);
+  EXPECT_EQ(cb_ctx.late_calls, 1);
+
+  ut22p_tx_ctx_destroy(ctx);
+}
+
+TEST(St22PipelineTxDropWhenLate, OnTimeFrameIsTransmittedNotDropped) {
+  ASSERT_EQ(ut22p_tx_init(), 0) << "EAL init failed";
+
+  ut22p_tx_ctx* ctx = ut22p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut22p_tx_set_flags(ctx, ST22P_TX_FLAG_DROP_WHEN_LATE | ST22P_TX_FLAG_USER_PACING);
+  ut22p_tx_set_fps(ctx, ST_FPS_P25);
+
+  CallbackCtx cb_ctx;
+  ut22p_tx_set_notify_frame_done(ctx, OnFrameDone, &cb_ctx);
+  ut22p_tx_set_notify_frame_late(ctx, OnFrameLate, &cb_ctx);
+
+  struct st_frame* frame = ut22p_tx_get_frame(ctx);
+  ASSERT_NE(frame, nullptr);
+  frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+  frame->timestamp = kBaseTaiNs;
+  ASSERT_EQ(ut22p_tx_put_frame(ctx, frame), 0);
+  int idx0 = ut22p_tx_frame_idx(frame);
+
+  /* mock wall clock still within the TX window. */
+  ut22p_tx_set_ptp_ns(ctx, kBaseTaiNs + kFramePeriodNs25Fps - 1);
+
+  uint16_t idx;
+  EXPECT_EQ(ut22p_tx_next_frame(ctx, &idx), 0);
+  EXPECT_EQ(idx, idx0);
+  EXPECT_EQ(ut22p_tx_frame_stat(ctx, idx0), 6 /* IN_TRANSMITTING */);
+  EXPECT_EQ(cb_ctx.late_calls, 0);
+
+  ut22p_tx_ctx_destroy(ctx);
+}
+
+TEST(St22PipelineTxDropWhenLate, MissingUserPacingFlagDoesNotDrop) {
+  ASSERT_EQ(ut22p_tx_init(), 0) << "EAL init failed";
+
+  ut22p_tx_ctx* ctx = ut22p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut22p_tx_set_flags(ctx, ST22P_TX_FLAG_DROP_WHEN_LATE); /* no USER_PACING */
+  ut22p_tx_set_fps(ctx, ST_FPS_P25);
+
+  CallbackCtx cb_ctx;
+  ut22p_tx_set_notify_frame_done(ctx, OnFrameDone, &cb_ctx);
+  ut22p_tx_set_notify_frame_late(ctx, OnFrameLate, &cb_ctx);
+
+  struct st_frame* frame = ut22p_tx_get_frame(ctx);
+  ASSERT_NE(frame, nullptr);
+  frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+  frame->timestamp = kBaseTaiNs;
+  ASSERT_EQ(ut22p_tx_put_frame(ctx, frame), 0);
+  int idx0 = ut22p_tx_frame_idx(frame);
+
+  /* would be late if the gate were satisfied. */
+  ut22p_tx_set_ptp_ns(ctx, kBaseTaiNs + kFramePeriodNs25Fps);
+
+  uint16_t idx;
+  EXPECT_EQ(ut22p_tx_next_frame(ctx, &idx), 0);
+  EXPECT_EQ(idx, idx0);
+  EXPECT_EQ(ut22p_tx_frame_stat(ctx, idx0), 6 /* IN_TRANSMITTING */);
+  EXPECT_EQ(cb_ctx.late_calls, 0);
+
+  ut22p_tx_ctx_destroy(ctx);
+}
+
+TEST(St22PipelineTxDropWhenLate, MissingDropWhenLateFlagDoesNotDrop) {
+  ASSERT_EQ(ut22p_tx_init(), 0) << "EAL init failed";
+
+  ut22p_tx_ctx* ctx = ut22p_tx_ctx_create(1);
+  ASSERT_NE(ctx, nullptr);
+  ut22p_tx_set_flags(ctx, ST22P_TX_FLAG_USER_PACING); /* no DROP_WHEN_LATE */
+  ut22p_tx_set_fps(ctx, ST_FPS_P25);
+
+  CallbackCtx cb_ctx;
+  ut22p_tx_set_notify_frame_done(ctx, OnFrameDone, &cb_ctx);
+  ut22p_tx_set_notify_frame_late(ctx, OnFrameLate, &cb_ctx);
+
+  struct st_frame* frame = ut22p_tx_get_frame(ctx);
+  ASSERT_NE(frame, nullptr);
+  frame->tfmt = ST10_TIMESTAMP_FMT_TAI;
+  frame->timestamp = kBaseTaiNs;
+  ASSERT_EQ(ut22p_tx_put_frame(ctx, frame), 0);
+  int idx0 = ut22p_tx_frame_idx(frame);
+
+  ut22p_tx_set_ptp_ns(ctx, kBaseTaiNs + kFramePeriodNs25Fps);
+
+  uint16_t idx;
+  EXPECT_EQ(ut22p_tx_next_frame(ctx, &idx), 0);
+  EXPECT_EQ(idx, idx0);
+  EXPECT_EQ(ut22p_tx_frame_stat(ctx, idx0), 6 /* IN_TRANSMITTING */);
+  EXPECT_EQ(cb_ctx.late_calls, 0);
+
+  ut22p_tx_ctx_destroy(ctx);
+}

--- a/tests/unit/pipeline/st22p_tx_harness.c
+++ b/tests/unit/pipeline/st22p_tx_harness.c
@@ -25,9 +25,16 @@ struct ut22p_tx_ctx {
   struct st22p_tx_ctx pipeline;
   struct st22p_tx_frame* framebuffs;
   int framebuff_cnt;
+  uint64_t mock_ptp_ns;
 };
 
 #include "pipeline/st22p_tx_harness.h"
+
+static uint64_t ut22p_ptp_time_fn(struct mtl_main_impl* impl, enum mtl_port port) {
+  (void)port;
+  struct ut22p_tx_ctx* ctx = (struct ut22p_tx_ctx*)impl; /* impl is ctx's first member */
+  return ctx->mock_ptp_ns;
+}
 
 int ut22p_tx_init(void) {
   return ut_eal_init();
@@ -39,6 +46,7 @@ ut22p_tx_ctx* ut22p_tx_ctx_create(int framebuff_cnt) {
 
   ctx->framebuff_cnt = framebuff_cnt;
   ctx->impl.type = MT_HANDLE_MAIN;
+  ctx->impl.inf[MTL_PORT_P].ptp_get_time_fn = ut22p_ptp_time_fn;
 
   ctx->framebuffs = calloc(framebuff_cnt, sizeof(struct st22p_tx_frame));
   if (!ctx->framebuffs) {
@@ -81,6 +89,32 @@ void ut22p_tx_ctx_destroy(ut22p_tx_ctx* ctx) {
 
 int ut22p_tx_framebuff_cnt(const ut22p_tx_ctx* ctx) {
   return ctx->framebuff_cnt;
+}
+
+void ut22p_tx_set_ptp_ns(ut22p_tx_ctx* ctx, uint64_t ns) {
+  ctx->mock_ptp_ns = ns;
+}
+
+void ut22p_tx_set_flags(ut22p_tx_ctx* ctx, uint32_t flags) {
+  ctx->pipeline.ops.flags |= flags;
+}
+
+void ut22p_tx_set_fps(ut22p_tx_ctx* ctx, enum st_fps fps) {
+  ctx->pipeline.ops.fps = fps;
+}
+
+void ut22p_tx_set_notify_frame_done(ut22p_tx_ctx* ctx,
+                                    int (*cb)(void* priv, struct st_frame* frame),
+                                    void* priv) {
+  ctx->pipeline.ops.notify_frame_done = cb;
+  ctx->pipeline.ops.priv = priv;
+}
+
+void ut22p_tx_set_notify_frame_late(ut22p_tx_ctx* ctx,
+                                    int (*cb)(void* priv, uint64_t epoch_skipped),
+                                    void* priv) {
+  ctx->pipeline.ops.notify_frame_late = cb;
+  ctx->pipeline.ops.priv = priv;
 }
 
 struct st_frame* ut22p_tx_get_frame(ut22p_tx_ctx* ctx) {

--- a/tests/unit/pipeline/st22p_tx_harness.h
+++ b/tests/unit/pipeline/st22p_tx_harness.h
@@ -38,6 +38,25 @@ void ut22p_tx_ctx_destroy(ut22p_tx_ctx* ctx);
 
 int ut22p_tx_framebuff_cnt(const ut22p_tx_ctx* ctx);
 
+/** Set the mock PTP wall-clock time returned by mt_get_ptp_time(). */
+void ut22p_tx_set_ptp_ns(ut22p_tx_ctx* ctx, uint64_t ns);
+
+/** OR the given bits into ops.flags (e.g. ST22P_TX_FLAG_DROP_WHEN_LATE). */
+void ut22p_tx_set_flags(ut22p_tx_ctx* ctx, uint32_t flags);
+
+/** Set ops.fps, used by tx_st22p_if_frame_late() to derive the frame period. */
+void ut22p_tx_set_fps(ut22p_tx_ctx* ctx, enum st_fps fps);
+
+/** Register ops.notify_frame_done. */
+void ut22p_tx_set_notify_frame_done(ut22p_tx_ctx* ctx,
+                                    int (*cb)(void* priv, struct st_frame* frame),
+                                    void* priv);
+
+/** Register ops.notify_frame_late. */
+void ut22p_tx_set_notify_frame_late(ut22p_tx_ctx* ctx,
+                                    int (*cb)(void* priv, uint64_t epoch_skipped),
+                                    void* priv);
+
 /* producer (app) side */
 struct st_frame* ut22p_tx_get_frame(ut22p_tx_ctx* ctx);
 int ut22p_tx_put_frame(ut22p_tx_ctx* ctx, struct st_frame* frame);

--- a/tests/validation/mtl_engine/application_base.py
+++ b/tests/validation/mtl_engine/application_base.py
@@ -263,6 +263,34 @@ class Application(ABC):
         """Check if a parameter was explicitly provided by the user."""
         return param_name in self._user_provided_params
 
+    def count_tx_dropped_frames(self) -> int:
+        """Total TX frames the MTL pipeline dropped during the last run.
+
+        MTL logs, at every stats interval, a TX pipeline line such as
+        ``TX_st20p(0), frame get try X succ Y, put Z, drop D`` (st20p/st22p/
+        st30p/st40p share the shape). Each interval resets its own counter, so
+        the run total is the sum of the per-interval ``drop`` values. This
+        output is emitted by the library itself, independent of which framework
+        drives it, so the parsing belongs here in the base class rather than in
+        any single adapter.
+
+        Returns the summed drop count, or -1 if no TX pipeline stats line was
+        found in the captured output.
+        """
+        if not self.last_output:
+            return -1
+        pattern = re.compile(
+            r"TX_st\d\dp\(\d+\),\s*frame get try \d+ succ \d+, put \d+, drop (\d+)"
+        )
+        total = 0
+        seen = False
+        for line in self.last_output.split("\n"):
+            m = pattern.search(line)
+            if m:
+                seen = True
+                total += int(m.group(1))
+        return total if seen else -1
+
     def prepare_execution(self, build: str, host=None, **kwargs):
         """Hook method called before execution to perform framework-specific setup.
 

--- a/tests/validation/mtl_engine/config/universal_params.py
+++ b/tests/validation/mtl_engine/config/universal_params.py
@@ -57,6 +57,9 @@ UNIVERSAL_PARAMS = {
     # Quality and encoding parameters
     "pacing": "gap",  # Pacing mode (gap, auto, etc.)
     "packing": "BPM",  # Packing mode
+    "user_pacing": False,  # TX user pacing (app supplies per-frame timestamps)
+    "drop_when_late": False,  # Drop TX frames that miss their pacing window
+    "user_time_offset": None,  # User-pacing clock offset in ns (negative = past)
     "device": "AUTO",  # Device selection
     "codec": "JPEG-XS",  # Codec for compressed formats
     "quality": "speed",  # Quality setting

--- a/tests/validation/mtl_engine/rxtxapp.py
+++ b/tests/validation/mtl_engine/rxtxapp.py
@@ -880,6 +880,10 @@ class RxTxApp(Application):
                 if is_tx:
                     session["input_format"] = pixel_format
                     session["st20p_url"] = p("input_file")
+                    if p("user_pacing", False):
+                        session["user_pacing"] = True
+                    if p("drop_when_late", False):
+                        session["drop_when_late"] = True
                 else:
                     session["output_format"] = p("output_pixel_format") or pixel_format
                     session["measure_latency"] = p("measure_latency")
@@ -1001,6 +1005,13 @@ class RxTxApp(Application):
             if st_entry:
                 config["tx_sessions"][0].setdefault(session_type, [])
                 config["tx_sessions"][0][session_type].append(st_entry)
+
+        # Group-level user-pacing clock offset (ns). A negative value starts the
+        # pacing clock in the past so frames are presented late and the
+        # drop-when-late flag must drop them (used by the drop-when-late test).
+        user_time_offset = self.params.get("user_time_offset")
+        if user_time_offset is not None:
+            config["tx_sessions"][0]["user_time_offset"] = int(user_time_offset)
 
         # Populate RX sessions
         if direction in (None, "rx"):

--- a/tests/validation/tests/single/st20p/test_drop_when_late.py
+++ b/tests/validation/tests/single/st20p/test_drop_when_late.py
@@ -2,7 +2,6 @@
 # Copyright(c) 2026 Intel Corporation
 
 import pytest
-
 from common.nicctl import InterfaceSetup
 from mtl_engine import ip_pools
 from mtl_engine.media_files import yuv_files_422rfc10

--- a/tests/validation/tests/single/st20p/test_drop_when_late.py
+++ b/tests/validation/tests/single/st20p/test_drop_when_late.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2026 Intel Corporation
+
+import pytest
+
+from common.nicctl import InterfaceSetup
+from mtl_engine import ip_pools
+from mtl_engine.media_files import yuv_files_422rfc10
+
+pytestmark = pytest.mark.verified
+
+# Start the user-pacing clock one second in the past. With user pacing enabled
+# this makes roughly one second's worth of frames (~fps) already late when the
+# session starts transmitting; ST20P_TX_FLAG_DROP_WHEN_LATE must drop that
+# backlog before the schedule catches up to real time and frames flow normally.
+LATE_OFFSET_NS = -1_000_000_000
+
+# fps label -> nominal frames per second, used for the "around fps" bound.
+_FPS_VALUE = {
+    "p25": 25,
+    "p30": 30,
+    "p50": 50,
+    "p60": 60,
+}
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "application",
+    [
+        "rxtxapp",
+    ],
+)
+@pytest.mark.parametrize(
+    "media_file",
+    [yuv_files_422rfc10["ParkJoy_1080p"]],
+    indirect=["media_file"],
+    ids=["ParkJoy_1080p"],
+)
+@pytest.mark.parametrize("fps", ["p25", "p30", "p50", "p60"])
+def test_st20p_drop_when_late(
+    application,
+    app_factory,
+    hosts,
+    mtl_path,
+    setup_interfaces: InterfaceSetup,
+    test_config,
+    fps,
+    media_file,
+):
+    """Test that ST20P drop-when-late drops late frames.
+
+    With the user-pacing clock started a second in the past every frame is
+    late, so the TX pipeline must drop frames. Assert at least one frame-rate's
+    worth (>= fps) was dropped. The drop count is read via the app-agnostic
+    ``count_tx_dropped_frames`` helper so the test stays framework-neutral.
+    """
+    media_file_info, media_file_path = media_file
+    host = list(hosts.values())[0]
+    interfaces_list = setup_interfaces.get_interfaces_list_single(
+        test_config.get("interface_type", "VF")
+    )
+
+    # Run longer than one MTL stats interval (10s) so at least one TX_st20p
+    # stats line reporting the dropped backlog is emitted.
+    test_time = 15
+
+    app = app_factory(application)
+    app.create_command(
+        session_type="st20p",
+        nic_port_list=interfaces_list,
+        test_mode="multicast",
+        destination_ip=ip_pools.rx_multicast[0],
+        port=20000,
+        width=media_file_info["width"],
+        height=media_file_info["height"],
+        framerate=fps,
+        pixel_format=media_file_info["file_format"],
+        transport_format=media_file_info["format"],
+        input_file=media_file_path,
+        test_time=test_time,
+        user_pacing=True,
+        drop_when_late=True,
+        user_time_offset=LATE_OFFSET_NS,
+    )
+
+    # Late frames deliberately break RX continuity, so do not let the default
+    # RX/TX result gate fail the test; assert on the drop count directly.
+    app.execute_test(
+        build=mtl_path, test_time=test_time, host=host, fail_on_error=False
+    )
+
+    dropped = app.count_tx_dropped_frames()
+    assert dropped >= 0, "no TX pipeline stats line found in application output"
+
+    # With the pacing clock a full second behind, at least one frame-rate's
+    # worth of late frames must have been dropped.
+    expected = _FPS_VALUE[fps]
+    assert dropped >= expected, (
+        f"dropped only {dropped} frames, expected at least fps={expected} "
+        f"(drop-when-late not active?)"
+    )


### PR DESCRIPTION
Seting the frame_done_cb_called to true after invoking the callback notify_frame_done makes the notify_ext_frame_free release the slot from IN_USER to FREE, and a producer can immiediatly raclaim that slot via get_frame, and reset the frame_done_cb_called to false, before the callback returns, and then the callback returns, and the frame_done_cb_called is set to true.
Corrupting the state of the slot.