### PR TITLE
Fix: skip pre-start timesync init for igc

### DIFF
--- a/lib/src/dev/mt_dev.c
+++ b/lib/src/dev/mt_dev.c
@@ -1917,7 +1917,7 @@ int mt_dev_create(struct mtl_main_impl* impl) {
 #if RTE_VERSION >= RTE_VERSION_NUM(21, 11, 0, 0)
     /* DPDK 21.11 support start time sync before rte_eth_dev_start */
     if ((mt_user_ptp_service(impl) || mt_user_hw_timestamp(impl)) &&
-        (port_type == MT_PORT_PF)) {
+        (port_type == MT_PORT_PF) && (inf->drv_info.drv_type != MT_DRV_IGC)) {
       ret = dev_start_timesync(inf);
       if (ret >= 0) inf->feature |= MT_IF_FEATURE_TIMESYNC;
     }


### PR DESCRIPTION
## Summary
This PR updates `mt_dev_create()` to avoid pre-start time sync initialization on IGC. 
IGC requires different handling for timesync startup timing. This change prevents invoking the pre-start timesync init path for IGC while keeping existing behavior unchanged for other PF drivers.


## File changed
- `lib/src/dev/mt_dev.c`

## Diff
In the DPDK 21.11+ pre-start timesync path, add an extra guard:
- Before: run `dev_start_timesync()` for PF ports when PTP service or HW timestamp is requested.
- After: same logic, but skip this path when `inf->drv_info.drv_type == MT_DRV_IGC`.

```c
if ((mt_user_ptp_service(impl) || mt_user_hw_timestamp(impl)) &&
    (port_type == MT_PORT_PF) && (inf->drv_info.drv_type != MT_DRV_IGC)) {
  ret = dev_start_timesync(inf);
  if (ret >= 0) inf->feature |= MT_IF_FEATURE_TIMESYNC;
}
```

- Minimal, one-line condition change.
- No API surface changes.
