### PR TITLE
Fix: i225 smoke

### DIFF
--- a/.github/scripts/ci/pytest-setup.sh
+++ b/.github/scripts/ci/pytest-setup.sh
@@ -115,6 +115,36 @@ resolve_nic() {
 	fi
 }
 
+# The ceiling on what a socket may ask to buffer, which the kernel socket
+# datapath needs raised.
+#
+# rx_socket_init_fd() sizes every RX socket itself, asking for 4 MiB. It asks
+# with SO_RCVBUFFORCE first, which ignores this ceiling -- but that needs
+# CAP_NET_ADMIN, and the suite's apps reach the host over SSH as an ordinary
+# user, so the ask falls back to SO_RCVBUF and the ceiling caps it. The symptom
+# and the numbers: see doc/kernel_socket.md.
+#
+# The kernel clamps the ask against this ceiling before doubling it, so the
+# ceiling has to be the size of the ask rather than twice it. A ceiling is not an
+# allocation: a socket that does not ask still gets net.core.rmem_default, so
+# this costs nothing on a leg that never opens one. Raised, never lowered, so a
+# host already tuned higher keeps its value.
+#
+# Not conditional on the leg's datapath: tests/single/kernel_socket runs
+# kernel:<ifname> on every host, whatever its own card resolved to.
+RMEM_MAX_MIN=$((4 * 1024 * 1024))
+
+ensure_socket_rcvbuf_ceiling() {
+	local current
+	current=$(sysctl -n net.core.rmem_max)
+	if ((current >= RMEM_MAX_MIN)); then
+		echo "net.core.rmem_max is ${current}, enough for the kernel socket datapath"
+		return 0
+	fi
+	sudo sysctl -q -w "net.core.rmem_max=${RMEM_MAX_MIN}"
+	echo "net.core.rmem_max: raised ${current} -> ${RMEM_MAX_MIN} for the kernel socket datapath"
+}
+
 # Raw video is enormous, and the suite records it into the workspace: an FFmpeg
 # RX case writes what it receives to tests/<case>_<stamp>_out_<n>.yuv for as long
 # as the case runs -- 1080p yuv422p10le is 8.3 MB a frame, so about 250 MB/s --
@@ -369,6 +399,7 @@ nic-labels)
 	;;
 pci)
 	read -r pci_device interface_type < <(resolve_nic "${NIC:?NIC is required}")
