### PR TITLE
Fix: Stop st30p integrity check deadlocking the nightly

### DIFF
--- a/.github/copilot-docs/mtl-knowledge-base.md
+++ b/.github/copilot-docs/mtl-knowledge-base.md
@@ -241,7 +241,7 @@ Default mempool ops: `"stack"` (LIFO) — better cache reuse than FIFO ring ops.
 ### RX Frame Buffers
 - Allocated via `mt_rte_zmalloc_socket()` (`rte_zmalloc_socket` wrapper) — zero-initialized
 - `framebuff_cnt` typically 3: one assembling, one for app, one spare
-- Zero-init rationale: partial frames (packet loss) have zeroed gaps instead of garbage
+- Zero-init covers a buffer's **first use only** — buffers are recycled, so a gap left as-is reads as the frame the buffer carried before
 
 ### DMA Copy Engine (RX)
 
@@ -566,7 +566,7 @@ mt_bitmap_test_and_set(bitmap, pkt_idx) → atomic, skip if already set
 2. `dma_nb == 0` (all DMA copies finished)
 3. No pending mbuf borrows
 
-Complete → `rv_slot_full_frame()` → `ST_FRAME_STATUS_COMPLETE`. Incomplete/evicted → `ST_FRAME_STATUS_CORRUPTED`.
+Complete → `rv_slot_full_frame()` → `ST_FRAME_STATUS_COMPLETE`. Incomplete/evicted → `ST_FRAME_STATUS_CORRUPTED`, recycled rather than delivered unless the app set `ST20_RX_FLAG_RECEIVE_INCOMPLETE_FRAME` (`rv_frame_notify()`).
 
 ### Inflight Pattern (Cooperative Non-Blocking Retry)
 - **Builder inflight**: ring full → save packets to `s->inflight[port][]` → return → retry next iteration
@@ -616,6 +616,7 @@ Same lifecycle pattern as video, simplified:
 - Low scheduler quota
 - Shared queue friendly
 - ST2110-41: payload type 115, header 58 bytes, API in `st41_api.h`
+- ST30 RX, like ST20: a short frame counts `stat_frames_incomplete` and is recycled, or zeroed-then-delivered under `ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME`
 
 ### Manager Pattern
 Sessions organized into managers (`st_tx_video_sessions_mgr`), one per session type per scheduler:

--- a/.github/instructions/mtl-acceptance-tests.instructions.md
+++ b/.github/instructions/mtl-acceptance-tests.instructions.md
@@ -87,6 +87,8 @@ sudo grep -E "EAL|hugepage|VF|RxTxApp|RemoteProcess|Traceback|err:" \
 | `No module named pytest` / `pytest_mfd_config` | You used `sudo python3`. Re-run with `sudo -E ./venv/bin/python3`. |
 | `unrecognized arguments: --topology_config` | Run from `tests/acceptance/` (local `conftest.py` registers the plugin). |
 | Test hung > test_time + ~30 s | Stale process. `sudo pkill -9 RxTxApp MtlManager ffmpeg gst-launch-1.0` and retry. |
+| Test hung for hours, no output, idle `audio_integrity.py`, pytest in `futex_wait_queue` | The checker printed past the ~2 MiB paramiko channel window, which `mfd_connect` drains only at command exit. `audio_integrity.py` caps per-frame reports (`MAX_BAD_FRAME_REPORTS`); `video_integrity.py` reports per frame, far under. `integrity_runner.py` bounds file-mode checks at `_INTEGRITY_TIMEOUT`. |
+| `is missing N frame(s) of audio within its first 5` (st30p, still PASSED) | Expected: the RX joins a stream in flight, so MTL suppresses its first short frames (`JOIN_FRAMES`/`MAX_JOIN_GAP_FRAMES` in `audio_integrity.py`). A wider gap, or one in a later segment, fails. |
 | `EBU server configuration not found` (test still PASSED) | Data path passed; compliance verdict was skipped. Re-run setup with `--ebu-ip=`/`--ebu-user=`/`--ebu-password=`/`--capture-pci-device=` (ask the user first) so `ebu_server`/`capture_cfg` get populated in `test_config.yaml`. |
 | `netsniff-ng: command not found` | `sudo apt install -y netsniff-ng`. |
 | `build_dpdk.sh: line ...: unzip: command not found` | **(setup)** Fixed: `unzip` now in base apt deps. Re-run setup. |

--- a/.github/instructions/mtl-c-coding.instructions.md
+++ b/.github/instructions/mtl-c-coding.instructions.md
@@ -54,7 +54,7 @@ These rules are **mandatory** for all C source in the MTL codebase. For deep arc
 
 - DPDK allocations: `mt_rte_zmalloc()` / `mt_rte_free()` — always specify `socket_id` via `mt_socket_id(impl, port)`
 - Frame buffers: `rte_zmalloc_socket()`, not from mempool
-- RX frame buffers must be **zero-initialized** (partial frames have zeroed gaps, not garbage)
+- RX frame buffers must be **zero-initialized**; that covers a buffer's first use only, so a recycled buffer's un-arrived gaps must be re-zeroed before it is delivered
 - NUMA socket mismatch causes 2× DMA latency
 - DMA copies must not cross hugepage boundaries
 - Mempool names must include `recovery_idx` suffix for uniqueness across recovery cycles

--- a/doc/stats_guide.md
+++ b/doc/stats_guide.md
@@ -103,13 +103,13 @@ All counters are `uint64_t`, monotonic, thread-safe (per-session spinlock).
  │         charged at frame recycle, not at completion, so late                │
  │         redundant twins are counted first (stats appear one frame later)    │
  │                                                                             │
- │     ST20 / ST22 (transport): intra-frame loss detected                       │
+ │     ST20 / ST22 / ST30 (transport): intra-frame loss detected               │
  │                                    ──► stat_frames_incomplete++             │
  │                                                                             │
- │     ST20p / ST30p / ST40p: frame delivered with unrecovered loss     │
+ │     ST20p / ST30p / ST40p: frame has unrecovered loss                       │
  │                                    ──► stat_frames_corrupted++              │
- │                                        (frame still delivered with          │
- │                                         ST_FRAME_STATUS_CORRUPTED)          │
+ │                                        (ST_FRAME_STATUS_CORRUPTED; see      │
+ │                                         Frame-level counters)               │
  │                                                                             │
  │     Pipeline (ST20p / ST30p / ST40p):                                       │
  │       no free user framebuff       ──► stat_frames_dropped++                │
@@ -168,7 +168,7 @@ frames did the app receive / drop / send".
 |---|---|---|
 | `stat_frames_received`  | RX | Frames delivered to the app via the get-frame / notify path |
 | `stat_frames_dropped`   | RX | Frames the pipeline could not deliver (no free user slot) |
-| `stat_frames_corrupted` | RX | Frames delivered with `ST_FRAME_STATUS_CORRUPTED` (unrecovered intra-frame loss); the frame is still handed to the app |
+| `stat_frames_corrupted` | RX | Frames delivered with `ST_FRAME_STATUS_CORRUPTED` (unrecovered intra-frame loss). ST40p hands such a frame up unconditionally; ST20p and ST30p only when `RECEIVE_INCOMPLETE_FRAME` is set |
 | `stat_frames_sent`      | TX | Frames whose final packet was committed to the wire (`notify_frame_done(COMPLETE)`) |
 | `stat_frames_dropped`   | TX | Frames the pipeline dropped because the app handed them too late (`notify_frame_done(DROPPED)`); also bumped on `put_frame_abort` |
 
@@ -177,8 +177,9 @@ RX and TX). For transport-only paths and types with no per-frame
 integrity concept (`stat_frames_corrupted` on `ST41` RX),
 the relevant counters stay 0.
 
-> **ST20 / ST22 only:** the transport-layer field `stat_frames_incomplete`
-> (in `st20_rx_user_stats`) is **not** the same as `stat_frames_corrupted`.
+> **ST20 / ST22 / ST30 only:** the transport-layer field `stat_frames_incomplete`
+> (in `st20_rx_user_stats` / `st30_rx_user_stats`) is **not** the same as
+> `stat_frames_corrupted`.
 > `stat_frames_incomplete` fires whenever the transport detects intra-frame
 > loss, including when the frame is then silently discarded because
 > `RECEIVE_INCOMPLETE_FRAME` is not set; `stat_frames_corrupted` only
@@ -327,12 +328,14 @@ Cross-frame reorders are not tracked. Watch
 
 **Audio/Anc/FMD (ST30/40/41).** Loss uses post-redundancy `session_seq_id` →
 `stat_pkts_unrecovered` is **exact**. ST30 adds `stat_pkts_dropped`,
-`stat_pkts_len_mismatch_dropped`, `stat_slot_get_frame_fail`. ST40/41 add
+`stat_pkts_len_mismatch_dropped`, `stat_slot_get_frame_fail`,
+`stat_frames_incomplete`. ST40/41 add
 `stat_pkts_wrong_interlace_dropped`, `stat_pkts_enqueue_fail`. ST20p,
 ST30p and ST40p RX mark frames whose constituent packets had unrecovered
 (post-redundancy) gaps as `ST_FRAME_STATUS_CORRUPTED` and count them in
