### PR TITLE
Docs: Add an orchestrator agent, two skills and MCP server tests

### DIFF
--- a/.github/agents/mtl-orchestrator.agent.md
+++ b/.github/agents/mtl-orchestrator.agent.md
@@ -1,0 +1,163 @@
+---
+description: "Runs a task board across the MTL agent fleet: picks what happens next, decides what can happen at the same time, dispatches the specialist, and records the evidence. Owns the active task document (`taks.md`). Use for: a list of tasks with more than one owner, work that alternates between code, host and CI, anything where the next step depends on a result that has not arrived yet. Do NOT use for: a single task with an obvious owner (invoke that agent), producing a plan for the user to approve (→ MTL Planner), or writing code, running builds, or configuring hosts itself — it dispatches, it does not implement. Tools: `read`, `codebase`, `search`, `edit` (task document only), `execute` (observation commands only), `agent`, `todo`, `askQuestions`, `memory`."
+name: "MTL Orchestrator"
+tools: ['read', 'codebase', 'search', 'edit', 'execute', 'agent', 'todo', 'askQuestions', 'memory']
+agents: ['Explore', 'MTL Planner', 'MTL Developer (TDD)', 'MTL Reviewer', 'MTL System Admin']
+user-invocable: true
+model:
+  - Claude Sonnet 4.5 (copilot)
+  - Gemini 2.5 Pro (copilot)
+handoffs:
+  - label: Plan This First
+    agent: MTL Planner
+    prompt: "The board above has a task whose shape is not yet known well enough to dispatch. Produce a phased plan for it with the user, then return it so the board can be refilled."
+    send: false
+  - label: Review the Board
+    agent: MTL Reviewer
+    prompt: "Review everything the board above records as done. Intent: <restate the board's goal>. Report BLOCKERs against the combined diff, not against individual dispatches."
+    send: false
+---
+
+# MTL Orchestrator
+
+You run a board of tasks across the MTL agent fleet. You own exactly one
+decision, and you make it over and over:
+
+> **What happens next, who does it, and what can happen at the same time?**
+
+You are the only agent that may invoke the other specialists (frontmatter
+`agents:`). MTL Planner lists them as buttons for the *user* to click; you call
+them yourself. That is the difference between the two, and it is why you must be
+strict with yourself about the rest: **you never implement.** No production edit,
+no build, no test run, no host change. Every one of those is a dispatch.
+
+Run on the largest context window available to you. Holding the whole board, the
+diff so far, and every subagent's report in one context is the point — a
+dispatcher that has forgotten the last three results starts making the same
+decision twice.
+
+## Rules
+
+- **The board is a file, not a memory.** You read it at the start of every turn
+  and write it back before you finish one. Default path: `taks.md` at the
+  repository root, or whatever file the user pointed you at. A result you did not
+  write down did not happen.
+- **One owner per task.** Resolve it from the *Agent Routing Matrix* in
+  [.github/copilot-instructions.md](../copilot-instructions.md). Cite it, do not
+  redefine it. If the matrix is silent — CI workflows, `Taskfile.yml`,
+  `.github/scripts/`, runner provisioning — the owner is the *main agent* with
+  the [`mtl-cicd`](../skills/mtl-cicd/SKILL.md) skill; say so explicitly rather
+  than routing CI work to an agent that cannot do it.
+- **Dispatch on evidence, not on optimism.** A task moves to done when there is
+  an observable artifact: a test name that failed and then passed, a clean build
+  line, a verdict, a job conclusion with a non-empty `runner_name`. "The agent
+  said it fixed it" is not evidence. See § Evidence.
+- **Separate blocked-on-a-result from blocked-on-a-human.** A queued CI job is
+  the first and you wait for it. An apt package missing from a runner, a cable
+  nobody has plugged in, an analyser nobody has deployed is the second: CI jobs
+  install nothing and neither do you. Record it as one line the user can act on
+  and route around it. Do not retry it.
+- **Ask once, early.** Use `askQuestions` when two readings of the board would
+  lead to materially different dispatches. Do not ask about anything you can
+  settle by reading the repository.
+- **Edit only the board.** `edit` exists so the document stays current. Any other
+  file is a dispatch, even a one-line one. `execute` is for observation only:
+  `git log`/`status`/`diff`, `gh run`/`api`, `ci_watch_run`, `task ci:report`,
+  `shellcheck`, `shfmt -d`, `--collect-only`, `--dry-run`. Not builds, not tests,
+  not installs, not pushes.
+
+## Capability contract
+
+| Can | Cannot |
+|---|---|
+| Invoke Explore, MTL Planner, MTL Developer (TDD), MTL Reviewer, MTL System Admin | Edit any file except the board (dispatch instead) |
+| Read the whole repository (`read`, `codebase`, `search`) | Build, format, or run any test suite |
+| Run observation commands via `execute` (list above) | Configure a host, bind a NIC, load a module |
+| Rewrite the board; keep a `todo` mirroring the live wave | Push, merge, or open a pull request without being asked |
+| Ask the user via `askQuestions`; persist context via `memory` | Declare a task done without an artifact naming it |
+
+## The board
+
+Keep it brief and scannable — nested `1. [ ]` / `1. [x]` checklists, one line per
+task, an indented note only where the *why* is not obvious. Every open task
+carries its owner and, where it matters, what it is waiting on. Sections:
+**Doing now** (the live wave), **Blocked** (each line naming the human act that
+unblocks it), **Next**, **Done**. Move lines between sections; do not rewrite
+history. Trim `Done` when it stops earning its length — the durable version of a
+finding belongs in `doc/`, not on a board.
+
+## Workflow
+
+1. **Read the board** and the repository state it claims (`git log --oneline`,
+   `git status`, the last CI run). Reconcile silently: the board is often behind.
+2. **Find the frontier** — every task whose inputs exist. Ignore the rest.
+3. **Build a wave** — the largest subset of the frontier that passes the
+   parallel-safety test below. Anything failing it goes into the next wave.
+4. **Dispatch the wave**, one message, one `agent` call per task, each prompt
+   carrying: the goal, the files in scope, the files explicitly *out* of scope
+   (this is how the wave stays disjoint), and the exit criterion you will check.
+5. **Collect evidence.** Read each report against its exit criterion. A report
+   without its artifact is not done — send it back once, with the artifact named.
+6. **Write the board back.** Move lines, add what the wave discovered, record
+   each blocked-on-a-human line.
+7. **Repeat or stop.** Stop when the frontier is empty, when everything left is
+   blocked on a human, or when a result invalidates a task the user chose — then
+   report, do not re-plan around them.
+
+## The parallel-safety test
+
+Two tasks may run in the same wave only if they share none of these. Each is a
+mutex in this repository, not a style preference:
+
+1. **A file.** Two agents editing one path serialise, always.
+2. **The build tree.** `build/` and the acceptance virtualenv under
+   `${XDG_CACHE_HOME:-$HOME/.cache}/mtl-ci` are per-checkout singletons. Two
+   builds in one checkout collide; parallel implementation needs parallel
+   worktrees, which is usually more setup than the wave saves.
+3. **A physical host.** Hugepages, VF layout, DPDK bindings, MtlManager and port
+   ownership are host-global. Two MTL System Admin tasks on *one* host never
+   overlap. On two different hosts they always may.
+4. **A NIC label.** The fleet is one host per label (`e810`, `e830`, `e835`,
+   `e825`, `i225`, `i226`, `perf`). Dispatching a second job at a label does not
+   add throughput, it adds a queue — and a queued bare-metal job can sit for
+   hours. Fleet width is the real cap on CI parallelism, and it is 1 per label.
+5. **A gate chain.** Gates 2→3→4→5→6 of *one* change are strictly serial; the
+   failing test has to exist before the fix, and the review after it. Parallelism
+   lives *across* changes, never inside one.
+
+Read-only work is exempt: Explore fan-out, and MTL Reviewer on a saved diff,
+parallelise as wide as the work has independent areas.
+
+And the honest limit: **do not fan out wider than the work has seams.** Three
+agents on two independent areas produce two results and a merge conflict.
+
+## Evidence
+
+| Dispatch | What closes the task |
+|---|---|
+| MTL Developer (TDD) | the Gate 2 test named, failing, then the same name passing, plus a clean `./build.sh` |
+| MTL Reviewer | a verdict, and for APPROVE no unaddressed BLOCKER |
+| MTL System Admin | the `KahawaiTest` filter and its result on real VFs |
+| CI (main agent + `mtl-cicd`) | `ci_watch_run(pr=<n>)`: a run ID, a job conclusion, and a **non-empty `runner_name`** |
+| Explore | the paths and symbols, specific enough to dispatch against |
+
+The `runner_name` clause is not pedantry. A job queued because the fleet is busy
+and a job queued because *no host advertises its label* are the same grey dot in
+the Actions UI; the field is the only place they differ, and reading the dot
+instead cost this repository two days on the `i225` leg
+([doc/i225_leg_analysis.md](../../doc/i225_leg_analysis.md)).
+
+## Anti-patterns
+
+- **Implementing "just this one line."** It is a dispatch. Your edit is unreviewed
+  by construction — you are the one agent no gate is watching.
+- **Re-planning after every report.** The board changes when a result invalidates
+  a *later* task, not when one arrives.
+- **A wave of one.** If the frontier holds one task, dispatch it and say nothing
+  about parallelism.
+- **Waiting serially on CI.** A leg that will queue for an hour is not a reason to
+  idle: dispatch the disjoint work, then read the result.
+- **Retrying a host fact.** The third dispatch fails for the same missing package
+  as the first. Write the one-liner down and move on.
+- **A board that only grows.** If nothing has moved to Done in three waves,
+  everything left is blocked on a human. Say that instead of re-dispatching.

--- a/.github/claude/CLAUDE.md
+++ b/.github/claude/CLAUDE.md
@@ -20,6 +20,8 @@ re-deriving things from source:
 
 | Doc | Use when |
 |---|---|
+| `tasks.md` | The active work list at the repository root. Read it first for any multi-step request. `mtl-orchestrator` owns it. |
+| `upstreaming.md` | Source record for `tasks.md`: the DPDK patch set MTL carries, what upstream 26.07 covers, and why each remaining patch stays. Every task names the section it needs. |
 | `.github/copilot-docs/mtl-knowledge-base.md` | Architecture reference (§1 design, §2 scheduler, §3 memory, §4 locking, §5 pacing, §6 session lifecycle, §7 DPDK patterns, §8 testing). Read the relevant § before any non-trivial library change. |
 | `.github/instructions/mtl-c-coding.instructions.md` | Mandatory C rules — naming, memory, locking, tasklet constraints, error handling. |
 | `.github/instructions/mtl-gtest.instructions.md` | Running/debugging `KahawaiTest`, suite map, pacing modes, failure signatures. |
@@ -36,8 +38,7 @@ The Copilot workflow above has been ported to Claude Code equivalents, so the sa
 skills, and MCP servers are usable directly.
 
 Everything lives in `.github/claude/`, next to the Copilot originals it mirrors. Claude Code
-only discovers config at fixed paths, so three tracked symlinks bridge the two — the same idiom
-`.clang-format -> .github/linters/.clang-format` already uses:
+only discovers config at fixed paths, so three tracked symlinks bridge the two:
 
 | Discovery path | Real file |
 |---|---|
@@ -52,6 +53,7 @@ Edit the file under `.github/claude/`, never the symlink. Personal, machine-loca
 
 | Agent | Use for |
 |---|---|
+| `mtl-orchestrator` | First point of contact for multi-step work. Holds the work list in `tasks.md`, picks the next task, groups what can run in parallel, delegates, verifies the result, and fires Gates 5 and 6 that `mtl-developer` can only name. Does not write code. |
 | `mtl-developer` | Any code change to `lib/`, `include/`, `app/`, `plugins/`, `ecosystem/`, `tests/unit/`, `tests/integration_tests/`. Owns Gates 0–4 of the TDD loop (knowledge → failing test → implement → green build) in one context window. Also owns building and unit gtest. |
 | `mtl-reviewer` | Adversarial read-only review of a saved diff. Gate 5 — no exemption. Refuses if `git diff` is empty. Give it scope + one-line intent; do not paste the diff. |
 | `mtl-system-admin` | Host setup (hugepages, VFs, ICE, MtlManager) and running `KahawaiTest` on real VFs. MCP-only, never shell. Gate 6 for data-plane changes. |
@@ -60,7 +62,8 @@ Edit the file under `.github/claude/`, never the symlink. Personal, machine-loca
 Built-in `Explore` covers read-only Q&A and code archaeology; use it for fan-out reads instead of
 burning the specialist agents' context.
 
-**Skills** (`.github/claude/skills/`) — `mtl-build`, `mtl-write-test`, `mtl-commit`. Each is
+**Skills** (`.github/claude/skills/`) — `mtl-build`, `mtl-write-test`, `mtl-commit`,
+`mtl-ste-writing`. Each is
 itself a symlink to `.github/skills/<name>/`, whose `SKILL.md` frontmatter is already valid for
 both Copilot and Claude Code. So there is exactly one copy of every skill and it cannot drift,
 and relative links inside a skill body resolve against `.github/skills/<name>/`.
@@ -75,10 +78,16 @@ create and populate `.github/mcp/.venv` on first launch.
 `.github/instructions/*.md`. That reproduces the Copilot `applyTo:` auto-attach, so the C rules
 or the gtest/pytest instructions load when you actually work in those trees.
 
-One difference from the Copilot version worth knowing: `mtl-system-admin`'s "MCP tools only, never
-a shell" rule is enforced by its prompt rather than by withholding the Bash tool, because MCP
-wildcards in a subagent's `tools:` list aren't reliably supported. If you see it reach for Bash,
-that's a bug in the agent's behavior, not permission to allow it.
+Two differences from the Copilot version are worth knowing:
+
+* `mtl-system-admin`'s "MCP tools only, never a shell" rule is enforced by its prompt rather than
+  by withholding the Bash tool, because MCP wildcards in a subagent's `tools:` list aren't
+  reliably supported. If you see it reach for Bash, that's a bug in the agent's behavior, not
+  permission to allow it.
+* `mtl-orchestrator` has no Copilot counterpart in `.github/agents/`. The Copilot workflow leaves
+  gate-firing and the work list to the user; here one agent owns both. Everything else it uses —
+  the routing matrix, the six gates, the exemption rules — is the shared version in
+  `.github/copilot-instructions.md`, so the two sides cannot disagree on process.
 
 ## Build
 
@@ -107,12 +116,32 @@ versions live in `versions.env` (DPDK, ICE, JPEG-XS, FFmpeg, xdp-tools, libbpf).
 ## Format and lint
 
 ```bash
-./format-coding.sh          # clang-format-14 (C/C++), isort+black (Python), shfmt (shell)
+./checkpatch.sh             # verify everything — what CI and the git hooks run
+./checkpatch.sh --staged    # verify staged files only
+./checkpatch.sh --files a.c # verify specific files
+./format-coding.sh          # apply every autofix
+./format-coding.sh --staged # apply the autofixes to staged files only
+./format-coding.sh --files a.c # apply the autofixes to specific files
+./format-coding.sh --check  # preview the blast radius, then restore the tree
 ```
 
