### PR TITLE
Ci: assume the nightly is only needed on workdays

### DIFF
--- a/.github/workflows/nightly-gtest.yml
+++ b/.github/workflows/nightly-gtest.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: ''
   schedule:
-  - cron: '0 20 * * *' # Every day at 8 PM UTC
+  - cron: '0 20 * * 1-5' # Monday to Friday at 8 PM UTC
 permissions:
   contents: read
   checks: read

--- a/.github/workflows/nightly-pytest.yml
+++ b/.github/workflows/nightly-pytest.yml
@@ -3,7 +3,7 @@ on:
   # allow manually trigger
   workflow_dispatch:
   schedule:
-  - cron: '0 20 * * *' # Every day at 8 PM UTC
+  - cron: '0 20 * * 1-5' # Monday to Friday at 8 PM UTC
 permissions:
   contents: read
   checks: read


### PR DESCRIPTION
Due to high compute demand only run the nightly on workdays.