-`stat_frames_corrupted`; the frame is still delivered to the app (the app
-should consult `frame->status`). For count-based assembly (ST30 audio /
+`stat_frames_corrupted` (the app should consult `frame->status`; for whether
+such a frame is delivered at all see [Frame-level
+counters](#frame-level-counters)). For count-based assembly (ST30 audio /
 ST40 anc) a fully-lost frame is absorbed — the delivered frame count drops
 rather than emitting an extra incomplete frame — so under heavy contiguous
 loss `stat_frames_corrupted` is a lower bound on frame-integrity impact.

--- a/include/st30_api.h
+++ b/include/st30_api.h
@@ -90,6 +90,14 @@ typedef struct st_rx_audio_session_handle_impl* st30_rx_handle;
 #define ST30_RX_FLAG_SIMULATE_PKT_LOSS (MTL_BIT32(3))
 /**
  * Flag bit in flags of struct st30_rx_ops.
+ * Only for ST30_TYPE_FRAME_LEVEL.
+ * If set, lib will pass the incomplete frame to app also by notify_frame_ready.
+ * User can check st30_rx_frame_meta data for the frame integrity. The packets
+ * that never arrived read as zero(silence).
+ */
+#define ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME (MTL_BIT32(4))
+/**
+ * Flag bit in flags of struct st30_rx_ops.
  * Enable the timing analyze in the stat dump
  */
 #define ST30_RX_FLAG_TIMING_PARSER_STAT (MTL_BIT32(16))
@@ -573,6 +581,7 @@ struct st30_rx_user_stats {
   uint64_t stat_pkts_dropped;
   uint64_t stat_pkts_len_mismatch_dropped;
   uint64_t stat_slot_get_frame_fail;
+  uint64_t stat_frames_incomplete;
 };
 
 /**

--- a/include/st30_pipeline_api.h
+++ b/include/st30_pipeline_api.h
@@ -252,6 +252,14 @@ enum st30p_rx_flag {
    */
   ST30P_RX_FLAG_SIMULATE_PKT_LOSS = (MTL_BIT32(3)),
 
+  /**
+   * Flag bit in flags of struct st30p_rx_ops.
+   * If set, lib will pass the incomplete frame to app also. User can check
+   * st30_frame status for the frame integrity. The packets that never arrived
+   * read as zero(silence).
+   */
+  ST30P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME = (MTL_BIT32(4)),
+
   /** Enable the st30p_rx_get_frame block behavior to wait until a frame becomes
    available or timeout(default: 1s, use st30p_rx_set_block_timeout to customize) */
   ST30P_RX_FLAG_BLOCK_GET = (MTL_BIT32(15)),

--- a/include/st_api.h
+++ b/include/st_api.h
@@ -451,8 +451,8 @@ struct st_rx_user_stats {
   /**
    * Total frames delivered with status ST_FRAME_STATUS_CORRUPTED, i.e.
    * frames whose constituent packets had unrecoverable gaps after
-   * redundancy. The frame is still handed to the application; the
-   * application should consult frame->status to decide what to do.
+   * redundancy. ST40p hands such a frame up unconditionally; ST20p and ST30p
+   * only when the app set that media type's RECEIVE_INCOMPLETE_FRAME flag.
    * Populated by RX session types that classify per-frame integrity
    * (ST20p, ST30p, ST40p). Always 0 for types with no per-frame
    * corruption concept (ST41).

--- a/lib/src/st2110/pipeline/st30_pipeline_rx.c
+++ b/lib/src/st2110/pipeline/st30_pipeline_rx.c
@@ -109,7 +109,8 @@ static int rx_st30p_frame_ready(void* priv, void* addr, struct st30_rx_frame_met
 
   struct st30_frame* frame = &framebuff->frame;
   frame->addr = addr;
-  frame->data_size = meta->frame_recv_size;
+  /* whole frame, like st20p: an incomplete frame's gaps read as silence */
+  frame->data_size = ctx->ops.framebuff_size;
   frame->tfmt = meta->tfmt;
   frame->timestamp = meta->timestamp;
   frame->receive_timestamp = meta->timestamp_first_pkt;
@@ -164,6 +165,8 @@ static int rx_st30p_create_transport(struct mtl_main_impl* impl, struct st30p_rx
   }
   if (ops->flags & ST30P_RX_FLAG_SIMULATE_PKT_LOSS)
     ops_rx.flags |= ST30_RX_FLAG_SIMULATE_PKT_LOSS;
+  if (ops->flags & ST30P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME)
+    ops_rx.flags |= ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
 
   transport = st30_rx_create(impl, &ops_rx);
   if (!transport) {

--- a/lib/src/st2110/st_rx_audio_session.c
+++ b/lib/src/st2110/st_rx_audio_session.c
@@ -269,13 +269,13 @@ static int rx_audio_session_open_frame(struct st_rx_audio_session_impl* s,
     return -EIO;
   }
 
-  /* Anchor on the grid floor carried by s->tmstamp so a missing leading packet
-   * leaves slot 0 unset; resync to the arriving ts on a jump beyond one frame. */
-  uint32_t spp = s->samples_per_pkt ? s->samples_per_pkt : 1;
+  /* Floor onto the grid s->tmstamp carries so frame boundaries never move. Signed:
+   * the redundancy filter can force-accept a packet from behind the floor. */
+  int64_t ticks = s->rtp_ticks_per_frame ? s->rtp_ticks_per_frame : 1;
   uint32_t grid_base = (uint32_t)(s->tmstamp + 1);
-  uint32_t base = (((uint32_t)(tmstamp - grid_base) / spp) < (uint32_t)s->st30_total_pkts)
-                      ? grid_base
-                      : tmstamp;
+  int32_t delta = (int32_t)(tmstamp - grid_base);
+  int64_t frames = delta / ticks - (delta % ticks < 0); /* floor, not truncate */
+  uint32_t base = grid_base + (uint32_t)(frames * ticks);
 
   memset(s->frame_bitmap, 0, ((size_t)s->st30_total_pkts + 7) / 8);
   s->frame_recv_size = 0;
@@ -286,10 +286,18 @@ static int rx_audio_session_open_frame(struct st_rx_audio_session_impl* s,
   return 0;
 }
 
-/* Close the open frame: COMPLETE when every positional slot was filled,
- * CORRUPTED otherwise (mirrors st20 rv_frame_notify). The floor watermark is
- * advanced to the next frame so a late packet for this just-closed frame is
- * dropped by the redundancy filter. */
+/* Zero the slots that never arrived; the recycled buffer still holds older audio. */
+static void rx_audio_session_zero_frame_gaps(struct st_rx_audio_session_impl* s,
+                                             struct st_frame_trans* frame) {
+  for (int i = 0; i < s->st30_total_pkts; i++) {
+    if (mt_bitmap_test(s->frame_bitmap, i)) continue;
+    memset((uint8_t*)frame->addr + (size_t)i * s->pkt_len, 0, s->pkt_len);
+  }
+}
+
+/* Close the open frame: COMPLETE when every slot was filled, else CORRUPTED and
+ * discarded unless the app opted in -- the discard policy of st20 rv_frame_notify.
+ * The floor advances a frame, so a late packet for it is dropped as redundant. */
 static void rx_audio_session_frame_notify(struct mtl_main_impl* impl,
                                           struct st_rx_audio_session_impl* s) {
   struct st30_rx_ops* ops = &s->ops;
@@ -321,8 +329,13 @@ static void rx_audio_session_frame_notify(struct mtl_main_impl* impl,
   meta->channel = ops->channel;
   meta->rtp_timestamp = s->first_pkt_rtp_ts;
   meta->frame_recv_size = s->frame_recv_size;
-  meta->status = (s->frame_recv_size >= s->st30_frame_size) ? ST_FRAME_STATUS_COMPLETE
-                                                            : ST_FRAME_STATUS_CORRUPTED;
+  bool incomplete = s->frame_recv_size < s->st30_frame_size;
+  bool deliver = !incomplete || (ops->flags & ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME);
+  meta->status = incomplete ? ST_FRAME_STATUS_CORRUPTED : ST_FRAME_STATUS_COMPLETE;
+  if (incomplete) {
+    s->port_user_stats.stat_frames_incomplete++;
+    rx_audio_session_zero_frame_gaps(s, frame);
+  }
 
   MT_USDT_ST30_RX_FRAME_AVAILABLE(s->mgr->idx, s->idx, frame->idx, frame->addr,
                                   s->first_pkt_rtp_ts, meta->frame_recv_size);
@@ -332,20 +345,24 @@ static void rx_audio_session_frame_notify(struct mtl_main_impl* impl,
     rx_audio_session_usdt_dump_close(s);
   }
 
-  bool time_measure = mt_sessions_time_measure(impl);
-  if (time_measure) tsc_start = mt_get_tsc(impl);
-  int ret = ops->notify_frame_ready(ops->priv, frame->addr, meta);
-  if (time_measure) {
-    uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
-    s->stat_max_notify_frame_us = RTE_MAX(s->stat_max_notify_frame_us, delta_us);
-  }
-  if (ret < 0) {
-    warn("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
+  if (!deliver) {
     rx_audio_session_put_frame(s, frame);
+  } else {
+    if (!incomplete) rte_atomic32_inc(&s->stat_frames_received);
+    bool time_measure = mt_sessions_time_measure(impl);
+    if (time_measure) tsc_start = mt_get_tsc(impl);
+    int ret = ops->notify_frame_ready(ops->priv, frame->addr, meta);
+    if (time_measure) {
+      uint32_t delta_us = (mt_get_tsc(impl) - tsc_start) / NS_PER_US;
+      s->stat_max_notify_frame_us = RTE_MAX(s->stat_max_notify_frame_us, delta_us);
+    }
+    if (ret < 0) {
+      warn("%s(%d), notify_frame_ready return fail %d\n", __func__, s->idx, ret);
+      rx_audio_session_put_frame(s, frame);
+    }
   }
 
   s->tmstamp = (int64_t)(uint32_t)(s->first_pkt_rtp_ts + s->rtp_ticks_per_frame - 1);
-  rte_atomic32_inc(&s->stat_frames_received);
   s->st30_cur_frame = NULL;
 }
 
@@ -468,10 +485,7 @@ static int rx_audio_session_handle_frame_pkt(struct mtl_main_impl* impl,
   uint32_t idx = (tmstamp - s->first_pkt_rtp_ts) / spp;
 
   if (idx >= (uint32_t)s->st30_total_pkts) {
-    /* forward jump: close the open frame (CORRUPTED if partial), emit nothing
-     * for any wholly-missing frames in between, then open a fresh frame at this
-     * timestamp. A late packet for the just-closed frame is dropped — the
-     * single slot keeps no history of it. */
+    /* not the open frame: ahead of it, or (unsigned underflow) behind it */
     rx_audio_session_frame_notify(impl, s);
     if (rx_audio_session_open_frame(s, s_port, tmstamp,
                                     mt_mbuf_time_stamp(impl, mbuf, port)) < 0) {
@@ -1098,6 +1112,7 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
       us->stat_pkts_len_mismatch_dropped - snap->stat_pkts_len_mismatch_dropped;
   uint64_t slot_get_frame_fail =
       us->stat_slot_get_frame_fail - snap->stat_slot_get_frame_fail;
+  uint64_t frames_incomplete = us->stat_frames_incomplete - snap->stat_frames_incomplete;
 
   if (pkts_redundant) {
     notice("RX_AUDIO_SESSION(%d,%d:%s): fps %f frames %d pkts %" PRIu64
@@ -1159,6 +1174,10 @@ static void rx_audio_session_stat(struct st_rx_audio_sessions_mgr* mgr,
         pkts_unrecovered);
   }
 
+  if (frames_incomplete) {
+    notice("RX_AUDIO_SESSION(%d,%d): incomplete frames %" PRIu64 "\n", m_idx, idx,
+           frames_incomplete);
+  }
   if (pkts_dropped) {
     notice("RX_AUDIO_SESSION(%d,%d): dropped pkts %" PRIu64 "\n", m_idx, idx,
            pkts_dropped);

--- a/tests/acceptance/common/integrity/README.md
+++ b/tests/acceptance/common/integrity/README.md
@@ -7,7 +7,8 @@ This directory contains tools for validating the integrity of video and audio da
 The integrity tools provide functionality to:
 
 - Validate video frames using MD5 checksums and text recognition
-- Validate audio frames using MD5 checksums of PCM data
+- Validate audio frames byte-for-byte against the looped source the transmitter
+  sends, starting wherever the receiver joined that loop
 - Support both file-based and stream-based (segmented files) testing
 
 ## Prerequisites
@@ -29,8 +30,13 @@ Compares a single audio file against a reference source file:
 ```bash
 python audio_integrity.py file <source_file> <output_file> \
     --sample_size 2 --sample_num 480 --channel_num 2 \
-    --output_path /path/to/output/dir
+    --output_path /path/to/output/dir \
+    --min_frames 2500
 ```
+
+`--sample_num` is the samples per *frame buffer*, not per packet. `--min_frames`
+fails a capture holding fewer frames than a healthy run of that length records;
+it defaults to 0, which applies no floor.
 
 #### Audio Stream Mode
 
@@ -87,6 +93,7 @@ runner = FileAudioIntegrityRunner(
     sample_num=480,
     channel_num=2,
     out_path="/mnt/ramdisk",
+    min_frames=2500,
 )
 
 # Run the integrity check

--- a/tests/acceptance/common/integrity/audio_integrity.py
+++ b/tests/acceptance/common/integrity/audio_integrity.py
@@ -7,7 +7,18 @@ import logging
 import sys
 from pathlib import Path
 
-from video_integrity import calculate_chunk_hashes
+# The RX joins a running stream, so MTL drops its first short frames: at worst
+# two whole frames inside the first five on this suite.
+JOIN_FRAMES = 5
+MAX_JOIN_GAP_FRAMES = 2
+
+# Per-frame error lines a failing check may emit; an unbounded report fills the
+# SSH channel window and hangs the run (see integrity_runner.py).
+MAX_BAD_FRAME_REPORTS = 20
+
+# Places the capture first frame may match in the source loop. Silence or a flat
+# pattern matches nearly everywhere: that is a vacuous pass, not a check.
+MAX_START_POSITIONS = 64
 
 
 def get_pcm_frame_size(sample_size: int, sample_num: int, channel_num: int) -> int:
@@ -15,6 +26,13 @@ def get_pcm_frame_size(sample_size: int, sample_num: int, channel_num: int) -> i
 
 
 class AudioIntegritor:
+    """Compares a capture against the loop of the source file the TX sends.
+
+    A correct capture is a window onto that loop starting wherever the RX joined,
+    not a copy from byte 0. RxTxApp loops whole frames, ffmpeg the whole file, so
+    both periods are tried.
+    """
+
     def __init__(
         self,
         logger: logging.Logger,
@@ -25,6 +43,7 @@ class AudioIntegritor:
         channel_num: int = 2,
         out_path: str = "/mnt/ramdisk",
         delete_file: bool = True,
+        min_frames: int = 0,
     ):
         self.logger = logger
         self.src_url = src_url
@@ -35,79 +54,192 @@ class AudioIntegritor:
         self.frame_size = get_pcm_frame_size(sample_size, sample_num, channel_num)
         self.out_path = out_path
         self.delete_file = delete_file
-        self.src_chunk_sums = calculate_chunk_hashes(src_url, self.frame_size)
-
-
-class AudioFileIntegritor(AudioIntegritor):
-    def check_integrity_file(self, out_url) -> bool:
-        self.logger.info(
-            f"Checking integrity for src {self.src_url} and out {out_url} "
-            f"with frame size {self.frame_size}"
-        )
-        src_chunk_sums = self.src_chunk_sums
-        out_chunk_sums = calculate_chunk_hashes(out_url, self.frame_size)
-
-        src_frames = len(src_chunk_sums)
-        out_frames = len(out_chunk_sums)
-
-        # In some pipelines the input is looped and transmitted multiple times.
-        # In that case the output may contain multiple repetitions of the source.
-        # We only validate the first `src_frames` frames and ignore any trailing frames.
-        if out_frames > src_frames:
-            self.logger.info(
-                f"Output contains {out_frames} frames; source contains {src_frames} frames. "
-                f"Ignoring {out_frames - src_frames} trailing frames (looped output)."
+        self.min_frames = min_frames
+        with open(src_url, "rb") as src_file:
+            self.src = src_file.read()
+        if len(self.src) < self.frame_size:
+            raise ValueError(
+                f"{src_url} holds {len(self.src)} bytes, less than one "
+                f"{self.frame_size}-byte frame"
             )
+        group = sample_size * channel_num
+        whole_frames_end = len(self.src) // self.frame_size * self.frame_size
+        whole_groups_end = len(self.src) // group * group
+        self.periods = sorted({whole_frames_end, whole_groups_end})
+        self._repeats = {}
 
-        frames_to_check = min(src_frames, out_frames)
-        bad_frames = 0
-        for idx in range(frames_to_check):
-            if out_chunk_sums[idx] != src_chunk_sums[idx]:
-                self.logger.error(f"Bad audio frame at index {idx} in {out_url}")
+    def _repeated(self, period: int) -> bytes:
+        """The first *period* bytes plus one frame of wrap, so a loop-straddling
+        window is a slice. One frame is all either consumer reads past a start
+        position, and a start position is always below *period*."""
+        if period not in self._repeats:
+            self._repeats[period] = self.src[:period] + self.src[: self.frame_size]
+        return self._repeats[period]
+
+    def _start_positions(self, out: bytes, period: int):
+        """Byte positions in the source loop where *out* can begin, or None if it
+        could begin in too many to tell. Each candidate is then compared in full."""
+        repeated = self._repeated(period)
+        probe = out[: self.frame_size]
+        positions, at = [], 0
+        while True:
+            at = repeated.find(probe, at)
+            if at < 0 or at >= period:
+                return positions
+            positions.append(at)
+            if len(positions) > MAX_START_POSITIONS:
+                return None
+            at += 1
+
+    def _compare(
+        self,
+        out: bytes,
+        period: int,
+        position: int,
+        report: bool = False,
+        joining_window: int = JOIN_FRAMES,
+    ) -> tuple:
+        """Compare *out* against the loop of *period* bytes starting at *position*.
+
+        Returns (first differing frame index or None, differing frames, frames
+        missing at the join). With *report* off it returns at the first difference,
+        so a wrong start position costs one comparison. Within the first
+        *joining_window* frames a frame may instead match up to MAX_JOIN_GAP_FRAMES
+        frames on -- audio sent before the RX joined; the source position only moves
+        forward, so no written or unsent audio is absorbed.
+        """
+        size, repeated = self.frame_size, self._repeated(period)
+        first_bad, bad_frames = None, 0
+        missing, src_at = 0, position
+        for index in range(-(-len(out) // size)):
+            chunk = out[index * size : (index + 1) * size]
+            joining = index < joining_window
+            for gap in range(MAX_JOIN_GAP_FRAMES - missing + 1 if joining else 1):
+                at = (src_at + gap * size) % period
+                if chunk == repeated[at : at + len(chunk)]:
+                    missing += gap
+                    src_at = (at + size) % period
+                    break
+            else:
                 bad_frames += 1
-        if bad_frames:
+                if first_bad is None:
+                    first_bad = index
+                if not report:
+                    return first_bad, bad_frames, missing
+                if bad_frames <= MAX_BAD_FRAME_REPORTS:
+                    self.logger.error(
+                        f"Bad audio frame at output index {index} "
+                        f"(source byte {src_at})"
+                    )
+                elif bad_frames == MAX_BAD_FRAME_REPORTS + 1:
+                    self.logger.error(
+                        f"Suppressing further per-frame errors after "
+                        f"{MAX_BAD_FRAME_REPORTS}; see the totals below."
+                    )
+                src_at = (src_at + size) % period
+        return first_bad, bad_frames, missing
+
+    def check_integrity_file(
+        self, out_url, joining_window: int = JOIN_FRAMES, out: bytes | None = None
+    ) -> bool:
+        if out is None:  # given *out*, *out_url* only names the capture in reports
+            with open(out_url, "rb") as out_file:
+                out = out_file.read()
+        size = self.frame_size
+        out_frames = len(out) // size
+        # A short final frame is compared too, so it counts as one.
+        out_chunks = -(-len(out) // size)
+        self.logger.info(
+            f"Checking integrity for src {self.src_url} ({len(self.src)} bytes) "
+            f"and out {out_url} ({len(out)} bytes, {out_frames} frames) "
+            f"with frame size {size}"
+        )
+
+        if not out_frames:
+            self.logger.error(f"{out_url} holds no full {size}-byte frame to check")
+            return False
+
+        if out_frames < self.min_frames:
             self.logger.error(
-                f"Received {bad_frames} bad frames out of {frames_to_check} checked."
+                f"{out_url} holds {out_frames} frames, fewer than the "
+                f"{self.min_frames} a complete run captures."
             )
             return False
 
-        self.logger.info(
-            f"All {frames_to_check} checked frames in {out_url} are correct."
+        best = None  # (first bad frame, period, position)
+        for period in self.periods:
+            positions = self._start_positions(out, period)
+            if positions is None:
+                self.logger.error(
+                    f"{out_url} starts in over {MAX_START_POSITIONS} places at period "
+                    f"{period} in {self.src_url}: join point cannot be told (silence?)"
+                )
+                return False
+            for position in positions:
+                first_bad, _, missing = self._compare(
+                    out, period, position, joining_window=joining_window
+                )
+                if first_bad is None:
+                    if missing:
+                        self.logger.warning(
+                            f"{out_url} is missing {missing} frame(s) of audio "
+                            f"within its first {joining_window} while joining."
+                        )
+                    self.logger.info(
+                        f"All {out_chunks} frames of {out_url} are correct "
+                        f"(source byte {position}, loop period {period})."
+                    )
+                    return True
+                if best is None or first_bad > best[0]:
+                    best = (first_bad, period, position)
+
+        if best is None:
+            self.logger.error(
+                f"No position in {self.src_url} explains the leading frames of "
+                f"{out_url}, at either loop period {self.periods}."
+            )
+            return False
+
+        first_bad, period, position = best
+        _, bad_frames, _ = self._compare(
+            out, period, position, report=True, joining_window=joining_window
         )
-        return True
+        self.logger.error(
+            f"{out_url} follows {self.src_url} from source byte {position} "
+            f"(loop period {period}) but {bad_frames} of its {out_chunks} "
+            f"frames differ, the first at index {first_bad}."
+        )
+        return False
 
 
 class AudioStreamIntegritor(AudioIntegritor):
     def get_out_files(self):
-        return sorted(Path(self.out_path).glob(f"{self.out_name}*"))
+        """Segments in capture order. Plain sorting misorders them as soon as the
+        counter grows a digit, so shorter names -- lower numbers -- come first."""
+        files = Path(self.out_path).glob(f"{self.out_name}*")
+        return sorted(files, key=lambda path: (len(path.name), path.name))
 
     def check_stream_integrity(self) -> bool:
-        bad_frames_total = 0
         out_files = self.get_out_files()
         if not out_files:
             self.logger.error(
                 f"No output files found for stream in {self.out_path} with prefix {self.out_name}"
             )
             return False
-        for out_file in out_files:
-            self.logger.info(f"Checking integrity for segment file: {out_file}")
-            out_chunk_sums = calculate_chunk_hashes(str(out_file), self.frame_size)
-            for idx, chunk_sum in enumerate(out_chunk_sums):
-                if (
-                    idx >= len(self.src_chunk_sums)
-                    or chunk_sum != self.src_chunk_sums[idx]
-                ):
-                    self.logger.error(f"Bad audio frame at index {idx} in {out_file}")
-                    bad_frames_total += 1
-            if self.delete_file:
+        # The segments are consecutive cuts of one capture, so check them joined.
+        # Checked one by one, a segment re-anchors on the source wherever it can,
+        # which hides audio lost across a boundary; joined, only the head of the
+        # stream carries the join allowance, which is where the RX joined.
+        joined = b"".join(out_file.read_bytes() for out_file in out_files)
+        ok = self.check_integrity_file(
+            f"{len(out_files)} stream segments "
+            f"{out_files[0].name}..{out_files[-1].name}",
+            out=joined,
+        )
+        if self.delete_file:
+            for out_file in out_files:
                 out_file.unlink()
-        if bad_frames_total:
-            self.logger.error(
-                f"Received {bad_frames_total} bad frames in stream segments."
-            )
-            return False
-        self.logger.info("All frames in stream segments are correct.")
-        return True
+        return ok
 
 
 def main():
@@ -193,7 +325,8 @@ Example: ffmpeg -i input.wav -f segment -segment_time 3 out_name_%03d.pcm"""
     file_help = """Check integrity for single audio file.
 
 This mode compares a single output audio file against a source reference file.
-It performs frame-by-frame integrity checking using MD5 checksums."""
+The transmitter loops the source, so the capture is compared frame by frame
+against that loop starting wherever the receiver joined it."""
     file_parser = subparsers.add_parser(
         "file",
         help="Check integrity for single audio file",
@@ -201,6 +334,12 @@ It performs frame-by-frame integrity checking using MD5 checksums."""
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_common_arguments(file_parser)
+    file_parser.add_argument(
+        "--min_frames",
+        type=int,
+        default=0,
+        help="Fail if the capture holds fewer frames than this (default: 0)",
+    )
 
     # Parse the arguments
     args = parser.parse_args()
@@ -221,7 +360,7 @@ It performs frame-by-frame integrity checking using MD5 checksums."""
     elif args.mode == "file":
         # For file mode, construct the full output file path
         out_file = Path(args.output_path) / args.out
-        integrator = AudioFileIntegritor(
+        integrator = AudioIntegritor(
             logger,
             args.src,
             args.out,
@@ -230,6 +369,7 @@ It performs frame-by-frame integrity checking using MD5 checksums."""
             args.channel_num,
             args.output_path,
             args.delete_file,
+            args.min_frames,
         )
         result = integrator.check_integrity_file(str(out_file))
     else:

--- a/tests/acceptance/common/integrity/integrity_runner.py
+++ b/tests/acceptance/common/integrity/integrity_runner.py
@@ -8,6 +8,10 @@ logger = logging.getLogger(__name__)
 # given, so this is the only place the directory name needs to be correct.
 _INTEGRITY_DIR = ("tests", "acceptance", "common", "integrity")
 
+# Hard bound on a remote check: without it, a checker that outfills the SSH
+# channel window blocks forever (mfd_connect drains stdout only after exit).
+_INTEGRITY_TIMEOUT = 600
+
 
 def _default_integrity_path(host, test_repo_path, module_name):
     """Path to *module_name* under the acceptance repo's integrity dir."""
@@ -118,7 +122,11 @@ class FileVideoIntegrityRunner(VideoIntegrityRunner):
             f"Running integrity check on {self.host.name} for {self.out_name} with command: {cmd}"
         )
         result = self.host.connection.execute_command(
-            cmd, shell=True, stderr_to_stdout=True, expected_return_codes=(0, 1)
+            cmd,
+            shell=True,
+            stderr_to_stdout=True,
+            expected_return_codes=(0, 1),
+            timeout=_INTEGRITY_TIMEOUT,
         )
         if result.return_code > 0:
             logger.error(f"Integrity check failed on {self.host.name}: {self.out_name}")
@@ -270,6 +278,7 @@ class FileAudioIntegrityRunner(AudioIntegrityRunner):
         python_path=None,
         integrity_path=None,
         delete_file: bool = True,
+        min_frames: int = 0,
     ):
         super().__init__(
             host,
@@ -284,6 +293,7 @@ class FileAudioIntegrityRunner(AudioIntegrityRunner):
             integrity_path,
             delete_file,
         )
+        self.min_frames = min_frames
 
     def run(self):
         cmd = " ".join(
@@ -299,6 +309,8 @@ class FileAudioIntegrityRunner(AudioIntegrityRunner):
                 str(self.sample_num),
                 "--channel_num",
                 str(self.channel_num),
+                "--min_frames",
+                str(self.min_frames),
                 "--output_path",
                 self.out_path,
                 "--delete_file" if self.delete_file else "--no_delete_file",
@@ -308,7 +320,11 @@ class FileAudioIntegrityRunner(AudioIntegrityRunner):
             f"Running audio integrity check on {self.host.name} for {self.out_name} with command: {cmd}"
         )
         result = self.host.connection.execute_command(
-            cmd, shell=True, stderr_to_stdout=True, expected_return_codes=(0, 1)
+            cmd,
+            shell=True,
+            stderr_to_stdout=True,
+            expected_return_codes=(0, 1),
+            timeout=_INTEGRITY_TIMEOUT,
         )
         if result.return_code > 0:
             logger.error(

--- a/tests/acceptance/mtl_engine/application_base.py
+++ b/tests/acceptance/mtl_engine/application_base.py
@@ -333,6 +333,7 @@ class Application(ABC):
             audio_channels=self.params.get("audio_channels"),
             audio_sampling=self.params.get("audio_sampling"),
             audio_ptime=self.params.get("audio_ptime"),
+            test_time=self.params.get("test_time") or 30,
         )
 
     def set_params(self, **kwargs):

--- a/tests/acceptance/mtl_engine/integrity.py
+++ b/tests/acceptance/mtl_engine/integrity.py
@@ -109,6 +109,7 @@ def get_sample_size(format: str) -> int:
 
 
 def get_sample_number(sampling: str, ptime: str) -> int:
+    """Samples per channel in one RTP packet of *ptime* at *sampling*."""
     match sampling:
         case "48kHz":
             match ptime:
@@ -134,7 +135,37 @@ def get_sample_number(sampling: str, ptime: str) -> int:
                     return 32
                 case "4":
                     return 384
+    log_fail(f"Unknown audio sampling/ptime combination: {sampling}/{ptime}")
     return 0
+
+
+# Samples per second per channel, keyed by the sampling string tests pass.
+_SAMPLING_HZ = {"48kHz": 48000, "96kHz": 96000}
+
+# An st30p frame holds as many whole ptime packets as fit in 10 ms
+# (st30_calculate_framebuff_size, lib/src/st2110/st_fmt.c).
+_FRAME_TIME_MS = 10
+
+
+def get_frame_sample_number(sampling: str, ptime: str) -> int:
+    """Samples per channel in one st30p *frame*, not one packet -- the unit the
+    checker compares and RxTxApp's TX wraps its source file by."""
+    packet_samples = get_sample_number(sampling, ptime)
+    if not packet_samples:
+        # get_sample_number already reported the unknown combination.
+        return 0
+
+    frame_samples = _SAMPLING_HZ[sampling] * _FRAME_TIME_MS // 1000
+    return frame_samples // packet_samples * packet_samples
+
+
+def get_min_frame_number(sampling: str, ptime: str, test_time: int) -> int:
+    """Frames a healthy RX must capture in *test_time* seconds -- a truncated
+    capture is bit-exact, so only length catches it."""
+    frame_samples = get_frame_sample_number(sampling, ptime)
+    if not frame_samples:
+        return 0
+    return min_expected_frames(_SAMPLING_HZ[sampling] / frame_samples, test_time)
 
 
 def get_channel_number(channel: str) -> int:
@@ -156,6 +187,7 @@ def get_channel_number(channel: str) -> int:
 
             if match:
                 return int(match.group(1))
+    log_fail(f"Unknown audio channel: {channel}")
     return 0
 
 

--- a/tests/acceptance/mtl_engine/integrity_session.py
+++ b/tests/acceptance/mtl_engine/integrity_session.py
@@ -24,7 +24,7 @@ Runners), on whichever host produced the file -- this module only owns
 import logging
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Protocol
+from typing import TYPE_CHECKING, NoReturn, Optional, Protocol
 
 from common.integrity.integrity_runner import (
     FileAudioIntegrityRunner,
@@ -33,7 +33,12 @@ from common.integrity.integrity_runner import (
 from common.integrity.video_integrity import calculate_yuv_frame_size
 
 from .execute import log_fail
-from .integrity import get_channel_number, get_sample_number, get_sample_size
+from .integrity import (
+    get_channel_number,
+    get_frame_sample_number,
+    get_min_frame_number,
+    get_sample_size,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +69,8 @@ class IntegrityIntent:
     audio_channels: Optional[list] = None
     audio_sampling: Optional[str] = None
     audio_ptime: Optional[str] = None
+    # How long the run lasted, which bounds how much the RX must have captured.
+    test_time: int = 0
 
 
 class IntegrityCheck(Protocol):
@@ -140,8 +147,16 @@ class IntegritySession:
                     "content integrity for this test.",
                     fail_on_error,
                 )
-            runner = self._build_runner(intent)
-            if not runner.run():
+            try:
+                passed = self._build_runner(intent).run()
+            except Exception as exc:
+                # Must surface as AssertionError: _finalize_run() narrows to it,
+                # and anything else would skip validate_results().
+                self._fail(
+                    f"Integrity check did not complete for {intent.out_url}: {exc}",
+                    fail_on_error,
+                )
+            if not passed:
                 self._fail(
                     f"Integrity check failed content comparison for "
                     f"{intent.out_url} against {intent.src_url}.",
@@ -166,10 +181,15 @@ class IntegritySession:
                 src_url=intent.src_url,
                 out_name=out_name,
                 sample_size=get_sample_size(intent.audio_format),
-                sample_num=get_sample_number(intent.audio_sampling, intent.audio_ptime),
+                sample_num=get_frame_sample_number(
+                    intent.audio_sampling, intent.audio_ptime
+                ),
                 channel_num=get_channel_number(channel),
                 out_path=out_path,
                 delete_file=False,
+                min_frames=get_min_frame_number(
+                    intent.audio_sampling, intent.audio_ptime, intent.test_time
+                ),
             )
         min_frames = intent.min_frames
         if intent.max_file_size:
@@ -217,7 +237,7 @@ class IntegritySession:
                 "or media_integrity.skip(...)."
             )
 
-    def _fail(self, msg: str, fail_on_error: bool) -> None:
+    def _fail(self, msg: str, fail_on_error: bool) -> NoReturn:
         if fail_on_error:
             log_fail(msg)
         else:

--- a/tests/acceptance_unit/test_audio_frame_geometry.py
+++ b/tests/acceptance_unit/test_audio_frame_geometry.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2026 Intel Corporation
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tests/acceptance"))
+
+# The only dependency of these modules outside the stdlib is log_fail, and its
+# module pulls in pytest, which the unit tier does not have. Stand it in so the
+# modules under test import as themselves, recording the failures they report.
+_reported = []
+_stub = types.ModuleType("mtl_engine.execute")
+_stub.log_fail = _reported.append
+sys.modules["mtl_engine.execute"] = _stub
+
+from mtl_engine import integrity, integrity_session  # noqa: E402
+
+# Both hold their own reference to log_fail now, so drop the stand-in again:
+# left in place it would also answer the import in every other test module of
+# this tier, which discovery imports into the same interpreter.
+sys.modules.pop("mtl_engine.execute", None)
+
+
+class AudioGeometryTests(unittest.TestCase):
+    """What the audio integrity checker is handed. Passing the per-PACKET sample
+    count is what made it compare 12-byte chunks of a 960-byte frame."""
+
+    def _runner(self, sampling="48kHz", ptime="0.12", test_time=60):
+        host = SimpleNamespace(
+            name="rx", connection=SimpleNamespace(path=lambda *parts: "/".join(parts))
+        )
+        intent = integrity_session.IntegrityIntent(
+            host=host,
+            test_repo_path="/repo",
+            src_url="/mnt/media/src.pcm",
+            out_url="/mnt/ramdisk/out.pcm",
+            kind="audio",
+            audio_format="PCM16",
+            audio_channels=["U02"],
+            audio_sampling=sampling,
+            audio_ptime=ptime,
+            test_time=test_time,
+        )
+        return integrity_session.IntegritySession()._build_runner(intent)
+
+    def test_checker_gets_frame_samples_not_packet_samples(self):
+        # 0.12 ms is 6 samples on the wire at 48 kHz, but 480 in a frame.
+        self.assertEqual(self._runner().sample_num, 480)
+        self.assertEqual(self._runner(sampling="96kHz").sample_num, 960)
+        # A frame holds whole packets only: at 4 ms it is 2 packets of 192, not
+        # the 480 samples that fit in 10 ms.
+        self.assertEqual(self._runner(ptime="4").sample_num, 384)
+
+    def test_checker_gets_a_floor_a_truncated_capture_misses(self):
+        # A capture cut short is bit-exact, so only its length gives it away; on
+        # the ffmpeg leg nothing else fails. 100 frames make a second at 48 kHz.
+        floor = self._runner().min_frames
+        self.assertLess(floor, 100 * (60 - 8.5), "the worst healthy shortfall seen")
+        self.assertGreater(floor, 100 * 20, "ffmpeg stopped 20 s into a 60 s run")
+
+    def test_unknown_combination_reports_and_returns_zero(self):
+        _reported.clear()
+        self.assertEqual(integrity.get_frame_sample_number("44kHz", "0.12"), 0)
+        self.assertTrue(_reported)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/acceptance_unit/test_integrity_checkers.py
+++ b/tests/acceptance_unit/test_integrity_checkers.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2026 Intel Corporation
+
+import logging
+import random
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+INTEGRITY = Path(__file__).resolve().parents[2] / "tests/acceptance/common/integrity"
+CHECKER = INTEGRITY / "audio_integrity.py"
+sys.path.insert(0, str(INTEGRITY))
+
+import audio_integrity as ai  # noqa: E402
+
+SAMPLE_SIZE, SAMPLE_NUM, CHANNELS = 2, 4, 2
+FRAME = SAMPLE_SIZE * SAMPLE_NUM * CHANNELS
+GROUP = SAMPLE_SIZE * CHANNELS
+_rand = random.Random(0)
+F = [bytes(_rand.randrange(256) for _ in range(FRAME)) for _ in range(24)]
+SRC = b"".join(F[:20]) + bytes(5)  # ends mid-group, as a real source file may
+FOREIGN = b"".join(F[20:]) * 20
+FRAME_LOOP, GROUP_LOOP = SRC[: 20 * FRAME], SRC[: len(SRC) // GROUP * GROUP]
+
+
+def window(loop, skip_bytes, frames):
+    """A capture of `frames` frames that joined `skip_bytes` into `loop`."""
+    return (loop[skip_bytes:] + loop * 3)[: frames * FRAME]
+
+
+def frames(*indexes):
+    return b"".join(F[i] for i in indexes)
+
+
+class AudioLoopWindowTests(unittest.TestCase):
+    """A correct capture is a window onto the looped source starting wherever the
+    RX joined. Every case below is a shape a real st30p run produces."""
+
+    def check(self, out, src=SRC, min_frames=0, stream=False):
+        """Check one capture, or a list of them as consecutive stream segments."""
+        records = []
+        handler = logging.Handler()
+        handler.emit = records.append
+        logger = logging.getLogger(self.id())
+        logger.handlers, logger.propagate = [handler], False
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "src.pcm").write_bytes(src)
+            for index, part in enumerate(out if stream else [out]):
+                name = f"out.pcm.{index:03d}" if stream else "out.pcm"
+                Path(tmp, name).write_bytes(part)
+            checker = (ai.AudioStreamIntegritor if stream else ai.AudioIntegritor)(
+                logger,
+                f"{tmp}/src.pcm",
+                "out.pcm",
+                SAMPLE_SIZE,
+                SAMPLE_NUM,
+                CHANNELS,
+                tmp,
+                False,
+                min_frames,
+            )
+            ok = (
+                checker.check_stream_integrity()
+                if stream
+                else checker.check_integrity_file(f"{tmp}/out.pcm")
+            )
+        return ok, [r.getMessage() for r in records]
+
+    def test_join_on_a_packet_boundary_passes(self):
+        # The RX anchors frame 0 on its first accepted packet, so a healthy capture
+        # starts a part-frame in -- FRAME // 4 here is exactly one sample group.
+        ok, msgs = self.check(window(FRAME_LOOP, 9 * FRAME + FRAME // 4, 40))
+        self.assertTrue(ok, msgs)
+
+    def test_group_loop_period_passes(self):
+        # The ffmpeg leg drops the source's trailing partial sample group, so its
+        # loop period is the whole-group prefix, not the whole-frame one.
+        ok, msgs = self.check(window(GROUP_LOOP, 5 * GROUP, 40))
+        self.assertTrue(ok, msgs)
+
+    def test_unrelated_capture_fails(self):
+        ok, msgs = self.check(FOREIGN)
+        self.assertFalse(ok)
+        self.assertTrue(any("No position in" in m for m in msgs), msgs)
+
+    def test_a_capture_that_could_start_anywhere_is_inconclusive(self):
+        # Silence matches at every offset, so comparing it anyway would pass a
+        # receiver that wrote nothing but zeroed frame buffers.
+        silence = bytes(20 * FRAME)
+        ok, msgs = self.check(silence[: 10 * FRAME], src=silence)
+        self.assertFalse(ok)
+        self.assertTrue(any("cannot be told" in m for m in msgs), msgs)
+
+    def test_truncated_capture_fails_only_against_the_floor(self):
+        short = window(FRAME_LOOP, 0, 5)
+        self.assertTrue(self.check(short)[0], "bit-exact frames, no floor asked")
+        self.assertFalse(self.check(short, min_frames=40)[0])
+
+    def test_only_a_small_gap_at_the_join_is_tolerated(self):
+        src = frames(*range(20))
+        joined = self.check(frames(0, *range(2, 20)), src=src)  # 1 frame missing
+        self.assertTrue(joined[0], joined[1])
+        self.assertTrue(any("missing 1 frame(s)" in m for m in joined[1]))
+        for name, out in (
+            ("stale repeat", frames(0, 0, *range(2, 20))),
+            ("wider than the allowance", frames(0, *range(4, 20))),
+            (
+                "past the join window",
+                frames(*range(ai.JOIN_FRAMES + 3), *range(ai.JOIN_FRAMES + 4, 20)),
+            ),
+        ):
+            with self.subTest(name):
+                rejected, why = self.check(out, src=src)
+                self.assertFalse(rejected)
+                self.assertTrue(any("frames differ" in m for m in why), why)
+
+    def test_only_the_first_stream_segment_may_hold_a_gap(self):
+        # Only the first segment can hold the join. A later one was cut from a
+        # stream the RX had already joined, so the same gap there is lost audio.
+        src = frames(*range(20))
+        joined, later = frames(0, *range(2, 20)), frames(10, *range(12, 20))
+        self.assertTrue(self.check([joined], src=src, stream=True)[0])
+        ok, msgs = self.check([joined, later], src=src, stream=True)
+        self.assertFalse(ok, msgs)
+        self.assertTrue(any("out.pcm.001" in m for m in msgs), msgs)
+
+    def test_audio_lost_across_a_segment_boundary_fails(self):
+        # The segments are one capture. Checked one by one, the second re-anchors
+        # on the source past the hole and the loss reads as correct.
+        src = frames(*range(20))
+        whole = [frames(*range(10)), frames(*range(10, 20))]
+        holed = [frames(*range(10)), frames(*range(11, 20))]  # frame 10 lost
+        self.assertTrue(self.check(whole, src=src, stream=True)[0])
+        ok, msgs = self.check(holed, src=src, stream=True)
+        self.assertFalse(ok, msgs)
+
+    def test_per_frame_report_is_bounded(self):
+        # The failure that hung the nightly: 411k report lines past the ~2 MiB SSH
+        # channel window, which the caller drains only after the checker exits.
+        ok, msgs = self.check(FRAME_LOOP[: 3 * FRAME] + FOREIGN)
+        self.assertFalse(ok)
+        bad = [m for m in msgs if m.startswith("Bad audio frame")]
+        self.assertTrue(bad, "a failing check must still name some frames")
+        self.assertLessEqual(len(bad), ai.MAX_BAD_FRAME_REPORTS)
+        self.assertTrue(any("Suppressing" in m for m in msgs))
+
+    def test_cli_reports_the_verdict_in_its_exit_code(self):
+        # integrity_runner.py reads nothing but the exit code, so a failing check
+        # that exits 0 passes the acceptance test silently.
+        for name, out, expected in (("good", FRAME_LOOP, 0), ("bad", FOREIGN, 1)):
+            with self.subTest(name), tempfile.TemporaryDirectory() as tmp:
+                Path(tmp, "src.pcm").write_bytes(SRC)
+                Path(tmp, "out.pcm").write_bytes(out)
+                flags = (
+                    f"--sample_size {SAMPLE_SIZE} --sample_num {SAMPLE_NUM}"
+                    f" --channel_num {CHANNELS} --min_frames 5 --no_delete_file"
+                ).split()
+                argv = [sys.executable, str(CHECKER), "file", f"{tmp}/src.pcm"]
+                argv += ["out.pcm", *flags, "--output_path", tmp]
+                done = subprocess.run(argv, capture_output=True)
+                self.assertEqual(done.returncode, expected, done.stderr.decode())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration_tests/st30p_test.cpp
+++ b/tests/integration_tests/st30p_test.cpp
@@ -899,7 +899,8 @@ TEST(St30p, redundant_stats) {
 /*
  * Verify ST30p RX reports per-frame corruption when post-redundancy packet
  * loss occurs. ST30P_RX_FLAG_SIMULATE_PKT_LOSS drops packets on the RX side
- * so frames close short of full coverage; those frames must be delivered to
+ * so frames close short of full coverage; with
+ * ST30P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME those frames must be delivered to
  * the app with status ST_FRAME_STATUS_CORRUPTED and counted in
  * common.stat_frames_corrupted.
  */
@@ -971,7 +972,8 @@ TEST(St30p, rx_simulate_pkt_loss) {
   ops_rx.framebuff_size = st30_calculate_framebuff_size(
       ops_rx.fmt, ops_rx.ptime, ops_rx.sampling, ops_rx.channel, 10 * NS_PER_MS, NULL);
   ops_rx.framebuff_cnt = test_ctx_rx->fb_cnt;
-  ops_rx.flags |= ST30P_RX_FLAG_BLOCK_GET | ST30P_RX_FLAG_SIMULATE_PKT_LOSS;
+  ops_rx.flags |= ST30P_RX_FLAG_BLOCK_GET | ST30P_RX_FLAG_SIMULATE_PKT_LOSS |
+                  ST30P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME;
 
   test_ctx_rx->frame_size = ops_rx.framebuff_size;
   test_ctx_rx->audio_fmt = ops_rx.fmt;

--- a/tests/unit/pipeline/st30p_harness.c
+++ b/tests/unit/pipeline/st30p_harness.c
@@ -87,8 +87,11 @@ ut30p_ctx* ut30p_ctx_create(int framebuff_cnt) {
   for (int i = 0; i < framebuff_cnt; i++) {
     ctx->framebuffs[i].stat = ST30P_RX_FRAME_FREE;
     ctx->framebuffs[i].idx = i;
-    /* mirrors production init: put_frame() recovers framebuf via frame->priv */
+    /* mirrors production init: put_frame() recovers framebuf via frame->priv,
+     * and both sizes start at framebuff_size */
     ctx->framebuffs[i].frame.priv = &ctx->framebuffs[i];
+    ctx->framebuffs[i].frame.buffer_size = ctx->framebuffs[i].frame.data_size =
+        UT30P_FRAMEBUFF_SIZE;
   }
 
   struct st30p_rx_ctx* p = &ctx->pipeline;
@@ -98,6 +101,7 @@ ut30p_ctx* ut30p_ctx_create(int framebuff_cnt) {
   p->type = MT_ST30_HANDLE_PIPELINE_RX;
   p->framebuff_cnt = framebuff_cnt;
   p->framebuffs = ctx->framebuffs;
+  p->ops.framebuff_size = UT30P_FRAMEBUFF_SIZE;
   p->ready = true;
   p->transport = (st30_rx_handle)(uintptr_t)0x1;
 

--- a/tests/unit/pipeline/st30p_harness.h
+++ b/tests/unit/pipeline/st30p_harness.h
@@ -9,9 +9,7 @@
  *   - stat_frames_dropped bumps in rx_st30p_frame_ready() when no free
  *     framebuffer is available (back-pressure; transport-side buffer is
  *     released by the pipeline returning -EBUSY).
- *
- * ST30p has no stat_frames_corrupted — audio frames are never delivered
- * with status CORRUPTED at this layer.
+ *   - stat_frames_corrupted bumps in st30p_rx_get_frame().
  */
 
 #ifndef _ST30P_PIPELINE_HARNESS_H_
@@ -28,6 +26,9 @@ extern "C" {
 #endif
 
 typedef struct ut30p_ctx ut30p_ctx;
+
+/** 1 ms of 48 kHz stereo PCM16, i.e. one packet payload. */
+#define UT30P_FRAMEBUFF_SIZE (192)
 
 int ut30p_init(void);
 

--- a/tests/unit/pipeline/st30p_test.cpp
+++ b/tests/unit/pipeline/st30p_test.cpp
@@ -152,6 +152,8 @@ TEST_F(St30PipelineRxTest, CorruptedDeliveredAndCounted) {
   for (int i = 0; i < 3; i++) {
     struct st30_frame* f = get_frame();
     ASSERT_NE(f, nullptr) << "frame " << i;
+    EXPECT_EQ(f->data_size, f->buffer_size)
+        << "frame " << i << " spans the whole buffer; a gap reads as silence";
     EXPECT_EQ(put_frame(f), 0);
   }
 

--- a/tests/unit/session/st30/corruption_test.cpp
+++ b/tests/unit/session/st30/corruption_test.cpp
@@ -4,7 +4,10 @@
  * Per-frame corruption status: a post-redundancy session_seq_id gap charged
  * to the frame under assembly must close that frame as
  * ST_FRAME_STATUS_CORRUPTED, while clean / reordered / redundancy-recovered
- * streams must stay ST_FRAME_STATUS_COMPLETE (no false positive).
+ * streams must stay ST_FRAME_STATUS_COMPLETE (no false positive). Plus the
+ * delivery policy for such a frame: suppressed unless the app opts in with
+ * ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME, and once delivered its missing slots
+ * read as silence rather than as the recycled buffer's previous audio.
  *
  * Build: meson setup build_unit -Denable_unit_tests=true && ninja -C build_unit
  * Run:   ./build_unit/tests/unit/UnitTest --gtest_filter='St30RxCorruptionTest.*'
@@ -13,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "session/st30/st30_rx_test_base.h"
+#include "st30_api.h"
 #include "st_api.h"
 
 class St30RxCorruptionTest : public St30RxBaseTest {
@@ -21,6 +25,18 @@ class St30RxCorruptionTest : public St30RxBaseTest {
     ut30_ctx_destroy(ctx_);
     ctx_ = ut30_ctx_create(1);
     ASSERT_NE(ctx_, nullptr);
+    /* a partial frame only reaches the app when this flag is set */
+    ut30_ctx_set_flags(ctx_, ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME);
+  }
+
+  /* Feed one frame's worth of packets, every payload byte set to `fill`. A
+   * `skip_slot` of -1 feeds the whole frame. */
+  void feed_frame(uint16_t* seq, uint32_t base, uint8_t fill, int skip_slot) {
+    for (int i = 0; i < ppf(); i++) {
+      if (i == skip_slot) continue;
+      ut30_feed_pkt_fill(ctx_, (*seq)++, base + (uint32_t)i * spp(), MTL_SESSION_PORT_P,
+                         fill);
+    }
   }
 
   uint64_t complete() {
@@ -31,6 +47,18 @@ class St30RxCorruptionTest : public St30RxBaseTest {
   }
   int last_status() {
     return ut30_last_frame_status(ctx_);
+  }
+
+  ::testing::AssertionResult SlotIs(int i, int slot, uint8_t expect) {
+    const uint8_t* p =
+        (const uint8_t*)ut30_frame_log_addr(ctx_, i) + (size_t)slot * ut30_pkt_len(ctx_);
+    for (uint32_t b = 0; b < ut30_pkt_len(ctx_); b++) {
+      if (p[b] != expect)
+        return ::testing::AssertionFailure()
+               << "slot " << slot << " byte " << b << " is " << (unsigned)p[b] << " want "
+               << (unsigned)expect;
+    }
+    return ::testing::AssertionSuccess();
   }
 };
 
@@ -198,6 +226,7 @@ TEST_F(St30RxCorruptionTest, RedundancyCoveredLossComplete) {
 /* (g) Redundancy: loss on both ports leaves a missing slot, so the frame
  * closes CORRUPTED on the forward jump. */
 TEST_F(St30RxCorruptionTest, RedundancyBothPortsLostCorrupted) {
+  ut30_ctx_set_flags(ctx_, ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME);
   int n = ppf();
   uint32_t s = spp();
   uint32_t base = 1000;
@@ -323,8 +352,8 @@ TEST_F(St30RxCorruptionTest, LeadingPacketLossCorrupts) {
 }
 
 /* Leading-loss followed by a whole-frame skip: the partial frame closes
- * CORRUPTED, the wholly-missing frame emits nothing, and the large forward
- * jump resyncs onto the arriving (still grid-aligned) timestamp. */
+ * CORRUPTED, the wholly-missing frame emits nothing, and the large forward jump
+ * is floored onto the grid, which the arriving timestamp already sits on. */
 TEST_F(St30RxCorruptionTest, LeadingLossThenWholeFrameSkip) {
   use_single_port();
   int n = ppf();
@@ -351,4 +380,52 @@ TEST_F(St30RxCorruptionTest, LeadingLossThenWholeFrameSkip) {
   EXPECT_EQ(ut30_frame_log_status(ctx_, 1), ST_FRAME_STATUS_CORRUPTED);
   EXPECT_EQ(ut30_frame_log_ts(ctx_, 2), base4);
   EXPECT_EQ(ut30_frame_log_status(ctx_, 2), ST_FRAME_STATUS_COMPLETE);
+}
+
+/* ── delivery policy for an incomplete frame ────────────────────────────── */
+
+/* Default policy: a frame missing a packet is never handed to the app, is
+ * accounted as wire loss only, and its buffer goes back to the pool. More
+ * partial frames than framebuffers, so a buffer that leaked would show up. */
+TEST_F(St30RxCorruptionTest, IncompleteFramesSuppressedRecycledCountedAsWireLoss) {
+  use_single_port();
+  ut30_ctx_set_flags(ctx_, 0);
+  uint16_t seq = 0;
+  uint32_t base = 1000;
+
+  for (int f = 0; f < 5; f++) {
+    feed_frame(&seq, base, 0x11, 5);
+    base += (uint32_t)ppf() * spp();
+  }
+  /* close the last partial frame */
+  ut30_feed_pkt_fill(ctx_, seq++, base, MTL_SESSION_PORT_P, 0x11);
+
+  EXPECT_EQ(ut30_frame_log_count(ctx_), 0)
+      << "flags=0 (no ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME): app must see no frame";
+  EXPECT_EQ(ut30_stat_frames_incomplete(ctx_), 5u);
+  EXPECT_EQ(frames_done(), 0) << "a frame never handed up is not a frame received";
+}
+
+/* Opt-in: the partial frame is delivered, flagged CORRUPTED, and the slot that
+ * never arrived reads as silence rather than as the audio the previous frame left
+ * one frame earlier in the same recycled buffer. */
+TEST_F(St30RxCorruptionTest, OptInGapOfReusedBufferReadsAsSilence) {
+  use_single_port();
+  uint16_t seq = 0;
+  uint32_t base = 1000;
+  uint32_t base2 = base + (uint32_t)ppf() * spp();
+
+  feed_frame(&seq, base, 0xa5, -1);
+  feed_frame(&seq, base2, 0x5a, 5);
+  feed(seq++, base2 + (uint32_t)ppf() * spp(), MTL_SESSION_PORT_P);
+
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 2);
+  ASSERT_EQ(ut30_frame_log_status(ctx_, 1), ST_FRAME_STATUS_CORRUPTED);
+  ASSERT_EQ(ut30_frame_log_addr(ctx_, 1), ut30_frame_log_addr(ctx_, 0))
+      << "the two frames must share a framebuffer for this to be the reuse case";
+  EXPECT_EQ(ut30_stat_frames_incomplete(ctx_), 1u);
+  EXPECT_EQ(frames_done(), 1) << "a delivered CORRUPTED frame is not a frame received";
+
+  EXPECT_TRUE(SlotIs(1, 4, 0x5a)) << "received slots keep this frame's audio";
+  EXPECT_TRUE(SlotIs(1, 5, 0x00)) << "missing slot must be silence, not stale 0xa5";
 }

--- a/tests/unit/session/st30/redundancy_test.cpp
+++ b/tests/unit/session/st30/redundancy_test.cpp
@@ -155,7 +155,8 @@ TEST_F(St30RxRedundancyTest, InterleavedPortsIncreasingTs) {
  * `port[i].frames`. Redundant packets filtered by the timestamp check do
  * not even reach the credit branch.
  *
- * Invariant per session: port[P].frames + port[R].frames == frames_received
+ * Invariant per session, while every frame arrives whole: port[P].frames +
+ * port[R].frames == frames_received.
  * ───────────────────────────────────────────────────────────────────────── */
 
 /* P delivers all frames; R is silent. P is credited once per frame. */

--- a/tests/unit/session/st30/timestamp_test.cpp
+++ b/tests/unit/session/st30/timestamp_test.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include "session/st30/st30_rx_test_base.h"
+#include "st_api.h"
 
 class St30RxTimestampTest : public St30RxBaseTest {};
 
@@ -34,6 +35,76 @@ TEST_F(St30RxTimestampTest, AudioFrameBoundary) {
   EXPECT_EQ(received(), (uint64_t)total_pkts);
   EXPECT_EQ(frames_done(), 1);
   EXPECT_EQ(unrecovered(), 0u);
+}
+
+/* A loss burst ending mid-frame must not move the frame grid. Re-anchoring on
+ * the arriving timestamp instead shifts every later frame by a fraction of a
+ * frame, so the audio written out is no longer a frame-aligned window of what
+ * was sent. */
+TEST_F(St30RxTimestampTest, FrameGridSurvivesGapEndingMidFrame) {
+  const int total_pkts = ppf();
+  const uint32_t ticks = (uint32_t)total_pkts * spp();
+  const uint32_t first = 1000;
+
+  uint16_t seq = 0;
+  for (int i = 0; i < total_pkts; i++)
+    feed(seq++, first + (uint32_t)i * spp(), MTL_SESSION_PORT_P);
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 1);
+  ASSERT_EQ(ut30_frame_log_ts(ctx_, 0), first);
+
+  /* lose all of frame 1 and the leading 3 packets of frame 2 */
+  const int lost_head = 3;
+  for (int i = lost_head; i < total_pkts; i++)
+    feed(seq++, first + 2 * ticks + (uint32_t)i * spp(), MTL_SESSION_PORT_P);
+  /* frame 3 arrives whole */
+  for (int i = 0; i < total_pkts; i++)
+    feed(seq++, first + 3 * ticks + (uint32_t)i * spp(), MTL_SESSION_PORT_P);
+
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 2) << "the partial frame 2 must not be handed up";
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 1), ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 1), first + 3 * ticks)
+      << "frame after the gap must stay on the grid, not re-anchor to the first"
+         " packet that got through";
+}
+
+/* A long burst from behind the floor makes the redundancy filter give up and
+ * accept one (ST_SESSION_REDUNDANT_ERROR_THRESHOLD), opening a frame from a
+ * timestamp the stream moved past. It must land a whole number of frames back
+ * on the same grid, or every later frame is spliced mid-frame. */
+TEST_F(St30RxTimestampTest, FrameGridSurvivesPacketAcceptedFromBehindTheFloor) {
+  ut30_ctx_destroy(ctx_);
+  ctx_ = ut30_ctx_create(1);
+  ASSERT_NE(ctx_, nullptr);
+
+  const int total_pkts = ppf();
+  const uint32_t ticks = (uint32_t)total_pkts * spp();
+  const uint32_t first = 1000;
+
+  uint16_t seq = 0;
+  for (int f = 0; f < 2; f++)
+    for (int i = 0; i < total_pkts; i++)
+      feed(seq++, first + (uint32_t)f * ticks + (uint32_t)i * spp(), MTL_SESSION_PORT_P);
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 2);
+
+  /* the second frame arrives all over again, long after the stream moved on */
+  uint64_t recv_before = received();
+  for (int i = 0; i < total_pkts; i++)
+    feed(seq++, first + ticks + (uint32_t)i * spp(), MTL_SESSION_PORT_P);
+  ASSERT_GT(received(), recv_before)
+      << "the filter must give up on a burst this long, or this case never opens"
+         " a frame from behind the floor";
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 2)
+      << "the re-opened frame is partial and must not be handed up";
+
+  /* the stream continues where it left off */
+  for (int i = 0; i < total_pkts; i++)
+    feed(seq++, first + 3 * ticks + (uint32_t)i * spp(), MTL_SESSION_PORT_P);
+
+  ASSERT_EQ(ut30_frame_log_count(ctx_), 3);
+  EXPECT_EQ(ut30_frame_log_status(ctx_, 2), ST_FRAME_STATUS_COMPLETE);
+  EXPECT_EQ(ut30_frame_log_ts(ctx_, 2), first + 3 * ticks)
+      << "a frame opened from behind the floor must snap to a whole frame back,"
+         " leaving the grid the stream joined on unchanged";
 }
 
 /* 32-bit timestamp wraparound from near UINT32_MAX past zero. Positional

--- a/tests/unit/session/st30_harness.c
+++ b/tests/unit/session/st30_harness.c
@@ -45,6 +45,7 @@ struct ut30_test_ctx {
   /* ordered log of delivered frames for timeline assertions */
   uint64_t rec_ts[64];
   int rec_status[64];
+  const void* rec_addr[64];
   int rec_n;
 };
 
@@ -74,6 +75,7 @@ static int ut30_notify_frame_ready(void* priv, void* frame,
     if (ctx->rec_n < (int)(sizeof(ctx->rec_ts) / sizeof(ctx->rec_ts[0]))) {
       ctx->rec_ts[ctx->rec_n] = meta->timestamp;
       ctx->rec_status[ctx->rec_n] = meta->status;
+      ctx->rec_addr[ctx->rec_n] = frame;
       ctx->rec_n++;
     }
   }
@@ -222,11 +224,7 @@ static struct rte_mbuf* make_audio_mbuf(uint16_t seq, uint32_t ts) {
 
 int ut30_feed_pkt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
                   enum mtl_session_port port) {
-  struct rte_mbuf* m = make_audio_mbuf(seq, ts);
-  if (!m) return -1;
-  int rc = rx_audio_session_handle_frame_pkt(&ctx->impl, &ctx->session, m, port);
-  rte_pktmbuf_free(m);
-  return rc;
+  return ut30_feed_pkt_fill(ctx, seq, ts, port, 0);
 }
 
 void ut30_feed_burst(ut30_test_ctx* ctx, uint16_t seq_start, int count, uint32_t ts,
@@ -235,6 +233,17 @@ void ut30_feed_burst(ut30_test_ctx* ctx, uint16_t seq_start, int count, uint32_t
   for (int i = 0; i < count; i++) {
     ut30_feed_pkt(ctx, seq_start + i, ts + (uint32_t)i * spp, port);
   }
+}
+
+int ut30_feed_pkt_fill(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                       enum mtl_session_port port, uint8_t fill) {
+  struct rte_mbuf* m = make_audio_mbuf(seq, ts);
+  if (!m) return -1;
+  memset(rte_pktmbuf_mtod(m, uint8_t*) + sizeof(struct st_rfc3550_audio_hdr), fill,
+         UT30_PKT_PAYLOAD);
+  int rc = rx_audio_session_handle_frame_pkt(&ctx->impl, &ctx->session, m, port);
+  rte_pktmbuf_free(m);
+  return rc;
 }
 
 int ut30_feed_pkt_pt(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
@@ -285,6 +294,10 @@ void ut30_ctx_set_ssrc(ut30_test_ctx* ctx, uint32_t ssrc) {
   ctx->session.ops.ssrc = ssrc;
 }
 
+void ut30_ctx_set_flags(ut30_test_ctx* ctx, uint32_t flags) {
+  ctx->session.ops.flags = flags;
+}
+
 /* ── stat accessors ───────────────────────────────────────────────────── */
 
 uint64_t ut30_stat_unrecovered(const ut30_test_ctx* ctx) {
@@ -331,6 +344,10 @@ int ut30_pkts_per_frame(const ut30_test_ctx* ctx) {
   return ctx->session.st30_total_pkts;
 }
 
+uint32_t ut30_pkt_len(const ut30_test_ctx* ctx) {
+  return ctx->session.pkt_len;
+}
+
 uint32_t ut30_samples_per_pkt(const ut30_test_ctx* ctx) {
   return ctx->session.samples_per_pkt;
 }
@@ -347,6 +364,11 @@ uint64_t ut30_frame_log_ts(const ut30_test_ctx* ctx, int i) {
 int ut30_frame_log_status(const ut30_test_ctx* ctx, int i) {
   if (i < 0 || i >= ctx->rec_n) return -1;
   return ctx->rec_status[i];
+}
+
+const void* ut30_frame_log_addr(const ut30_test_ctx* ctx, int i) {
+  if (i < 0 || i >= ctx->rec_n) return NULL;
+  return ctx->rec_addr[i];
 }
 
 uint64_t ut30_stat_port_pkts(const ut30_test_ctx* ctx, enum mtl_session_port port) {
@@ -376,6 +398,10 @@ uint64_t ut30_stat_port_duplicates(const ut30_test_ctx* ctx, enum mtl_session_po
 uint64_t ut30_stat_port_err_packets(const ut30_test_ctx* ctx,
                                     enum mtl_session_port port) {
   return ctx->session.port_user_stats.common.port[port].err_packets;
+}
+
+uint64_t ut30_stat_frames_incomplete(const ut30_test_ctx* ctx) {
+  return ctx->session.port_user_stats.stat_frames_incomplete;
 }
 
 uint64_t ut30_stat_wrong_pt(const ut30_test_ctx* ctx) {

--- a/tests/unit/session/st30_harness.h
+++ b/tests/unit/session/st30_harness.h
@@ -67,6 +67,9 @@ int ut30_feed_pkt_len(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
 void ut30_ctx_set_pt(ut30_test_ctx* ctx, uint8_t pt);
 void ut30_ctx_set_ssrc(ut30_test_ctx* ctx, uint32_t ssrc);
 
+/* Replace st30_rx_ops::flags; call before feeding any packet. */
+void ut30_ctx_set_flags(ut30_test_ctx* ctx, uint32_t flags);
+
 /* Wrapper feeder — drives the production `_handle_mbuf` wrapper instead of
  * the per-packet handler. Use this whenever the test asserts on per-port
  * `err_packets` or per-port `packets`. All RTP fields are explicit so a
@@ -127,14 +130,23 @@ void ut30_reset(ut30_test_ctx* ctx);
  * synthetic configuration. Tests use it to derive expected counts. */
 int ut30_pkts_per_frame(const ut30_test_ctx* ctx);
 
+/* Payload bytes carried by one packet, i.e. the stride of a positional slot
+ * inside the frame buffer. */
+uint32_t ut30_pkt_len(const ut30_test_ctx* ctx);
+
 /* Sample-clock ticks carried by one packet (RTP timestamp advance per packet). */
 uint32_t ut30_samples_per_pkt(const ut30_test_ctx* ctx);
 
 /* Ordered log of delivered frames, captured by the frame-ready stub. `count` is
- * the number logged; `ts`/`status` index into it. */
+ * the number logged; `ts`/`status`/`addr` index into it. Two entries sharing an
+ * `addr` were carried by the same recycled framebuffer. */
 int ut30_frame_log_count(const ut30_test_ctx* ctx);
 uint64_t ut30_frame_log_ts(const ut30_test_ctx* ctx, int i);
 int ut30_frame_log_status(const ut30_test_ctx* ctx, int i);
+const void* ut30_frame_log_addr(const ut30_test_ctx* ctx, int i);
+
+/* Frames not fully assembled from the wire, delivered or not. */
+uint64_t ut30_stat_frames_incomplete(const ut30_test_ctx* ctx);
 
 /* Per-reason drop counters. */
 uint64_t ut30_stat_wrong_pt(const ut30_test_ctx* ctx);
@@ -152,6 +164,10 @@ void ut30_set_hold_frames(ut30_test_ctx* ctx, bool hold);
  * in its own positional slot. */
 void ut30_feed_full_frame(ut30_test_ctx* ctx, uint16_t seq_start, uint32_t ts_start,
                           enum mtl_session_port port);
+
+/* Feed one packet whose payload bytes are all `fill`. */
+int ut30_feed_pkt_fill(ut30_test_ctx* ctx, uint16_t seq, uint32_t ts,
+                       enum mtl_session_port port, uint8_t fill);
 
 /* Drive the mt_stat-thread stat callback synchronously for assertions on
  * the rate-limited stat lines. */


### PR DESCRIPTION
## The symptom

The nightly `st30p` pytest suite hung for hours with no output (runs `34322321667`,
`34322745492`, `34283935732`). It hung rather than failed, and it took down the whole suite from
the first case to reach the bad path.

## Why it hung

The hang is entirely in the pytest audio checker. Two things were wrong with the comparison:

- it was handed the per-**packet** sample count for an argument documented as per-**frame**, so it
  compared chunks a fraction of a frame long;
- it compared capture index *i* against source index *i* from byte 0, an alignment a receiver
  joining an already-looping stream mid-flight can essentially never satisfy.

So every chunk mismatched, and every mismatch logged its own uncapped `logger.error` — 412,003
lines, about 39 MB, in the case that was measured.

That is what deadlocks. `mfd_connect`'s `SSHConnection._exec_command()` waits on
`chan.recv_exit_status()` *before* reading stdout, and paramiko credits the channel window only
from `Channel.recv()`. Once the checker's output passed `DEFAULT_WINDOW_SIZE` (2,097,152 bytes) it
blocked in `write()` forever: the reader was waiting for exit, the writer was waiting for window,
and with `default_timeout` unset nothing broke the cycle. Confirmed on two live hung runners —
`/proc/<pid>/io` `wchar = 2162558`, i.e. 2 MiB plus one buffer.

## The library bugs this uncovered

Correcting the comparison turns the hang into a *failure*, because ST30 RX has two real defects of
its own that only a correct comparison can see:

1. **It delivered frames it never fully received.** `doc/design.md` §6.7 is the library-wide RX
   contract: a session delivers only complete frames and discards incomplete ones unless the app
   sets `ST**_RX_FLAG_RECEIVE_INCOMPLETE_FRAME`. Video has enforced that in `rv_frame_notify()`
   all along; ST30 did not — `c0b1b5574` added the CORRUPTED status without a gate, and
   `fc9f668d5` made short frames reachable at all by placing packets positionally rather than by
   byte count. (ST40 also delivers unconditionally and has no such flag; out of scope here.)
   Because framebuffers are recycled, the slots that never arrived held the **previous frame's
   audio**, not silence.
2. **The frame grid could re-anchor mid-stream.** `rx_audio_session_open_frame()` floored the
   arriving timestamp with unsigned arithmetic. After
   `ST_SESSION_REDUNDANT_ERROR_THRESHOLD` consecutive rejects the redundancy filter force-accepts
   a packet from behind the floor; that distance is negative, and truncating it toward zero moved
   the grid permanently, so every later frame was written a fraction of a frame off the boundaries
   the receiver had joined on. Fixing the signedness alone would **not** have fixed it: the same
   predicate's other branch re-synced to the arriving timestamp on any forward jump beyond one
   frame, and that branch is what moved the grid. A loss burst ending mid-frame produces exactly
   such a jump, so removing the re-sync is part of the fix, not collateral damage.

Both halves are needed, and they are independently load-bearing — measured on an E810 runner:

| Library | Checker | Result |
|---|---|---|
| base | base | hangs for hours |
| base | fixed | **6 cases fail** in 3:58 (`test_st30p_ptime` 0.25/0.33 ms, content mismatch) |
| fixed | fixed | 91 passed, 15 skipped, 58:45, no hang, 0 integrity failures |

The sub-millisecond `ptime` legs are where the RX joins mid-frame, which is exactly what defect 1
mishandles.

## The fix

Library — one source file:

- `rx_audio_session_open_frame()`: signed, floored grid arithmetic, so the boundaries the receiver
  joined on stay the boundaries every later frame keeps.
- `rx_audio_session_frame_notify()`: an incomplete frame is recycled rather than delivered,
  matching video.
- `rx_audio_session_zero_frame_gaps()`: slots that never arrived are zeroed — before the USDT pcm
  dump, so neither the app that opted in nor the dump ever sees the recycled buffer's older audio.
- the session-level `stat_frames_received` now counts only frames actually handed up, and a new
  `stat_frames_incomplete` counts every frame found short — delivered or not, so an app that opts
  in still sees the loss. That field already exists in `st20_rx_user_stats` with exactly this
  meaning; ST30 was the outlier for lacking it.

API — one flag per layer, mirroring ST20 (`MTL_BIT32(4)`, free in both):
`ST30_RX_FLAG_RECEIVE_INCOMPLETE_FRAME` and `ST30P_RX_FLAG_RECEIVE_INCOMPLETE_FRAME`. The st30p
pipeline now reports the whole frame in `data_size`, as st20p already does — a byte count is not a
length when the gaps are interior, and the flag promises they read as silence.

Acceptance harness:

- `audio_integrity.py`: compares against the source as the byte-cyclic loop the TX actually sends,
  locating where the capture joined it; bounds the number of candidate join positions, so a
  capture that could start anywhere (silence, a flat pattern) is reported as inconclusive instead
  of passing; tolerates a bounded start-up join gap, and only where the RX joined — stream segments
  are consecutive cuts of one capture, so they are checked joined rather than one by one, since a
  segment checked alone re-anchors on the source wherever it can and hides audio lost across a
  boundary; caps per-frame reports at `MAX_BAD_FRAME_REPORTS`.
- `integrity_runner.py`: `timeout=600`, so a pathological check fails loudly in ten minutes
  instead of hanging. This is also the sole anti-hang guard on the video legs: `video_integrity.py`
  reports per multi-megabyte frame, so its worst case is ~350 KB — 6× under the channel window —
  and it needs no cap of its own.
- `integrity.py` / `integrity_session.py`: pass the per-**frame** sample count, and a
  capture-length floor built from the module's existing `min_expected_frames()` helper.

Each of those pieces earns its place in the 85 integrity checks of the full nightly run: 12 checks
started at a nonzero source byte (byte-0 comparison would have failed them), 4 matched only the
secondary loop period, and 6 consumed the join allowance.

**The length floor is load-bearing, not belt-and-braces.** On the ffmpeg leg a 1 s gap makes
`st30p_rx_get_frame()` return NULL, the plugin returns `AVERROR(EIO)`, and `ffmpeg_demux.c` turns
that into exit 0 without `-xerror`. A receiver that captured one good frame and died would
otherwise pass every content rule.

## Behavior change

ST30 and ST30p no longer deliver a `CORRUPTED` frame by default; an app that wants them must set
the new flag. This aligns ST30 with the documented default and with video and ST20p.
(ST40 also delivers unconditionally and has no such flag; that is out of scope here.)
`TEST(St30p, rx_simulate_pkt_loss)` is updated to set it.

The receiver also no longer re-anchors its frame grid on a large forward timestamp jump. If a sender
restarts on a fresh off-grid timestamp, exactly one frame at the transition is now incomplete (and
so discarded by default), after which every frame is complete again; the reported timestamp of a
frame's first sample can sit up to one packet time early. `st30_rx_update_source()` remains the
deliberate way to re-anchor.

## Verification

- `./build.sh unit` 579/579; `python3 -m unittest discover -s tests/acceptance_unit` 34/34; full
  `./build.sh` clean with zero warnings; every pre-commit hook (clang-format-14, isort, black,
  flake8, ruff, gitleaks, gitlint) passes.
- The new gtests fail against the pre-change library and pass against the fix, with no NIC and no
  root. Reverting **only** `open_frame` to the old arithmetic fails exactly the two
  `St30RxTimestampTest` grid cases (577 pass / 2 fail), and the failure is exact: at the harness
  geometry (48 kHz PCM16, 1 ms ptime, 48 ticks/packet, 42 packets/frame) losing a whole frame plus
  the next frame's 3 leading packets re-anchored the grid 144 ticks — those 3 packets — past its
  slot, so the frame handed up at timestamp 5176 instead of the grid's 7048 was a splice of 39
  packets from one sender frame and 3 from the next.
- Each library behavior has a test proven to catch its removal by mutation: forcing delivery of
  incomplete frames, disabling the gap zeroing (fails on the stale byte `0xa5`), dropping the
  `!incomplete` guard on `stat_frames_received`, and reporting a short `data_size` each fail
  exactly one case.
- The new checker tests fail against the uncapped checker: an all-silence capture against an
  all-silence source passed before the candidate-position bound, and is now rejected; a frame lost
  exactly at a stream-segment boundary passed silently — no warning, no error — and is now rejected.
- Hardware A/B/A on one E810 runner, swapping only `st_rx_audio_session.c`: base library → the
  same 6 cases fail; fixed library restored byte-identical → they pass again.
