### PR TITLE
Ci: Consolidate dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,35 +94,35 @@ jobs:
 
       - name: 'stash: Restore DPDK cache'
         id: dpdk-cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: stash-dpdk-${{ needs.checksums.outputs.dpdk }}
           path: .local_install/dpdk
 
       - name: 'stash: Restore MTL cache'
         id: mtl-cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: stash-mtl-${{ needs.checksums.outputs.mtl }}
           path: .local_install/mtl
 
       - name: 'stash: Restore FFmpeg cache'
         id: ffmpeg-cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: stash-ffmpeg-${{ needs.checksums.outputs.ffmpeg }}
           path: .local_install/ffmpeg
 
       - name: 'stash: Restore GStreamer cache'
         id: gstreamer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: stash-gstreamer-${{ needs.checksums.outputs.gstreamer }}
           path: .local_install/gstreamer
 
       - name: 'stash: Restore plugins cache'
         id: plugins-cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: stash-plugins-${{ needs.checksums.outputs.plugins }}
           path: .local_install/plugins

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,4 +24,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -72,14 +72,14 @@ jobs:
 
       - name: Set up Docker Buildx
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' }}
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           buildkitd-flags: "--debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host"
           platforms: "linux/amd64/v4"
           driver-opts: memory=14Gib,memory-swap=25Gib,env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000,env.BUILDKIT_STEP_LOG_MAX_SPEED=10000000
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         if: ${{ needs.changes.outputs.ubuntu_build == 'true' && env.DOCKER_REGISTRY_LOGIN == 'true' }}
         id: dockerLoginStep
         continue-on-error: true
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           buildkitd-flags: "--debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host"
           platforms: "linux/amd64/v4"
@@ -130,7 +130,7 @@ jobs:
         run: echo "VERSION=$(cat VERSION)">> "$GITHUB_OUTPUT"
 
       - name: Login to Docker Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         if: ${{ env.DOCKER_REGISTRY_LOGIN == 'true' }}
         id: dockerLoginStep
         continue-on-error: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -72,6 +72,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -68,7 +68,7 @@ jobs:
           output: Trivy-dockerfile.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: Trivy-dockerfile.sarif
 
@@ -111,7 +111,7 @@ jobs:
           output: Trivy-manager-dockerfile.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: Trivy-manager-dockerfile.sarif
 

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -6,7 +6,7 @@
 # Please review and modify as necessary before using in a production environment.
 
 # Build stage, ubuntu 24.04
-FROM ubuntu@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS builder
+FROM ubuntu@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba AS builder
 
 LABEL maintainer="andrzej.wilczynski@intel.com,dawid.wesierski@intel.com,marek.kasiewicz@intel.com"
 
@@ -41,7 +41,7 @@ RUN meson setup build && \
     DESTDIR=/install meson install -C build
 
 # Runtime stage, ubuntu 24.04
-FROM ubuntu@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+FROM ubuntu@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
 
 # Install runtime dependencies
 RUN apt-get update -y && \

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -6,7 +6,7 @@
 # Please review and modify as necessary before using in a production environment.
 
 # Build stage, ubuntu 24.04
-FROM ubuntu@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba AS builder
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS builder
 
 LABEL maintainer="andrzej.wilczynski@intel.com,dawid.wesierski@intel.com,marek.kasiewicz@intel.com"
 
@@ -41,7 +41,7 @@ RUN meson setup build && \
     DESTDIR=/install meson install -C build
 
 # Runtime stage, ubuntu 24.04
-FROM ubuntu@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
 
 # Install runtime dependencies
 RUN apt-get update -y && \

--- a/tests/acceptance/requirements.txt
+++ b/tests/acceptance/requirements.txt
@@ -11,7 +11,7 @@
 # and install with `pip install -r requirements.txt -c constraints.txt`.
 
 # --- pytest core + plugins directly used by test code ---
-pytest==9.0.3
+pytest==9.1.1
 pytest-check==2.8.0              # `from pytest_check import check`
 pytest-mfd-config==3.27.0        # TopologyModel + auto-loaded plugin
 pytest-mfd-logging==1.26.0       # AmberLogFormatter + auto-loaded plugin


### PR DESCRIPTION
## Summary

- consolidate the latest unique updates from nine open Dependabot PRs
- update five GitHub Actions, the manager Ubuntu digest, and pytest
- pin `actions/cache` v5.0.5 to its immutable commit for self-hosted runners

Supersedes #1512, #1598, #1599, #1600, #1601, #1602, #1603, #1638, and #1639. The older pytest and Ubuntu digest PRs are represented by their latest replacements.

## Validation

- `./format-coding.sh`
- `./build.sh`
- scoped `actionlint` and exact action-reference checks
- clean virtual environment install and `pip check`
- acceptance collection: 1,226 tests collected
- independent `mtl-reviewer`: approved, no findings