### PR TITLE
Fix: Bound ST22 RX box lengths and copy offset

### DIFF
--- a/lib/src/st2110/st_rx_video_session.c
+++ b/lib/src/st2110/st_rx_video_session.c
@@ -1972,21 +1972,38 @@ struct st22_box {
 
 /* Video Support Box and Color Specification Box */
 static int rv_parse_st22_boxes(struct st_rx_video_session_impl* s, void* boxes,
+                               uint16_t payload_length,
                                struct st_rx_video_slot_impl* slot) {
   uint32_t jpvs_len = 0;
   uint32_t colr_len = 0;
+  uint32_t left = payload_length; /* payload not consumed by a box yet */
   struct st22_box* box;
 
-  box = boxes;
-  if (0 == strncmp(box->tbox, "jpvs", 4)) {
-    jpvs_len = ntohl(box->lbox);
-    boxes += jpvs_len;
+  /* lbox is network-supplied: bound every box by what is left of this pkt,
+   * else advancing lands outside the mbuf */
+  if (left >= sizeof(*box)) {
+    box = boxes;
+    if (0 == strncmp(box->tbox, "jpvs", 4)) {
+      jpvs_len = ntohl(box->lbox);
+      if ((jpvs_len < sizeof(*box)) || (jpvs_len > left)) {
+        dbg("%s(%d): err jpvs_len %u, left %u\n", __func__, s->idx, jpvs_len, left);
+        return -EIO;
+      }
+      boxes += jpvs_len;
+      left -= jpvs_len;
+    }
   }
 
-  box = boxes;
-  if (0 == strncmp(box->tbox, "colr", 4)) {
-    colr_len = ntohl(box->lbox);
-    boxes += colr_len;
+  if (left >= sizeof(*box)) {
+    box = boxes;
+    if (0 == strncmp(box->tbox, "colr", 4)) {
+      colr_len = ntohl(box->lbox);
+      if ((colr_len < sizeof(*box)) || (colr_len > left)) {
+        dbg("%s(%d): err colr_len %u, left %u\n", __func__, s->idx, colr_len, left);
+        return -EIO;
+      }
+      boxes += colr_len;
+    }
   }
 
   if ((jpvs_len + colr_len) > 512) {
@@ -2015,6 +2032,12 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
                               enum mtl_session_port s_port, bool ctrl_thread) {
   MTL_MAY_UNUSED(s_port);
   MTL_MAY_UNUSED(ctrl_thread);
+  /* a pkt shorter than the hdr would underflow payload_length below; the kernel
+   * socket path can deliver a datagram smaller than the rtp hdr */
+  if (mbuf->data_len < sizeof(struct st22_rfc9134_video_hdr)) {
+    s->port_user_stats.stat_pkts_wrong_len_dropped++;
+    return -EIO;
+  }
   struct st20_rx_ops* ops = &s->ops;
   // size_t hdr_offset = mbuf->l2_len + mbuf->l3_len + mbuf->l4_len;
   size_t hdr_offset =
@@ -2131,7 +2154,7 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
       if (s->st22_ops_flags & ST22_RX_FLAG_DISABLE_BOXES) {
         slot->st22_box_hdr_length = 0;
       } else {
-        ret = rv_parse_st22_boxes(s, payload, slot);
+        ret = rv_parse_st22_boxes(s, payload, payload_length, slot);
         if (ret < 0) {
           s->port_user_stats.stat_pkts_idx_dropped++;
           return -EIO;
@@ -2154,6 +2177,12 @@ static int rv_handle_st22_pkt(struct st_rx_video_session_impl* s, struct rte_mbu
   /* copy payload */
   uint32_t offset;
   if (!pkt_counter) { /* first pkt */
+    /* box hdr length was measured against the pkt that declared it; a later
+     * pkt with pkt_counter 0 may be shorter and underflow payload_length */
+    if (payload_length < slot->st22_box_hdr_length) {
+      s->port_user_stats.stat_pkts_wrong_len_dropped++;
+      return -EIO;
+    }
     offset = 0;
     payload += slot->st22_box_hdr_length;
     payload_length -= slot->st22_box_hdr_length;

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -80,6 +80,7 @@ unit_sources = [
   'session/st20/stats_test.cpp',
   'session/st20/err_packets_test.cpp',
   'session/st20/timestamp_source_test.cpp',
+  'session/st20/st22_box_parse_test.cpp',
   'session/st20_tx_harness.c',
   'session/st20_tx/epoch_test.cpp',
   'session/st20_tx/pacing_test.cpp',

--- a/tests/unit/session/st20/st22_box_parse_test.cpp
+++ b/tests/unit/session/st20/st22_box_parse_test.cpp
@@ -1,0 +1,190 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * ST 2110-22 first-packet box parsing (rv_parse_st22_boxes).
+ *
+ * Both lengths these tests drive are attacker-controlled on the wire: the JPEG
+ * 2000 box lengths (lbox) and the datagram length itself. Each must be bounded
+ * against the bytes the packet actually carries BEFORE it is used as a pointer
+ * offset, otherwise a single crafted packet walks the parse pointer out of the
+ * mbuf.
+ */
+
+#include <gtest/gtest.h>
+
+#include "session/st20/st20_rx_test_base.h"
+
+/* On-the-wire lbox of a well-formed pair (struct st22_jpvs / st22_colr). */
+static constexpr uint32_t kJpvsLen = 42;
+static constexpr uint32_t kColrLen = 18;
+static constexpr uint16_t kBoxesLen = kJpvsLen + kColrLen;
+/* A box header is lbox(4) + tbox(4). */
+static constexpr uint16_t kBoxHdrLen = 8;
+
+class St22RxBoxParseTest : public St20RxBaseTest {
+ protected:
+  void SetUp() override {
+    St20RxBaseTest::SetUp();
+    ut20_ctx_enable_st22(ctx_);
+  }
+
+  uint64_t idx_dropped() {
+    return ut20_stat_idx_dropped(ctx_);
+  }
+  uint64_t st22_boxes() {
+    return ut20_stat_st22_boxes(ctx_);
+  }
+  uint64_t wrong_len() {
+    return ut20_stat_wrong_len(ctx_);
+  }
+  uint64_t frames_ready() {
+    return ut20_st22_frames_ready(ctx_);
+  }
+  size_t last_frame_size() {
+    return ut20_st22_last_frame_size(ctx_);
+  }
+
+  /* First packet of a frame carrying `payload_length` bytes of `payload`. */
+  int feed_first(const void* payload, uint16_t payload_length) {
+    return ut20_feed_st22_pkt(ctx_, 100, 1000, 0, false, payload, payload_length,
+                              MTL_SESSION_PORT_P);
+  }
+};
+
+/* Positive control: one well-formed marker pkt completes a frame, and the size
+ * delivered is the payload minus the boxes, so box bytes are skipped not copied. */
+TEST_F(St22RxBoxParseTest, WellFormedMarkerPktCompletesFrame) {
+  uint8_t payload[kBoxesLen + 40];
+  memset(payload, 0xA5, sizeof(payload));
+  ASSERT_EQ(ut20_st22_build_boxes(payload, kJpvsLen, kColrLen), kBoxesLen);
+
+  ASSERT_EQ(ut20_feed_st22_pkt(ctx_, 100, 1000, 0, true, payload, sizeof(payload),
+                               MTL_SESSION_PORT_P),
+            0);
+  EXPECT_EQ(frames_ready(), 1u);
+  EXPECT_EQ(last_frame_size(), 40u);
+  EXPECT_EQ(idx_dropped(), 0u);
+  EXPECT_EQ(offset_dropped(), 0u);
+  EXPECT_EQ(wrong_len(), 0u);
+  EXPECT_EQ(idx_oo_bitmap(), 0u);
+}
+
+/* An lbox of 0xF0000000 must be rejected where it is read, not after the parse
+ * pointer has already been advanced by ~4 GiB and dereferenced (CWE-125). */
+TEST_F(St22RxBoxParseTest, OversizedJpvsBoxRejected) {
+  uint8_t payload[kBoxesLen] = {0};
+  ut20_st22_build_boxes(payload, 0xF0000000, kColrLen);
+
+  /* only the 8 byte jpvs box hdr is on the wire */
+  EXPECT_EQ(feed_first(payload, kBoxHdrLen), -EIO);
+  EXPECT_EQ(idx_dropped(), 1u);
+  EXPECT_EQ(st22_boxes(), 0u);
+  /* must die in the box parser, not by luck in a later bounds check */
+  EXPECT_EQ(offset_dropped(), 0u);
+}
+
+/* An lbox under the 512 byte total cap but past the end of this packet is still
+ * out of bounds for the colr read that follows it. */
+TEST_F(St22RxBoxParseTest, JpvsBoxLargerThanPayloadRejected) {
+  uint8_t payload[kBoxesLen] = {0};
+  ut20_st22_build_boxes(payload, 512, kColrLen);
+
+  EXPECT_EQ(feed_first(payload, kBoxHdrLen), -EIO);
+  EXPECT_EQ(idx_dropped(), 1u);
+  EXPECT_EQ(offset_dropped(), 0u);
+}
+
+/* An lbox smaller than the box header it sits in cannot describe a box. */
+TEST_F(St22RxBoxParseTest, JpvsBoxSmallerThanBoxHeaderRejected) {
+  uint8_t payload[kBoxesLen] = {0};
+  ut20_st22_build_boxes(payload, kBoxHdrLen - 4, kColrLen);
+
+  EXPECT_EQ(feed_first(payload, kBoxHdrLen), -EIO);
+  EXPECT_EQ(idx_dropped(), 1u);
+}
+
+/* The same floor applies to the second box, whose length is added to
+ * st22_box_hdr_length and so shifts where the codestream is taken to start. */
+TEST_F(St22RxBoxParseTest, ColrBoxSmallerThanBoxHeaderRejected) {
+  uint8_t payload[kBoxesLen] = {0};
+  ut20_st22_build_boxes(payload, kJpvsLen, kBoxHdrLen - 4);
+
+  EXPECT_EQ(feed_first(payload, kJpvsLen + kBoxHdrLen), -EIO);
+  EXPECT_EQ(idx_dropped(), 1u);
+}
+
+/* The colr length must be bounded by what is left AFTER jpvs: colr=45 clears
+ * both the 512 byte cap and the 50 byte payload, only the 8 bytes left reject it. */
+TEST_F(St22RxBoxParseTest, ColrBoxLargerThanRemainingPayloadRejected) {
+  uint8_t payload[kBoxesLen] = {0};
+  ut20_st22_build_boxes(payload, kJpvsLen, 45);
+
+  EXPECT_EQ(feed_first(payload, kJpvsLen + kBoxHdrLen), -EIO);
+  EXPECT_EQ(idx_dropped(), 1u);
+  EXPECT_EQ(offset_dropped(), 0u);
+}
+
+/* A payload too short to hold a box header carries no boxes: the tbox compare
+ * must stop at data_len, though a full box hdr sits past it in the mbuf. */
+TEST_F(St22RxBoxParseTest, PayloadTooShortForBoxHeaderIgnored) {
+  const uint8_t payload[kBoxHdrLen] = {0xF0, 0x00, 0x00, 0x00, 'j', 'p', 'v', 's'};
+
+  EXPECT_EQ(ut20_feed_st22_pkt_data_len(ctx_, 100, 1000, payload, sizeof(payload),
+                                        ut20_st22_hdr_len() + kBoxHdrLen - 4,
+                                        MTL_SESSION_PORT_P),
+            0);
+  EXPECT_EQ(st22_boxes(), 0u);
+  EXPECT_EQ(idx_dropped(), 0u);
+}
+
+/* The bytes left after jpvs must be bounded before the colr tbox is compared;
+ * here only 4 of the well-formed colr sitting behind jpvs are on the wire. */
+TEST_F(St22RxBoxParseTest, ColrBoxPastPayloadEndIgnored) {
+  uint8_t payload[kBoxesLen] = {0};
+  ASSERT_EQ(ut20_st22_build_boxes(payload, kJpvsLen, kColrLen), kBoxesLen);
+
+  EXPECT_EQ(
+      ut20_feed_st22_pkt_data_len(ctx_, 100, 1000, payload, sizeof(payload),
+                                  ut20_st22_hdr_len() + kJpvsLen + 4, MTL_SESSION_PORT_P),
+      0);
+  EXPECT_EQ(st22_boxes(), 1u);
+  EXPECT_EQ(idx_dropped(), 0u);
+}
+
+/* Exact fit: a real sender's 60 byte jpvs+colr pair leaves colr filling the 18
+ * bytes left after jpvs, so the colr bound must be `>` and not `>=`. */
+TEST_F(St22RxBoxParseTest, BoxesExactlyFillingPayloadAccepted) {
+  uint8_t payload[kBoxesLen] = {0};
+  ASSERT_EQ(ut20_st22_build_boxes(payload, kJpvsLen, kColrLen), kBoxesLen);
+
+  EXPECT_EQ(feed_first(payload, kBoxesLen), 0);
+  EXPECT_EQ(st22_boxes(), 1u);
+  EXPECT_EQ(idx_dropped(), 0u);
+}
+
+/* st22_box_hdr_length is measured against the pkt that declared it, yet every
+ * pkt_counter 0 pkt is stripped by it, so a shorter later one underflows. */
+TEST_F(St22RxBoxParseTest, SecondFirstPktShorterThanBoxesRejected) {
+  uint8_t payload[kBoxesLen + 40];
+  memset(payload, 0xA5, sizeof(payload));
+  ASSERT_EQ(ut20_st22_build_boxes(payload, kJpvsLen, kColrLen), kBoxesLen);
+  ASSERT_EQ(feed_first(payload, sizeof(payload)), 0);
+
+  /* marker, so the payload_length equality check does not reject it first */
+  EXPECT_EQ(ut20_feed_st22_pkt(ctx_, 101, 1000, 0, true, payload, 10, MTL_SESSION_PORT_P),
+            -EIO);
+  EXPECT_EQ(wrong_len(), 1u);
+  EXPECT_EQ(offset_dropped(), 0u);
+  EXPECT_EQ(frames_ready(), 0u);
+}
+
+/* A datagram shorter than the 58 byte header underflows payload_length to ~64K,
+ * which is what the box bounds above are measured against. Reachable on the
+ * kernel socket datapath, which sizes data_len from recvfrom. */
+TEST_F(St22RxBoxParseTest, TruncatedPktBelowHeaderRejected) {
+  EXPECT_EQ(
+      ut20_feed_st22_pkt_data_len(ctx_, 100, 1000, nullptr, 0, 50, MTL_SESSION_PORT_P),
+      -EIO);
+  EXPECT_EQ(wrong_len(), 1u);
+  EXPECT_EQ(st22_boxes(), 0u);
+}

--- a/tests/unit/session/st20_harness.c
+++ b/tests/unit/session/st20_harness.c
@@ -54,6 +54,9 @@ struct ut20_test_ctx {
   bool hold_frames;
   struct mt_ptp_impl ptp_storage;
   uint64_t last_timestamp_first_pkt;
+  struct st22_rx_video_info st22_info; /* only used after ut20_ctx_enable_st22() */
+  uint64_t st22_frames_ready;
+  size_t st22_last_frame_size;
 };
 
 #include "session/st20_harness.h"
@@ -68,21 +71,23 @@ static uint64_t ut20_ptp_time(struct mtl_main_impl* impl, enum mtl_port port) {
 
 /* ── frame-ready callback ─────────────────────────────────────────────── */
 
+static void ut20_release_frame(ut20_test_ctx* ctx, void* frame) {
+  struct st_rx_video_session_impl* s = &ctx->session;
+  if (!s->st20_frames) return;
+  for (int i = 0; i < s->st20_frames_cnt; i++) {
+    if (s->st20_frames[i].addr == frame) {
+      rte_atomic32_dec(&s->st20_frames[i].refcnt);
+      return;
+    }
+  }
+}
+
 static int ut20_notify_frame_ready(void* priv, void* frame,
                                    struct st20_rx_frame_meta* meta) {
   ut20_test_ctx* ctx = priv;
   if (!ctx || !frame) return 0;
   ctx->last_timestamp_first_pkt = meta->timestamp_first_pkt;
-  if (ctx->hold_frames) return 0;
-
-  struct st_rx_video_session_impl* s = &ctx->session;
-  for (int i = 0; i < s->st20_frames_cnt; i++) {
-    if (!s->st20_frames) break;
-    if (s->st20_frames[i].addr == frame) {
-      rte_atomic32_dec(&s->st20_frames[i].refcnt);
-      break;
-    }
-  }
+  if (!ctx->hold_frames) ut20_release_frame(ctx, frame);
   return 0;
 }
 
@@ -391,6 +396,117 @@ int ut20_feed_rtp_pkt(ut20_test_ctx* ctx, int pkt_idx, uint32_t seq, uint32_t ts
   return rc;
 }
 
+/* ── ST 2110-22 (codestream) mode ─────────────────────────────────────── */
+
+static int ut20_st22_notify_frame_ready(void* priv, void* frame,
+                                        struct st22_rx_frame_meta* meta) {
+  ut20_test_ctx* ctx = priv;
+  if (!ctx || !frame) return 0;
+  ctx->st22_frames_ready++;
+  ctx->st22_last_frame_size = meta->frame_total_size;
+  if (!ctx->hold_frames) ut20_release_frame(ctx, frame);
+  return 0;
+}
+
+void ut20_ctx_enable_st22(ut20_test_ctx* ctx) {
+  struct st_rx_video_session_impl* s = &ctx->session;
+  s->st22_info = &ctx->st22_info;
+  ctx->st22_info.notify_frame_ready = ut20_st22_notify_frame_ready;
+  s->st22_ops_flags = 0;
+  s->pkt_handler = rv_handle_st22_pkt;
+}
+
+/* Build one RFC 9134 codestream packet. `payload`/`payload_length` are the
+ * bytes right after the rtp hdr (boxes first, if any). A non-zero
+ * `data_len_override` is written into mbuf->data_len verbatim, so a test can
+ * declare a datagram shorter than the bytes it wrote (or shorter than the hdr,
+ * as the kernel socket path can deliver). */
+static struct rte_mbuf* make_st22_mbuf(uint32_t seq, uint32_t ts, uint32_t pkt_counter,
+                                       bool marker, const void* payload,
+                                       uint16_t payload_length,
+                                       uint16_t data_len_override) {
+  struct rte_mbuf* m = rte_pktmbuf_alloc(ut_pool());
+  if (!m) return NULL;
+
+  size_t total = sizeof(struct st22_rfc9134_video_hdr) + payload_length;
+  /* the buffer has to hold whatever data_len ends up claiming */
+  size_t needed = (data_len_override > total) ? data_len_override : total;
+  if (rte_pktmbuf_tailroom(m) < needed) {
+    rte_pktmbuf_free(m);
+    return NULL;
+  }
+
+  uint8_t* buf = rte_pktmbuf_mtod(m, uint8_t*);
+  memset(buf, 0, total);
+
+  size_t hdr_offset =
+      sizeof(struct st22_rfc9134_video_hdr) - sizeof(struct st22_rfc9134_rtp_hdr);
+  struct st22_rfc9134_rtp_hdr* rtp = (struct st22_rfc9134_rtp_hdr*)(buf + hdr_offset);
+
+  rtp->base.version = 2;
+  rtp->base.marker = marker ? 1 : 0;
+  rtp->base.seq_number = htons((uint16_t)(seq & 0xFFFF));
+  rtp->base.tmstamp = htonl(ts);
+  /* P counter (11 bit) counts pkts in a sep unit, Sep counter (11 bit) the
+   * sep units; the handler recombines them as p + sep * 2048 */
+  uint32_t p_counter = pkt_counter % 2048;
+  uint32_t sep_counter = pkt_counter / 2048;
+  rtp->p_counter_lo = p_counter & 0xFF;
+  rtp->p_counter_hi = (p_counter >> 8) & 0x7;
+  rtp->sep_counter_lo = sep_counter & 0x1F;
+  rtp->sep_counter_hi = (sep_counter >> 5) & 0x3F;
+
+  if (payload && payload_length)
+    memcpy(buf + sizeof(struct st22_rfc9134_video_hdr), payload, payload_length);
+
+  m->data_len = data_len_override ? data_len_override : (uint16_t)total;
+  m->pkt_len = m->data_len;
+  m->next = NULL;
+  return m;
+}
+
+int ut20_feed_st22_pkt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts,
+                       uint32_t pkt_counter, bool marker, const void* payload,
+                       uint16_t payload_length, enum mtl_session_port port) {
+  struct rte_mbuf* m =
+      make_st22_mbuf(seq, ts, pkt_counter, marker, payload, payload_length, 0);
+  if (!m) return -1;
+  int rc = rv_handle_st22_pkt(&ctx->session, m, port, true);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+int ut20_feed_st22_pkt_data_len(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts,
+                                const void* payload, uint16_t payload_length,
+                                uint16_t data_len, enum mtl_session_port port) {
+  struct rte_mbuf* m =
+      make_st22_mbuf(seq, ts, 0, false, payload, payload_length, data_len);
+  if (!m) return -1;
+  int rc = rv_handle_st22_pkt(&ctx->session, m, port, true);
+  rte_pktmbuf_free(m);
+  return rc;
+}
+
+uint16_t ut20_st22_hdr_len(void) {
+  return (uint16_t)sizeof(struct st22_rfc9134_video_hdr);
+}
+
+uint16_t ut20_st22_build_boxes(void* buf, uint32_t jpvs_lbox, uint32_t colr_lbox) {
+  struct st22_jpvs jpvs;
+  struct st22_colr colr;
+
+  memset(&jpvs, 0, sizeof(jpvs));
+  jpvs.lbox = htonl(jpvs_lbox);
+  memcpy(jpvs.tbox, "jpvs", 4);
+  memset(&colr, 0, sizeof(colr));
+  colr.lbox = htonl(colr_lbox);
+  memcpy(colr.tbox, "colr", 4);
+
+  memcpy(buf, &jpvs, sizeof(jpvs));
+  memcpy((uint8_t*)buf + sizeof(jpvs), &colr, sizeof(colr));
+  return (uint16_t)(sizeof(jpvs) + sizeof(colr));
+}
+
 int ut20_feed_pkt_pt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts, uint16_t line_num,
                      uint16_t line_offset, uint16_t line_length,
                      enum mtl_session_port port, uint8_t pt) {
@@ -570,6 +686,22 @@ uint64_t ut20_stat_offset_dropped(const ut20_test_ctx* ctx) {
 
 uint64_t ut20_stat_wrong_len(const ut20_test_ctx* ctx) {
   return ctx->session.port_user_stats.stat_pkts_wrong_len_dropped;
+}
+
+uint64_t ut20_stat_idx_dropped(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_pkts_idx_dropped;
+}
+
+uint64_t ut20_stat_st22_boxes(const ut20_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_st22_boxes;
+}
+
+uint64_t ut20_st22_frames_ready(const ut20_test_ctx* ctx) {
+  return ctx->st22_frames_ready;
+}
+
+size_t ut20_st22_last_frame_size(const ut20_test_ctx* ctx) {
+  return ctx->st22_last_frame_size;
 }
 
 uint64_t ut20_stat_port_err_packets(const ut20_test_ctx* ctx,

--- a/tests/unit/session/st20_harness.h
+++ b/tests/unit/session/st20_harness.h
@@ -211,6 +211,48 @@ uint64_t ut20_stat_wrong_ssrc(const ut20_test_ctx* ctx);
 uint64_t ut20_stat_wrong_interlace(const ut20_test_ctx* ctx);
 uint64_t ut20_stat_offset_dropped(const ut20_test_ctx* ctx);
 uint64_t ut20_stat_wrong_len(const ut20_test_ctx* ctx);
+/* Bumped when a pkt cannot be placed in the frame: no seq base yet, or an
+ * ST 2110-22 box parse failure. */
+uint64_t ut20_stat_idx_dropped(const ut20_test_ctx* ctx);
+/* Bumped once per frame whose first pkt carried accepted ST 2110-22 boxes. */
+uint64_t ut20_stat_st22_boxes(const ut20_test_ctx* ctx);
+
+/* ── ST 2110-22 (codestream) mode ─────────────────────────────────────── */
+
+/* Switch the session into ST 2110-22 frame mode: install the st22 rx info and
+ * route packets through rv_handle_st22_pkt. Call once after ut20_ctx_create*()
+ * and before feeding. The synthetic geometry is reused as-is, so
+ * st20_frame_size (40 * pkts_per_frame) is the codestream frame budget. */
+void ut20_ctx_enable_st22(ut20_test_ctx* ctx);
+
+/* Frames handed to the st22 notify_frame_ready callback. */
+uint64_t ut20_st22_frames_ready(const ut20_test_ctx* ctx);
+/* frame_total_size reported with the last delivered st22 frame. */
+size_t ut20_st22_last_frame_size(const ut20_test_ctx* ctx);
+
+/* Feed one RFC 9134 codestream packet directly to rv_handle_st22_pkt.
+ * `pkt_counter` is the combined P&Sep counter (0 selects the first-packet path
+ * that parses the boxes), `payload`/`payload_length` the bytes after the rtp
+ * hdr. Returns the production handler's return code. */
+int ut20_feed_st22_pkt(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts,
+                       uint32_t pkt_counter, bool marker, const void* payload,
+                       uint16_t payload_length, enum mtl_session_port port);
+
+/* Feed a first packet whose mbuf->data_len claims `data_len` bytes regardless of
+ * the `payload_length` bytes actually written. Below ut20_st22_hdr_len() this
+ * forges a runt datagram; above the payload end it leaves planted bytes past the
+ * declared datagram, where a parser that overreads sees them. */
+int ut20_feed_st22_pkt_data_len(ut20_test_ctx* ctx, uint32_t seq, uint32_t ts,
+                                const void* payload, uint16_t payload_length,
+                                uint16_t data_len, enum mtl_session_port port);
+
+/* Bytes of RFC 9134 headers that precede the codestream payload in a packet. */
+uint16_t ut20_st22_hdr_len(void);
+
+/* Write a jpvs box followed by a colr box into `buf` (needs 60 bytes) with the
+ * given on-the-wire lbox values, and return the bytes written. Pass the real
+ * struct sizes (42 / 18) for a well-formed pair. */
+uint16_t ut20_st22_build_boxes(void* buf, uint32_t jpvs_lbox, uint32_t colr_lbox);
 
 /* Fixed geometry constant: number of packets that make up one full frame
  * in the harness's synthetic 16x2 YUV422-10bit configuration. Tests use it


### PR DESCRIPTION
A crafted or malformed ST 2110-22 stream could drive four out-of-bounds accesses in rv_handle_st22_pkt: an unchecked JPEG 2000 lbox advanced the box parser outside the mbuf, a datagram shorter than the RTP header underflowed payload_length to ~64K, the 22-bit wire packet counter indexed the dedup bitmap unchecked, and the copy offset both overflowed 32 bit and underflowed against a box length that outlives slot recycle. Bound each before use, reusing the existing drop counters. Well-formed traffic is unaffected.

Widening the offset to 64 bit is not sufficient alone: it turns the underflow from a faulting wild write into a silent 20-byte heap underflow, so the floor check lands with it.

Also corrects the unit tier's ASan claims, which is why the new tests fence frame buffers with guard bands rather than relying on a sanitizer.