### PR TITLE
Fix: Narrow the init-time NUMA affinity instead of replacing it

### DIFF
--- a/.github/copilot-docs/mtl-knowledge-base.md
+++ b/.github/copilot-docs/mtl-knowledge-base.md
@@ -199,6 +199,16 @@ If `rte_eth_tx_burst()` returns fewer than requested:
 | Socket TX/RX (×4 each) | Kernel socket backend | Only with `kernel:` backend |
 | SRSS (×1) | Shared RSS polling | Only for NICs without flow director |
 
+### Init-Time NUMA Binding (`mt_bind_process_numa()`)
+- `mtl_init()` narrows the **calling thread's** affinity to `node cpus ∩ current affinity` and `numa_set_membind()`s the primary port's node. Threads created afterwards inherit it; pre-existing threads do not. Skipped on a single-node host or with `MTL_FLAG_NOT_BIND_PROCESS_NUMA`.
+- It must never *widen*. `numa_bind()` did: its `numa_run_on_node_mask()` builds the cpu set from the node's hardware cpumap and replaces the caller's mask.
+- **isolcpus trap**: `isolcpus=managed_irq,domain,60-70` makes the kernel hand every process `Cpus_allowed_list: 0-59,71-…`. Widening 60-70 back in strands the caller and its children on one isolated cpu — no scheduling domain, so the balancer never migrates off it and `wake_up_new_task` leaves children on the parent's cpu.
+  Signature: an app-side TX thread starved to ~20 of 25 fps; `St20_rx.digest_ooo_slice_4320p` `incomplete_frame_cnt` 128-144 vs a limit of 16, on the isolcpus host only. A cross-node DMA channel gives the same case the same count (`doc/ci_runner_setup.md`) — the app-side starvation and the one affected host are what tell them apart.
+- Empty intersection (caller deliberately placed on another socket) is not an error: memory is bound, affinity untouched.
+- The **lcore** data plane does not depend on this mask once EAL is up: DPDK takes its lcore set from the affinity inherited at `rte_eal_init()` (MTL passes `--remap-lcore-ids` on DPDK ≥ 25.11 builds, so a sparse set gets contiguous lcore ids) and then pins each lcore thread explicitly, so no later mask change moves one.
+  `mt_dev.c` calls `rte_eal_init()` on a throwaway pthread so the caller's own mask survives it.
+- The threads started **after** the bind with a plain `pthread_create` and no affinity call of their own *do* run under this mask — tasklet-thread mode schedulers (`mt_sch.c`), kernel-socket TX/RX (`mt_dp_socket.c`), SRSS poll (`mt_shared_rss.c`). Do not reason about `MTL_FLAG_TASKLET_THREAD` placement as if EAL had pinned it.
+
 ---
 
 ## §3 Memory Management
@@ -626,7 +636,7 @@ Sessions organized into managers (`st_tx_video_sessions_mgr`), one per session t
 Per-scheduler (not global) → no filtering needed in tasklet hot path.
 
 ### Global Init Ordering