-`clang-format-14` specifically — CI rejects output from other versions. Run before every
-commit. `.clang-format` symlinks to `.github/linters/.clang-format`. Markdown is checked
-with `.markdown-lint.yml`, YAML/shell/actions via super-linter (see README §6.2.3).
+`.pre-commit-config.yaml` is the **single source of truth** for which tool, which version,
+which arguments and which files; rule content lives in `.github/linters/` (plus
+`.clang-format` at the root, which must stay a real file — clang-format searches upward, and
+a symlink materializes as a text file on Windows). `checkpatch.sh`, the git hooks and
+`.github/workflows/linter.yml` all run that one hook list and define no rule of their own.
+Adding a linter or changing a rule means editing that config and nowhere else.
+
+`pre-commit` installs the pinned clang-format 22.1.8, shfmt, shellcheck, markdownlint,
+textlint, yamllint, actionlint and gitleaks itself — plus its own Node — so none of them
+need to be on `PATH`; do not `apt install clang-format-22`. Bootstrap with `./checkpatch.sh --bootstrap`, install
+the hooks with `./checkpatch.sh --install-hooks`. On a PEP 668 host (Fedora, Arch,
+Debian 12+) `--bootstrap` cannot use pip and prints the distribution package instead.
+
+Four CI checks are not yet reproduced locally (`BASH_EXEC`, dotenv-linter, ESLint over
+`*.ts`, rustfmt/clippy) and run in the `residual-linters` job. See
+[doc/coding_standard.md](../../doc/coding_standard.md) for the parity table and the rationale
+behind every pin and omission.
 
 ## Tests
 
@@ -167,8 +196,11 @@ sudo sysctl -w vm.nr_hugepages=2048              # lost on reboot
 sudo MtlManager                                  # lcore/queue arbitration daemon
 ```
 
-`script/build_ice_driver.sh` builds the patched ICE module required for hardware rate-limit
-pacing. A SEGFAULT in `iavf_tm_node_add` means the stock ICE driver is loaded.
+`script/build_drivers.sh --driver ice` builds the patched ICE module required for hardware
+rate-limit pacing. It downloads `ice-${ICE_VER}` from the Intel download mirror and applies
+`patches/ice_drv/${ICE_VER}/*.patch` — the public release carries none of those changes, so an
+unpatched driver is always the wrong driver. A SEGFAULT in `iavf_tm_node_add` means the stock
+ICE driver is loaded.
 
 ## Architecture essentials
 
@@ -233,3 +265,6 @@ simpler media types.
 Minimal diffs; no speculative helpers, no commented-out code, no reformatting lines you
 aren't functionally changing. `./format-coding.sh` then `./build.sh` before proposing a
 change; add or extend a test at the cheapest tier that can catch the bug.
+
+A new lint or formatting rule goes in `.pre-commit-config.yaml` and nowhere else — not in a
+workflow, not in a script, not in a document. Anything else is drift by construction.

--- a/.github/claude/agents/mtl-developer.md
+++ b/.github/claude/agents/mtl-developer.md
@@ -119,8 +119,9 @@ your reply with:
 
 > "Gates 0–4 complete. Awaiting Reviewer verdict (Gate 5). Invoke `mtl-reviewer` with: *Review the diff I just produced. Intent: `<one-line goal>`. Scope: `<staged | branch range>`. Working tree is saved.* If BLOCKERs appear, re-invoke me with them."
 
-The user owns whether to commit. If Reviewer raises BLOCKERs they re-invoke you and you walk
-Gates 2–4 again for the fix. If and when the user asks you to commit, use the `mtl-commit`
+The user owns whether to commit. Your invoker fires Gate 5 — `mtl-orchestrator` when it drives
+the task, the user otherwise. If Reviewer raises BLOCKERs your invoker re-invokes you and you
+walk Gates 2–4 again for the fix. If and when the user asks you to commit, use the `mtl-commit`
 skill — never commit on your own initiative.
 
 ### Gate 6 — Integration (handoff, when applicable)

--- a/.github/claude/agents/mtl-orchestrator.md
+++ b/.github/claude/agents/mtl-orchestrator.md
@@ -1,0 +1,184 @@
+---
+name: mtl-orchestrator
+description: First point of contact for multi-step MTL work. Holds the plan in tasks.md, picks the next task, names the agent that runs it, says what runs at the same time, delegates, verifies the result with real test output, and writes the state back. Use it when the request is "what is next", "keep going", "run the tasks", or when a task needs more than one agent. Use it before a long piece of work, not after. Do NOT use for a single-file edit (mtl-developer), read-only Q&A (Explore), or design-only research (mtl-planner).
+tools: Read, Edit, Write, Bash, Grep, Glob, Agent, AskUserQuestion, TodoWrite, Skill
+model: inherit
+---
+
+# MTL Orchestrator
+
+You are the orchestrator of the Media Transport Library repository. You hold the plan. You
+decide the order of the work, who does each piece, and what runs at the same time. You keep
+`tasks.md` true.
+
+You have a large context. Use it. Read the whole task list, the whole file you are about to
+delegate, and every file the task touches, before you delegate. Do not send a subagent to find
+something you can already see.
+
+You do not write production code. You route, verify, and record.
+
+## Read first, in this order
+
+1. `tasks.md` — the work list and its state, at the repository root. This is the one source of
+   truth for what is open. If it does not exist, create it from the template below.
+2. `CLAUDE.md` — repository layout, the two-world rule, the conventions, the build and test
+   tiers.
+3. `.github/copilot-instructions.md` — the agent routing matrix and the six-gate TDD loop. The
+   gate numbering there is canonical; cite it, never renumber it.
+4. `.github/instructions/mtl-kb-routing.instructions.md` — which
+   `.github/copilot-docs/mtl-knowledge-base.md` § applies to the subsystem a task touches. Name
+   the § in the prompt you hand to a subagent.
+
+## Capability contract
+
+| Can | Cannot |
+|---|---|
+| Read any file; `Bash` for `git diff`, `git log`, `grep`, `ls` | Edit `lib/`, `include/`, `app/`, `plugins/`, `ecosystem/`, `tests/` — delegate to `mtl-developer` |
+| `Write`/`Edit` **`tasks.md` only** | Configure the host — hugepages, VFs, drivers, MtlManager (delegate to `mtl-system-admin`) |
+| Verify independently: `./build.sh`, `./build.sh unit`, `./checkpatch.sh` | Run `KahawaiTest` or any `sudo` command (delegate to `mtl-system-admin`) |
+| Spawn every agent, including `mtl-developer`, `mtl-reviewer`, `mtl-system-admin`, `mtl-planner`, `Explore` | Commit, push, or open a pull request on your own initiative |
+| Ask the user with `AskUserQuestion` | Declare a task done without a Reviewer verdict (Gate 5 has no exemption) |
+
+You have `Bash`, so nothing mechanically stops you from editing a file with a shell command or
+running `KahawaiTest`. Do not. A change you make yourself has no Gate 2 test behind it and no
+Reviewer verdict in front of it.
+
+## What you do
+
+1. **Read the state.** List every open task with its blockers.
+2. **Pick the next task.** Choose by value, not by order in the file. A task that unblocks
+   other tasks comes first. A task that needs hardware you do not have, or a person outside
+   this machine, goes to **BLOCKED** and you move on.
+3. **Split the task.** Write the subtasks yourself. Each subtask has one deliverable, one file
+   set, and one acceptance test named as a runnable command with its `--gtest_filter`.
+4. **Group for parallel work.** Say the groups out loud before you start. The rules are in
+   *What may run at the same time* below — they are tighter here than in a pure software
+   repository, because this tree has one `build/`, one MtlManager, and one set of VFs.
+5. **Delegate.** One agent per subtask. Give it the file paths, the KB §section, the convention
+   file, and the acceptance test. Send the agents of one group in one message so they run
+   together.
+6. **Check the result.** Read the diff with `git diff`. Re-run the acceptance test yourself.
+   Do not trust a report that says "done" with no test output — if the subagent pasted no
+   failure output at Gate 2 and no pass output at Gate 4, the gate did not happen.
+7. **Write the state back.** Update `tasks.md`: mark the task, add one short note that says
+   what changed and what proves it, and add any new task the work uncovered.
+
+## Which agent for which work
+
+The routing matrix in `.github/copilot-instructions.md` is canonical. This is the short form:
+
+| Work | Agent |
+|---|---|
+| Find where something lives, sweep many files, code archaeology | `Explore` |
+| Design an approach for work crossing 2+ subsystems, before code exists | `mtl-planner` |
+| Write or change C/C++ in `lib/`, `include/`, `app/`, `plugins/`, `ecosystem/`, `tests/unit/`, `tests/integration_tests/`; build; run unit gtest | `mtl-developer` |
+| Review a saved diff for over-engineering, convention violations, correctness | `mtl-reviewer` |
+| Host setup (hugepages, VFs, ICE, DPDK, MtlManager) and `KahawaiTest` on real VFs | `mtl-system-admin` |
+| Prepare or run pytest under `tests/acceptance/` | Yourself, per `.github/instructions/mtl-acceptance-tests.instructions.md` |
+| Questions about Claude Code, the SDK, or the API | `claude-code-guide` |
+| Anything else | `general-purpose` |
+
+`mtl-planner` plans and never executes. When you use it, you own the execution of the plan it
+returns, and you tell it so in the prompt.
+
+Skills are not agents. Read the skill yourself and follow it: `mtl-build` for build modes and
+build failures, `mtl-write-test` for the test-tier decision, `mtl-commit` for staging a commit
+after the user asks for one.
+
+## The six gates are yours to drive
+
+`mtl-developer` walks Gates 0–4 inside one invocation and then stops. Gates 5 and 6 are
+handoffs it can only name. **You fire them.** That is the whole reason you exist:
+
+| Gate | Owner | What you do with it |
+|---|---|---|
+| 0–4 | `mtl-developer` | Check the pasted Gate 2 failure and Gate 4 pass output are real |
+| 5 | `mtl-reviewer` | Always fire it. Give scope + one-line intent, never the diff. Route BLOCKERs back to `mtl-developer` and re-run Gates 2–4 |
+| 6 | `mtl-system-admin` | Fire it when the change touches data-plane, session-lifecycle, pacing, DMA, RSS, kernel-socket, AF_XDP, or virtio-user. Otherwise record the exemption and the change class in `tasks.md` |
+
+A Gate 2 exemption (pure refactor, docs, build-system) and a Gate 6 exemption (pure
+control-plane) are the only exemptions that exist. Record which one you allowed and why. Gate 5
+has no exemption, ever.
+
+## What may run at the same time
+
+Two subtasks run at the same time only when they write to different files, neither reads the
+other's output, **and** neither needs a resource this machine has only one of:
+
+- **One `build/` tree.** Two `mtl-developer` agents building at once race on `build/` and on
+  `/usr/local`. Run one, or give each `isolation: "worktree"` so they build in separate trees.
+- **One host.** `mtl-system-admin` runs alone. VFs, hugepages, the ICE module, and MtlManager
+  are global state; `ice_driver_rebuild` destroys every VF under a running test.
+- **One `KahawaiTest` process.** It calls `mtl_init()` once per run and binds the VFs. Never two
+  at once, and never a `NoCtxTest.*` filter that matches several cases — use
+  `tests/integration_tests/noctx/run.sh`.
+- **`Explore` fans out freely.** Read-only agents have no such limit. Prefer 2–3 parallel
+  `Explore` agents over one serial sweep.
+
+## Rules you cannot break
+
+- **Ask before touching the host.** Any VF create or destroy, driver install or rebuild, NIC
+  bind or unbind, hugepage change, MtlManager restart, or `sudo` anything needs one line of
+  intent and a confirmation from the user. Another person may be running a live test on these
+  NICs; an ICE reload kills it.
+- **Ask before publishing.** `git commit`, `git push`, `gh pr create`, `gh issue create`, and
+  any comment on an upstream pull request. The user decides when a diff is ready; you then use
+  the `mtl-commit` skill.
+- **Never print a secret.** No keys, tokens, or `.env` contents in your reply or in `tasks.md`.
+  Refer to a file by path. `gitleaks` runs in `./checkpatch.sh` and will catch what you leak.
+- **Never let a subagent do what you have not scoped.** A vague prompt returns vague work. Name
+  the files, the KB §section, and the exact test command.
+- **Never widen the scope of a task on your own.** A refactor you noticed goes into `tasks.md`
+  as a new task, not into the current diff.
+- **Prose is Simplified Technical English.** Active voice, short sentences, one name per thing,
+  no marketing words. This applies to `tasks.md` and to your reply.
+- **Report the truth.** A test that failed is a failure. A step you skipped is a skipped step.
+  Say which part of the task you did not do, and why.
+
+## `tasks.md` format
+
+`tasks.md` lives at the repository root and is **tracked**. Its source record is `upstreaming.md`,
+also at the root; read the section a task names before you start the task. Update `tasks.md` as you
+work, but commit it only when the user asks, and never in the same commit as the code a task
+produced. One task per `##` heading. Status is one of `OPEN`, `IN PROGRESS`, `BLOCKED`, `DONE`.
+
+Keep the `## Decisions` table. It records what the user has already locked, so you do not
+re-litigate a choice. Add a row; never silently change one.
+
+```markdown
+# Tasks
+
+## T-01 One-line outcome — IN PROGRESS
+- **Owner:** mtl-developer
+- **Files:** lib/src/st2110/st_rx_ancillary_session.c
+- **Acceptance:** ./build_unit/tests/unit/UnitTest --gtest_filter='St40*'
+- **Gates:** 0-4 done; 5 pending; 6 required (RX data-plane)
+- **Note:** slot index wrapped before the bitmap reset; test pinned in tests/unit/st40_test.cpp
+
+## T-02 One-line outcome — BLOCKED
+- **Blocked by:** no E830 VF on this host; owner must run script/nicctl.sh create_vf
+```
+
+Keep a note to one line. The history belongs in `git log`, not here.
+
+## Output
+
+End every run with:
+
+1. What is done, with the test output that proves it.
+2. What runs next, and which agent has it.
+3. What is blocked, and who unblocks it.
+4. The lines you changed in `tasks.md`.
+
+Keep it short. The owner reads the list, not an essay.
+
+## Anti-patterns
+
+- **Doing the work yourself.** A one-line C fix still needs a Gate 2 test and a Gate 5 verdict.
+  Delegate it.
+- **Skipping Gate 5 because the diff is small.** Size is not an exemption.
+- **Trusting a "done" with no output.** Re-run the test.
+- **Fanning out two `mtl-developer` agents on the same tree.** They race on `build/`.
+- **Re-planning after every phase.** Re-plan only when a result invalidates a later phase.
+- **Letting `tasks.md` drift from the tree.** A task marked DONE with an unreviewed diff in the
+  working tree is a false record.

--- a/.github/claude/agents/mtl-planner.md
+++ b/.github/claude/agents/mtl-planner.md
@@ -35,8 +35,8 @@ planning threads do not collide.
   single-agent task — invoke `<agent name>` directly. The Planner is overhead here."*
 - **You may only spawn `Explore` subagents, and only during Discovery.** `mtl-developer`,
   `mtl-reviewer`, and `mtl-system-admin` are off-limits to you — they are named in your plan for
-  the **user** to invoke. Saying *"I'll invoke mtl-developer now"* is a contract violation, even
-  as prose.
+  the **user or `mtl-orchestrator`** to invoke. Saying *"I'll invoke mtl-developer now"* is a
+  contract violation, even as prose.
 
 ## Capability contract
 
@@ -105,8 +105,9 @@ Draft the plan per the *Plan style guide* below. The default skeleton is the six
 Save the full plan to the plan file and present a scannable version in your reply — the memory
 file is for persistence, not a substitute for showing the user.
 
-**Then stop and yield to the user.** Do not spawn any execution agent. The user reads the plan,
-then edits it, asks questions, or invokes the first phase's agent.
+**Then stop and yield to your invoker.** Do not spawn any execution agent. The user — or
+`mtl-orchestrator`, if it invoked you — reads the plan, then edits it, asks questions, or invokes
+the first phase's agent.
 
 ### 5. Refinement
 

--- a/.github/claude/skills/mtl-ste-writing
+++ b/.github/claude/skills/mtl-ste-writing
@@ -1,0 +1,1 @@
+../../skills/mtl-ste-writing

--- a/.github/copilot-docs/mtl-knowledge-base.md
+++ b/.github/copilot-docs/mtl-knowledge-base.md
@@ -794,8 +794,13 @@ Tests needing isolated `mtl_init`/`mtl_uninit` per test. DPDK EAL cannot
 re-init within one process, so each `NoCtxTest.*` case is run in its own
 `KahawaiTest` subprocess. `noctx/run.sh` enumerates cases via
 `--gtest_list_tests` and loops; the MCP `run_noctx_tests` tool does the same
-(accepts filters that match many cases). Requires 4 ports, 10s cooldown
-between processes.
+(accepts filters that match many cases). Requires 4 ports and waits 20s between
+processes, matching `run.sh`.
+
+Cases with a `_pf_` infix need a PF port, because VF drivers do not advertise
+TSN/launch-time pacing offload. `run_noctx_tests` excludes them; `noctx/run_pf.sh`
+and the MCP `run_noctx_pf_tests` tool run only those, against 2 PF ports, and
+wait 10s between processes.
 
 ### Fuzz Tests (`tests/fuzz/`)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ This is a **client-visible, production repository**. Every change goes through r
 - **Naming prefixes**: `mt_` (core internals), `mtl_` (public core API), `st_`/`st20_`/`st22_`/`st30_`/`st40_`/`st41_` (media APIs), `st20p_`/`st22p_`/`st30p_` (pipeline APIs).
 - **Error returns**: 0 = success, negative = error. Free resources in reverse allocation order on failure.
 - **Never block in tasklets** — no malloc, no mutex, no sleep, no INFO-level logging in data-plane paths.
-- **Formatting**: `clang-format-14` enforced by CI. Always run `./format-coding.sh` before committing.
+- **Formatting**: clang-format, at the version pinned in `.pre-commit-config.yaml` — the single source of truth for tool versions. `pre-commit` installs that pinned copy itself, so never `apt install` a clang-format package. Run `./format-coding.sh` to fix and `./checkpatch.sh` to verify — CI runs the identical hook list. See [doc/coding_standard.md](../doc/coding_standard.md).
 - **Build verification**: Always run `./build.sh` after changes to verify compilation.
 - **Logging**: Use `dbg()`/`info()`/`warn()`/`err()`. Never use `printf`.
 - **Comments**: Short and descriptive. Do not comment obvious code.
@@ -29,7 +29,13 @@ This is a **client-visible, production repository**. Every change goes through r
 ## Available Tooling
 
 - **MCP Server** (`mtl-system-setup`): 32 tools for host setup — hugepages, VFs, ICE driver, MtlManager, running gtests. Use these instead of raw shell commands for system administration.
-- **Agents**: "MTL Planner" (routes multi-subsystem work), "MTL Developer (TDD)" (writes code + tests in one context window, enforces the six-gate TDD loop), "MTL Reviewer" (adversarial code review — enforced exit gate), "MTL System Admin" (host setup + KahawaiTest via MCP — enforced exit gate for data-plane changes), "Explore" (read-only Q&A).
+- **Agents**:
+  "MTL Orchestrator" (runs a task board across the fleet — the only agent that invokes the others, and the one that decides what may run at once);
+  "MTL Planner" (routes multi-subsystem work);
+  "MTL Developer (TDD)" (writes code + tests in one context window, enforces the six-gate TDD loop);
+  "MTL Reviewer" (adversarial code review — enforced exit gate);
+  "MTL System Admin" (host setup + KahawaiTest via MCP — enforced exit gate for data-plane changes);
+  "Explore" (read-only Q&A).
   Pytest-environment prep (`tests/acceptance/`) has no dedicated agent — call `.github/scripts/acceptance_setup.sh` (interactive or `--auto`) or the `mtl-acceptance-setup` MCP tools directly; the interactive script already prompts for NFS/PF/EBU choices at zero token cost.
 - **Skills**: `/mtl-build` (build + format + verify workflow); `/mtl-write-test` (author a new unit/integration/pytest test — tier picker + golden templates); `/mtl-commit` (stage + commit as atomic, well-formed commits — user-triggered, never automatic).
 - **Knowledge Base**: `.github/copilot-docs/mtl-knowledge-base.md` — architecture, session API lifecycle, pacing, data-plane internals. Consult before non-trivial library changes.
@@ -41,6 +47,7 @@ Use this table to pick the right subagent. Resolve ambiguity in order:
 
 | Task | Agent | Why |
 |---|---|---|
+| A task list with more than one owner, or work alternating between code, host and CI | **MTL Orchestrator** | The only agent that may invoke the others; owns the board and the parallel-safety call |
 | Multi-step work crossing 2+ subsystems (code + host + manager + plugins…) | **MTL Planner** | Decomposes and routes; no execution |
 | Edit any of `lib/`, `include/`, `app/`, `plugins/`, `ecosystem/`, `tests/unit/`, `tests/integration_tests/` | **MTL Developer (TDD)** | Owns code + tests + the six-gate TDD loop in one context window |
 | Build (`./build.sh`, `ninja -C build`, `./format-coding.sh`) | **MTL Developer (TDD)** | Build is Gate 4 of its loop |

--- a/.github/instructions/mtl-acceptance-tests.instructions.md
+++ b/.github/instructions/mtl-acceptance-tests.instructions.md
@@ -50,16 +50,20 @@ cd tests/acceptance
 PY="sudo -E ./venv/bin/python3 -m pytest --topology_config=configs/topology_config.yaml --test_config=configs/test_config.yaml"
 
 $PY -m smoke -v                                              # marker
-$PY tests/single/st20p/fps/test_fps.py -m smoke --tb=short -v # proven first pass: p29/ParkJoy_1080p
+$PY tests/single/st20p/test_fps.py -m smoke -k rxtxapp -v    # proven first pass: p29
 $PY tests/single/st20p -v                                    # folder
 $PY tests/single/st40p -k multicast -v                       # substring
-$PY "tests/single/st20p/fps/test_fps.py::test_fps[|fps = p60|-ParkJoy_1080p]" -v   # exact (quote brackets)
+$PY "tests/single/st20p/test_fps.py::test_st20p_fps[|fps = p60|-Penguin_1080p-|application = rxtxapp|]" -v   # exact id, quoting required
 $PY <selector> --collect-only -q                             # dry run
 ```
 
-Selection markers: `smoke` (smallest), `nightly` (bulk single-host), `performance` (long,
-hardware-bound). The full marker set and its authoring rules live in
-[mtl-acceptance-authoring.instructions.md](mtl-acceptance-authoring.instructions.md#markers).
+Selection markers for `tests/single/`: `smoke` (smallest set that proves the host works),
+`nightly` (bulk single-host coverage), `ptp` (uses MTL's internal PTP). The performance
+markers (`performance`, `base_performance`) apply to `tests/dual/` items — select the
+`tests/single/performance/` modules by path, not by marker. `tests/acceptance/pytest.ini` holds
+the authoritative list. For the descriptive markers (`verified`, `refactored`,
+`tx_side`/`rx_side`/`tx_and_rx`, `allow_wide_compliance`) see
+[acceptance_quickstart.md § Markers](../../doc/acceptance_quickstart.md#markers).
 
 ## Backend per category
 
@@ -115,6 +119,13 @@ If you hit something not in this table: read `logs/latest/*.log` (sudo), match a
 ## Reporting
 
 Selector + counts (`X passed, Y failed, Z skipped`); for each FAIL/ERROR: 1-line root cause + offending log line + path to `logs/latest/`.
+
+`--tb` defaults to `auto`, which prints source context and the function arguments for each
+failure. Add `--showlocals` to see local variables, which `auto` never prints. Detail does not
+increase from `long` to `auto` to `short` to `line`, and `auto` equals `long` until the traceback
+exceeds two frames. Keep `auto` when one test fails, because `short` shows only one source line
+for each frame. Pass `--tb=short` when many tests fail, because `auto` prints more lines for each
+one. Pass `--tb=line` for one path line plus the exception message for each failure.
 
 ## See also
 

--- a/.github/instructions/mtl-c-coding.instructions.md
+++ b/.github/instructions/mtl-c-coding.instructions.md
@@ -93,5 +93,9 @@ These rules are **mandatory** for all C source in the MTL codebase. For deep arc
 
 ## Formatting
 
-- `clang-format-14` enforced by CI
-- Run `./format-coding.sh` before committing
+- clang-format 22 with `ColumnLimit: 90`, pinned in `.pre-commit-config.yaml`;
+  `pre-commit` installs it, so it does not need to be on `PATH`
+- A `/* clang-format off */` region is legitimate for hand-laid-out data tables
+  (see the permute tables in `st_avx512_vbmi.c`) and for nothing else
+- Run `./format-coding.sh` to fix, `./checkpatch.sh` to verify. CI runs the same
+  hooks — see [doc/coding_standard.md](../../doc/coding_standard.md)

--- a/.github/instructions/mtl-gtest.instructions.md
+++ b/.github/instructions/mtl-gtest.instructions.md
@@ -17,10 +17,18 @@ applyTo: "tests/integration_tests/**,.github/scripts/gtest.sh"
 --p_port <BDF>          Primary (producer) port
 --r_port <BDF>          Receiver port
 --auto_start_stop       Auto start/stop sessions (always use)
---pacing_way <mode>     auto (default, uses RL) | tsc (software fallback)
+--pacing_way <mode>     auto | rl | tsn | tsc | ptp | be. Default auto, which
+                        picks RL only when the driver advertises TM
+                        (lib/src/dev/mt_dev.c:1452-1461) and TSC otherwise
 --dma_dev <p>,<r>       DMA devices for DMA-accelerated tests
 --rss_mode <mode>       l3_l4 for RSS tests
 --p_sip <IP>            Primary station IP (auto-generated if omitted)
+--log_level <level>     debug | info | notice | warning | error. The binary
+                        defaults to error, which mutes the `dpdk version:`
+                        banner; notice is the quietest level that still prints it
+--no_ctx_tests          Select the NoCtxTest suite and skip the shared mtl_init
+--port_list <BDFs>      Comma-separated ports, up to MTL_PORT_MAX. Any suite
+                        accepts it; NoCtxTest uses it instead of --p_port/--r_port
 --gtest_filter=<pat>    Filter tests (supports wildcards)
 --gtest_list_tests      List tests without running
 ```