+	ensure_socket_rcvbuf_ceiling
 	{
 		printf 'PCI_DEVICE=%s\n' "$pci_device"
 		printf 'INTERFACE_TYPE=%s\n' "$interface_type"

--- a/doc/kernel_socket.md
+++ b/doc/kernel_socket.md
@@ -44,3 +44,29 @@ If you want to select kernel socket data path from the API level, please follow 
   snprintf(p->port[MTL_PORT_P], sizeof(p->port[MTL_PORT_P]), "%s", "kernel:enp24s0f0");
   ...
 ```
+
+## 4. Receive Buffer
+
+The default `net.core.rmem_default` (212992 bytes, about 100 datagrams) is far too small for
+a video stream, so the library sizes every RX socket itself, asking for up to 4 MiB. The
+kernel charges buffered packets against twice the ask, so that is 33 ms of a 1080p29 stream.
+It asks with `SO_RCVBUFFORCE`, which needs `CAP_NET_ADMIN`; a process with `CAP_NET_RAW` but
+not `CAP_NET_ADMIN` falls back to `SO_RCVBUF`, which `net.core.rmem_max` caps — before the
+doubling, so the ceiling has to be the size of the ask rather than twice it. Raise it
+wherever the datapath runs unprivileged — see
+[net.core.rmem_max](experimental/performance_optimizations.md):
+
+```bash
+sudo sysctl -w net.core.rmem_max=4194304
+```
+
+Without it a 1080p29 session buffers under 3 ms, and any hiccup in the receiver drops
+packets. That reaches an application as a handful of incomplete frames rather than as
+anything about buffers, so the library says which one the session got at create:
+
+```text
+rx_socket_init_fd(0,524), rcvbuf 8388608 in force, 4194304 asked ...   # the ask was honoured
+rx_socket_init_fd(0,524), rcvbuf 425984 in force but 4194304 asked ... # capped, expect losses
+```
+
+`nstat UdpRcvbufErrors` counts the packets lost this way.

--- a/lib/src/datapath/mt_dp_socket.c
+++ b/lib/src/datapath/mt_dp_socket.c
@@ -13,6 +13,9 @@
 #define MT_RX_DP_SOCKET_PREFIX "SR_"
 #define MT_TX_DP_SOCKET_PREFIX "SR_"
 
+/* largest receive buffer rx_socket_init_fd asks the kernel for */
+#define MT_RX_DP_SOCKET_RCVBUF_MAX (4 * 1024 * 1024)
+
 #ifndef UDP_SEGMENT
 /* fix for centos build */
 #define UDP_SEGMENT 103 /* Set GSO segmentation size */
@@ -470,6 +473,34 @@ static int rx_socket_init_fd(struct mt_rx_socket_entry* entry, int fd, bool reus
   if (ret < 0) {
     err("%s(%d,%d), SO_BINDTODEVICE to %s fail %d\n", __func__, port, fd, if_name, ret);
     return ret;
+  }
+
+  /* net.core.rmem_default is only ~100 mtu datagrams, under 1ms of a 1080p stream, so a
+   * scheduler hiccup overflows the queue and the kernel drops the packets. Ask for one rx
+   * ring of them, capped because nb_rx_desc is a public tunable and the kernel both
+   * doubles what it is asked for and, under SO_RCVBUFFORCE, ignores net.core.rmem_max.
+   * The force variant comes first because that cap silently truncates SO_RCVBUF. */
+  int rcvbuf_sz = RTE_MIN(mt_if_nb_rx_desc(impl, port) * entry->pool_element_sz,
+                          MT_RX_DP_SOCKET_RCVBUF_MAX);
+  if (setsockopt(fd, SOL_SOCKET, SO_RCVBUFFORCE, &rcvbuf_sz, sizeof(rcvbuf_sz)) < 0 &&
+      setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf_sz, sizeof(rcvbuf_sz)) < 0) {
+    warn("%s(%d,%d), set rcvbuf %d fail %s\n", __func__, port, fd, rcvbuf_sz,
+         strerror(errno));
+  }
+  int rcvbuf_got = 0;
+  socklen_t rcvbuf_got_len = sizeof(rcvbuf_got);
+  if (!getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf_got, &rcvbuf_got_len)) {
+    /* the kernel clamps the ask to net.core.rmem_max and then doubles it, so anything
+     * short of twice the ask means the ceiling truncated it and this session drops
+     * packets whenever the reader is late. Say so here: the only other trace of it is a
+     * receiver that reports lost packets under load, and nstat UdpRcvbufErrors counting
+     * them. */
+    if (rcvbuf_got < rcvbuf_sz * 2)
+      warn("%s(%d,%d), rcvbuf %d in force but %d asked, raise net.core.rmem_max to %d\n",
+           __func__, port, fd, rcvbuf_got, rcvbuf_sz, rcvbuf_sz);
+    else
+      info("%s(%d,%d), rcvbuf %d in force, %d asked and the kernel doubles the ask\n",
+           __func__, port, fd, rcvbuf_got, rcvbuf_sz);
   }
 
   /* bind to port */

--- a/tests/acceptance/common/integrity/integrity_runner.py
+++ b/tests/acceptance/common/integrity/integrity_runner.py
@@ -81,6 +81,7 @@ class FileVideoIntegrityRunner(VideoIntegrityRunner):
         delete_file: bool = True,
         python_path=None,
         integrity_path=None,
+        min_frames: int = 1,
     ):
         super().__init__(
             host,
@@ -94,6 +95,7 @@ class FileVideoIntegrityRunner(VideoIntegrityRunner):
             python_path,
             integrity_path,
         )
+        self.min_frames = min_frames
 
     def run(self):
         cmd = " ".join(
@@ -108,6 +110,8 @@ class FileVideoIntegrityRunner(VideoIntegrityRunner):
                 "--output_path",
                 self.out_path,
                 "--delete_file" if self.delete_file else "--no_delete_file",
+                "--min_frames",
+                str(self.min_frames),
             ]
         )
         logger.debug(

--- a/tests/acceptance/common/integrity/video_integrity.py
+++ b/tests/acceptance/common/integrity/video_integrity.py
@@ -356,11 +356,13 @@ class VideoFileIntegritor(VideoIntegritor):
         file_format: str = "yuv422p10le",
         out_path: str = "/mnt/ramdisk",
         delete_file: bool = True,
+        min_frames: int = 1,
     ):
         super().__init__(
             logger, src_url, out_name, resolution, file_format, out_path, delete_file
         )
         self.logger = logging.getLogger(__name__)
+        self.min_frames = min_frames
 
     def get_out_file(self):
         try:
@@ -374,6 +376,14 @@ class VideoFileIntegritor(VideoIntegritor):
 
     def check_st20p_integrity(self) -> bool:
         output_file = self.get_out_file()
+        frames = output_file.stat().st_size // self.frame_size
+        if frames < self.min_frames:
+            self.logger.error(
+                f"{output_file} holds {frames} whole frames, {self.min_frames} "
+                f"expected -- the recording was cut short, so the frames it does "
+                f"hold cannot vouch for the ones it does not."
+            )
+            return False
         self.shift_src_chunk_by_first_frame_no(output_file)
         result = self.check_integrity_file(output_file)
         return result
@@ -479,6 +489,12 @@ It performs frame-by-frame integrity checking using MD5 checksums."""
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_common_arguments(file_parser)
+    file_parser.add_argument(
+        "--min_frames",
+        type=int,
+        default=1,
+        help="Whole frames the recording must hold to count as complete (default: 1)",
+    )
 
     # Parse the arguments
     args = parser.parse_args()
@@ -505,6 +521,7 @@ It performs frame-by-frame integrity checking using MD5 checksums."""
             args.fmt,
             args.output_path,
             args.delete_file,
+            args.min_frames,
         )
     else:
         parser.print_help()

--- a/tests/acceptance/configs/gen_config.py
+++ b/tests/acceptance/configs/gen_config.py
@@ -53,7 +53,13 @@ def gen_test_config(
         "media_path": media_path,
         "test_time": test_time,
         "ramdisk": {
-            "media": {"mountpoint": "/mnt/ramdisk/media", "size_gib": 16},
+            # A case stages one source here and records beside it, so 16 GiB is
+            # short: the largest source is 13.9 GiB, and an FFmpeg or GStreamer
+            # recording has no equivalent of the rx_max_file_size cap in
+            # mtl_engine/config/universal_params.py -- 1080p yuv422p10le is
+            # 8.3 MB a frame, so 100 s of it is 23 GiB. 32 GiB is what the
+            # framework's other configs already document.
+            "media": {"mountpoint": "/mnt/ramdisk/media", "size_gib": 32},
             "tmpfs_size_gib": 8,
         },
     }

--- a/tests/acceptance/mtl_engine/application_base.py
+++ b/tests/acceptance/mtl_engine/application_base.py
@@ -12,6 +12,7 @@ from typing import Callable, Optional
 
 from .config.universal_params import UNIVERSAL_PARAMS
 from .execute import kill_stale_processes, log_fail, run
+from .integrity import min_expected_frames
 from .integrity_session import NO_INTEGRITY, IntegrityIntent
 from .pcap_compliance import CAPTURE_SETTLE_TIME, NO_COMPLIANCE, CaptureIntent
 
@@ -293,6 +294,14 @@ class Application(ABC):
             return int(self.params.get("replicas", 1))
         return 0
 
+    def rx_recording_cap(self) -> int:
+        """Bytes at which this app stops writing an RX recording, 0 if unbounded.
+
+        ``rx_max_file_size`` is a universal parameter, but only the adapters that
+        actually hand it to a receiver that enforces it override this.
+        """
+        return 0
+
     def integrity_intent(self, test_repo_path: str, host) -> IntegrityIntent:
         """Build the :class:`IntegrityIntent` an ``IntegritySession`` needs to evaluate.
 
@@ -315,6 +324,11 @@ class Application(ABC):
             width=self.params.get("width"),
             height=self.params.get("height"),
             file_format=self.params.get("pixel_format"),
+            min_frames=min_expected_frames(
+                self.extract_framerate(self.params.get("framerate")),
+                self.params.get("test_time") or 30,
+            ),
+            max_file_size=self.rx_recording_cap(),
             audio_format=self.params.get("audio_format"),
             audio_channels=self.params.get("audio_channels"),
             audio_sampling=self.params.get("audio_sampling"),

--- a/tests/acceptance/mtl_engine/config/universal_params.py
+++ b/tests/acceptance/mtl_engine/config/universal_params.py
@@ -100,7 +100,11 @@ UNIVERSAL_PARAMS = {
     "runtime_session": False,  # Start instance before creating sessions
     "rx_timing_parser": False,  # Enable timing check for video RX streams
     "auto_stop": False,  # Auto stop after input file ends
-    "rx_max_file_size": 0,  # Maximum RX file size in bytes (0 = no limit)
+    # Uncapped, one RX recording grows until it fills the ramdisk (4K p119 writes
+    # 2.5 GB/s). RxTxApp stops on a frame boundary here and keeps receiving, so the
+    # file stays a complete, verifiable prefix. configs/gen_config.py sizes the
+    # media ramdisk for this.
+    "rx_max_file_size": 8 * 1024**3,  # Maximum RX file size in bytes (0 = no limit)
     "pcapng_dump": None,  # Dump n packets to pcapng files
     "rx_video_file_frames": None,  # Dump received video frames to yuv file
     "promiscuous": False,  # Enable RX promiscuous mode

--- a/tests/acceptance/mtl_engine/ffmpeg.py
+++ b/tests/acceptance/mtl_engine/ffmpeg.py
@@ -75,6 +75,7 @@ class FFmpeg(Application):
         self._tx_commands: list[str] = []
         self._build: str | None = None
         self._rx_output: str | None = None
+        self._rx_frame_spec: tuple[str, str, int] | None = None
 
     # ------------------------------------------------------------------ ABCs
     def get_app_name(self) -> str:
@@ -283,6 +284,9 @@ class FFmpeg(Application):
             pix_fmt = ffmpeg_pix_fmt(self.params["pixel_format"])
         else:
             pix_fmt = "yuv422p10le"
+
+        # Geometry and rate the command was actually built with, for validate_results().
+        self._rx_frame_spec = (video_size, pix_fmt, fps)
 
         rx_f_flag = "-f rawvideo" if output_format == "yuv" else "-c:v libopenh264"
 
@@ -732,14 +736,22 @@ class FFmpeg(Application):
         try:
             if mode == _MODE_YUV_H264:
                 output_format = self._ff_params.get("output_format", "yuv")
-                video_format = self.params["video_format"]
-                video_size, _ = ffmpeg_app.decode_video_format_16_9(video_format)
                 video_url = self.params["video_url"]
                 if output_format == "yuv":
+                    video_size, pix_fmt, fps = self._rx_frame_spec
                     passed = ffmpeg_app.check_output_video_yuv(
-                        self._output_files[0], host, build, video_url
+                        self._output_files[0],
+                        host,
+                        build,
+                        video_url,
+                        video_size,
+                        pix_fmt,
+                        fps,
+                        self.params.get("test_time") or 30,
                     )
                 else:
+                    video_format = self.params["video_format"]
+                    video_size, _ = ffmpeg_app.decode_video_format_16_9(video_format)
                     passed = ffmpeg_app.check_output_video_h264(
                         self._output_files[0], video_size, host, build, video_url
                     )

--- a/tests/acceptance/mtl_engine/ffmpeg.py
+++ b/tests/acceptance/mtl_engine/ffmpeg.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 
-from mtl_engine import ffmpeg_app, ip_pools
+from mtl_engine import ffmpeg_app, ip_pools, media_files
 from mtl_engine.application_base import (
     MTL_ENCODER_PLUGIN_MAP,
     Application,
@@ -159,12 +159,24 @@ class FFmpeg(Application):
 
         Used by every mode: yuv|h264 (raw 422p10le), rgb24 (yuv422p10be →
         rgb24 filter, single stream), rgb24_multiple (same, two streams).
-        ``framerate`` only emitted for the rgb24 family — yuv_h264 omits
-        ``-framerate`` because the source already carries the canonical fps.
-        ``filter_v`` is the full ``-filter:v <chain>`` token (empty by default).
-        ``ptp_enable`` is independent from ``pacing_way``.
+        ``framerate`` is a pXX label (or its bare integer); it is converted to
+        the exact rate before being handed to FFmpeg — see the ``-re`` note
+        below. ``filter_v`` is the full ``-filter:v <chain>`` token (empty by
+        default). ``ptp_enable`` is independent from ``pacing_way``.
         """
-        framerate_token = f"-framerate {framerate} " if framerate is not None else ""
+        # ``-framerate`` on the rawvideo demuxer is a real rate, not a SMPTE
+        # label, and combined with ``-re`` below it becomes a hard cap on the
+        # producer. Passing the label verbatim caps it at 29 fps while the
+        # mtl_st20p muxer scans the ST 2110 rates for the first whose tolerance
+        # window holds 29 -- ST_FPS_P29_97, window [28.97, 29.99] -- and paces
+        # at 30000/1001, so the pacer starves by ~1 frame/s and drops it
+        # (``TX_VIDEO_SESSION ... epoch drop``, ``busy as no ready frame from
+        # user``).
+        framerate_token = (
+            f"-framerate {media_files.pformat_to_exact_fps(framerate)} "
+            if framerate is not None
+            else ""
+        )
         filter_token = f"{filter_v} " if filter_v else ""
         ptp_token = ""
         if ptp_enable:
@@ -404,6 +416,9 @@ class FFmpeg(Application):
         framerate = self.params.get("framerate", "p60")
         # Convert "pXX" string to numeric fps for FFmpeg -framerate flag.
         fps_num = framerate.lstrip("p") if isinstance(framerate, str) else framerate
+        # The fps filter sets a real rate, so it takes the exact one; MTL's own
+        # -fps option below resolves the label's digits itself.
+        filter_fps = media_files.pformat_to_exact_fps(framerate)
         pix_fmt = self._ff_params.get("pix_fmt", "yuv422p10le")
         st22_codec = self._ff_params.get("st22_codec", "jpegxs")
         bpp = self._ff_params.get("bpp", 3.0)
@@ -420,7 +435,7 @@ class FFmpeg(Application):
             f"{FFMPEG_EXE} -stream_loop -1 "
             f"-video_size {video_size} -f rawvideo -pix_fmt {pix_fmt} "
             f"-i {input_file} "
-            f"-filter:v fps={fps_num} "
+            f"-filter:v fps={filter_fps} "
             f"-p_port {nic_port_list[1]} -p_sip {ip_pools.tx[0]} "
             f"-p_tx_ip {ip_pools.rx_multicast[0]} "
             f"-udp_port {udp_port} -payload_type 112 "

--- a/tests/acceptance/mtl_engine/ffmpeg_app.py
+++ b/tests/acceptance/mtl_engine/ffmpeg_app.py
@@ -9,10 +9,12 @@ import re
 import threading
 import time
 
+from common.integrity.video_integrity import calculate_yuv_frame_size
 from mfd_connect import SSHConnection
 from mfd_connect.exceptions import ConnectionCalledProcessError
 from mtl_engine import ip_pools
 from mtl_engine.const import FFMPEG_EXE, FFPROBE_EXE, RXTXAPP_EXE
+from mtl_engine.integrity import min_expected_frames
 
 from . import rxtxapp_config
 from .execute import log_fail, run
@@ -380,7 +382,16 @@ def execute_test(
     passed = False
     match output_format:
         case "yuv":
-            passed = check_output_video_yuv(output_files[0], host, build, video_url)
+            passed = check_output_video_yuv(
+                output_files[0],
+                host,
+                build,
+                video_url,
+                video_size,
+                pix_fmt,
+                fps,
+                test_time,
+            )
         case "h264":
             passed = check_output_video_h264(
                 output_files[0], video_size, host, build, video_url
@@ -640,7 +651,21 @@ def execute_test_rgb24_multiple(
     return True
 
 
-def check_output_video_yuv(output_file: str, host, build: str, input_file: str):
+def check_output_video_yuv(
+    output_file: str,
+    host,
+    build: str,
+    input_file: str,
+    video_size: str,
+    pix_fmt: str,
+    fps: int,
+    test_time: int,
+):
+    """Check an RX raw-video recording holds the frames the run should carry.
+
+    A nonzero byte count proves nothing, so whole frames are counted instead. The
+    partial tail a timer-killed FFmpeg leaves is normal, and is not counted.
+    """
     # Log input file size
     try:
         input_stat_proc = run(f"stat -c '%s' {input_file}", host=host)
@@ -655,15 +680,36 @@ def check_output_video_yuv(output_file: str, host, build: str, input_file: str):
     # Use run() to check output file size
     stat_proc = run(f"stat -c '%s' {output_file}", host=host)
 
-    if stat_proc.return_code == 0:
-        output_file_size = int(stat_proc.stdout_text.strip())
-        logger.info(f"Output file size: {output_file_size} bytes for {output_file}")
-        result = output_file_size > 0
-        logger.info(f"YUV check result: {result}")
-        return result
-    else:
+    if stat_proc.return_code != 0:
         logger.info(f"Could not get output file size for {output_file}")
         return False
+
+    output_file_size = int(stat_proc.stdout_text.strip())
+    logger.info(f"Output file size: {output_file_size} bytes for {output_file}")
+
+    width, height = (int(dim) for dim in video_size.split("x"))
+    try:
+        frame_size = calculate_yuv_frame_size(width, height, pix_fmt)
+    except ValueError:
+        # Counting frames needs a frame size; without one, fall back to the
+        # non-empty check rather than erroring out of validation.
+        logger.warning(f"Cannot size {pix_fmt} frames, checking only for non-empty")
+        return output_file_size > 0
+    frames = output_file_size // frame_size
+    min_frames = min_expected_frames(fps, test_time)
+
+    if frames < min_frames:
+        # Not log_fail(): every caller records it, and one may be fail_on_error=False.
+        logger.error(
+            f"{output_file} holds {frames} whole frames of {frame_size} bytes, at "
+            f"least {min_frames} expected from {fps} fps over {test_time}s -- the "
+            f"recording is short, so check for a full filesystem where it was "
+            f"written and for RX errors in the app log"
+        )
+        return False
+
+    logger.info(f"YUV check result: True ({frames} frames of {frame_size} bytes)")
+    return True
 
 
 def check_output_video_h264(
@@ -1155,7 +1201,16 @@ def execute_dual_test(
     passed = False
     match output_format:
         case "yuv":
-            passed = check_output_video_yuv(output_files[0], rx_host, build, video_url)
+            passed = check_output_video_yuv(
+                output_files[0],
+                rx_host,
+                build,
+                video_url,
+                video_size,
+                "yuv422p10le",
+                fps,
+                test_time,
+            )
         case "h264":
             passed = check_output_video_h264(
                 output_files[0], video_size, rx_host, build, video_url

--- a/tests/acceptance/mtl_engine/integrity.py
+++ b/tests/acceptance/mtl_engine/integrity.py
@@ -7,6 +7,19 @@ from math import floor
 
 from .execute import log_fail
 
+# Fraction of the nominal frame count a recording must reach to count as complete.
+MIN_RECORDED_FRAME_RATIO = 0.5
+
+
+def min_expected_frames(fps: float, test_time: float) -> int:
+    """Frames a *test_time*-second recording at *fps* must hold to be complete.
+
+    RX opens before TX and both are killed on a timer, and pacing training eats
+    the first seconds, so healthy recordings land well short of nominal. Never 0
+    -- an empty recording must never pass.
+    """
+    return max(1, int(fps * test_time * MIN_RECORDED_FRAME_RATIO))
+
 
 def check_st20p_integrity(
     src_url: str, out_url: str, frame_size: int, skip_frames: int = 1

--- a/tests/acceptance/mtl_engine/integrity_session.py
+++ b/tests/acceptance/mtl_engine/integrity_session.py
@@ -30,6 +30,7 @@ from common.integrity.integrity_runner import (
     FileAudioIntegrityRunner,
     FileVideoIntegrityRunner,
 )
+from common.integrity.video_integrity import calculate_yuv_frame_size
 
 from .execute import log_fail
 from .integrity import get_channel_number, get_sample_number, get_sample_size
@@ -56,6 +57,8 @@ class IntegrityIntent:
     width: Optional[int] = None
     height: Optional[int] = None
     file_format: Optional[str] = None
+    min_frames: int = 1
+    max_file_size: int = 0
     # audio-only
     audio_format: Optional[str] = None
     audio_channels: Optional[list] = None
@@ -168,6 +171,20 @@ class IntegritySession:
                 out_path=out_path,
                 delete_file=False,
             )
+        min_frames = intent.min_frames
+        if intent.max_file_size:
+            # The cap stops the write on a frame boundary and the session keeps
+            # receiving, so the recording is a complete prefix.
+            try:
+                frame_size = calculate_yuv_frame_size(
+                    intent.width, intent.height, intent.file_format
+                )
+            except ValueError:
+                # A format the integritor cannot size fails in the runner with its
+                # own message; sizing it here must not pre-empt that with an error.
+                pass
+            else:
+                min_frames = min(min_frames, max(1, intent.max_file_size // frame_size))
         return FileVideoIntegrityRunner(
             host=intent.host,
             test_repo_path=intent.test_repo_path,
@@ -177,6 +194,7 @@ class IntegritySession:
             file_format=intent.file_format,
             out_path=out_path,
             delete_file=False,
+            min_frames=min_frames,
         )
 
     def close(self, enforce_dispatch: bool = True) -> None:

--- a/tests/acceptance/mtl_engine/media_files.py
+++ b/tests/acceptance/mtl_engine/media_files.py
@@ -34,6 +34,29 @@ def parse_fps_to_pformat(fps_field: Union[str, int]) -> str:
     return f"p{fps_val}"
 
 
+# The four rates whose pXX label truncates, by the NTSC convention above: p23 is
+# 23.98, p29 is 29.97, p59 is 59.94, p119 is 119.88. Every other label is exact.
+_TRUNCATED_FPS_LABELS = frozenset({23, 29, 59, 119})
+
+
+def pformat_to_exact_fps(fps_field: Union[str, int]) -> str:
+    """Inverse of :func:`parse_fps_to_pformat`: the rate a pXX label stands for.
+
+    Returned as an FFmpeg rational ('30000/1001'), exact rather than rounded.
+
+    A label is not a rate. MTL resolves a rate to whichever ST 2110 rate's
+    tolerance window it falls in and paces at *that*, so anything setting a real
+    FFmpeg rate -- ``-framerate`` on a demuxer, the ``fps`` filter -- has to be
+    given the rate. Handing it the label instead leaves a producer running ~1
+    frame/s slower than MTL paces, which starves the pacer into dropping one
+    frame every second (``TX_VIDEO_SESSION ... epoch drop``).
+    """
+    fps_val = int(str(fps_field).lstrip("pi"))
+    if fps_val in _TRUNCATED_FPS_LABELS:
+        return f"{(fps_val + 1) * 1000}/1001"
+    return str(fps_val)
+
+
 yuv_files = dict(
     i720p23={
         "filename": "HDR_BBC_v4_008_Penguin1_1280x720_10bit_25Hz_P422_180frames.yuv",

--- a/tests/acceptance/mtl_engine/rxtxapp.py
+++ b/tests/acceptance/mtl_engine/rxtxapp.py
@@ -1279,6 +1279,16 @@ class RxTxApp(Application):
             for session in group.get("st20p") or []
         )
 
+    def rx_recording_cap(self) -> int:
+        """Return the byte limit RxTxApp stops this recording at, 0 if unbounded.
+
+        ``--rx_max_file_size`` is honoured by the st20p receiver alone
+        (``tests/tools/RxTxApp/src/rx_st20p_app.c``), so only st20p reports a cap.
+        """
+        if self.params.get("session_type") != "st20p":
+            return 0
+        return int(self.params.get("rx_max_file_size") or 0)
+
     def _resolve_capture_dst_ips(self) -> tuple[str, ...]:
         """Return the destination IPs for netsniff capture, possibly empty.
 


### PR DESCRIPTION
## Problem

#1700 added the i225 leg to the smoke matrix, but it had never produced a usable verdict. As
the fleet's only single-port card it is the only leg on MTL's **kernel-socket** datapath, and
with no third port to sniff it also runs without a capture. That combination reaches faults no
other NIC hits. Three stopped the leg outright, one was latent; the leg is `optional: true`, so
none of it blocked a gate — it only meant the leg's result said nothing.

## What was wrong, and what changed

**Kernel-socket RX dropped packets inside the kernel** — f3d3f5e4, 80f4a4b4

`rx_socket_init_fd()` never sized the receive buffer, so every RX socket kept
`net.core.rmem_default` — 212992 bytes, 0.84 ms of a 1080p29 ST 2110-20 stream. Any longer
hiccup overflows the queue and the kernel drops the packets before MTL can read them. It is
invisible on this datapath, since kernel-socket ports count only packets already read; it
surfaced as `unrecovered: 370` / `per-port lost pkts 370` and a failed content comparison, with
`nstat UdpRcvbufErrors` up by exactly those 370.

The socket now asks for one RX ring of datagrams capped at 4 MiB, `SO_RCVBUFFORCE` with an
`SO_RCVBUF` fallback for a process without `CAP_NET_ADMIN`, warning rather than failing session
create. It reads the size back, because neither `setsockopt` reports the cap it landed under.
CI raises `net.core.rmem_max` to 4 MiB too, since the suite's apps arrive over SSH unprivileged
and take the capped fallback. 4 MiB is the whole requirement, not half: the kernel clamps the
ask against `rmem_max` and *then* doubles it, so a 4 MiB ceiling still yields `sk_rcvbuf`
8388608.

**JPEG-XS had no plugin registry** — 33128340

Both st22p cases died with `st22p_tx_create(0), get encoder fail -22`. The registry stage
exports `KAHAWAI_CFG_PATH`, which serves the gtest jobs but not the acceptance suite — that one
reaches the DUT over SSH inheriting none of the job's environment, so `mt_config_init()` fell
back to the tracked `kahawai.json`, which ships `st22_svt_jpegxs` disabled. The step now also
installs the rendered registry at the repository root, the cwd the suite launches apps with.

**A 100 s recording did not fit the media ramdisk** — 6f660f28

The mount was a constant 16 GiB, but an st20p case records beside the source it transmits, so
100 s of 1080p29 wants 23.15 GiB next to a 1.39 GiB source. It died at frame 1892 of 2997 with
`error code: -28 (No space left on device)`.

Sizing the mount from `test_time` does not work — `gen_config.py` is never told the marker, and
nightly's worst case wants more memory than the host has. So the write is bounded instead:
`rx_max_file_size` defaults to 8 GiB and the mount goes to the 32 GiB the framework's other
configs already document. Separately, a short recording used to *pass* — the checks asked only
whether the file was non-empty and compared whatever frames were present, so 3 frames out of
900 matched and passed. Both now compare against the frames the run had time to deliver, with a
cap-aware floor.

**Latent: the FFmpeg producer ran 3% slow** — 515d2f31

`-framerate` is a real rate, not a SMPTE label, and the st20p TX builder pairs it with `-re`,
making it a hard cap. It was passing the label's digits, so a p29 case ran the producer at
29.000 fps while the muxer paced at 30000/1001 — starving the pacer into 56 skipped epochs over
100 s. Nothing caught it: a skipped epoch is dead air, not a lost frame, so the recording stays
byte-exact and an st20p *fps* test transmitting 3% off rate reported success. All four NTSC
labels are affected, on every leg.

## Scope

16 files, +309/−21. The only shipped library change is `lib/src/datapath/mt_dp_socket.c`; the
rest is CI scripts, the acceptance harness, and docs. No workflow YAML is touched.