### PR TITLE
Fix: Retry rte_flow_create on transient VF timeout in rte_rx_flow_create

### DIFF
--- a/lib/src/mt_flow.c
+++ b/lib/src/mt_flow.c
@@ -175,9 +175,22 @@ static struct rte_flow* rte_rx_flow_create(struct mt_interface* inf, uint16_t q,
     return NULL;
   }
 
+  const int max_retry = 5;
+  int retry = 0;
+
+retry:
   mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
   r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
   mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+  if (!r_flow) {
+    err("%s(%d), rte_flow_create fail for queue %d, retry %d, %s\n", __func__, port, q,
+        retry, mt_string_safe(error.message));
+    retry++;
+    if (retry < max_retry) {
+      mt_sleep_ms(10); /* WA: to wait pf finish the vf request */
+      goto retry;
+    }
+  }
 
   /* WA specific for e810 for PF interfaces */
   if (!has_ip_flow && !r_flow) {
@@ -264,7 +277,7 @@ static int rx_flow_free(struct mt_interface* inf, struct mt_rx_flow_rsp* rsp) {
   enum mtl_port port = inf->port;
   struct rte_flow_error error;
   int ret;
-  int max_retry = 5;
+  const int max_retry = 5;
   int retry = 0;
 
 retry:

--- a/lib/src/mt_flow.c
+++ b/lib/src/mt_flow.c
@@ -176,20 +176,16 @@ static struct rte_flow* rte_rx_flow_create(struct mt_interface* inf, uint16_t q,
   }
 
   const int max_retry = 5;
-  int retry = 0;
 
-retry:
-  mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
-  r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
-  mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
-  if (!r_flow) {
+  for (int retry = 0; retry < max_retry;) {
+    mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
+    r_flow = rte_flow_create(port_id, &attr, pattern, action, &error);
+    mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+    if (r_flow) break;
     err("%s(%d), rte_flow_create fail for queue %d, retry %d, %s\n", __func__, port, q,
         retry, mt_string_safe(error.message));
     retry++;
-    if (retry < max_retry) {
-      mt_sleep_ms(10); /* WA: to wait pf finish the vf request */
-      goto retry;
-    }
+    if (retry < max_retry) mt_sleep_ms(10); /* WA: to wait pf finish the vf request */
   }
 
   /* WA specific for e810 for PF interfaces */
@@ -278,25 +274,21 @@ static int rx_flow_free(struct mt_interface* inf, struct mt_rx_flow_rsp* rsp) {
   struct rte_flow_error error;
   int ret;
   const int max_retry = 5;
-  int retry = 0;
 
-retry:
   if (rsp->flow_id > 0) {
     mt_socket_remove_flow(inf->parent, port, rsp->flow_id, rsp->dst_port);
     rsp->flow_id = -1;
   }
   if (rsp->flow) {
-    mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
-    ret = rte_flow_destroy(inf->port_id, rsp->flow, &error);
-    mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
-    if (ret < 0) {
+    for (int retry = 0; retry < max_retry;) {
+      mt_pthread_mutex_lock(&inf->vf_cmd_mutex);
+      ret = rte_flow_destroy(inf->port_id, rsp->flow, &error);
+      mt_pthread_mutex_unlock(&inf->vf_cmd_mutex);
+      if (ret >= 0) break;
       err("%s(%d), flow destroy fail, queue %d, retry %d\n", __func__, port,
           rsp->queue_id, retry);
       retry++;
-      if (retry < max_retry) {
-        mt_sleep_ms(10); /* WA: to wait pf finish the vf request */
-        goto retry;
-      }
+      if (retry < max_retry) mt_sleep_ms(10); /* WA: to wait pf finish the vf request */
     }
     rsp->flow = NULL;
   }

--- a/tests/unit/dev/mt_flow_harness.c
+++ b/tests/unit/dev/mt_flow_harness.c
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ */
+
+/*
+ * Harness for the mt_flow.c retry loops (SDBQ-3703 style transient VF flow
+ * timeouts): compiles the real mt_flow.c with rte_flow_validate/create/destroy
+ * and rte_free replaced by controllable stubs, so the retry logic runs against
+ * synthetic failures instead of a real NIC.
+ */
+
+#include <errno.h>
+#include <rte_flow.h>
+#include <stdlib.h>
+#include <string.h>
+
+#undef MTL_HAS_USDT
+#include "dev/mt_flow_harness.h"
+
+/*
+ * ut_flow_ctx is defined after mt_flow.c is included below, once mt_main.h's
+ * types are visible. The rte_free shadow only takes effect on the mt_rte_free()
+ * body inside mt_mem.h if that header has not been included yet, so mt_main.h
+ * must not be pulled in before the #define block.
+ */
+struct ut_flow_ctx;
+static struct ut_flow_ctx* ut_active_ctx;
+
+static int ut_rte_flow_validate(uint16_t port_id, const struct rte_flow_attr* attr,
+                                const struct rte_flow_item pattern[],
+                                const struct rte_flow_action actions[],
+                                struct rte_flow_error* error);
+static struct rte_flow* ut_rte_flow_create(uint16_t port_id,
+                                           const struct rte_flow_attr* attr,
+                                           const struct rte_flow_item pattern[],
+                                           const struct rte_flow_action actions[],
+                                           struct rte_flow_error* error);
+static int ut_rte_flow_destroy(uint16_t port_id, struct rte_flow* flow,
+                               struct rte_flow_error* error);
+static void ut_rte_free(void* ptr);
+
+#define rte_flow_validate ut_rte_flow_validate
+#define rte_flow_create ut_rte_flow_create
+#define rte_flow_destroy ut_rte_flow_destroy
+#define rte_free ut_rte_free
+#include "mt_flow.c"
+#undef rte_free
+#undef rte_flow_destroy
+#undef rte_flow_create
+#undef rte_flow_validate
+
+struct ut_flow_ctx {
+  struct mtl_main_impl impl;
+  /* rte_rx_flow_create() indexes inf->rx_queues[q] via mt_if_hdr_split_pool()
+   * before the retry loop even runs; must be a real, zeroed queue so that
+   * path resolves a NULL pool and skips the (untested) hdr-split branch. */
+  struct mt_rx_queue rx_queue;
+  int create_calls;
+  /* -1 fails every rte_flow_create() call; N fails the first N calls then
+   * lets call N+1 succeed. */
+  int create_fail_count;
+  /* attr.group observed on each rte_flow_create() call, used to confirm the
+   * e810 group-2 fallback attempt. */
+  uint32_t create_call_group[8];
+  int destroy_calls;
+  /* Same shape as create_fail_count, for rte_flow_destroy(). */
+  int destroy_fail_count;
+  bool last_free_flow_cleared;
+};
+
+static int ut_rte_flow_validate(uint16_t port_id, const struct rte_flow_attr* attr,
+                                const struct rte_flow_item pattern[],
+                                const struct rte_flow_action actions[],
+                                struct rte_flow_error* error) {
+  (void)port_id;
+  (void)attr;
+  (void)pattern;
+  (void)actions;
+  memset(error, 0, sizeof(*error));
+  return 0;
+}
+
+static struct rte_flow* ut_rte_flow_create(uint16_t port_id,
+                                           const struct rte_flow_attr* attr,
+                                           const struct rte_flow_item pattern[],
+                                           const struct rte_flow_action actions[],
+                                           struct rte_flow_error* error) {
+  (void)port_id;
+  (void)pattern;
+  (void)actions;
+  struct ut_flow_ctx* ctx = ut_active_ctx;
+
+  if ((size_t)ctx->create_calls < RTE_DIM(ctx->create_call_group))
+    ctx->create_call_group[ctx->create_calls] = attr->group;
+  ctx->create_calls++;
+
+  memset(error, 0, sizeof(*error));
+  bool fail =
+      (ctx->create_fail_count < 0) || (ctx->create_calls <= ctx->create_fail_count);
+  if (fail) {
+    error->message = "ut simulated create failure";
+    return NULL;
+  }
+  return (struct rte_flow*)(uintptr_t)0x1;
+}
+
+static int ut_rte_flow_destroy(uint16_t port_id, struct rte_flow* flow,
+                               struct rte_flow_error* error) {
+  (void)port_id;
+  (void)flow;
+  struct ut_flow_ctx* ctx = ut_active_ctx;
+
+  ctx->destroy_calls++;
+  memset(error, 0, sizeof(*error));
+  bool fail =
+      (ctx->destroy_fail_count < 0) || (ctx->destroy_calls <= ctx->destroy_fail_count);
+  return fail ? -EAGAIN : 0;
+}
+
+/*
+ * rx_flow_free() unconditionally calls mt_rte_free(rsp) at the end. Real DPDK
+ * rte_free() on a stack-allocated struct would corrupt the allocator, so this
+ * is a no-op: the caller passes a stack-local struct mt_rx_flow_rsp it reads
+ * back after the call, which a real free would make a use-after-free.
+ */
+static void ut_rte_free(void* ptr) {
+  (void)ptr;
+}
+
+ut_flow_ctx* ut_flow_create_ctx(void) {
+  ut_flow_ctx* ctx = calloc(1, sizeof(*ctx));
+  if (!ctx) return NULL;
+
+  struct mt_interface* inf = &ctx->impl.inf[MTL_PORT_P];
+  inf->parent = &ctx->impl;
+  inf->port = MTL_PORT_P;
+  inf->port_id = 0;
+  inf->nb_rx_q = 1;
+  inf->rx_queues = &ctx->rx_queue;
+  mt_pthread_mutex_init(&inf->vf_cmd_mutex, NULL);
+  ut_active_ctx = ctx;
+  return ctx;
+}
+
+void ut_flow_destroy_ctx(ut_flow_ctx* ctx) {
+  if (!ctx) return;
+  if (ut_active_ctx == ctx) ut_active_ctx = NULL;
+  mt_pthread_mutex_destroy(&ctx->impl.inf[MTL_PORT_P].vf_cmd_mutex);
+  free(ctx);
+}
+
+void ut_flow_set_create_fail_count(ut_flow_ctx* ctx, int fail_count) {
+  ctx->create_fail_count = fail_count;
+}
+
+void ut_flow_set_destroy_fail_count(ut_flow_ctx* ctx, int fail_count) {
+  ctx->destroy_fail_count = fail_count;
+}
+
+int ut_flow_create_calls(const ut_flow_ctx* ctx) {
+  return ctx->create_calls;
+}
+
+int ut_flow_destroy_calls(const ut_flow_ctx* ctx) {
+  return ctx->destroy_calls;
+}
+
+uint32_t ut_flow_create_call_group(const ut_flow_ctx* ctx, int call_index) {
+  return ctx->create_call_group[call_index];
+}
+
+bool ut_flow_rx_flow_create(ut_flow_ctx* ctx, bool no_ip_flow) {
+  ut_active_ctx = ctx;
+
+  struct mt_rxq_flow flow;
+  memset(&flow, 0, sizeof(flow));
+  flow.dip_addr[0] = 192;
+  flow.dip_addr[1] = 168;
+  flow.dip_addr[2] = 1;
+  flow.dip_addr[3] = 100;
+  flow.sip_addr[0] = 192;
+  flow.sip_addr[1] = 168;
+  flow.sip_addr[2] = 1;
+  flow.sip_addr[3] = 1;
+  flow.dst_port = 20000;
+  if (no_ip_flow) flow.flags |= MT_RXQ_FLOW_F_NO_IP;
+
+  struct rte_flow* result = rte_rx_flow_create(&ctx->impl.inf[MTL_PORT_P], 0, &flow);
+  return result != NULL;
+}
+
+int ut_flow_rx_flow_free(ut_flow_ctx* ctx) {
+  ut_active_ctx = ctx;
+
+  struct mt_rx_flow_rsp rsp;
+  memset(&rsp, 0, sizeof(rsp));
+  rsp.flow = (struct rte_flow*)(uintptr_t)0x1;
+  rsp.flow_id = -1;
+  rsp.queue_id = 0;
+  rsp.dst_port = 20000;
+
+  int ret = rx_flow_free(&ctx->impl.inf[MTL_PORT_P], &rsp);
+  ctx->last_free_flow_cleared = (rsp.flow == NULL);
+  return ret;
+}
+
+bool ut_flow_last_free_flow_cleared(const ut_flow_ctx* ctx) {
+  return ctx->last_free_flow_cleared;
+}

--- a/tests/unit/dev/mt_flow_harness.h
+++ b/tests/unit/dev/mt_flow_harness.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ */
+
+#ifndef TESTS_UNIT_DEV_MT_FLOW_HARNESS_H
+#define TESTS_UNIT_DEV_MT_FLOW_HARNESS_H
+
+/*
+ * C API for exercising the mt_flow.c rte_flow_create()/rte_flow_destroy()
+ * retry loops without a NIC. Callers configure how many times the DPDK stub
+ * should fail, invoke the static production function directly, then read
+ * back call counts and outcome through this API.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ut_flow_ctx ut_flow_ctx;
+
+ut_flow_ctx* ut_flow_create_ctx(void);
+void ut_flow_destroy_ctx(ut_flow_ctx* ctx);
+
+/* rte_flow_create: fail the first fail_count calls then succeed; -1 fails every call. */
+void ut_flow_set_create_fail_count(ut_flow_ctx* ctx, int fail_count);
+/* rte_flow_destroy: same shape as ut_flow_set_create_fail_count. */
+void ut_flow_set_destroy_fail_count(ut_flow_ctx* ctx, int fail_count);
+
+int ut_flow_create_calls(const ut_flow_ctx* ctx);
+int ut_flow_destroy_calls(const ut_flow_ctx* ctx);
+uint32_t ut_flow_create_call_group(const ut_flow_ctx* ctx, int call_index);
+
+/* Calls the static rte_rx_flow_create() directly for a unicast flow. */
+bool ut_flow_rx_flow_create(ut_flow_ctx* ctx, bool no_ip_flow);
+
+/* Calls the static rx_flow_free() directly on a synthetic response with a flow set. */
+int ut_flow_rx_flow_free(ut_flow_ctx* ctx);
+bool ut_flow_last_free_flow_cleared(const ut_flow_ctx* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/unit/dev/mt_flow_retry_test.cpp
+++ b/tests/unit/dev/mt_flow_retry_test.cpp
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ */
+
+#include <gtest/gtest.h>
+
+#include "dev/mt_flow_harness.h"
+
+// Pins the retry loops in lib/src/mt_flow.c that work around a transient VF
+// flow-rule timeout: rte_rx_flow_create() retries rte_flow_create() up to 5
+// times (10ms apart) before giving up or, for no-ip flows, falling back to
+// the e810 group-2 attribute; rx_flow_free() retries rte_flow_destroy() the
+// same way. The harness shadows the three rte_flow_* entry points so no
+// hardware or DPDK PMD is involved.
+class MtFlowRetryTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    ctx_ = ut_flow_create_ctx();
+    ASSERT_NE(ctx_, nullptr);
+  }
+
+  void TearDown() override {
+    ut_flow_destroy_ctx(ctx_);
+  }
+
+  ut_flow_ctx* ctx_ = nullptr;
+};
+
+// A transient failure that clears up inside the retry budget must still
+// produce a usable flow, using exactly the calls it took to succeed (no
+// extra call once rte_flow_create() finally returns non-NULL).
+TEST_F(MtFlowRetryTest, CreateSucceedsOnFifthRetry) {
+  ut_flow_set_create_fail_count(ctx_, 4);
+  EXPECT_TRUE(ut_flow_rx_flow_create(ctx_, false));
+  EXPECT_EQ(ut_flow_create_calls(ctx_), 5);
+}
+
+// A failure that never clears must stop at exactly max_retry attempts, not
+// loop forever or under-try. has_ip_flow stays true here, so the e810
+// group-2 fallback (which only applies to no-ip flows) must not fire either.
+TEST_F(MtFlowRetryTest, CreateExhaustsRetriesWithIpFlow) {
+  ut_flow_set_create_fail_count(ctx_, -1);
+  EXPECT_FALSE(ut_flow_rx_flow_create(ctx_, false));
+  EXPECT_EQ(ut_flow_create_calls(ctx_), 5);
+}
+
+// When has_ip_flow is false (MT_RXQ_FLOW_F_NO_IP), exhausting the 5 default
+// attempts must still fall through to the e810 group-2 fallback for one more
+// rte_flow_validate()+rte_flow_create() pair, and that 6th create call must
+// carry attr.group == 2.
+TEST_F(MtFlowRetryTest, CreateFallsBackToGroupTwoWithoutIpFlow) {
+  ut_flow_set_create_fail_count(ctx_, 5);
+  EXPECT_TRUE(ut_flow_rx_flow_create(ctx_, true));
+  EXPECT_EQ(ut_flow_create_calls(ctx_), 6);
+  EXPECT_EQ(ut_flow_create_call_group(ctx_, 5), 2u);
+}
+
+// Mirrors CreateSucceedsOnFifthRetry for the destroy side: a transient
+// destroy failure that clears within budget succeeds, and rsp->flow is
+// cleared to NULL on the success path.
+TEST_F(MtFlowRetryTest, FreeSucceedsOnFourthRetry) {
+  ut_flow_set_destroy_fail_count(ctx_, 3);
+  EXPECT_EQ(ut_flow_rx_flow_free(ctx_), 0);
+  EXPECT_EQ(ut_flow_destroy_calls(ctx_), 4);
+  EXPECT_TRUE(ut_flow_last_free_flow_cleared(ctx_));
+}
+
+// rx_flow_free() has no error return path: even after exhausting every
+// retry it still clears rsp->flow and returns 0, since the caller has no use
+// for a destroy failure once the rsp is being torn down anyway.
+TEST_F(MtFlowRetryTest, FreeExhaustsRetriesButStillReturnsZero) {
+  ut_flow_set_destroy_fail_count(ctx_, -1);
+  EXPECT_EQ(ut_flow_rx_flow_free(ctx_), 0);
+  EXPECT_EQ(ut_flow_destroy_calls(ctx_), 5);
+  EXPECT_TRUE(ut_flow_last_free_flow_cleared(ctx_));
+}

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -44,6 +44,8 @@ unit_sources = [
   'ffmpeg/mtl_common_test.cpp',
   'dev/mt_dev_harness.c',
   'dev/mt_dev_igc_test.cpp',
+  'dev/mt_flow_harness.c',
+  'dev/mt_flow_retry_test.cpp',
   'session/st40_harness.c',
   'session/st40_tx_test_harness.c',
   'session/st40/redundancy_test.cpp',


### PR DESCRIPTION
E835 VFs can time out applying flow rules right after a PF request, same race already worked around in rx_flow_free. Retry up to 5 times with a 10ms backoff outside the mutex before falling through to the existing e810 group-2 fallback.

Fixes: SDBQ-3703