### PR TITLE
Add missing st30p and st22p details

### DIFF
--- a/include/st30_pipeline_api.h
+++ b/include/st30_pipeline_api.h
@@ -339,6 +339,8 @@ int st30p_rx_put_frame_abort(st30p_rx_handle handle, struct st30_frame* frame);
 int st30p_rx_free(st30p_rx_handle handle);
 /** Create one rx st2110-30 pipeline session */
 st30p_rx_handle st30p_rx_create(mtl_handle mt, struct st30p_rx_ops* ops);
+/** Update the source for the rx st2110-30 pipeline session. */
+int st30p_rx_update_source(st30p_rx_handle handle, struct st_rx_source_info* src);
 /** Wake up the block wait on st30p_rx_get_frame if ST30P_RX_FLAG_BLOCK_GET is enabled.*/
 int st30p_rx_wake_block(st30p_rx_handle handle);
 /** Set the block timeout time on st30p_rx_get_frame if ST30P_RX_FLAG_BLOCK_GET is

--- a/include/st_pipeline_api.h
+++ b/include/st_pipeline_api.h
@@ -534,6 +534,10 @@ enum st22p_rx_flag {
   ST22P_RX_FLAG_EXT_FRAME = (MTL_BIT32(4)),
   /** Force the numa of the created session, both CPU and memory */
   ST22P_RX_FLAG_FORCE_NUMA = MTL_BIT32(5),
+  /**
+   * Disable ST22 boxes
+   */
+  ST22P_RX_FLAG_DISABLE_BOXES = MTL_BIT32(6),
 
   /** Enable the st22p_rx_get_frame block behavior to wait until a frame becomes
      available or timeout(default: 1s, use st22p_rx_set_block_timeout to customize) */

--- a/lib/src/st2110/pipeline/st22_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st22_pipeline_rx.c
@@ -392,6 +392,8 @@ static int rx_st22p_create_transport(struct mtl_main_impl* impl, struct st22p_rx
     ops_rx.socket_id = ops->socket_id;
     ops_rx.flags |= ST22_RX_FLAG_FORCE_NUMA;
   }
+  if (ops->flags & ST22P_RX_FLAG_DISABLE_BOXES)
+    ops_rx.flags |= ST22_RX_FLAG_DISABLE_BOXES;
   ops_rx.pacing = ST21_PACING_NARROW;
   ops_rx.width = ops->width;
   ops_rx.height = ops->height;


### PR DESCRIPTION
The API is missing the function to update the source of an `st30p` session.

The `st22p_rx` code is missing the `ST22P_RX_FLAG_DISABLE_BOXES` flag, which is used to preserve the boxes from the received codestream.