-`mtl_init()`: DMA → queues → ARP/mcast → CNI → admin → plugins → DHCP → PTP → TSC calibration thread
+`mtl_init()`: EAL/dev init → per-port NUMA resolve → process NUMA bind (§2) → DMA → queues → ARP/mcast → CNI → admin → plugins → DHCP → PTP → TSC calibration thread
 
 `mtl_start()` blocks on TSC calibration via `mt_wait_tsc_stable()` before starting ports.
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -117,6 +117,14 @@ For user convenience, the built-in RxTxApp also offers a command-line option `--
 > This is fixed in kernel 6.19 by the following patch: [sched/fair: Fix imbalance overflow for SD_NUMA domain](https://kernel.googlesource.com/pub/scm/linux/kernel/git/sudeep.holla/linux/+/4d6dd05d07d00bc3bd91183dab4d75caa8018db9). If running an older kernel on GNR, consider backporting this fix,
 > upgrading your kernel, or working with taskset.
 >
+### 2.8. Process NUMA binding
+
+On a multi-socket host, `mtl_init()` binds the calling thread — and so every thread it creates afterwards — to the NUMA node of the primary port: its memory to that node, and its CPU affinity to the node's CPUs that the thread is *already* allowed to run on.
+Any restriction already in place is therefore kept: a `taskset`, a cgroup `cpuset`, or the housekeeping-only affinity the kernel gives every process on a host booted with `isolcpus`.
+If the node offers no CPU the caller may use, only the memory is bound.
+
+Pass `MTL_FLAG_NOT_BIND_PROCESS_NUMA` to skip the binding entirely.
+
 ## 3. Memory management
 
 ### 3.1. Huge Page

--- a/lib/src/mt_main.c
+++ b/lib/src/mt_main.c
@@ -35,6 +35,60 @@ enum mtl_port mt_port_by_id(struct mtl_main_impl* impl, uint16_t port_id) {
   return MTL_PORT_MAX;
 }
 
+#ifndef WINDOWSENV
+/* Bind the calling thread to a port's numa node: memory to that node, cpu affinity
+ * to the node's cpus this thread may already use.
+ *
+ * Not numa_bind(): it takes the node's whole hardware cpumap, so it replaces the
+ * caller's mask instead of narrowing it -- handing back cpus the caller was kept
+ * off, which on an isolcpus host strands it and every thread it creates later. */
+int mt_bind_process_numa(int socket_id) {
+  if (socket_id < 0 || socket_id > numa_max_node()) {
+    err("%s, invalid numa node %d\n", __func__, socket_id);
+    return -EINVAL;
+  }
+
+  struct bitmask* nodes = numa_allocate_nodemask();
+  struct bitmask* cpus = numa_allocate_cpumask();
+  struct bitmask* allowed = numa_allocate_cpumask();
+  int ret = 0;
+
+  if (numa_node_to_cpus(socket_id, cpus) < 0) {
+    err("%s, no cpu list for numa node %d\n", __func__, socket_id);
+    ret = -EINVAL;
+    goto out;
+  }
+  if (numa_sched_getaffinity(0, allowed) < 0) {
+    err("%s, get cpu affinity fail\n", __func__);
+    ret = -EIO;
+    goto out;
+  }
+  /* drop the node cpus this thread is already kept off */
+  for (unsigned int cpu = 0; cpu < cpus->size; cpu++) {
+    if (!numa_bitmask_isbitset(allowed, cpu)) numa_bitmask_clearbit(cpus, cpu);
+  }
+
+  if (!numa_bitmask_weight(cpus)) {
+    warn("%s, no usable cpu on numa node %d, binding its memory only\n", __func__,
+         socket_id);
+  } else if (numa_sched_setaffinity(0, cpus) < 0) {
+    /* all or nothing: do not bind memory to a node this thread cannot run on */
+    err("%s, set cpu affinity to numa node %d fail\n", __func__, socket_id);
+    ret = -EIO;
+    goto out;
+  }
+
+  numa_bitmask_setbit(nodes, socket_id);
+  numa_set_membind(nodes);
+
+out:
+  numa_bitmask_free(allowed);
+  numa_bitmask_free(cpus);
+  numa_bitmask_free(nodes);
+  return ret;
+}
+#endif
+
 int mt_dst_ip_mac(struct mtl_main_impl* impl, uint8_t dip[MTL_IP_ADDR_LEN],
                   struct rte_ether_addr* ea, enum mtl_port port, int timeout_ms) {
   int ret;
@@ -451,14 +505,10 @@ mtl_handle mtl_init(struct mtl_init_params* p) {
   int numa_nodes = 0;
   if (numa_available() >= 0) numa_nodes = numa_max_node() + 1;
   if (!(p->flags & MTL_FLAG_NOT_BIND_PROCESS_NUMA) && (numa_nodes > 1)) {
-    /* bind current thread and its children to socket node */
-    struct bitmask* mask = numa_bitmask_alloc(numa_nodes);
-
+    /* bind current thread and its children to socket node, best effort */
     info("%s, bind to socket %d, numa_nodes %d\n", __func__, socket[MTL_PORT_P],
          numa_nodes);
-    numa_bitmask_setbit(mask, socket[MTL_PORT_P]);
-    numa_bind(mask);
-    numa_bitmask_free(mask);
+    mt_bind_process_numa(socket[MTL_PORT_P]);
   }
 #endif
 

--- a/lib/src/mt_main.h
+++ b/lib/src/mt_main.h
@@ -1293,6 +1293,8 @@ uint8_t* mt_sip_gateway(struct mtl_main_impl* impl, enum mtl_port port);
 int mt_dst_ip_mac(struct mtl_main_impl* impl, uint8_t dip[MTL_IP_ADDR_LEN],
                   struct rte_ether_addr* ea, enum mtl_port port, int timeout_ms);
 
+int mt_bind_process_numa(int socket_id);
+
 static inline enum mtl_pmd_type mt_pmd_type(struct mtl_main_impl* impl,
                                             enum mtl_port port) {
   return mt_get_user_params(impl)->pmd[port];

--- a/tests/unit/core/mt_numa_harness.c
+++ b/tests/unit/core/mt_numa_harness.c
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ */
+
+#include "core/mt_numa_harness.h"
+
+#include "mt_main.h"
+
+int ut_bind_process_numa(int socket_id) {
+  return mt_bind_process_numa(socket_id);
+}

--- a/tests/unit/core/mt_numa_harness.h
+++ b/tests/unit/core/mt_numa_harness.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * Reaches mt_main.c's numa binding from a C++ test. mt_main.h is a C header
+ * with no extern "C" of its own, so a C++ translation unit that included it
+ * would ask the linker for C++ linkage and not find the symbol.
+ */
+
+#ifndef TESTS_UNIT_CORE_MT_NUMA_HARNESS_H
+#define TESTS_UNIT_CORE_MT_NUMA_HARNESS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** mt_bind_process_numa() of lib/src/mt_main.c. */
+int ut_bind_process_numa(int socket_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/unit/core/numa_bind_test.cpp
+++ b/tests/unit/core/numa_bind_test.cpp
@@ -1,0 +1,228 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2026 Intel Corporation
+ *
+ * mtl_init() binds the calling process to the numa node its primary port sits
+ * on. It must narrow the cpu affinity to that node, never widen it back out --
+ * see mt_bind_process_numa() for why. Widening turned
+ * St20_rx.digest_ooo_slice_4320p red on an isolcpus runner and nowhere else.
+ *
+ * Two of the four cases need a second numa node and skip without one, so on the
+ * single-node image the unit workflow runs, a green CI gates the no-widening
+ * case and the range guard only. Read a verdict here as the whole contract only
+ * on a multi-node host.
+ */
+
+#include <gtest/gtest.h>
+#include <numa.h>
+
+#include <cerrno>
+#include <vector>
+
+#include "core/mt_numa_harness.h"
+
+namespace {
+
+/* A libnuma cpu mask that frees itself, so a failed assertion cannot leak it. */
+class CpuMask {
+ public:
+  CpuMask() : mask_(numa_allocate_cpumask()) {
+  }
+  ~CpuMask() {
+    numa_bitmask_free(mask_);
+  }
+  CpuMask(const CpuMask&) = delete;
+  CpuMask& operator=(const CpuMask&) = delete;
+
+  bitmask* get() const {
+    return mask_;
+  }
+  bool has(unsigned int cpu) const {
+    return numa_bitmask_isbitset(mask_, cpu);
+  }
+  unsigned int size() const {
+    return mask_->size;
+  }
+  unsigned int weight() const {
+    return numa_bitmask_weight(mask_);
+  }
+  std::vector<int> cpus() const {
+    std::vector<int> out;
+    for (unsigned int cpu = 0; cpu < size(); cpu++)
+      if (has(cpu)) out.push_back((int)cpu);
+    return out;
+  }
+
+ private:
+  bitmask* mask_;
+};
+
+class MtNumaBindTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    if (numa_available() < 0) GTEST_SKIP() << "libnuma reports no numa support";
+    ASSERT_GE(numa_sched_getaffinity(0, saved_cpus_.get()), 0);
+    saved_cpus_valid_ = true;
+    saved_membind_ = numa_get_membind();
+  }
+
+  void TearDown() override {
+    /* Every other case in this binary runs on this same thread, and an EAL init
+     * in one of them would take its lcore set from whatever mask is left here.
+     * Put back exactly what was found. */
+    if (saved_cpus_valid_) numa_sched_setaffinity(0, saved_cpus_.get());
+    /* still null when SetUp skipped or asserted before getting this far --
+     * TearDown runs either way, and numa_set_membind(nullptr) segfaults. */
+    if (saved_membind_) {
+      numa_set_membind(saved_membind_);
+      numa_bitmask_free(saved_membind_);
+    }
+  }
+
+  /* Runs this thread on every cpu of `node` the host will actually allow, and
+   * reports what that turned out to be. False when the node has none. */
+  bool RunOnNode(int node, CpuMask* granted) {
+    CpuMask wanted;
+    if (numa_node_to_cpus(node, wanted.get()) < 0) return false;
+    if (!wanted.weight()) return false;
+    if (numa_sched_setaffinity(0, wanted.get()) < 0) return false; /* offline cpus */
+    if (numa_sched_getaffinity(0, granted->get()) < 0) return false;
+    return granted->weight() > 0;
+  }
+
+  CpuMask saved_cpus_;
+  bool saved_cpus_valid_ = false;
+  bitmask* saved_membind_ = nullptr;
+};
+
+/* The regression. A cpu withheld from this thread must not come back. */
+TEST_F(MtNumaBindTest, NeverAddsACpuTheCallerWasNotAllowedToUse) {
+  int node = -1;
+  CpuMask node_cpus;
+  for (int n = 0; n <= numa_max_node(); n++) {
+    if (RunOnNode(n, &node_cpus) && node_cpus.weight() >= 2) {
+      node = n;
+      break;
+    }
+  }
+  if (node < 0) GTEST_SKIP() << "no numa node offers 2 cpus this thread may use";
+
+  /* Hand over every cpu of the node but one. */
+  const int withheld = node_cpus.cpus().back();
+  CpuMask given;
+  for (int cpu : node_cpus.cpus())
+    if (cpu != withheld) numa_bitmask_setbit(given.get(), (unsigned int)cpu);
+  ASSERT_GE(numa_sched_setaffinity(0, given.get()), 0);
+
+  ASSERT_EQ(ut_bind_process_numa(node), 0);
+
+  CpuMask got;
+  ASSERT_GE(numa_sched_getaffinity(0, got.get()), 0);
+  EXPECT_FALSE(got.has((unsigned int)withheld))
+      << "cpu " << withheld << " was withheld from this thread but numa node " << node
+      << " binding handed it back";
+  for (int cpu : got.cpus())
+    EXPECT_TRUE(given.has((unsigned int)cpu)) << "cpu " << cpu << " was not on offer";
+  EXPECT_GT(got.weight(), 0u) << "binding left this thread with no cpu at all";
+
+  /* The memory half of the binding is the point of doing this at all. */
+  bitmask* membind = numa_get_membind();
+  EXPECT_TRUE(numa_bitmask_isbitset(membind, (unsigned int)node));
+  EXPECT_EQ(numa_bitmask_weight(membind), 1u);
+  numa_bitmask_free(membind);
+}
+
+/* A healthy host: nothing of the node is withheld, so all of it has to be
+ * applied -- and nothing outside it. Entering with one foreign cpu in the mask
+ * is what makes this fail for a binding that narrows too far and for one that
+ * does nothing at all. */
+TEST_F(MtNumaBindTest, AppliesTheWholeNodeAndOnlyTheNode) {
+  if (numa_max_node() < 1) GTEST_SKIP() << "single numa node host";
+
+  int node = -1;
+  CpuMask node_cpus;
+  for (int n = 0; n <= numa_max_node(); n++) {
+    if (RunOnNode(n, &node_cpus)) {
+      node = n;
+      break;
+    }
+  }
+  if (node < 0) GTEST_SKIP() << "no numa node offers a cpu this thread may use";
+
+  int foreign = -1;
+  for (int n = 0; n <= numa_max_node() && foreign < 0; n++) {
+    if (n == node) continue;
+    CpuMask other;
+    if (numa_node_to_cpus(n, other.get()) < 0) continue;
+    for (int cpu : other.cpus())
+      if (saved_cpus_.has((unsigned int)cpu)) {
+        foreign = cpu;
+        break;
+      }
+  }
+  if (foreign < 0) GTEST_SKIP() << "no cpu off this node that this thread may use";
+
+  CpuMask entry;
+  for (int cpu : node_cpus.cpus()) numa_bitmask_setbit(entry.get(), (unsigned int)cpu);
+  numa_bitmask_setbit(entry.get(), (unsigned int)foreign);
+  ASSERT_GE(numa_sched_setaffinity(0, entry.get()), 0);
+
+  ASSERT_EQ(ut_bind_process_numa(node), 0);
+
+  CpuMask got;
+  ASSERT_GE(numa_sched_getaffinity(0, got.get()), 0);
+  EXPECT_EQ(got.cpus(), node_cpus.cpus())
+      << "expected all of numa node " << node << " and not cpu " << foreign;
+}
+
+/* A caller placed on another socket on purpose keeps its cpus. Stranding it on
+ * a node it may not run on would be worse than not binding at all. */
+TEST_F(MtNumaBindTest, KeepsTheAffinityWhenTheNodeOffersNoUsableCpu) {
+  if (numa_max_node() < 1) GTEST_SKIP() << "single numa node host";
+
+  int home = -1, other = -1;
+  CpuMask home_cpus;
+  for (int n = 0; n <= numa_max_node() && home < 0; n++)
+    if (RunOnNode(n, &home_cpus)) home = n;
+  if (home < 0) GTEST_SKIP() << "no numa node offers a cpu this thread may use";
+
+  CpuMask other_cpus;
+  for (int n = 0; n <= numa_max_node(); n++) {
+    if (n == home) continue;
+    if (numa_node_to_cpus(n, other_cpus.get()) < 0) continue;
+    if (other_cpus.weight()) {
+      other = n;
+      break;
+    }
+  }
+  if (other < 0) GTEST_SKIP() << "no second numa node with cpus";
+
+  /* Back onto the home node only, then ask for the other one. */
+  ASSERT_GE(numa_sched_setaffinity(0, home_cpus.get()), 0);
+  EXPECT_EQ(ut_bind_process_numa(other), 0);
+
+  CpuMask got;
+  ASSERT_GE(numa_sched_getaffinity(0, got.get()), 0);
+  EXPECT_EQ(got.cpus(), home_cpus.cpus());
+
+  /* The memory half still applies -- that is the half worth keeping here. */
+  bitmask* membind = numa_get_membind();
+  EXPECT_TRUE(numa_bitmask_isbitset(membind, (unsigned int)other));
+  EXPECT_EQ(numa_bitmask_weight(membind), 1u);
+  numa_bitmask_free(membind);
+}
+
+/* MTL_PORT_FLAG_FORCE_NUMA hands over whatever socket_id the caller put in
+ * mtl_init_params, and nothing validates it on the way here. */
+TEST_F(MtNumaBindTest, RejectsANodeThatDoesNotExist) {
+  /* The negative half is the one only MTL can catch: libnuma range-checks a node
+   * above numa_max_node() itself, but for a negative one numa_node_to_cpus()
+   * indexes its node_cpu_mask array out of bounds. */
+  EXPECT_EQ(ut_bind_process_numa(-1), -EINVAL);
+  EXPECT_EQ(ut_bind_process_numa(numa_max_node() + 1), -EINVAL);
+
+  CpuMask got;
+  ASSERT_GE(numa_sched_getaffinity(0, got.get()), 0);
+  EXPECT_EQ(got.cpus(), saved_cpus_.cpus()) << "a rejected node still moved this thread";
+}
+
+}  // namespace

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -40,6 +40,8 @@ endif
 
 unit_sources = [
   'common/ut_common.c',
+  'core/mt_numa_harness.c',
+  'core/numa_bind_test.cpp',
   'ffmpeg/mtl_common_harness.c',
   'ffmpeg/mtl_common_test.cpp',
   'dev/mt_dev_harness.c',
@@ -129,6 +131,6 @@ executable('UnitTest', unit_sources,
   link_args : unit_link_args,
   build_rpath : unit_build_rpath,
   include_directories : unit_include_dirs,
-  dependencies : [mtl_internal_dep, dpdk_dep, libm_dep, gtest_dep, gmock_dep, libpthread_dep,
-                  usdt_provider_header_dep] + unit_extra_deps,
+  dependencies : [mtl_internal_dep, dpdk_dep, libm_dep, libnuma_dep, gtest_dep, gmock_dep,
+                  libpthread_dep, usdt_provider_header_dep] + unit_extra_deps,
   install : false)


### PR DESCRIPTION
## Problem

`St20_rx.digest_ooo_slice_4320p` fails on mtl-runner-1 and passes on every other runner at the same sha, with `incomplete_frame_cnt` 128-144 against a limit of 16 and the TX feeder delivering about 8 of the 25 fps it should.

`mtl_init()` bound the calling thread to the primary port's NUMA node with `numa_bind()`. That calls `numa_run_on_node_mask()`, which builds the CPU set from the node's *hardware* cpumap and **replaces** the caller's affinity mask rather than intersecting with it. Runner-1 boots `isolcpus=managed_irq,domain,60-70`, so the process inherits mask `0-59,71-239`; its E810 port sits on node 2, whose CPUs are 60-89. The binding therefore handed CPUs 60-70 straight back.

An isolated CPU is in no scheduling domain, so nothing balances a task off it, and `wake_up_new_task()` keeps a child on its parent's CPU. Once `mtl_init()` placed the caller on CPU 60, every thread the test created afterwards piled onto that one core -- including the ST20_TYPE_RTP_LEVEL TX feeder this case builds by hand, which is why the failure is a starved sender rather than a starved receiver.

The widening bought the data plane nothing. `rte_eal_init()` has already run by this point and has pinned each lcore thread to its own CPU, fatal on failure, so no later change to the process mask can move one. Its lcore set also came from the affinity inherited at that point, which did not include the isolated CPUs, so the data plane never ran on them.

Introduced in b99c830d ("Intel(R) ST 2110 Media Streaming Library v0.7.0 release", 2021-11-19), the first appearance of `numa_bind()` in the tree, then carried through five renames and relocations unchanged.

## What changed

`mt_bind_process_numa()` intersects the node's CPU list with the affinity the caller already holds and applies that. It never hands back a CPU the caller was kept off, so an isolated core is used only if the application was started with access to it. When the intersection is empty -- a caller deliberately placed on another socket -- the affinity is left alone and only the memory is bound; stranding it on CPUs it may not run on would be worse than not binding at all. `socket_id` is now range checked, which `MTL_PORT_FLAG_FORCE_NUMA` can reach with any int.

On 8 of the 10 reachable CI runners the mask this computes is bit-identical to the one `numa_bind()` applied, which is why the same sha is green there. Two differ, and on both the port's own node is the affected one: runner-1, which fails this test, and runner-7, a performance runner whose E830 VFs are all on node 0 while it boots `isolcpus=4-20`. There the widening distorts the numbers the perf leg reports instead of failing a case.

## Verification

A/B on mtl-runner-1, same tree, library swapped through `LD_LIBRARY_PATH` so the CI workspace was never modified:

| arm | runs | result | fb_send | framerate | caller CPU | |---|---|---|---|---|---|
| baseline | 6 | 0 pass | 224-230 | 7.8-8.9 | 60 or 61, isolated | | fixed | 6 | 6 pass | 275-276 | 24.0-25.1 | 71-75 |

Both arms ran 107 DPDK lcore threads with an identical lcore-to-CPU map, so the data plane is measurably unaffected. A full `St20_rx` shard against the fixed library is 36/36 in a single process.

`tests/unit/core/numa_bind_test.cpp` covers the narrowing, the whole-node case, the empty intersection and the range guard. Each of the four is the sole detector of a distinct wrong implementation, confirmed by interposing five mutants on the built binary: the old `numa_bind()`, a memory-only bind, one that narrows to a single CPU, one with the range guard deleted (SIGSEGV inside libnuma), and one with the empty-intersection guard deleted. No case is redundant.