@@ -64,12 +72,22 @@ sudo ./build/tests/KahawaiTest \
 
 ## CI Script
 
-`.github/scripts/gtest.sh` provides full CI orchestration:
-- Auto-discovers VF ports and DMA devices
+`.github/scripts/gtest.sh` runs the suite on a host the job already prepared,
+and changes no host state itself:
+- Discovers the four vfio-pci ports of one PF and two DMA channels, preferring
+  that PF's NUMA node — it does not create VFs, bind devices or load a module
 - Shards `St20_rx*` and `St20_tx*` into 2 parts for parallelism
 - Randomizes station IPs
-- Retries failed tests (MAX_RETRIES=2, RETRY_DELAY=20s)
+- Retries failed tests (MAX_RETRIES=2, RETRY_DELAY=20s) on the same ports
 - TEST_CASE_TIMEOUT=1800s per test case
+
+Preparing that state is the job's own step, and it is what to run by hand when
+the script reports the host is not prepared:
+
+```bash
+sudo task ci:activate-ice      # E8xx cards, which need the Kahawai driver
+sudo task ci:bind-test-ports   # trusted VFs on one PF, two DMA channels
+```
 
 Key env vars: `TEST_PORT_1..4`, `TEST_DMA_PORT_P`, `TEST_DMA_PORT_R`, `NIGHTLY=1`
 
@@ -81,7 +99,9 @@ run in its own KahawaiTest process**. Never pass a filter that matches multiple
 NoCtxTest cases to a single `KahawaiTest` invocation — the second case will
 fail with `dev_eal_init, eal not support re-init`.
 
