### PR TITLE
Feat: ffmpeg_plugin add AVOptions for p2-p7 NIC ports

### DIFF
--- a/ecosystem/ffmpeg_plugin/README.md
+++ b/ecosystem/ffmpeg_plugin/README.md
@@ -107,6 +107,26 @@ Reading from a yuv stream from a local file and sending a ST 2110-20 10-bit YUV4
 ffmpeg -stream_loop -1 -video_size 1920x1080 -f rawvideo -pix_fmt yuv422p10le -i yuv422p10le_1080p.yuv -filter:v fps=59.94 -p_port 0000:af:01.1 -p_sip 192.168.96.3 -p_tx_ip 239.168.85.20 -udp_port 20000 -payload_type 96 -f mtl_st20p -
 ```
 
+### 2.2.1 Additional NIC port options (multi-BDF)
+
+The TX path supports additional NIC bindings beyond primary/redundant by using:
+
+1. `-p2_port` / `-p2_sip`
+1. `-p3_port` / `-p3_sip`
+1. `-p4_port` / `-p4_sip`
+1. `-p5_port` / `-p5_sip`
+1. `-p6_port` / `-p6_sip`
+1. `-p7_port` / `-p7_sip`
+
+Each `*_port` expects a PCI BDF (for example `0000:af:01.2`) and each `*_sip` is the
+source IP bound to that NIC.
+
+Example with two additional NICs:
+
+```bash
+ffmpeg -stream_loop -1 -video_size 1920x1080 -f rawvideo -pix_fmt yuv422p10le -i yuv422p10le_1080p.yuv -filter:v fps=59.94 -p_port 0000:af:01.1 -p_sip 192.168.96.3 -p2_port 0000:af:01.2 -p2_sip 192.168.97.3 -p3_port 0000:af:01.3 -p3_sip 192.168.98.3 -p_tx_ip 239.168.85.20 -udp_port 20000 -payload_type 96 -f mtl_st20p -
+```
+
 ### 2.3. Supported pixel formats
 
 The `mtl_st20p` plugin maps the following FFmpeg `pix_fmt` values to MTL frame

--- a/ecosystem/ffmpeg_plugin/mtl_common.h
+++ b/ecosystem/ffmpeg_plugin/mtl_common.h
@@ -157,6 +157,30 @@
        AV_OPT_TYPE_STRING,                                                                 \
        {.str = NULL},                                                                      \
        .flags = ENC},                                                                      \
+      {"p2_port",          "mtl port 2 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_2]), \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p2_sip",           "mtl port 2 local ip",         OFFSET(devArgs.sip[MTL_PORT_2]),  \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p3_port",          "mtl port 3 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_3]), \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p3_sip",           "mtl port 3 local ip",         OFFSET(devArgs.sip[MTL_PORT_3]),  \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p4_port",          "mtl port 4 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_4]), \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p4_sip",           "mtl port 4 local ip",         OFFSET(devArgs.sip[MTL_PORT_4]),  \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p5_port",          "mtl port 5 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_5]), \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p5_sip",           "mtl port 5 local ip",         OFFSET(devArgs.sip[MTL_PORT_5]),  \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p6_port",          "mtl port 6 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_6]), \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p6_sip",           "mtl port 6 local ip",         OFFSET(devArgs.sip[MTL_PORT_6]),  \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p7_port",          "mtl port 7 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_7]), \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p7_sip",           "mtl port 7 local ip",         OFFSET(devArgs.sip[MTL_PORT_7]),  \
+        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
       {"dma_dev",          "mtl dma dev", OFFSET(devArgs.dma_dev),                         \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
       {"r_rx_queues",                                                                      \

--- a/ecosystem/ffmpeg_plugin/mtl_common.h
+++ b/ecosystem/ffmpeg_plugin/mtl_common.h
@@ -157,30 +157,78 @@
        AV_OPT_TYPE_STRING,                                                                 \
        {.str = NULL},                                                                      \
        .flags = ENC},                                                                      \
-      {"p2_port",          "mtl port 2 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_2]), \
+      {"p2_port",                                                                          \
+       "mtl port 2 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_2]),                    \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p2_sip",           "mtl port 2 local ip",         OFFSET(devArgs.sip[MTL_PORT_2]),  \
+      {"p2_sip",                                                                           \
+       "mtl port 2 local ip", OFFSET(devArgs.sip[MTL_PORT_2]),                             \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p3_port",          "mtl port 3 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_3]), \
+      {"p3_port",                                                                          \
+       "mtl port 3 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_3]),                    \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p3_sip",           "mtl port 3 local ip",         OFFSET(devArgs.sip[MTL_PORT_3]),  \
+      {"p3_sip",                                                                           \
+       "mtl port 3 local ip", OFFSET(devArgs.sip[MTL_PORT_3]),                             \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p4_port",          "mtl port 4 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_4]), \
+      {"p4_port",                                                                          \
+       "mtl port 4 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_4]),                    \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p4_sip",           "mtl port 4 local ip",         OFFSET(devArgs.sip[MTL_PORT_4]),  \
+      {"p4_sip",                                                                           \
+       "mtl port 4 local ip", OFFSET(devArgs.sip[MTL_PORT_4]),                             \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p5_port",          "mtl port 5 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_5]), \
+      {"p5_port",                                                                          \
+       "mtl port 5 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_5]),                    \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p5_sip",           "mtl port 5 local ip",         OFFSET(devArgs.sip[MTL_PORT_5]),  \
+      {"p5_sip",                                                                           \
+       "mtl port 5 local ip", OFFSET(devArgs.sip[MTL_PORT_5]),                             \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p6_port",          "mtl port 6 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_6]), \
+      {"p6_port",                                                                          \
+       "mtl port 6 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_6]),                    \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p6_sip",           "mtl port 6 local ip",         OFFSET(devArgs.sip[MTL_PORT_6]),  \
+      {"p6_sip",                                                                           \
+       "mtl port 6 local ip", OFFSET(devArgs.sip[MTL_PORT_6]),                             \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p7_port",          "mtl port 7 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_7]), \
+      {"p7_port",                                                                          \
+       "mtl port 7 (additional NIC)", OFFSET(devArgs.port[MTL_PORT_7]),                    \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
-      {"p7_sip",           "mtl port 7 local ip",         OFFSET(devArgs.sip[MTL_PORT_7]),  \
-        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p7_sip",                                                                           \
+       "mtl port 7 local ip", OFFSET(devArgs.sip[MTL_PORT_7]),                             \
+       AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
+      {"p2_tx_queues",                                                                     \
+       "mtl port 2 amount of tx queues", OFFSET(devArgs.tx_queues_cnt[MTL_PORT_2]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p2_rx_queues",                                                                     \
+       "mtl port 2 amount of rx queues", OFFSET(devArgs.rx_queues_cnt[MTL_PORT_2]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p3_tx_queues",                                                                     \
+       "mtl port 3 amount of tx queues", OFFSET(devArgs.tx_queues_cnt[MTL_PORT_3]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p3_rx_queues",                                                                     \
+       "mtl port 3 amount of rx queues", OFFSET(devArgs.rx_queues_cnt[MTL_PORT_3]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p4_tx_queues",                                                                     \
+       "mtl port 4 amount of tx queues", OFFSET(devArgs.tx_queues_cnt[MTL_PORT_4]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p4_rx_queues",                                                                     \
+       "mtl port 4 amount of rx queues", OFFSET(devArgs.rx_queues_cnt[MTL_PORT_4]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p5_tx_queues",                                                                     \
+       "mtl port 5 amount of tx queues", OFFSET(devArgs.tx_queues_cnt[MTL_PORT_5]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p5_rx_queues",                                                                     \
+       "mtl port 5 amount of rx queues", OFFSET(devArgs.rx_queues_cnt[MTL_PORT_5]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p6_tx_queues",                                                                     \
+       "mtl port 6 amount of tx queues", OFFSET(devArgs.tx_queues_cnt[MTL_PORT_6]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p6_rx_queues",                                                                     \
+       "mtl port 6 amount of rx queues", OFFSET(devArgs.rx_queues_cnt[MTL_PORT_6]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p7_tx_queues",                                                                     \
+       "mtl port 7 amount of tx queues", OFFSET(devArgs.tx_queues_cnt[MTL_PORT_7]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
+      {"p7_rx_queues",                                                                     \
+       "mtl port 7 amount of rx queues", OFFSET(devArgs.rx_queues_cnt[MTL_PORT_7]),        \
+       AV_OPT_TYPE_INT, {.i64 = 16}, -1, INT_MAX, ENC},                                    \
       {"dma_dev",          "mtl dma dev", OFFSET(devArgs.dma_dev),                         \
        AV_OPT_TYPE_STRING, {.str = NULL}, .flags = ENC},                                   \
       {"r_rx_queues",                                                                      \


### PR DESCRIPTION
## Summary
This change extends FFmpeg plugin TX device AVOptions in ecosystem/ffmpeg_plugin/mtl_common.h to support additional NIC port/IP pairs beyond primary/redundant.

Added AVOptions for additional MTL device ports:
p2_port, p2_sip
p3_port, p3_sip
p4_port, p4_sip
p5_port, p5_sip
p6_port, p6_sip
p7_port, p7_sip
Kept existing options unchanged.
Fixed AVOption list continuation so the macro remains syntactically valid.