### PR TITLE
Fix: Guard st22 plugin block waits with pending flags

### DIFF
--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -33,6 +33,7 @@ static void rx_st22p_block_wake(struct st22p_rx_ctx* ctx) {
 static void rx_st22p_decode_block_wake(struct st22p_rx_ctx* ctx) {
   /* notify block */
   mt_pthread_mutex_lock(&ctx->decode_block_wake_mutex);
+  ctx->decode_block_wake_pending = true;
   mt_pthread_cond_signal(&ctx->decode_block_wake_cond);
   mt_pthread_mutex_unlock(&ctx->decode_block_wake_mutex);
 }
@@ -211,11 +212,15 @@ static int rx_st22p_notify_event(void* priv, enum st_event event, void* args) {
 }
 
 static int rx_st22p_decode_get_block_wait(struct st22p_rx_ctx* ctx) {
-  /* wait on the block cond */
   mt_pthread_mutex_lock(&ctx->decode_block_wake_mutex);
-  mt_pthread_cond_timedwait_ns(&ctx->decode_block_wake_cond,
-                               &ctx->decode_block_wake_mutex,
-                               ctx->decode_block_timeout_ns);
+  while (!ctx->decode_block_wake_pending &&
+         !atomic_load_explicit(&ctx->lc_destroying, memory_order_acquire)) {
+    int _ret = mt_pthread_cond_timedwait_ns(&ctx->decode_block_wake_cond,
+                                            &ctx->decode_block_wake_mutex,
+                                            ctx->decode_block_timeout_ns);
+    if (_ret) break;
+  }
+  ctx->decode_block_wake_pending = false;
   mt_pthread_mutex_unlock(&ctx->decode_block_wake_mutex);
   return 0;
 }

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.h
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.h
@@ -58,6 +58,7 @@ struct st22p_rx_ctx {
   pthread_cond_t decode_block_wake_cond;
   pthread_mutex_t decode_block_wake_mutex;
   uint64_t decode_block_timeout_ns;
+  bool decode_block_wake_pending;
 
   bool ready;
   bool derive; /* output_fmt == transport_fmt */

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.c
@@ -46,6 +46,7 @@ static void tx_st22p_notify_frame_available(struct st22p_tx_ctx* ctx) {
 static void tx_st22p_encode_block_wake(struct st22p_tx_ctx* ctx) {
   /* notify block */
   mt_pthread_mutex_lock(&ctx->encode_block_wake_mutex);
+  ctx->encode_block_wake_pending = true;
   mt_pthread_cond_signal(&ctx->encode_block_wake_cond);
   mt_pthread_mutex_unlock(&ctx->encode_block_wake_mutex);
 }
@@ -295,11 +296,15 @@ static int tx_st22p_notify_event(void* priv, enum st_event event, void* args) {
 }
 
 static int tx_st22p_encode_get_block_wait(struct st22p_tx_ctx* ctx) {
-  /* wait on the block cond */
   mt_pthread_mutex_lock(&ctx->encode_block_wake_mutex);
-  mt_pthread_cond_timedwait_ns(&ctx->encode_block_wake_cond,
-                               &ctx->encode_block_wake_mutex,
-                               ctx->encode_block_timeout_ns);
+  while (!ctx->encode_block_wake_pending &&
+         !atomic_load_explicit(&ctx->lc_destroying, memory_order_acquire)) {
+    int _ret = mt_pthread_cond_timedwait_ns(&ctx->encode_block_wake_cond,
+                                            &ctx->encode_block_wake_mutex,
+                                            ctx->encode_block_timeout_ns);
+    if (_ret) break;
+  }
+  ctx->encode_block_wake_pending = false;
   mt_pthread_mutex_unlock(&ctx->encode_block_wake_mutex);
   return 0;
 }

--- a/lib/src/st2110/pipeline/st22_pipeline_tx.h
+++ b/lib/src/st2110/pipeline/st22_pipeline_tx.h
@@ -61,6 +61,7 @@ struct st22p_tx_ctx {
   pthread_cond_t encode_block_wake_cond;
   pthread_mutex_t encode_block_wake_mutex;
   uint64_t encode_block_timeout_ns;
+  bool encode_block_wake_pending;
 
   bool ready;
   bool derive; /* input_fmt == transport_fmt */


### PR DESCRIPTION
Sibling of Coverity CID 560632. rx_st22p_decode_get_block_wait and tx_st22p_encode_get_block_wait used a bare mt_pthread_cond_timedwait_ns with no predicate loop and no lc_destroying check. A spurious wakeup, or a wake fired before the plugin thread took the mutex during destroy, returned immediately with no frame, so decoder/encoder plugins yielded instead of blocking up to the configured timeout. Adopt the same predicate-loop pattern already used by st22p_tx_get_frame, on both plugin-facing channels.