### PR TITLE
Ci: Restore performance host configuration

### DIFF
--- a/.github/scripts/ci/configure-host.sh
+++ b/.github/scripts/ci/configure-host.sh
@@ -128,7 +128,8 @@ shadow-credentials)
 	credentials=${SHADOW_HOST_FILE:?SHADOW_HOST_FILE is required}
 	# shellcheck disable=SC1090
 	. "$credentials"
-	printf 'ip=%s\nuser=%s\n' "${IP:?IP is required}" "${USER:?USER is required}" \
+	printf 'ip=%s\nuser=%s\n' "${SHADOW_IP:-${IP:?IP is required}}" \
+		"${SHADOW_USER:-${USER:?USER is required}}" \
 		>>"${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 	;;
 shadow-sync)

--- a/.github/scripts/ci/pytest-setup.sh
+++ b/.github/scripts/ci/pytest-setup.sh
@@ -378,7 +378,7 @@ pci-env)
 	# For runners that carry no NIC label (the perf SUT pair): the host states
 	# which ports the perf rig owns, and an E830 pair is the default.
 	load_runner_env
-	printf 'PCI_DEVICE=%s\n' "${PCI_DEVICE:-8086:12d2,8086:12d2}" \
+	printf 'PCI_DEVICE=%s\n' "${PCI_DEVICE:-${PERF_PCI_DEVICE:-8086:12d2,8086:12d2}}" \
 		>>"${GITHUB_ENV:?GITHUB_ENV is required}"
 	;;
 config-single)

--- a/.github/workflows/perf-pytest.yml
+++ b/.github/workflows/perf-pytest.yml
@@ -63,7 +63,7 @@ jobs:
         id: validate
         uses: ./.github/actions/validate-host
         with:
-          shadow_host: '/etc/mtl-ci/shadow-host'
+          shadow_host: '/etc/mtl-ci/runner.env'
       - name: Ensure the acceptance virtualenv
         run: task ci:pytest-setup -- ensure
       - name: Set session ID

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -31,6 +31,7 @@ jobs:
       actions: read
 
   run-smoke-tests:
+    name: run-smoke-tests (${{ matrix.nic }})
     needs: pr-gate
     concurrency:
       group: smoke-${{ github.workflow }}-${{ github.ref }}-${{ matrix.nic }}


### PR DESCRIPTION
## Summary

Restore `perf-pytest` after the CI refactor in #1700.

The workflow still passed the removed `/etc/mtl-ci/shadow-host` file to host validation, while the performance runner's managed host facts now live in `/etc/mtl-ci/runner.env`. The credential helper now accepts that file's `SHADOW_IP` and `SHADOW_USER` names while preserving legacy `IP` and `USER` support. The performance PCI setup also honors the managed `PERF_PCI_DEVICE` value instead of silently selecting the fallback device.

Failed run: https://github.com/OpenVisualCloud/Media-Transport-Library/actions/runs/33696506540

## Validation

- Reproduced the missing shadow credential file failure from the Actions log
- Verified managed and legacy shadow credential formats
- Verified `PCI_DEVICE` / `PERF_PCI_DEVICE` precedence
- Verified complete `config-perf` argument generation for both hosts
- Verified SUT SSH access to the local and shadow hosts
- Ran `./format-coding.sh` including shellcheck, yamllint, and actionlint