### PR TITLE
Ci: Fix combined pytest report flattening

### DIFF
--- a/.github/workflows/nightly-combined-report.yml
+++ b/.github/workflows/nightly-combined-report.yml
@@ -141,6 +141,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Flatten pytest report structure
+        env:
+          REPORT_DIR: pytest-reports
         run: task ci:report -- flatten-pytest
 
       - name: Flatten gtest report structure

--- a/.github/workflows/nightly-combined-report.yml
+++ b/.github/workflows/nightly-combined-report.yml
@@ -197,13 +197,19 @@ jobs:
         if: needs.wait-for-both-workflows.outputs.baseline_pytest_run_id != ''
         env:
           REPORT_DIR: baseline-pytest-reports
-        run: task ci:report -- flatten-pytest
+        run: |
+          if [[ -d $REPORT_DIR ]]; then
+            task ci:report -- flatten-pytest
+          fi
 
       - name: Flatten baseline gtest report structure
         if: needs.wait-for-both-workflows.outputs.baseline_gtest_run_id != ''
         env:
           REPORT_DIR: baseline-gtest-reports
-        run: task ci:report -- flatten-gtest
+        run: |
+          if [[ -d $REPORT_DIR ]]; then
+            task ci:report -- flatten-gtest
+          fi
 
       - name: Get baseline pytest run metadata
         id: baseline-pytest-metadata


### PR DESCRIPTION
The combined workflow downloads pytest artifacts into pytest-reports, but the shared flatten command defaults to python-reports. Pass the workflow-specific directory so report generation can proceed.