### PR TITLE
Ci: update .github/ codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 * @Sakoram @DawidWesierski4 @moleksy @awilczyns @staszczuk @soopel
 
 # CI/CD and GitHub configuration
-/.github/ @staszczuk
+/.github/ @DawidWesierski4 @awilczyns
 
 # Core library
 /lib/ @Sakoram @DawidWesierski4 @moleksy @awilczyns


### PR DESCRIPTION
## Summary
Updates the `/.github/` ownership entry in `CODEOWNERS` from `@staszczuk` to `@DawidWesierski4 @awilczyns`, so CI/CD and GitHub configuration changes are reviewed by the current maintainers of that area.

## Changes
- `CODEOWNERS`: `/.github/` → `@DawidWesierski4 @awilczyns`

## Test plan
- No code changes; `CODEOWNERS` syntax unchanged (single path + owners line).
- GitHub will validate the entry and start requesting the new owners on subsequent PRs touching `/.github/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)