-Requires 4 VF ports. Run serially with a cooldown (10s) between processes:
+`run.sh` takes 4 VF ports (`TEST_PORT_1..4`) and waits 20s between processes.
+`run_pf.sh` takes 2 PF ports (`TEST_PF_PORT_1/2`) for the `_pf_` cases, whose
+TSN/launch-time pacing offload no VF driver advertises, and waits 10s:
 
 ```bash
 TEST_PORT_1=... TEST_PORT_2=... TEST_PORT_3=... TEST_PORT_4=... \
@@ -92,7 +112,17 @@ TEST_PORT_1=... TEST_PORT_2=... TEST_PORT_3=... TEST_PORT_4=... \
 process per test. The MCP tool `run_noctx_tests(gtest_filter=...)` does the
 same enumeration + one-process-per-test loop; it accepts filters that resolve
 to many cases (e.g. `*nonsplit*`, `NoCtxTest.st40i_*`) and reports per-test
-pass/fail.
+pass/fail. `run_noctx_pf_tests` covers the `_pf_` cases `run_noctx_tests`
+excludes. Each tool's `cooldown_seconds` default matches the script it mirrors —
+20 for `run.sh`, 10 for `run_pf.sh`.
+
+The argv both tools build, their listing parser and their sudo/exit-code
+handling are pinned by a no-NIC, no-subprocess unittest suite. Run it after any
+edit to `.github/mcp/mtl_mcp_server.py`:
+
+```bash
+.github/mcp/.venv/bin/python -m unittest discover -s .github/mcp -v
+```
 
 ## Interpreting Results
 
@@ -101,7 +131,7 @@ pass/fail.
 - `Error: DEV: Status: rx_hw_dropped_packets N` — NIC hardware drops, normal at high rates
 
 ### Actual failures
-- **SEGFAULT in `iavf_tm_node_add`** → Stock kernel ICE driver. Fix: `ice_driver_rebuild` + re-create VFs.
+- **SEGFAULT in `iavf_tm_node_add`** → Stock kernel ICE driver. Fix: `sudo task ci:activate-ice`, then `sudo task ci:bind-test-ports` to rebuild the VFs.
 - **`librte_*.so not found`** → Run `sudo ldconfig` or rebuild DPDK.
 - **Permission denied on CMakeCache.txt** → `mtl_clean_rebuild`.
 - **Test timeout** → Check if MtlManager is running. Check NUMA locality.

--- a/.github/mcp/mtl_acceptance_mcp_server.py
+++ b/.github/mcp/mtl_acceptance_mcp_server.py
@@ -39,8 +39,7 @@ ACCEPTANCE_DISCOVER_LIB = (
 
 mcp = FastMCP(
     "mtl-acceptance-setup",
-    instructions=textwrap.dedent(
-        """\
+    instructions=textwrap.dedent("""\
         MTL Acceptance Tests Setup MCP Server — takes a host to "ready to run
         tests/acceptance/tests/single/ pytest".
 
@@ -63,8 +62,7 @@ mcp = FastMCP(
           PF) to setup_acceptance_tests_full / setup_acceptance_tests_pytest. Without
           these, test_config.yaml's `compliance` stays false and the
           `pcap_capture` fixture only skips (no capture, no EBU upload).
-        """
-    ),
+        """),
 )
 
 

--- a/.github/mcp/mtl_mcp_server.py
+++ b/.github/mcp/mtl_mcp_server.py
@@ -50,8 +50,7 @@ NICCTL = REPO_ROOT / "script" / "nicctl.sh"
 
 mcp = FastMCP(
     "mtl-system-setup",
-    instructions=textwrap.dedent(
-        """\
+    instructions=textwrap.dedent("""\
         MTL System Setup MCP Server — tools for preparing a Linux host to run
         the Media Transport Library (SMPTE ST 2110 over DPDK).
 
@@ -76,8 +75,7 @@ mcp = FastMCP(
 
         Preparing tests/acceptance/ pytest (a separate .local_install tree)?
         Use the sibling `mtl-acceptance-setup` MCP server instead.
-    """
-    ),
+    """),
 )
 
 

--- a/.github/mcp/requirements.txt
+++ b/.github/mcp/requirements.txt
@@ -1,1 +1,5 @@
-mcp[cli]>=1.0.0
+# Ceiling is deliberate: mcp 2.x removed the mcp.server.fastmcp module that both
+# mtl_mcp_server.py and mtl_acceptance_mcp_server.py import. Lifting it to <3 breaks
+# every mtl-system-setup / mtl-acceptance-setup tool with ModuleNotFoundError.
+# Port both servers to the 2.x API before raising this.
+mcp[cli]>=1.0.0,<2.0.0

--- a/.github/mcp/run_acceptance_server.sh
+++ b/.github/mcp/run_acceptance_server.sh
@@ -23,8 +23,11 @@ if ! "$VENV_DIR/bin/python3" -m pip --version >/dev/null 2>&1; then
 	"$VENV_DIR/bin/python3" -m ensurepip --upgrade
 fi
 
-# Install deps if mcp module is missing
-if ! "$VENV_DIR/bin/python3" -c "import mcp" 2>/dev/null; then
+# Install deps if the module the server imports is missing. Test mcp.server.fastmcp, not
+# mcp: an mcp 2.x venv imports mcp but dropped fastmcp, so a bare "import mcp" guard skips
+# pip and the version ceiling in requirements.txt never applies.
+if ! "$VENV_DIR/bin/python3" -c "import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('mcp.server.fastmcp') else 1)" 2>/dev/null; then
 	"$VENV_DIR/bin/python3" -m pip install --quiet -r "$REQUIREMENTS"
 fi
 

--- a/.github/mcp/run_server.sh
+++ b/.github/mcp/run_server.sh
@@ -23,8 +23,11 @@ if ! "$VENV_DIR/bin/python3" -m pip --version >/dev/null 2>&1; then
 	"$VENV_DIR/bin/python3" -m ensurepip --upgrade
 fi
 
-# Install deps if mcp module is missing
-if ! "$VENV_DIR/bin/python3" -c "import mcp" 2>/dev/null; then
+# Install deps if the module the server imports is missing. Test mcp.server.fastmcp, not
+# mcp: an mcp 2.x venv imports mcp but dropped fastmcp, so a bare "import mcp" guard skips
+# pip and the version ceiling in requirements.txt never applies.
+if ! "$VENV_DIR/bin/python3" -c "import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('mcp.server.fastmcp') else 1)" 2>/dev/null; then
 	"$VENV_DIR/bin/python3" -m pip install --quiet -r "$REQUIREMENTS"
 fi
 

--- a/.github/mcp/test_mtl_mcp_server.py
+++ b/.github/mcp/test_mtl_mcp_server.py
@@ -1,0 +1,960 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2026 Intel Corporation
+"""
+Unit tests for the command construction and output parsing of mtl_mcp_server.
+
+These tests build argv lists, parse captured output, and drive the two test
+tools with `_run_rc` replaced by a stub. They start no test binary, need no NIC,
+and call no sudo, so they run anywhere:
+
+    .github/mcp/.venv/bin/python -m unittest discover -s .github/mcp -v
+
+stdlib unittest on purpose — it adds no entry to requirements.txt, which is
+the file that already broke every MCP tool once by floating a version.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import mtl_mcp_server
+import mtl_setup_common
+from mtl_mcp_server import (
+    _LD_PATH_PREFIXES,
+    DEFAULT_LD_LIBRARY_PATH,
+    REPO_ROOT,
+    _build_gtest_cmd,
+    _build_noctx_cmd,
+    _extract_dpdk_version,
+    _parse_noctx_listing,
+    _run_noctx_series,
+    _sudo_credential_error,
+    run_noctx_pf_tests,
+    run_noctx_tests,
+)
+
+BIN = "/repo/build/tests/KahawaiTest"
+
+
+class BuildGtestCmd(unittest.TestCase):
+    def test_pf_rl_run_at_notice_level_is_the_t05_step3_command(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            gtest_filter="St20p*",
+            pacing_way="rl",
+            log_level="notice",
+        )
+        self.assertEqual(err, "")
+        self.assertEqual(
+            cmd,
+            [
+                "sudo",
+                "-n",
+                "env",
+                "LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu",
+                BIN,
+                "--p_port",
+                "0000:15:00.0",
+                "--r_port",
+                "0000:15:00.1",
+                "--auto_start_stop",
+                "--log_level",
+                "notice",
+                "--pacing_way",
+                "rl",
+                "--gtest_filter=St20p*",
+            ],
+        )
+
+    def test_log_level_defaults_to_notice_so_the_dpdk_banner_is_never_muted(self):
+        cmd, err = _build_gtest_cmd(BIN, p_port="0000:15:00.0", r_port="0000:15:00.1")
+        self.assertEqual(err, "")
+        self.assertIn("--log_level", cmd)
+        self.assertEqual(cmd[cmd.index("--log_level") + 1], "notice")
+
+    def test_loader_path_is_forced_with_sudo_env_not_sudo_dash_e(self):
+        cmd, _err = _build_gtest_cmd(BIN, p_port="0000:15:00.0", r_port="0000:15:00.1")
+        self.assertEqual(cmd[:3], ["sudo", "-n", "env"])
+        self.assertNotIn("-E", cmd)
+        self.assertEqual(cmd[3], f"LD_LIBRARY_PATH={DEFAULT_LD_LIBRARY_PATH}")
+
+    def test_sudo_never_waits_on_a_password_prompt(self):
+        for ld in (DEFAULT_LD_LIBRARY_PATH, ""):
+            with self.subTest(ld_library_path=ld):
+                cmd, _err = _build_gtest_cmd(
+                    BIN,
+                    p_port="0000:15:00.0",
+                    r_port="0000:15:00.1",
+                    ld_library_path=ld,
+                )
+                self.assertEqual(cmd[:2], ["sudo", "-n"])
+
+    def test_empty_loader_path_leaves_the_loader_alone(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            ld_library_path="",
+        )
+        self.assertEqual(err, "")
+        self.assertEqual(cmd[:3], ["sudo", "-n", BIN])
+
+    def test_unknown_pacing_way_is_rejected(self):
+        cmd, err = _build_gtest_cmd(
+            BIN, p_port="0000:15:00.0", r_port="0000:15:00.1", pacing_way="turbo"
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("pacing_way", err)
+
+    def test_every_pacing_way_the_parser_accepts_is_allowed(self):
+        for way in ("auto", "rl", "tsn", "tsc", "ptp", "be"):
+            with self.subTest(pacing_way=way):
+                _cmd, err = _build_gtest_cmd(
+                    BIN, p_port="0000:15:00.0", r_port="0000:15:00.1", pacing_way=way
+                )
+                self.assertEqual(err, "")
+
+    def test_unknown_log_level_is_rejected(self):
+        cmd, err = _build_gtest_cmd(
+            BIN, p_port="0000:15:00.0", r_port="0000:15:00.1", log_level="verbose"
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("log_level", err)
+
+    def test_loader_path_with_shell_metacharacters_is_rejected(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            ld_library_path="/usr/local/lib:$(id)",
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+
+    def test_loader_path_must_be_absolute(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            ld_library_path="usr/local/lib",
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+
+    def test_dma_dev_must_be_a_list_of_bdfs(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            dma_dev="0000:00:01.0,;rm -rf /",
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("dma_dev", err)
+
+    def test_valid_dma_dev_pair_is_passed_through(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            dma_dev="0000:00:01.0,0000:00:01.1",
+        )
+        self.assertEqual(err, "")
+        self.assertEqual(cmd[cmd.index("--dma_dev") + 1], "0000:00:01.0,0000:00:01.1")
+
+    def test_malformed_port_bdf_is_rejected(self):
+        cmd, err = _build_gtest_cmd(BIN, p_port="15:00.0", r_port="0000:15:00.1")
+        self.assertEqual(cmd, [])
+        self.assertIn("p_port", err)
+
+    def test_gtest_filter_metacharacters_are_rejected(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            gtest_filter="St20p*; id",
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("gtest_filter", err)
+
+    def test_a_trailing_newline_on_the_filter_is_rejected(self):
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            gtest_filter="St20p*\n",
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("gtest_filter", err)
+
+    def test_a_trailing_newline_on_a_port_bdf_is_rejected(self):
+        cmd, err = _build_gtest_cmd(BIN, p_port="0000:15:00.0\n", r_port="0000:15:00.1")
+        self.assertEqual(cmd, [])
+        self.assertIn("p_port", err)
+
+    def test_a_bdf_list_rejects_the_whitespace_a_scalar_bdf_rejects(self):
+        """The list and scalar validators must agree on what a BDF is.
+
+        Accepting whitespace here and then emitting the unstripped value put a
+        string in argv that the scalar sibling rejects outright.
+        """
+        cmd, err = _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            dma_dev="0000:00:01.0\n , 0000:00:01.1",
+        )
+        self.assertEqual(cmd, [])
+        self.assertIn("dma_dev", err)
+
+
+class BuildNoctxCmd(unittest.TestCase):
+    PORTS = "0000:15:01.0,0000:15:01.1,0000:15:01.2,0000:15:01.3"
+
+    def test_listing_command_enumerates_without_running(self):
+        cmd, err = _build_noctx_cmd(
+            BIN, self.PORTS, "NoCtxTest.*-NoCtxTest.*_pf_*", list_tests=True
+        )
+        self.assertEqual(err, "")
+        self.assertEqual(
+            cmd,
+            [
+                "env",
+                f"LD_LIBRARY_PATH={DEFAULT_LD_LIBRARY_PATH}",
+                BIN,
+                "--no_ctx_tests",
+                "--gtest_list_tests",
+                f"--port_list={self.PORTS}",
+                "--gtest_filter=NoCtxTest.*-NoCtxTest.*_pf_*",
+            ],
+        )
+
+    def test_only_the_run_step_needs_root_not_the_enumeration(self):
+        list_cmd, _e1 = _build_noctx_cmd(
+            BIN, self.PORTS, "NoCtxTest.*", list_tests=True
+        )
+        run_cmd, _e2 = _build_noctx_cmd(BIN, self.PORTS, "NoCtxTest.init_32_queues")
+        self.assertNotIn("sudo", list_cmd)
+        self.assertEqual(run_cmd[:2], ["sudo", "-n"])
+
+    def test_the_enumeration_still_forces_the_loader_path(self):
+        cmd, _err = _build_noctx_cmd(BIN, self.PORTS, "NoCtxTest.*", list_tests=True)
+        self.assertEqual(cmd[:2], ["env", f"LD_LIBRARY_PATH={DEFAULT_LD_LIBRARY_PATH}"])
+
+    def test_an_empty_loader_path_leaves_the_enumeration_bare(self):
+        cmd, err = _build_noctx_cmd(
+            BIN, self.PORTS, "NoCtxTest.*", list_tests=True, ld_library_path=""
+        )
+        self.assertEqual(err, "")
+        self.assertEqual(cmd[0], BIN)
+
+    def test_run_command_names_exactly_one_case(self):
+        cmd, err = _build_noctx_cmd(BIN, self.PORTS, "NoCtxTest.init_32_queues")
+        self.assertEqual(err, "")
+        self.assertEqual(
+            cmd,
+            [
+                "sudo",
+                "-n",
+                "env",
+                f"LD_LIBRARY_PATH={DEFAULT_LD_LIBRARY_PATH}",
+                BIN,
+                "--no_ctx_tests",
+                "--auto_start_stop",
+                f"--port_list={self.PORTS}",
+                "--gtest_filter=NoCtxTest.init_32_queues",
+            ],
+        )
+
+    def test_malformed_port_in_the_list_names_the_port_that_failed(self):
+        cmd, err = _build_noctx_cmd(BIN, "0000:15:01.0,nope", "NoCtxTest.x")
+        self.assertEqual(cmd, [])
+        self.assertIn("port_2", err)
+        self.assertIn("nope", err)
+        self.assertEqual(err.count("Error:"), 1)
+
+    def test_filter_metacharacters_are_rejected(self):
+        cmd, err = _build_noctx_cmd(BIN, self.PORTS, "NoCtxTest.x && id")
+        self.assertEqual(cmd, [])
+        self.assertIn("gtest_filter", err)
+
+
+class LdLibraryPathTrustBoundary(unittest.TestCase):
+    """`ld_library_path` re-adds a loader search path across a sudo transition.
+
+    Syntax alone is not enough: every accepted element must also name a tree the
+    caller could only have populated with the privileges the check protects.
+    """
+
+    def _accepts(self, ld_library_path: str) -> tuple[list[str], str]:
+        return _build_gtest_cmd(
+            BIN,
+            p_port="0000:15:00.0",
+            r_port="0000:15:00.1",
+            ld_library_path=ld_library_path,
+        )
+
+    def test_world_writable_and_home_trees_are_rejected(self):
+        for ld in (
+            "/tmp/evil",
+            "/dev/shm/x",
+            "/var/tmp/evil",
+        ):
+            with self.subTest(ld_library_path=ld):
+                cmd, err = self._accepts(ld)
+                self.assertEqual(cmd, [])
+                self.assertIn("ld_library_path", err)
+
+    def test_dot_dot_traversal_out_of_an_allowed_prefix_is_rejected(self):
+        cmd, err = self._accepts("/usr/local/lib/../../../tmp/evil")
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+
+    def test_dot_dot_is_rejected_even_when_it_stays_inside_the_allowlist(self):
+        cmd, err = self._accepts("/usr/local/lib/x86_64-linux-gnu/../lib")
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+
+    def test_one_untrusted_element_rejects_the_whole_list(self):
+        cmd, err = self._accepts(f"/tmp/evil:{DEFAULT_LD_LIBRARY_PATH}")
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+
+    def test_a_sibling_of_an_allowed_prefix_does_not_inherit_its_trust(self):
+        cmd, err = self._accepts("/usr/local/libevil")
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+
+    def test_the_default_is_inside_the_allowlist(self):
+        _cmd, err = self._accepts(DEFAULT_LD_LIBRARY_PATH)
+        self.assertEqual(err, "")
+
+    def test_two_allowed_trees_can_be_joined_for_an_ab_run(self):
+        _cmd, err = self._accepts(f"{REPO_ROOT}/dpdk/lib:{DEFAULT_LD_LIBRARY_PATH}")
+        self.assertEqual(err, "")
+
+    def test_every_prefix_carries_its_own_justification(self):
+        """A prefix appended later does not inherit the argument for these three.
+
+        Each is writable only by the operator who already drives the sudo the
+        loader path crosses; a tree that is not must not be added silently.
+        """
+        justified = {
+            "/usr/local/lib": "root-owned; writing it already needs the same sudo",
+            str(REPO_ROOT): "the checkout whose KahawaiTest run_gtest execs as root",
+            str(
+                REPO_ROOT.parent / "Media-Transport-Library" / ".local_install"
+            ): "the sibling checkout's install tree, owned by the same operator",
+        }
+        self.assertEqual(
+            set(_LD_PATH_PREFIXES),
+            set(justified),
+            "every prefix needs a recorded justification and every justification "
+            "needs a prefix; state why the operator who can write a new tree "
+            "already holds the privilege this check guards, and drop the entry "
+            "when its prefix goes",
+        )
+
+    def test_the_sibling_install_tree_is_accepted_on_its_own(self):
+        sibling = str(REPO_ROOT.parent / "Media-Transport-Library" / ".local_install")
+        _cmd, err = self._accepts(f"{sibling}/lib/x86_64-linux-gnu")
+        self.assertEqual(err, "")
+
+    def test_a_trailing_newline_does_not_smuggle_a_second_line_past_the_anchor(self):
+        cmd, err = self._accepts(f"{DEFAULT_LD_LIBRARY_PATH}\n/tmp/evil")
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+
+    def test_a_trailing_slash_on_an_allowed_directory_is_accepted(self):
+        _cmd, err = self._accepts(f"{DEFAULT_LD_LIBRARY_PATH}/")
+        self.assertEqual(err, "")
+
+    def test_a_path_too_long_for_execve_is_rejected_before_exec(self):
+        long_but_allowlisted = f"{DEFAULT_LD_LIBRARY_PATH}/{'x' * 5000}"
+        cmd, err = self._accepts(long_but_allowlisted)
+        self.assertEqual(cmd, [])
+        self.assertIn("ld_library_path", err)
+        self.assertNotIn("x" * 5000, err)
+
+
+class SudoCredentialFailure(unittest.TestCase):
+    """`sudo -n` refusal must be named as such, not as an empty test listing."""
+
+    def test_a_refused_sudo_is_named_as_a_credential_failure(self):
+        err = _sudo_credential_error("sudo: a password is required\n")
+        self.assertIn("a password is required", err)
+        self.assertIn("credential", err.lower())
+
+    def test_no_refusal_that_can_stand_alone_is_left_unrecognised(self):
+        """Fixture is the sudo 1.9.15p5 catalogue with `%s` filled in.
+
+        Line numbers are `strings -a /usr/libexec/sudo/sudoers.so`, 3994 lines.
+        A regression pin against narrowing, not a gap: the classifier already
+        matches every fixture line, so the record below carries the gap argument.
+
+        The PAM block is every message the one `pam_acct_mgmt` call site can
+        print, resolved with `objdump -d` rather than inferred: the bounds check
+        at 0xe494 admits rc 0..27, the table at .rodata 0x73780 holds 28 int32
+        entries over 7 targets, and those emit 6 wordings. :2827 is both the
+        `default` (20 codes) and the rc 6/9/11 arm, so 23 of 28 codes reach it.
+
+        :2823 and :2825 were already matched by the `password (?:is )?expired`
+        clause, and :3131 by the clause :3259 pins, so all three are regression
+        pins rather than new coverage. The fixture is the sweep's whole matched
+        set: 12 of the catalogue's 3994 lines.
+
+        Two credential-phase entries stay unmatched, for different reasons:
+
+        * :2824 (`unable to change expired password`) — **proven** never to stand
+          alone. Its address 0x6cce8 has exactly one reference in the object, at
+          0xe5b4, and nothing branches into 0xe5a3..0xe5b4 from outside; the only
+          path there emits :2823 at 0xe56e first, which this test covers.
+        * :3269 (`sudoers specifies that root is not allowed to sudo`) — needs
+          euid root. An **assumption** about how this server is launched, not
+          something the code enforces.
+
+        Over the one boundary measured exactly — the `pam_acct_mgmt` switch — the
+        classifier is complete, the sixth of its six wordings being :2824 above.
+        Sudo's other refusal classes are unmatched by design and sit outside that
+        count. Sudoers configuration is one: :3123, :2414, :3182, :3183 and :3330
+        each reach stderr through `sudo_warn_gettext_v1` into
+        `sudo_warnx_nodebug_v1`, by a chain sweep that under-reports, so read
+        five as a floor; :2715 (`problem parsing sudoers`) reaches no warn at
+        all, its one load at 0x600dd being `dcgettext`ed into eventlog's
+        `mail_parse_errors` buffer. Option-policy refusals such as :3278 are
+        another, and need an option this server never passes. Matching either
+        class would trade a missed refusal for a misreported test failure, and a
+        sudoers file that does not parse fails every case of a series whether a
+        clause names it or not.
+        """
+        for line in (
+            "sudo: a password is required",  # sudoers.so:2708
+            "sudo: operator is not in the sudoers file.",  # :3258
+            "Sorry, user operator may not run sudo on build01.",  # :3261
+            "Sorry, user operator is not allowed to execute '/bin/ls' as root on build01.",  # :3262
+            "sudo: sorry, you must have a tty to run sudo",  # :3275
+            "sudo: labrat is not allowed to run sudo on build01.",  # :3259
+            "sudo: User labrat is not allowed to run sudo on build01.",  # :3131
+            "sudo: Account or password is expired, reset your password and try again",  # :2823
+            "sudo: Password expired, contact your system administrator",  # :2825
+            'sudo: Account expired or PAM config lacks an "account" section for sudo,'
+            " contact your system administrator",  # :2826
+            # 0xe4b0 default + 0xe4f0 (rc 6, 9, 11) — 23 of the 28 codes
+            "sudo: PAM account management error: Permission denied",  # :2827
+            "sudo: account validation failure, is your account locked?",  # :2822, rc 7
+        ):
+            with self.subTest(line=line):
+                self.assertNotEqual(_sudo_credential_error(f"{line}\n"), "")
+
+    def test_a_pam_account_refusal_does_not_prescribe_warming_the_cache(self):
+        """:2827 also carries PAM_SERVICE_ERR and PAM_SYSTEM_ERR, which no
+        credential cache can clear, so the remedy must not name one."""
+        err = _sudo_credential_error(
+            "sudo: PAM account management error: System error\n"
+        )
+        self.assertIn("PAM account check", err)
+        self.assertNotIn("Warm the sudo", err)
+
+    def test_an_expiry_that_demands_a_reset_does_not_prescribe_warming_the_cache(self):
+        """:2823, rc 12 — a warm cache cannot reset the password sudo asks for."""
+        err = _sudo_credential_error(
+            "sudo: Account or password is expired, reset your password and try"
+            " again\n"
+        )
+        self.assertIn("PAM account check", err)
+        self.assertNotIn("Warm the sudo", err)
+
+    def test_an_expired_password_does_not_prescribe_warming_the_cache(self):
+        """:2825, rc 27 — only the administrator named in the wording can clear it."""
+        err = _sudo_credential_error(
+            "sudo: Password expired, contact your system administrator\n"
+        )
+        self.assertIn("PAM account check", err)
+        self.assertNotIn("Warm the sudo", err)
+
+    def test_an_expired_account_does_not_prescribe_warming_the_cache(self):
+        """:2826, rc 13 — the account is gone, so no credential for it can be cached."""
+        err = _sudo_credential_error(
+            'sudo: Account expired or PAM config lacks an "account" section for'
+            " sudo, contact your system administrator\n"
+        )
+        self.assertIn("PAM account check", err)
+        self.assertNotIn("Warm the sudo", err)
+
+    def test_a_missing_credential_still_prescribes_warming_the_cache(self):
+        """The counterpart: a real credential refusal keeps the remedy."""
+        self.assertIn(
+            "Warm the sudo", _sudo_credential_error("sudo: a password is required\n")
+        )
+
+    def test_a_stale_hosts_warning_beside_a_loader_failure_is_not_a_refusal(self):
+        """The `sudo: ` prefix fronts this warning, so only the wording can reject it.
+
+        The binary never started, so nothing was killed and no case reported
+        starting. Misreading it abandons the other 27 cases of a series and
+        prescribes warming a credential cache that is already warm.
+        """
+        out = f"{ToolHarness.STALE_HOST}\n{NoctxEnumeration.LOADER_FAILURE}"
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_stale_hosts_warning_beside_an_eal_failure_is_not_a_refusal(self):
+        """Same shape as the loader failure, for a binary that dies inside EAL."""
+        out = f"{ToolHarness.STALE_HOST}\nEAL: FATAL: Cannot init memory\n"
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_real_listing_is_not_mistaken_for_a_credential_failure(self):
+        listing = (
+            "Note: Google Test filter = NoCtxTest.*\nNoCtxTest.\n  init_32_queues\n"
+        )
+        self.assertEqual(_sudo_credential_error(listing), "")
+
+    def test_a_bare_mention_of_sudo_is_not_a_refusal(self):
+        """A refusal is a wording; naming the program is not one."""
+        out = "MTL: cannot run sudo: see doc/run.md\n"
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_crashed_case_is_not_blamed_on_sudo(self):
+        """A process that reached `[ RUN` authenticated; the crash is the news."""
+        out = (
+            "sudo: unable to resolve host build01: Name or service not known\n"
+            "[ RUN      ] NoCtxTest.st30p_redundant_latency\n"
+            "EAL: Cannot init memory\n"
+            "Segmentation fault\n"
+        )
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_bare_stale_hosts_warning_is_not_a_refusal(self):
+        """The warning alone, with nothing else in the output to vouch for it."""
+        out = "sudo: unable to resolve host build01: Name or service not known\n"
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_stale_hosts_warning_does_not_discard_a_passing_run(self):
+        out = (
+            "sudo: unable to resolve host build01: Name or service not known\n"
+            "[ RUN      ] NoCtxTest.init_32_queues\n"
+            "[  PASSED  ] 1 test.\n"
+        )
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_stale_hosts_warning_does_not_mask_a_real_test_failure(self):
+        out = (
+            "sudo: unable to resolve host build01: Name or service not known\n"
+            "[  FAILED  ] 1 test, listed below:\n"
+        )
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_timed_out_run_is_not_blamed_on_sudo(self):
+        """A hang before `[ RUN` prints nothing but the marker and the warning."""
+        out = (
+            "sudo: unable to resolve host build01: Name or service not known\n"
+            "\n*** TIMEOUT after 600s ***"
+        )
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_a_timeout_outranks_a_refusal_printed_in_the_same_output(self):
+        """A killed run is what the caller must act on first, so the kill wins
+        even when a refusal wording sits in the same output."""
+        out = "sudo: a password is required\n\n*** TIMEOUT after 600s ***"
+        self.assertEqual(_sudo_credential_error(out), "")
+
+    def test_the_timeout_marker_is_the_one_run_rc_actually_writes(self):
+        """The classification keys on the marker, not on the rc sentinel."""
+        self.assertIn(
+            mtl_mcp_server._TIMEOUT_MARKER,
+            inspect.getsource(mtl_setup_common._run_rc),
+        )
+
+
+class NoctxSeriesSignature(unittest.TestCase):
+    def test_the_two_second_counts_cannot_be_passed_positionally(self):
+        params = inspect.signature(_run_noctx_series).parameters
+        for name in ("timeout_seconds", "cooldown_seconds"):
+            with self.subTest(parameter=name):
+                self.assertEqual(params[name].kind, inspect.Parameter.KEYWORD_ONLY)
+
+    def test_each_tool_waits_as_long_as_the_script_it_mirrors(self):
+        """Read the cooldown out of each script, so a change there fails here."""
+        noctx = REPO_ROOT / "tests/integration_tests/noctx"
+        scripts = (
+            (run_noctx_tests, noctx / "run.sh", r"^sleep_time=(\d+)$"),
+            (run_noctx_pf_tests, noctx / "run_pf.sh", r"^\s*sleep (\d+)$"),
+        )
+        for tool, script, pattern in scripts:
+            with self.subTest(tool=tool.__name__):
+                match = re.search(pattern, script.read_text(), re.MULTILINE)
+                self.assertIsNotNone(match, f"no cooldown found in {script}")
+                default = inspect.signature(tool).parameters["cooldown_seconds"].default
+                self.assertEqual(default, int(match.group(1)))
+
+
+class ParseNoctxListing(unittest.TestCase):
+    """Fixture is `KahawaiTest --no_ctx_tests --gtest_list_tests` as `_run_rc` returns it.
+
+    The 11 unindented lines before the suite block and the 8 after it are the
+    point: the fixture only proves the parser if it carries the diagnostics a
+    real enumeration prints around the one block it must pick out.
+    """
+
+    def test_only_the_noctx_cases_are_taken_from_a_real_enumeration(self):
+        names = _parse_noctx_listing(NOCTX_LISTING, pf_only=False)
+        self.assertEqual(len(names), 28)
+        self.assertEqual(names[0], "st30p_redundant_latency")
+        self.assertEqual(names[-1], "init_asymmetric_queues_rx_heavy")
+
+    def test_no_preamble_or_diagnostic_line_becomes_a_case_name(self):
+        for name in _parse_noctx_listing(NOCTX_LISTING, pf_only=False):
+            with self.subTest(name=name):
+                self.assertNotIn(" ", name)
+                self.assertFalse(name.startswith("MTL:"))
+
+    def test_pf_only_keeps_exactly_what_run_pf_sh_selects(self):
+        self.assertEqual(
+            _parse_noctx_listing(NOCTX_LISTING, pf_only=True),
+            [
+                "st20p_tx_epoch_onward_recovers_after_ptp_step_pf_tsn_pacing",
+                "st20p_tx_packets_are_spread_over_frame_pf_tsn_pacing",
+            ],
+        )
+
+    def test_a_foreign_suite_block_does_not_leak_its_cases(self):
+        mixed = f"{NOCTX_LISTING}St20pTest.\n  digest_1080p\n"
+        self.assertNotIn("digest_1080p", _parse_noctx_listing(mixed, pf_only=False))
+
+    def test_an_empty_listing_yields_no_cases_rather_than_a_blank_name(self):
+        self.assertEqual(_parse_noctx_listing("", pf_only=False), [])
+
+
+class ToolHarness(unittest.TestCase):
+    """Drives `run_gtest` and `_run_noctx_series` with `_run_rc` stubbed.
+
+    No binary is started, so this stays in the no-subprocess tier while still
+    pinning the real call sites, the return codes they must consult, and the log
+    that has to survive an aborted run. Holds no test of its own.
+    """
+
+    REFUSAL = "sudo: a password is required"
+    STALE_HOST = "sudo: unable to resolve host build01: Name or service not known"
+    PORTS = ("0000:15:01.0", "0000:15:01.1", "0000:15:01.2", "0000:15:01.3")
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        fake_repo = Path(tmp.name)
+        (fake_repo / "build/tests").mkdir(parents=True)
+        (fake_repo / "build/tests/KahawaiTest").write_text("")
+        self.saved_logs: dict[str, str] = {}
+        self.listing = (0, NOCTX_LISTING)
+        self.listing_calls = 0
+
+        def save_test_log(name: str, content: str) -> Path:
+            self.saved_logs[name] = content
+            return Path(f"/log/{name}")
+
+        stubs = {
+            "REPO_ROOT": fake_repo,
+            # Port auto-discovery would otherwise shell out to dpdk-devbind.py.
+            "_run_output": lambda *_a, **_k: "",
+            "_summarize_output": (
+                lambda name, out, **kw: f"<<log {name} {len(out)} rc={kw.get('rc')}>>"
+            ),
+            "_save_test_log": save_test_log,
+        }
+        for attr, stub in stubs.items():
+            patcher = mock.patch.object(mtl_mcp_server, attr, stub)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _gtest(self, rc: int, out: str) -> str:
+        with mock.patch.object(mtl_mcp_server, "_run_rc", return_value=(rc, out)):
+            return mtl_mcp_server.run_gtest(p_port=self.PORTS[0], r_port=self.PORTS[1])
+
+    def _series(
+        self,
+        *outcomes: tuple[int, str],
+        listing: tuple[int, str] | None = None,
+        pf_only: bool = False,
+    ) -> str:
+        """Drive the series on a stubbed enumeration plus one outcome per case.
+
+        The stub dispatches on argv, not on call order, so the enumeration keeps
+        its own return code however the tool chooses to fetch it. `listing_calls`
+        keeps what call order gave for free: a second enumeration is a second
+        60-second subprocess on a real host.
+        """
+        if listing is not None:
+            self.listing = listing
+        cases = iter(outcomes)
+
+        def run_rc(cmd: list[str], **_kw: object) -> tuple[int, str]:
+            if "--gtest_list_tests" in cmd:
+                self.listing_calls += 1
+                return self.listing
+            return next(cases)
+
+        with mock.patch.object(mtl_mcp_server, "_run_rc", run_rc):
+            return mtl_mcp_server._run_noctx_series(
+                list(self.PORTS),
+                "NoCtxTest.*",
+                timeout_seconds=1,
+                cooldown_seconds=0,
+                ld_library_path=DEFAULT_LD_LIBRARY_PATH,
+                pf_only=pf_only,
+            )
+
+
+class NoctxEnumeration(ToolHarness):
+    """An enumeration the binary never produced must not read as an empty suite."""
+
+    LOADER_FAILURE = (
+        "KahawaiTest: error while loading shared libraries: libmtl.so.0: "
+        "cannot open shared object file: No such file or directory"
+    )
+
+    def test_a_failed_enumeration_is_not_reported_as_nothing_to_do(self):
+        """Exit 127 and a VF-only host both list zero `_pf_` cases.
+
+        Only the return code separates them, so the headline must come from it
+        and not from the listing text.
+        """
+        result = self._series(listing=(127, self.LOADER_FAILURE), pf_only=True)
+        self.assertIn("127", result)
+        self.assertIn("libmtl.so.0", result)
+        self.assertNotIn("No PF-only", result)
+
+    def test_a_vf_only_host_listing_no_pf_cases_is_still_not_an_error(self):
+        """Keeps the real enumeration's diagnostics, which say `Error:` eight times.
+
+        So the headline is the only thing that can carry the verdict — a bare
+        `Error` substring search would pass on a stripped fixture and fail here.
+        """
+        vf_only = "\n".join(
+            line for line in NOCTX_LISTING.splitlines() if "_pf_" not in line
+        )
+        result = self._series(listing=(0, vf_only), pf_only=True)
+        self.assertIn("No PF-only", result)
+        self.assertFalse(result.startswith("Error"))
+
+    def test_an_enumeration_that_timed_out_is_not_reported_as_exit_minus_one(self):
+        """rc -1 is the harness sentinel, not an exit code the binary produced."""
+        result = self._series(listing=(-1, "\n*** TIMEOUT after 60s ***"))
+        self.assertIn("timed out", result)
+        self.assertNotIn("exit -1", result)
+
+    def test_the_enumeration_is_fetched_once_for_a_whole_series(self):
+        self._series(*[(0, "[  PASSED  ] 1 test.\n")] * 28)
+        self.assertEqual(self.listing_calls, 1)
+
+
+class SudoCredentialWiring(ToolHarness):
+    """Both test tools must consult `_sudo_credential_error` and keep the output."""
+
+    def test_run_gtest_names_a_refused_sudo_rather_than_counting_zero_tests(self):
+        result = self._gtest(1, f"{self.REFUSAL}\n")
+        self.assertIn("credential failure", result)
+        self.assertNotIn("Total: 0", result)
+
+    def test_run_gtest_keeps_the_output_it_captured_when_sudo_is_refused(self):
+        """The log marker alone proves nothing — the normal path emits it too."""
+        result = self._gtest(1, f"{self.REFUSAL}\n")
+        self.assertLess(result.index("credential failure"), result.index("<<log gtest"))
+
+    def test_run_gtest_marks_a_crashed_binary_failed_rather_than_zero_tests(self):
+        self.assertIn("rc=139", self._gtest(139, "EAL: Cannot init memory\n"))
+
+    def test_run_gtest_reports_a_run_that_sudo_allowed_as_a_run(self):
+        result = self._gtest(0, "[  PASSED  ] 42 tests.\n")
+        self.assertNotIn("credential", result)
+        self.assertIn("Passed: 42", result)
+
+    def test_the_series_names_a_refused_sudo_rather_than_calling_it_a_failure(self):
+        result = self._series((1, f"{self.REFUSAL}\n"))
+        self.assertIn("credential failure", result)
+
+    def test_a_refusal_mid_series_keeps_the_cases_that_already_ran(self):
+        result = self._series(
+            (0, "[  PASSED  ] 1 test.\n"),
+            (0, "[  PASSED  ] 1 test.\n"),
+            (1, f"{self.REFUSAL}\n"),
+        )
+        self.assertIn("credential failure", result)
+        self.assertIn("Status: FAILED", result)
+        self.assertIn("Aborted after 2 of 28 cases", result)
+        self.assertIn("- PASS: NoCtxTest.st30p_redundant_latency", result)
+        self.assertIn(
+            "===== NoCtxTest.st30p_redundant_latency2: PASS =====",
+            self.saved_logs["noctx"],
+        )
+
+    def test_the_aborting_case_keeps_the_diagnostics_that_explain_the_abort(self):
+        result = self._series((1, f"{self.REFUSAL}\nEAL: Cannot init memory\n"))
+        self.assertIn("credential failure", result)
+        self.assertIn("EAL: Cannot init memory", self.saved_logs["noctx"])
+
+    def test_a_case_name_the_filter_cannot_carry_aborts_instead_of_raising(self):
+        """A value-parameterised listing annotates a name with `# GetParam()`.
+
+        That aborts at the argv check, before `_run_rc`, so the abort path must
+        not read output a run never produced.
+        """
+        listing = "NoCtxTest.\n  init_32_queues/0  # GetParam() = 4\n"
+        result = self._series(listing=(0, listing))
+        self.assertIn("invalid gtest_filter", result)
+        self.assertIn("Aborted after 0 of 1 cases", result)
+
+    def test_an_abort_before_any_case_ran_does_not_lecture_about_build_mode(self):
+        result = self._series((1, f"{self.REFUSAL}\n"))
+        self.assertNotIn("MTL_SIMULATE_PACKET_DROPS", result)
+
+    def test_a_case_that_printed_pass_but_died_is_not_counted_as_a_pass(self):
+        result = self._series(
+            (139, "[  PASSED  ] 1 test.\n"),
+            *[(0, "[  PASSED  ] 1 test.\n")] * 27,
+        )
+        self.assertIn("- FAIL: NoCtxTest.st30p_redundant_latency", result)
+
+    def test_a_case_that_died_early_on_a_stale_hosts_host_does_not_abort_the_series(
+        self,
+    ):
+        """The blocker's cost: one misread warning discards the other 27 cases."""
+        result = self._series(
+            (127, f"{self.STALE_HOST}\n{NoctxEnumeration.LOADER_FAILURE}"),
+            *[(0, "[  PASSED  ] 1 test.\n")] * 27,
+        )
+        self.assertNotIn("credential", result)
+        self.assertNotIn("Aborted after", result)
+        self.assertIn("Tests run: 28 (passed 27, failed 1)", result)
+
+    def test_run_gtest_reports_a_timeout_rather_than_an_empty_run(self):
+        """Runs the real summarizer, because the stub cannot omit a result line.
+
+        rc -1 is the harness sentinel for a kill, so the call must pass no `rc`
+        at all: any verdict line would either print the sentinel as an exit code
+        or, for `rc=0`, report the kill as OK and suppress the log tail the
+        headline tells the reader to consult.
+        """
+        with mock.patch.object(
+            mtl_mcp_server, "_summarize_output", mtl_setup_common._summarize_output
+        ), mock.patch.object(
+            mtl_setup_common, "_save_test_log", lambda name, content: Path("/log/gtest")
+        ):
+            result = self._gtest(-1, f"{self.STALE_HOST}\n\n*** TIMEOUT after 600s ***")
+        self.assertNotIn("credential", result)
+        self.assertIn("TIMEOUT", result)
+        self.assertNotIn("Total: 0", result)
+        self.assertNotIn("**Result:", result)
+
+    def test_the_result_label_is_the_one_the_shared_summariser_writes(self):
+        """Pins the label the test above keys on, which lives in a module this
+        suite does not own; a rename there would revive the mutant silently."""
+        self.assertIn(
+            "**Result:", inspect.getsource(mtl_setup_common._summarize_output)
+        )
+
+    def test_a_timeout_before_any_case_started_does_not_prescribe_a_longer_budget(self):
+        """A sudoers lookup that hangs in sssd is killed with no case started."""
+        result = self._gtest(-1, f"{self.STALE_HOST}\n\n*** TIMEOUT after 600s ***")
+        self.assertIn("may not have started", result)
+        self.assertNotIn("Raise `timeout_seconds`", result)
+
+    def test_a_timeout_after_a_case_started_prescribes_a_longer_budget(self):
+        out = "[ RUN      ] St20pTest.digest\n\n*** TIMEOUT after 600s ***"
+        self.assertIn("Raise `timeout_seconds`", self._gtest(-1, out))
+
+    def test_a_timed_out_case_is_recorded_and_the_series_continues(self):
+        result = self._series(
+            (-1, f"{self.STALE_HOST}\n\n*** TIMEOUT after 1s ***"),
+            *[(0, "[  PASSED  ] 1 test.\n")] * 27,
+        )
+        self.assertNotIn("credential", result)
+        self.assertIn("- TIMEOUT: NoCtxTest.st30p_redundant_latency", result)
+        self.assertIn("Tests run: 28 (passed 27, failed 1)", result)
+
+    def test_a_series_sudo_never_refused_reports_every_case(self):
+        result = self._series(*[(0, "[  PASSED  ] 1 test.\n")] * 28)
+        self.assertNotIn("credential", result)
+        self.assertIn("Tests run: 28 (passed 28, failed 0)", result)
+
+
+# Captured from `KahawaiTest --no_ctx_tests --gtest_list_tests`. Split by stream
+# because the tool never sees them interleaved: _run_rc returns stdout, a
+# newline, then stderr — so the MTL diagnostics land *after* the case list, and
+# only indentation can still tell a case name from a diagnostic.
+NOCTX_STDOUT = (
+    "test_parse_port_list, port list "
+    "0000:c9:01.0,0000:c9:01.1,0000:c9:01.2,0000:c9:01.3\n"
+    "next_port: 0000:c9:01.0\n"
+    "next_port: 0000:c9:01.1\n"
+    "next_port: 0000:c9:01.2\n"
+    "next_port: 0000:c9:01.3\n"
+    "run_all_test, if ip 197.163.151.1 for port 0000:c9:01.0\n"
+    "run_all_test, if ip 197.163.151.198 for port 0000:c9:01.1\n"
+    "run_all_test, if ip 197.163.151.199 for port 0000:c9:01.2\n"
+    "run_all_test, if ip 197.163.151.200 for port 0000:c9:01.3\n"
+    "st_test_st22_plugin_register, decoder register fail\n"
+    "st_test_convert_plugin_register, converter register fail\n"
+    "NoCtxTest.\n"
+    "  st30p_redundant_latency\n"
+    "  st30p_redundant_latency2\n"
+    "  st30p_default_timestamps\n"
+    "  st30p_user_pacing\n"
+    "  st20p_redundant_latency_drops_even_odd\n"
+    "  st20p_default_timestamps\n"
+    "  st20p_user_pacing\n"
+    "  st20p_user_pacing_offset_jitter\n"
+    "  st20p_exact_user_pacing\n"
+    "  st20p_tx_multithread_stability\n"
+    "  st20p_tx_epoch_onward_recovers_after_ptp_step_pf_tsn_pacing\n"
+    "  st20p_tx_epoch_onward_recovers_after_ptp_step_tsc_pacing\n"
+    "  st20p_tx_packets_are_spread_over_frame_pf_tsn_pacing\n"
+    "  st40i_smoke\n"
+    "  st40i_split_flag_accepts_and_propagates\n"
+    "  st40i_split_multi_packet_roundtrip\n"
+    "  st40i_split_loopback\n"
+    "  st40i_split_seq_gap_reports_loss\n"
+    "  st40p_rx_auto_detect_interlace\n"
+    "  st40p_user_pacing\n"
+    "  st40p_user_pacing_59fps\n"
+    "  st40p_user_pacing_offset_jitter\n"
+    "  st40p_exact_user_pacing\n"
+    "  init_32_queues\n"
+    "  init_64_queues\n"
+    "  init_128_queues\n"
+    "  init_asymmetric_queues_tx_heavy\n"
+    "  init_asymmetric_queues_rx_heavy\n"
+)
+
+NOCTX_STDERR = (
+    "MTL: 2026-08-25 11:55:55, Error: mtl_port_ip_info, null handle\n"
+    "MTL: 2026-08-25 11:55:55, Error: mtl_port_ip_info, null handle\n"
+    "MTL: 2026-08-25 11:55:55, Error: mtl_port_ip_info, null handle\n"
+    "MTL: 2026-08-25 11:55:55, Error: mtl_port_ip_info, null handle\n"
+    "MTL: 2026-08-25 11:55:55, Error: mtl_iova_mode_get, null handle\n"
+    "MTL: 2026-08-25 11:55:55, Error: mtl_rss_mode_get, null handle\n"
+    "MTL: 2026-08-25 11:55:55, Error: st22_decoder_register, invalid impl\n"
+    "MTL: 2026-08-25 11:55:55, Error: st20_converter_register, null handle\n"
+)
+
+NOCTX_LISTING = f"{NOCTX_STDOUT}\n{NOCTX_STDERR}"
+
+
+class ExtractDpdkVersion(unittest.TestCase):
+    def test_banner_line_yields_the_loaded_dpdk_version(self):
+        out = (
+            "MTL: mtl_init, MTL version: 25.06.0, dpdk version: DPDK 26.07.0_mtl_0\n"
+            "[  PASSED  ] 42 tests.\n"
+        )
+        self.assertEqual(_extract_dpdk_version(out), "DPDK 26.07.0_mtl_0")
+
+    def test_muted_banner_yields_nothing_rather_than_a_guess(self):
+        self.assertEqual(_extract_dpdk_version("[  PASSED  ] 42 tests.\n"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/mtl-build/SKILL.md
+++ b/.github/skills/mtl-build/SKILL.md
@@ -19,18 +19,33 @@ Run from the repository root:
 ## Format Code
 
 ```bash
-./format-coding.sh
+./format-coding.sh               # apply every autofix
+./format-coding.sh --staged      # apply the autofixes to staged files only
+./format-coding.sh --files a.c   # apply the autofixes to specific files
+./format-coding.sh --check       # report, then restore -- same as --preview
 ```
 
-- `./format-coding.sh --check` previews changes (non-mutating check/diff
-  mode for every tool, exits 1 if anything would change) instead of writing
-  to disk. Always use this to inspect a formatting change's blast radius
-  before running the real, mutating command on a working tree that has
-  uncommitted work in it.
-- Requires `clang-format-14` (install via `sudo apt install clang-format-14`)
-- **CI rejects improperly formatted code** — always run before committing
-- Formats all C/C++ source files in the repository, plus Python (`isort` then
-  `black`) under `python/` and `tests/`, Markdown, and Shell scripts
+- Scope the write modes to what you actually changed. A bare run applies the autofixes to every
+  tracked file, so `--staged` or `--files` is the right default when you are
+  fixing a handful of files.
+- `--check` previews changes (runs the fixers on a clean tree, prints the full
+  diff, then restores it). Use it to inspect a formatting change's blast radius.
+  It refuses to run on a dirty tree — commit or stash uncommitted work first.
+- `./checkpatch.sh` is the same rule set in verify mode.
+  `./checkpatch.sh --staged` checks only staged files — what the git hook runs.
+  `./checkpatch.sh --files a.c` verifies specific files.
+- Exit status is `0` clean, `1` findings or anything a fixer would change, `2` a
+  usage or environment problem, `130` an interrupted `--preview` rolled back.
+- Requires only `pre-commit` (`./checkpatch.sh --bootstrap`, or the distribution
+  package it names on a PEP 668 host such as Fedora, Arch or Debian 12+). It
+  installs the pinned clang-format, shfmt, shellcheck, markdownlint, yamllint,
+  actionlint and gitleaks itself — do **not** `apt install` a clang-format
+  package, and do not rely on whatever version happens to be on `PATH`.
+- **CI runs the identical hook list** — always run before committing
+- Covers C/C++, Python (`isort`, `black`, `flake8`, `ruff`), shell, Markdown
+  (syntax and prose), YAML, GitHub Actions workflows, HTML and secrets
+- Rules live in `.pre-commit-config.yaml` and `.github/linters/` only. See
+  [doc/coding_standard.md](../../../doc/coding_standard.md)
 
 ## Verification Checklist
 
@@ -40,7 +55,7 @@ After building, verify:
    - `build/lib/libmtl.so` — shared library
    - `build/tests/KahawaiTest` — integration test binary
    - `build/app/RxTxApp` — reference application
-3. Run `./format-coding.sh` and check for any formatting changes
+3. Run `./checkpatch.sh` and check that it exits clean
 
 ## Common Build Errors
 
@@ -53,6 +68,6 @@ After building, verify:
 | Missing `libgtest-dev` | `sudo apt install libgtest-dev` |
 | Missing `libssl-dev` | `sudo apt install libssl-dev` |
 | Missing `systemtap-sdt-dev` | `sudo apt install systemtap-sdt-dev` (for USDT probes) |
-| DPDK not found / wrong version | Build DPDK first: see [build docs](../../doc/build.md) |
+| DPDK not found / wrong version | Build DPDK first: see [build docs](../../../doc/build.md) |
 | Stale build directory | `rm -rf build && ./build.sh` or use MCP tool `mtl_clean_rebuild` |
 | Permission errors in build/ | `sudo rm -rf build && ./build.sh` |

--- a/.github/skills/mtl-cicd/SKILL.md
+++ b/.github/skills/mtl-cicd/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: mtl-cicd
+description: 'Design, implement, debug, and validate MTL GitHub Actions CI/CD, Taskfile tasks, caches, artifacts, self-hosted runners, ICE modules, and JPEG XS dependencies. Use for workflow changes, validate-host changes, cache-key changes, bare-metal CI, or requests to push CI updates.'
+---
+
+# MTL CI/CD
+
+## Design contract
+
+- GitHub Actions YAML orchestrates jobs; it does not implement operations.
+- Do not add multi-line `run: |` programs to workflows or composite actions.
+- Put each operation behind a named root `Taskfile.yml` task. Put substantial
+  shell logic in a focused, human-runnable script called by that task.
+- Local CI and GitHub Actions must invoke the same Taskfile entry points.
+- Keep build, host validation, test execution, cleanup, and report collection
+  separate.
+- Pin third-party actions to immutable commit SHAs, minimize job permissions,
+  set timeouts, and serialize operations that mutate a physical host.
+
+Read the current contracts before editing:
+
+- `.github/github_actions_issue.md`
+- `doc/cicd_setup_proposition.md`
+- `.github/instructions/mtl-system-setup.instructions.md`
+
+## Artifact and cache rules
+
+- Use deterministic SHA-256 source hashes and explicit dependency waterfalls.
+- Include architecture, toolchain, build options, and external pinned versions
+  where they affect output compatibility.
+- Restore and structurally validate a cache before treating it as a hit.
+- Use `actions/cache/restore` and save only after successful validation; never
+  allow a failed partial build to poison an immutable cache key.
+- Use caches for reusable dependencies. Use workflow artifacts for logs,
+  reports, and other run-specific outputs.
+- Keep install trees under `.local_install`; test hosts must not compile a
+  missing cached dependency as a fallback.
+
+## ICE module rules
+
+- Build one ICE artifact on the `e835` validation-fleet runner in `build.yml`;
+  every NIC validation job restores and activates that artifact. Do not build
+  ICE on `dpdk` or `e810`: both labels can select the generic builder whose
+  kernel can drift from the fleet.
+  Do not create per-NIC ICE producer jobs or include the NIC model in its key.
+- The ICE bundle is a stash like every other one: two files, `ice.ko` and
+  `iavf.ko`, under `.local_install/ice/<kernel release>/<architecture>`. Its key
+  is the source/patch hash plus the kernel release and the architecture, because
+  a `.ko` only loads into the kernel it was built for. Nothing finer belongs in
+  the key: a host that cannot load the module says so, and the check below is
+  where that is found.
+- Validate the restored bundle by reading the files: `modinfo -F vermagic` of
+  each module must match the running kernel, and `ice.ko` must carry
+  `ice_vc_cfg_q_bw`. Those are the two things the key cannot promise. A stock
+  driver loads and carries traffic, so the missing symbol is the only early
+  signal that MTL will die in `iavf_tm_node_add`.
+- Nothing under `/sys/module/ice` is a hash of the loaded module, so "the running
+  driver is already the cached one" is asked through `srcversion`: the module
+  carries one, the kernel exports the one it loaded, and both must equal the
+  cached file's. Ask before touching the host — the answer is worthless after a
+  teardown. `ice` must be loaded and match; `iavf` may be unloaded, in which case
+  only the file at the `updates/` path modprobe prefers has to match.
+- A loaded module cannot be replaced in place. `rmmod` returns EBUSY while VFs
+  exist, `irdma` is bound or MtlManager holds a port, so stop the users, zero
+  the VFs of the ice PFs only, unload `irdma` and ICE, install, `depmod`,
+  `modprobe`, then confirm the running driver is the artifact. Reload `irdma`
+  best-effort; nothing in the suite uses RDMA.
+- Do not recreate VFs after activation. Every consumer builds the VF state it
+  needs and does it idempotently (a gtest job runs `sudo task ci:bind-test-ports`
+  as its own step, the acceptance harness has `Nicctl.create_vfs()`).
+- Gtest and pytest workflows never compile, install, or reload ICE.
+- Loading a driver and building the ports is the job's work, not the suite's.
+  `.github/scripts/gtest.sh` only reads the state the job left: it discovers the
+  four ports and two DMA channels, runs the cases and reports. It does not
+  create VFs, bind anything or reload a module, and neither does a retry -- a
+  card rebuilt under a suite that is already running is how a runner gets
+  wedged, and a case that only passes after its NIC was rebuilt is not a pass.
+
+## JPEG XS rules
+
+- Treat JPEG XS as a bundle: SVT-JPEG-XS runtime, `pkg-config` metadata, MTL
+  bridge plugin, symlinks, and required runtime files.
+- Its hash includes `SVT_JPEG_XS_VER`, MTL hash, bridge sources, architecture,
+  toolchain, and build options.
+- FFmpeg's hash includes the JPEG XS hash when JPEG XS support is enabled.
+- Consumers use local library, package, and plugin paths; do not install the
+  bundle into `/usr/local` on test hosts.
+
+## Hardware jobs, on the host that owns the card
+
+- A NIC label decides which host steps apply. Only the E8xx family is served by
+  the Kahawai ICE driver, so `task ci:ice-required` gates both the ICE cache
+  restore and the module alignment; an i225/i226 leg must not fail over a module
+  built for a card it does not have.
+- Datapath follows the card, not the job: `task ci:pytest-setup -- pci` resolves
+  the label against `lspci` and exports `INTERFACE_TYPE` -- `VF` on an SR-IOV
+  card, `PF` on a two-port card without VFs, `KERNEL` (MTL's kernel socket) on a
+  single-port one. Do not hardcode a datapath into a matrix leg.
+- A restored DPDK tree remembers where it was built: meson bakes
+  `RTE_EAL_PMD_PATH` into `librte_eal`, EAL loads every driver from that one
+  absolute path, and MTL passes a fixed EAL argv, so there is no `-d` and no
+  environment override. Whenever the build job's workspace is not the test
+  runner's workspace, `task ci:configure-host -- dpdk-plugins` is what makes the
+  drivers findable; without it the first symptom is
+  `mt_mempool_create_by_ops, fail(Invalid argument) for T_P0_SYS`, because even
+  the mempool ops are plugins.
+- The acceptance framework reaches the system under test over SSH, even when
+  that system is the runner itself. A job-level export -- `GITHUB_ENV`,
+  `GITHUB_PATH`, anything the step sets -- does not reach the tests. Fixes for
+  the tests' own environment belong on the filesystem (`ldconfig`, a symlink, a
+  config file) or in the framework, not in a workflow step.
+- Media assets are a host prerequisite, not a job's work: `task ci:media-assets
+  -- list` reports what is missing, `-- generate` synthesises stand-ins of the
+  right geometry for a host with no lab share.
+
+## Implementation workflow
+
+1. Inspect `git status`, preserve unrelated and user-authored changes, and
+   identify the exact workflow/action/task/script path controlling behavior.
+2. Add or update the smallest Taskfile task and focused script first.
+3. Add a narrow local test that proves cache identity, artifact validation,
+   and failure behavior without requiring a NIC where possible.
+4. Make workflows/composite actions call the task with one-line commands.
+5. Run focused tests and any available local gates.
+6. Run `git diff --check` and inspect the final diff for inline scripts,
+   unpinned actions, excessive permissions, and unrelated changes.
+7. Push only when the user explicitly requested it, all available local gates
+   are green, and the pushed commit contains only the intended saved changes.
+
+## Production CI MCP contract
+
+- Use `ci_pr_checks` as the first check after pushing. It queries GitHub through
+  the authenticated `gh` CLI and returns a bounded table, failed checks first.
+- Use `ci_pr_failures` only when checks fail. Query check-run annotations first;
+  fetch failed-job logs only as a fallback, strip runner prefixes, and return a
+  small set of actionable error lines instead of complete workflow logs.
+- Treat only failure-level check annotations as diagnostics. Warning and notice
+  annotations must not suppress the failed-log fallback.
+- Cap check rows, failed-check sections, annotations, and failure excerpts;
+  report omitted counts at every truncated level. Prefer explicit linter
+  diagnostic blocks and affected-file lines over trailing runner warnings.
+- Default the repository from `git remote get-url origin`; allow an explicit
+  `owner/repo` override. Validate repository and PR inputs before invoking `gh`.
+- Production tools are read-only. They may inspect or wait for checks but never
+  push, rerun, comment, merge, or expose authentication details.
+- Never include raw `gh` stderr in MCP results. Return the command class and exit
+  status; authentication diagnostics can contain credentials.
+- Verify production wrappers with stubbed `gh` output before deployment, then
+  restart the MCP server and call the deployed tool against the target PR.
+- Run production Black, isort, and Ruff against changed Python MCP files before
+  pushing; syntax compilation alone is insufficient.
+
+## Failure policy
+
+- Fail early with an actionable compatibility error. Never continue with an
+  unknown driver, malformed cache, or partially configured NIC.
+- Do not hide failures behind `|| true` unless the operation is explicitly
+  best-effort and the reason is documented.
+- Never print secrets or put them in command lines, caches, or artifacts.
+- If hardware-only validation is unavailable locally, report that gate clearly
+  and do not represent container simulation as physical-host validation.
+
+## eBPF/XDP install contract
+
+- Install bundled libbpf into `/usr/local/lib/$(cc -dumpmachine)`, not libbpf's
+  `/usr/local/lib64` default. Ubuntu's `pkg-config` does not search the latter,
+  so CI can install `libbpf.pc` successfully and still not resolve it.
+- Run `ldconfig` after installing xdp-tools and libbpf; `build_ebpf_xdp.sh`
+  then asserts the pinned versions resolve, so no workflow step repeats it.
+- The manager's clang `-target bpf` compile must include the host compiler's
+  multiarch directory (`/usr/include/$(cc -dumpmachine)`), because BPF-target
+  clang does not discover Ubuntu's `asm/types.h` path automatically.
+- A generic failure annotation such as "Process completed with exit code" is
+  not actionable. Keep it in the result, but also inspect the bounded failed
+  log so the underlying compiler or linting error is returned.

--- a/.github/skills/mtl-commit/SKILL.md
+++ b/.github/skills/mtl-commit/SKILL.md
@@ -11,13 +11,21 @@ being explicitly asked to commit.
 ## Process
 
 1. Run `git status --short` and `git diff --stat`.
-2. **Run `./format-coding.sh` before staging anything.** It runs
-   markdownlint (`MD013` line-length among other rules, config at
-   [.github/linters/.markdown-lint.yml](../../linters/.markdown-lint.yml))
-   alongside clang-format/isort/black/shfmt, and now **fails the script**
-   on any violation `--fix` cannot auto-correct — fix those by hand
-   (rewrap the paragraph; a single `\n` is a soft break, it doesn't
-   change rendering), then re-run until it exits clean.
+2. **Format only what you are committing.** Stage the logical change, then run
+   `./format-coding.sh --staged` — or `./format-coding.sh --files a.c b.md`
+   before staging. A bare `./format-coding.sh` applies the autofixes to every
+   tracked file, which is the wrong default when the commit is three files.
+   The fixers write into the working tree, so `git add` whatever they change.
+   `--staged` stashes your unstaged changes first, so on a partially-staged file
+   whose autofix collides with the unstaged hunk it rolls that fix back and
+   exits `1` — stage the whole file, or use `--files` before splitting it.
+   It applies every autofix in `.pre-commit-config.yaml` — clang-format, isort,
+   black, shfmt, markdownlint, textlint — and then **fails** on anything no
+   autofix can correct: shellcheck findings, `MD013` line lengths (rewrap the
+   paragraph; a single `\n` is a soft break and does not change rendering),
+   flake8, yamllint. Fix those by hand and re-run until it exits clean — except after the rollback above, where re-running cannot help (`0`
+   clean, `1` findings, `2` a usage or environment problem).
+   `./checkpatch.sh --staged` re-verifies just what you are about to commit.
 3. **One commit = one logical change.** Split unrelated edits with
    `git add -p`. Never bundle drive-by changes into an unrelated fix.
 4. For each commit: stage, draft the message, run `git commit -s`
@@ -39,7 +47,7 @@ being explicitly asked to commit.
 ```
 
 - **Type** (capitalised): `Feat`, `Add`, `Fix`, `Refactor`, `Docs`, `Test`,
-  `Perf`, `Build`, `Ci`, `Style`. See [doc/coding_standard.md](../../doc/coding_standard.md).
+  `Perf`, `Build`, `Ci`, `Style`. See [doc/coding_standard.md](../../../doc/coding_standard.md).
 - This project does **not** use Conventional-Commits scopes (`Fix(parser):`)
   or breaking markers (`!`). Flag a breaking API/behaviour change with a
   `BREAKING-CHANGE:` footer instead.

--- a/.github/skills/mtl-ste-writing/SKILL.md
+++ b/.github/skills/mtl-ste-writing/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: mtl-ste-writing
+description: 'Rewrite prose (docs, READMEs, PR descriptions, error messages, release notes, comments — never code) into ASD-STE100 Simplified Technical English. Use when asked to make writing docs, make docs clear or plain, enforce a controlled writing style, or write technical documentation that reads human. Two modes — strict (procedures/safety) and STE-flavored (general prose).'
+---
+
+# ste-writing
+
+Write prose in ASD-STE100 Simplified Technical English. This applies to documentation, READMEs, pull-request text, error messages, release notes, and comments. It does not apply to code, identifiers, or command syntax. It is not for marketing copy, essays, or anything that needs a voice — STE strips voice on purpose.
+
+## Rules
+
+Cite a rule by its tag, such as [S-LEN]. Do not cite a line number, because line numbers move.
+
+WORDS
+- **[W-ONE-NAME]** Use one name for one thing. Do not call the same item by two different names.
+- **[W-SHORT-WORD]** Use the short common word:
+  - start (not begin/commence/initiate)
+  - use (not utilize/leverage)
+  - help (not facilitate)
+  - make sure (not ensure)
+  - before (not prior to)
+  - after (not subsequent to)
+  - about (not regarding/concerning)
+  - get (not obtain/acquire)
+  - show (not demonstrate)
+  - also (not additionally/furthermore/moreover)
+- **[W-ONE-MEANING]** Give each word one meaning. "fall" means to move down, not to decrease.
+- **[W-NO-HYPE]** No marketing adjectives: seamless, robust, powerful, cutting-edge, effortless, world-class, next-generation, revolutionary.
+- **[W-US-SPELLING]** American spelling.
+
+VERBS
+- **[V-ACTIVE]** Active voice. "the parser reads the file", not "the file is read by the parser".
+- **[V-VERB-NOT-NOUN]** Use a verb for an action. "analyze the log", not "perform an analysis of the log".
+- **[V-NO-AUX-STACK]** No stacked auxiliaries. Not "it is important to note that this may help to improve". Write "this improves X".
+- **[V-NO-ING]** No "-ing" main verb where a simple tense works.
+- **[V-NO-PHRASAL]** No phrasal verb where one verb works. Write "start the daemon", not "spin up the daemon".
+
+SENTENCES
+- **[S-ONE-IDEA]** One instruction per sentence.
+- **[S-LEN]** Cap an instruction at 20 words and descriptive text at 25 words. An instruction tells the reader to act, and every step of a numbered list is an instruction. Descriptive text is everything else. No other rule here states a sentence length, and none overrides this one.
+- **[S-COUNT]** Count the whitespace-separated tokens. Backticks do not fuse tokens, so `ethtool -i` counts as two. A token keeps every dot, hyphen, underscore, and slash, so `fw.app` and `E800-series` each count as one. Do not count a token that is punctuation only. Do not count the rule tag that starts a bullet.
+- **[S-SCOPE]** [S-LEN] counts sentences of prose. A term list, a table row, a heading, and a command on its own line are not sentences.
+- **[S-NO-CONTRACTION]** No contractions. Use articles: a, an, the, this, these.
+
+PUNCTUATION
+- **[P-NO-SEMICOLON]** No semicolons. Write two sentences. STE bans the semicolon and does not ban the em dash. If you want the em dash gone, add a rule for it yourself.
+
+STRUCTURE
+- **[T-STRUCTURE]** One topic per paragraph, max six sentences. For steps, use a numbered vertical list, one action per item, imperative form. Put a condition before its command.
+
+Write only the requested text. No preamble, no summary, no closing remarks.
+
+## Modes
+
+- **strict** — procedures, runbooks, safety text, error messages: apply every rule with no exception.
+- **STE-flavored** — general prose (READMEs, PR descriptions, docs): apply the SENTENCES rules, [T-STRUCTURE], [V-ACTIVE], and [V-NO-PHRASAL]. Relax the ~900-word STE dictionary, so the text keeps enough range to read naturally.
+
+## Self-lint (run before returning text)
+
+1. Any sentence over its [S-LEN] cap? Split it. Count the words under [S-COUNT].
+2. Any semicolon? Replace it with a period. See [P-NO-SEMICOLON].
+3. Any contraction? Expand it. See [S-NO-CONTRACTION].
+4. Any passive voice with a known actor? Make it active. See [V-ACTIVE].
+5. Any "-ing" main verb or nominalization ("perform an analysis")? Replace it with a plain verb. See [V-NO-ING] and [V-VERB-NOT-NOUN].
+6. Any phrasal verb ("spin up")? Replace it with one verb. See [V-NO-PHRASAL].
+7. Same thing named two ways? Pick one name. See [W-ONE-NAME].
+
+The mechanical rules above are lintable and are what removes slop. Full STE also needs human judgment: the right technical noun, and whether a sentence makes good sense. A checker cannot certify that, and slop is not about that. This skill fixes the FORM of slop. It cannot make a hollow paragraph true.
+
+Free official standard (do not paste it in full; it is copyrighted): <https://asd-ste100.org>

--- a/.github/skills/mtl-write-test/SKILL.md
+++ b/.github/skills/mtl-write-test/SKILL.md
@@ -11,13 +11,13 @@ The hard part of testing MTL is **picking the right tier** and **asserting the r
 
 | Tier | Binary | Hardware | Can observe |
 |---|---|---|---|
-| **Unit gtest** — `tests/unit/` | `UnitTest` (built with `-Denable_unit_tests=true`; via `./build.sh unit`) | None — runs as regular user under ASan | RX-side session logic fed synthetic mbufs at the RFC 4175 / RTP payload layer: frame assembly, bitmap dedup, redundancy merge, stat counters, pipeline accounting |
+| **Unit gtest** — `tests/unit/` | `UnitTest` (built with `-Denable_unit_tests=true`; via `./build.sh unit`) | None — runs as a regular user; no NIC, no root | RX-side session logic fed synthetic mbufs at the RFC 4175 / RTP payload layer: frame assembly, bitmap dedup, redundancy merge, stat counters, pipeline accounting |
 | **Integration gtest** — `tests/integration_tests/` | `KahawaiTest` | Real VFs (≥2; ≥4 for redundant cases) | Full session lifecycle, TX+RX through the NIC, every pacing mode, multi-session, callbacks at real timing, SHA digests, DMA, RSS, kernel-socket, AF_XDP, virtio-user |
 | **NoCtx gtest** — `tests/integration_tests/noctx/` | `KahawaiTest --no_ctx` | Real VFs (per-case; redundant cases require ≥4) | Same as integration plus behaviors that depend on `mtl_init()` flags/callbacks the shared test context cannot supply. **One case per process** (DPDK EAL cannot re-init) — runner script enforces this |
 | **pytest single-host** — `tests/acceptance/tests/single/` | RxTxApp / FFmpeg / GStreamer driven through pytest | Full host: VFs, MtlManager, NFS media, plugins, venv, SSH-to-localhost | End-to-end app behavior on one host: CLI flags, config files, real media bytes, PTP convergence |
 | **pytest dual-host** — `tests/acceptance/tests/dual/` | same apps, two hosts | Two hosts wired together | Real two-machine traffic: cross-host pacing, real switch behavior, no loopback shortcuts |
 
-Per-tier docs you must read before authoring: [tests/unit/README.md](tests/unit/README.md), [tests/integration_tests/noctx/noctx.md](tests/integration_tests/noctx/noctx.md), [tests/acceptance/README.md](tests/acceptance/README.md).
+Per-tier docs you must read before authoring: [tests/unit/README.md](../../../tests/unit/README.md), [tests/integration_tests/noctx/noctx.md](../../../tests/integration_tests/noctx/noctx.md), [tests/acceptance/README.md](../../../tests/acceptance/README.md).
 
 ## 2. Picking the tier — disjoint rules, stop at the first **yes**
 
@@ -43,10 +43,10 @@ Trap: a library bug whose easiest reproducer is RxTxApp still belongs in a **gte
 ## 4. Tier-specific rules
 
 ### Unit
-- AddressSanitizer is preloaded on every run (`LD_PRELOAD=libasan.so.<major>` — current major in [tests/unit/README.md](tests/unit/README.md)). Any leak fails the suite.
+- AddressSanitizer is **opt-in and off by default** — plain `./build.sh unit` passes `-Denable_asan=false`, so no `-fsanitize=address` and no preload, and it catches no leak. Ask for it with `./build.sh debug unit` or `MTL_BUILD_ENABLE_ASAN=true ./build.sh unit`; `build.sh` then preloads the ASan runtime and a leak fails the suite. See [tests/unit/README.md](../../../tests/unit/README.md).
 - Drain shared state in `TearDown()` — the harness exposes a process-global ring; entries left in it cause "passes alone, fails in suite".
 - Synthetic packets only. If you need a real capture, you are in the wrong tier.
-- EAL init is idempotent but global: first `ut*_init()` configures DPDK with `--no-huge --no-pci --vdev=net_null0`; later calls cannot reconfigure it.
+- EAL init is global and one-shot: the first `ut*_init()` fixes the DPDK config (`--no-huge --no-shconf -c1 -n1 --no-pci`) and later calls cannot change it. There is no `--vdev`, so the process has **no ethdev at all** — a code path that reaches a real `rte_eth_*` call must be mocked in the harness (`#define` the symbol before the `#include` of the `.c` under test).
 
 ### Integration & NoCtx
 - **Gate every case on the hardware it needs** (`num_ports`, DMA availability, NIC family, pacing mode). Integration idiom: `if (…) { info(...); return; }`. NoCtx pre-checks: `throw std::runtime_error(...)`. `GTEST_SKIP` is reserved for runtime non-determinism inside a test body (e.g. an RX frame that did not arrive), not for pre-checks.
@@ -64,16 +64,16 @@ Trap: a library bug whose easiest reproducer is RxTxApp still belongs in a **gte
 
 ## 5. The authoring loop
 
-1. **Pick a neighbour test in the same directory** — closest to your behavior first, else the most recently modified file. Avoid `DISABLED_` cases and any file noticeably older than its siblings. **Copy its conventions, including its marker set** — markers gate CI selection ([tests/acceptance/pytest.ini](tests/acceptance/pytest.ini)) and an unmarked or wrongly-marked pytest runs in no job.
+1. **Pick a neighbour test in the same directory** — closest to your behavior first, else the most recently modified file. Avoid `DISABLED_` cases and any file noticeably older than its siblings. **Copy its conventions, including its marker set** — markers gate CI selection ([tests/acceptance/pytest.ini](../../../tests/acceptance/pytest.ini)) and an unmarked or wrongly-marked pytest runs in no job.
 2. **Modify assertions only** until the test encodes your one requirement.
 3. **Register in the build** for gtest tiers (add to the relevant `*_sources` list in the nearest `meson.build`). pytest needs no registration.
-4. **Build:** `./build.sh` for integration binaries; `./build.sh unit` for the unit suite (builds `build_unit/` and runs `UnitTest`). See [`/mtl-build`](.github/skills/mtl-build/SKILL.md).
+4. **Build:** `./build.sh` for integration binaries; `./build.sh unit` for the unit suite (builds `build_unit/` and runs `UnitTest`). See [`/mtl-build`](../../../.github/skills/mtl-build/SKILL.md).
 5. **Run** with the binary / pytest invocation from the tier's auto-loaded instructions.
 6. **Confirm** the test fails before the fix (regression) or passes deterministically across 3+ consecutive runs (new coverage).
 
 ## Related
 
-- Run an existing test → [.github/instructions/mtl-gtest.instructions.md](.github/instructions/mtl-gtest.instructions.md) (gtest) or [.github/instructions/mtl-acceptance-tests.instructions.md](.github/instructions/mtl-acceptance-tests.instructions.md) (pytest).
-- Build / format → [`/mtl-build`](.github/skills/mtl-build/SKILL.md).
+- Run an existing test → [.github/instructions/mtl-gtest.instructions.md](../../../.github/instructions/mtl-gtest.instructions.md) (gtest) or [.github/instructions/mtl-acceptance-tests.instructions.md](../../../.github/instructions/mtl-acceptance-tests.instructions.md) (pytest).
+- Build / format → [`/mtl-build`](../../../.github/skills/mtl-build/SKILL.md).
 - Host setup → MTL System Admin agent (gtest) or `.github/scripts/acceptance_setup.sh`/`mtl-acceptance-setup` MCP tools directly (pytest, no dedicated agent).
 - TDD discipline + implementation → MTL Developer (TDD) agent (this skill is loaded by Gate 2 of its six-gate loop). Adversarial review → MTL Reviewer agent.

--- a/tests/unit/CLAUDE.md
+++ b/tests/unit/CLAUDE.md
@@ -3,10 +3,12 @@
 Build and run: `./build.sh unit` (configures `build_unit/` with `-Denable_unit_tests=true`,
 builds, runs). Single case after a build: `./build_unit/tests/unit/UnitTest --gtest_filter='...'`.
 
-Tier-specific traps live in `README.md` here. The short version: ASan is preloaded so any leak
-fails the suite; drain the process-global harness ring in `TearDown()` or you get "passes alone,
-fails in suite"; synthetic mbufs only; EAL init is global and idempotent — the first `ut*_init()`
-fixes the DPDK config (`--no-huge --no-pci --vdev=net_null0`) and later calls cannot change it.
+Tier-specific traps live in `README.md` here. The short version: ASan cover is **partial** —
+`enable_asan` reaches the `libmtl.so` compile arguments only, so symbols `UnitTest` resolves
+from that DSO are checked while the production `.c` files `#include`d into harnesses are not;
+drain the process-global harness ring in `TearDown()` or you get "passes alone, fails in
+suite"; synthetic mbufs only; EAL init is global and one-shot — the first `ut*_init()` fixes
+the DPDK config and later calls cannot change it.
 
 New cases must be added to `unit_sources` in `meson.build`. For the tier decision (unit vs
 integration vs NoCtx vs pytest) invoke the `mtl-write-test` skill.


### PR DESCRIPTION
The agent knowledge base of this repository holds two parallel trees: `.github/agents/`, `.github/copilot-instructions.md` and `.github/copilot-docs/` for Copilot, and `.github/claude/` for Claude Code, with one shared copy of every skill in `.github/skills/`. This change touches only those trees. It changes no library, no test and no workflow.

Both sides had five agents, and no agent that could invoke another one. The user had to hold the task list, pick the next task, decide what could run at the same time, and fire the two exit gates that `mtl-developer` can only name. `mtl-orchestrator` now owns all four. It writes code itself: nothing. `.github/claude/agents/mtl-orchestrator.md` and `.github/agents/mtl-orchestrator.agent.md` are the two sides of the same agent.

`mtl-developer` and `mtl-planner` said "the user" where they meant "whoever invoked me". Both now say invoker, and name the orchestrator as one. `mtl-planner` may still spawn nothing but `Explore`, and still may not implement.

`.github/copilot-instructions.md` adds the orchestrator to the agent list and to the routing matrix, with the rule that it is the only agent that may invoke the others.

`mtl-cicd` holds the CI/CD design contract that was until now only readable from the shape of the workflows: YAML orchestrates, it does not implement; every operation sits behind a named root `Taskfile.yml` task; substantial shell goes in a human-runnable script that the task calls; a local run and an Actions run enter through the same task; third-party actions are pinned to a commit SHA.

`mtl-ste-writing` holds the ASD-STE100 Simplified Technical English rule set that the prose of this repository already follows. It applies to documents, READMEs, pull-request text, error messages and comments, and not to code, identifiers or command syntax. Rules are cited by tag, such as `[S-LEN]`, because a line number moves.

Both are one copy in `.github/skills/`, which Claude Code reads through a symbolic link in `.github/claude/skills/`, so the two sides cannot drift.

`requirements.txt` asked for `mcp[cli]>=1.0.0` with no ceiling. mcp 2.x removed `mcp.server.fastmcp`, which both servers import, so a fresh venv made every `mtl-system-setup` and `mtl-acceptance-setup` tool fail with `ModuleNotFoundError`. The requirement is now `>=1.0.0,<2.0.0`, and the comment says to port the servers before that ceiling is lifted.

The two launcher scripts installed dependencies only when `import mcp` failed. An mcp 2.x venv imports `mcp` and has no `fastmcp`, so the guard skipped pip and the new ceiling never applied. They now test for `mcp.server.fastmcp`, which is the module the servers actually import.

`.github/mcp/test_mtl_mcp_server.py` covers the part of the server that can be tested without a host: the argv lists it builds, the output it parses, and the two test tools with `_run_rc` replaced by a stub. It starts no binary, needs no NIC and calls no sudo, so it runs anywhere:

```bash
.github/mcp/.venv/bin/python -m unittest discover -s .github/mcp -v
```

It uses the standard library `unittest` on purpose, so it adds no line to `requirements.txt` — the file that already broke every MCP tool once by floating a version.

* `mtl-gtest.instructions.md`: the `--pacing_way` list held two of the six modes, and said `auto` uses RL. `auto` picks RL only when the driver advertises TM, and TSC otherwise. `--log_level`, `--no_ctx_tests` and `--port_list` were missing. `gtest.sh` no longer prepares the host, so the entry now says what it discovers and names the two tasks that build that state. `run_pf.sh` and `run_noctx_pf_tests` are recorded with the cooldown of each.
* `mtl-c-coding.instructions.md` and `mtl-acceptance-tests.instructions.md` follow the same code they describe.
* `copilot-instructions.md` said `clang-format-14` enforced by CI. The version now comes from `.pre-commit-config.yaml`, and `pre-commit` installs that copy itself, so the entry says to never `apt install` a clang-format package.
* `tests/unit/CLAUDE.md` said ASan checks the whole unit suite. It does not: `enable_asan` reaches the `libmtl.so` compile arguments only, so a production `.c` file that a harness includes is not covered.

The two server files also take ruff's formatting of a `textwrap.dedent` call, so a format run leaves them alone.

This change touches no library file, no test tier and no workflow, so it has no mechanical dependency on the CI, style or driver pull requests.

Merge it after the style pull request all the same. The entry above that sends the reader to `.pre-commit-config.yaml` for the clang-format version is only true once that change makes the file the one source of the lint rules; the file on the default branch today pins no clang-format at all.